### PR TITLE
feat: introduce core loader and effects normalizer

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,9 @@
     "build": "vite build",
     "build:dev": "vite build --mode development",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "export:core": "tsx scripts/export-core-json.ts",
+    "build:core": "CORE_SEED=2025-09-14 tsx scripts/export-core-json.ts"
   },
   "dependencies": {
     "@hookform/resolvers": "^3.10.0",

--- a/scripts/export-core-json.ts
+++ b/scripts/export-core-json.ts
@@ -1,0 +1,61 @@
+import { writeFileSync, mkdirSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { createHash } from 'node:crypto';
+import { normalizeDeck } from '../src/engine/normalizeEffects';
+import { CORE_TRUTH_DECK } from '../src/data/core/CORE_TRUTH_DECK';
+import { CORE_GOV_DECK } from '../src/data/core/CORE_GOV_DECK';
+
+const outDir = resolve(process.cwd(), 'public/core');
+mkdirSync(outDir, { recursive: true });
+
+const truth = normalizeDeck(CORE_TRUTH_DECK);
+const gov = normalizeDeck(CORE_GOV_DECK);
+const coreLibrary = [...truth, ...gov];
+
+const seed = process.env.CORE_SEED ?? new Date().toISOString().slice(0, 10);
+function seededShuffle<T>(arr: T[], seedStr: string): T[] {
+  let s = createHash('sha256').update(seedStr).digest().readUInt32BE(0);
+  const out = arr.slice();
+  for (let i = out.length - 1; i > 0; i--) {
+    s ^= s << 13;
+    s ^= s >>> 17;
+    s ^= s << 5;
+    const j = s % (i + 1);
+    [out[i], out[j]] = [out[j], out[i]];
+  }
+  return out;
+}
+const decklistIds = seededShuffle(coreLibrary.map(c => c.id), seed);
+
+function sha256(x: any) {
+  const data = typeof x === 'string' ? x : JSON.stringify(x);
+  return createHash('sha256').update(data).digest('hex');
+}
+
+const libPath = resolve(outDir, 'core-library.json');
+const deckPath = resolve(outDir, `core-decklist-${seed}.json`);
+const manifestPath = resolve(outDir, 'manifest.json');
+const latestPath = resolve(outDir, 'core-decklist-latest.json');
+
+writeFileSync(libPath, JSON.stringify(coreLibrary, null, 2));
+writeFileSync(deckPath, JSON.stringify({ seed, ids: decklistIds }, null, 2));
+writeFileSync(latestPath, JSON.stringify({ seed, ids: decklistIds }, null, 2));
+
+writeFileSync(
+  manifestPath,
+  JSON.stringify(
+    {
+      generatedAt: new Date().toISOString(),
+      seed,
+      files: {
+        library: { path: 'core-library.json', sha256: sha256(coreLibrary) },
+        decklist: { path: `core-decklist-${seed}.json`, sha256: sha256({ seed, ids: decklistIds }) },
+      },
+    },
+    null,
+    2,
+  ),
+);
+
+console.log('[core export] Done', { count: coreLibrary.length, seed });
+

--- a/src/data/core/CORE_GOV_DECK.ts
+++ b/src/data/core/CORE_GOV_DECK.ts
@@ -1,0 +1,31 @@
+import type { GameCard } from '../../types/cardTypes';
+
+export const CORE_GOV_DECK: GameCard[] = [
+  {
+    id: 'gov-1',
+    faction: 'government',
+    name: 'Propaganda Broadcast',
+    type: 'MEDIA',
+    rarity: 'common',
+    cost: 5,
+    text: 'Opponent discards 1 card at random.',
+    flavorTruth: 'They twist the truth again.',
+    flavorGov: 'Maintaining public order.',
+    target: { scope: 'global', count: 0 },
+    effects: { discardRandom: 1 },
+  },
+  {
+    id: 'gov-2',
+    faction: 'government',
+    name: 'Security Crackdown',
+    type: 'ATTACK',
+    rarity: 'uncommon',
+    cost: 8,
+    text: '-5% Truth.',
+    flavorTruth: 'A dark day for free speech.',
+    flavorGov: 'Stability restored.',
+    target: { scope: 'global', count: 0 },
+    effects: { truthDelta: -5 },
+  },
+];
+

--- a/src/data/core/CORE_TRUTH_DECK.ts
+++ b/src/data/core/CORE_TRUTH_DECK.ts
@@ -1,0 +1,31 @@
+import type { GameCard } from '../../types/cardTypes';
+
+export const CORE_TRUTH_DECK: GameCard[] = [
+  {
+    id: 'truth-1',
+    faction: 'truth',
+    name: 'Leaked Documents',
+    type: 'MEDIA',
+    rarity: 'common',
+    cost: 6,
+    text: '+5% Truth. Draw 1 card.',
+    flavorTruth: 'The people have a right to know.',
+    flavorGov: 'Unauthorized disclosure detected.',
+    target: { scope: 'global', count: 0 },
+    effects: { truthDelta: 5, draw: 1 },
+  },
+  {
+    id: 'truth-2',
+    faction: 'truth',
+    name: 'Investigative Report',
+    type: 'MEDIA',
+    rarity: 'common',
+    cost: 5,
+    text: '+4% Truth.',
+    flavorTruth: 'Facts speak louder than fiction.',
+    flavorGov: 'Misinformation campaign detected.',
+    target: { scope: 'global', count: 0 },
+    effects: { truthDelta: 4 },
+  },
+];
+

--- a/src/engine/core/loadCore.ts
+++ b/src/engine/core/loadCore.ts
@@ -1,0 +1,59 @@
+import { normalizeDeck } from '../normalizeEffects';
+import { CORE_BASE_URL, CORE_BUNDLED, coreFeatures } from './paths';
+
+async function loadBundled() {
+  try {
+    const [lib, deck] = await Promise.all([CORE_BUNDLED.library(), CORE_BUNDLED.decklist()]);
+    if (lib && deck) return { coreLibrary: lib, decklist: deck };
+  } catch {}
+  return null;
+}
+
+async function sha256Text(text: string): Promise<string> {
+  const enc = new TextEncoder().encode(text);
+  const buf = await crypto.subtle.digest('SHA-256', enc);
+  return Array.from(new Uint8Array(buf)).map(b => b.toString(16).padStart(2, '0')).join('');
+}
+
+async function loadViaFetch() {
+  const manifestRes = await fetch(CORE_BASE_URL + 'manifest.json');
+  if (!manifestRes.ok) throw new Error('Core manifest missing');
+  const manifestText = await manifestRes.text();
+  const manifest = JSON.parse(manifestText);
+
+  const libRes = await fetch(CORE_BASE_URL + manifest.files.library.path);
+  const libText = await libRes.text();
+  if (await sha256Text(libText) !== manifest.files.library.sha256) throw new Error('Core library integrity failed');
+  const coreLibrary = JSON.parse(libText);
+
+  const deckRes = await fetch(CORE_BASE_URL + manifest.files.decklist.path);
+  const deckText = await sha256Text(await deckRes.text());
+  const deckRaw = await (await fetch(CORE_BASE_URL + manifest.files.decklist.path)).text();
+  if (deckText !== manifest.files.decklist.sha256) throw new Error('Core decklist integrity failed');
+  const decklist = JSON.parse(deckRaw);
+
+  return { coreLibrary, decklist };
+}
+
+import { CORE_TRUTH_DECK } from '../../data/core/CORE_TRUTH_DECK';
+import { CORE_GOV_DECK } from '../../data/core/CORE_GOV_DECK';
+
+function loadFallback() {
+  const coreLibrary = [...normalizeDeck(CORE_TRUTH_DECK), ...normalizeDeck(CORE_GOV_DECK)];
+  const decklist = { seed: 'fallback', ids: coreLibrary.map(c => c.id) };
+  return { coreLibrary, decklist };
+}
+
+export async function loadCore() {
+  if (coreFeatures.useBundledFirst) {
+    const b = await loadBundled();
+    if (b) return b;
+  }
+  if (coreFeatures.allowHttpFetch) {
+    try {
+      return await loadViaFetch();
+    } catch {}
+  }
+  return loadFallback();
+}
+

--- a/src/engine/core/paths.ts
+++ b/src/engine/core/paths.ts
@@ -1,0 +1,12 @@
+export const CORE_BASE_URL = '/core/';
+export const CORE_BUNDLED = {
+  manifest: () => import('../../public/core/manifest.json').then(m => m.default).catch(() => null),
+  library: () => import('../../public/core/core-library.json').then(m => m.default).catch(() => null),
+  decklist: () => import('../../public/core/core-decklist-latest.json').then(m => m.default).catch(() => null),
+};
+
+export const coreFeatures = {
+  useBundledFirst: true,
+  allowHttpFetch: true,
+};
+

--- a/src/engine/deck/build.ts
+++ b/src/engine/deck/build.ts
@@ -1,0 +1,4 @@
+export function buildDeckFromIds(ids: string[], index: Map<string, any>): any[] {
+  return ids.map((id) => index.get(id)).filter(Boolean);
+}
+

--- a/src/engine/draw.ts
+++ b/src/engine/draw.ts
@@ -1,0 +1,8 @@
+import { normalizeCard } from './normalizeEffects';
+
+export function safePushToHand(gs: any, who: 'player' | 'ai', rawCard: any) {
+  const card = normalizeCard(rawCard);
+  if (gs.hands[who].length < 7) gs.hands[who].push(card);
+  else gs.discards[who].push(card);
+}
+

--- a/src/engine/effects.ts
+++ b/src/engine/effects.ts
@@ -1,18 +1,5 @@
-import { normalizeEffects } from './normalizeEffects';
+import { normalizeEffects, Effect } from './normalizeEffects';
 export type Rarity = 'common' | 'uncommon' | 'rare' | 'legendary';
-
-export type Effect =
-  | { k: 'ip'; who: 'player' | 'ai'; v: number }
-  | { k: 'truth'; who: 'player' | 'ai'; v: number }
-  | { k: 'pressure'; who: 'player' | 'ai'; state: string; v: number }
-  | { k: 'defense'; state: string; v: 1 | -1 }
-  | { k: 'draw'; who: 'player' | 'ai'; n: number }
-  | { k: 'discardRandom'; who: 'player' | 'ai'; n: number }
-  | { k: 'discardChoice'; who: 'player' | 'ai'; n: number }
-  | { k: 'addCard'; who: 'player' | 'ai'; cardId: string }
-  | { k: 'flag'; name: string; on?: boolean }
-  | { k: 'conditional'; if: (gs: any, target: any) => boolean; then: Effect[]; else?: Effect[] }
-  | { k: 'special'; fn: (gs: any, target: any) => void };
 
 function reshuffle(gs: any, who: 'player' | 'ai') {
   const deck = gs.decks[who];

--- a/src/engine/init.ts
+++ b/src/engine/init.ts
@@ -1,0 +1,27 @@
+import { loadCore } from './core/loadCore';
+import { buildDeckFromIds } from './deck/build';
+
+// Placeholder registries
+const library: any[] = [];
+const coreDecks: any[] = [];
+
+function registerCoreLibrary(cards: any[], deck: any[]) {
+  library.push(...cards);
+  coreDecks.push(...deck);
+}
+
+async function loadExpansions() {
+  // expansions would be loaded here
+}
+
+export async function initGame() {
+  const { coreLibrary, decklist } = await loadCore();
+
+  const index = new Map(coreLibrary.map((c: any) => [c.id, c]));
+  const coreDeck = buildDeckFromIds(decklist.ids, index);
+
+  registerCoreLibrary(coreLibrary, coreDeck);
+
+  await loadExpansions();
+}
+

--- a/src/engine/normalizeEffects.ts
+++ b/src/engine/normalizeEffects.ts
@@ -1,19 +1,17 @@
-// Normalizes legacy core cards into the new Effect[] schema.
-// New schema key summary:
-//  - truth       → { k:'truth', who:'player'|'ai', v:number }   (clamped 0..100 by engine)
-//  - ip          → { k:'ip',    who:'player'|'ai', v:number }   (min 0 by engine)
-//  - draw        → { k:'draw',  who:'player'|'ai', n:number }
-//  - pressure    → { k:'pressure', who:'player'|'ai', state:string, v:number }
-//  - defense     → { k:'defense', state:string, v:1|-1 }
-//  - discard rnd → { k:'discardRandom', who:'player'|'ai', n:number }
-//  - discard sel → { k:'discardChoice', who:'player'|'ai', n:number }
-//  - conditional → { k:'conditional', if:(gs,target)=>boolean, then:Effect[], else?:Effect[] }
-//  - addCard     → { k:'addCard', who:'player'|'ai', cardId:string }
-//  - flag        → { k:'flag', name:string, on?:boolean }
+export type Who = 'player' | 'ai';
 
-import type { Effect } from './effects'; // canonical Effect type
-
-type Who = 'player' | 'ai';
+export type Effect =
+  | { k: 'truth'; who: Who; v: number }
+  | { k: 'ip'; who: Who; v: number }
+  | { k: 'draw'; who: Who; n: number }
+  | { k: 'pressure'; who: Who; state: string; v: number }
+  | { k: 'defense'; state: string; v: 1 | -1 }
+  | { k: 'discardRandom'; who: Who; n: number }
+  | { k: 'discardChoice'; who: Who; n: number }
+  | { k: 'addCard'; who: Who; cardId: string }
+  | { k: 'flag'; name: string; on?: boolean }
+  | { k: 'conditional'; if: (gs: any, target?: any) => boolean; then: Effect[]; else?: Effect[] }
+  | { k: 'special'; fn: (gs: any, target?: any) => void };
 
 export type LegacyEffects =
   | Effect[]
@@ -36,20 +34,6 @@ function toWho(x?: any): Who {
   return x === 'ai' ? 'ai' : 'player';
 }
 
-function normalizeIpDelta(ip: any): Effect[] {
-  const out: Effect[] = [];
-  if (ip == null) return out;
-  if (typeof ip === 'number') {
-    out.push({ k: 'ip', who: 'player', v: ip });
-    return out;
-  }
-  const self = ip.self ?? 0;
-  const opp = ip.opponent ?? 0;
-  if (self !== 0) out.push({ k: 'ip', who: 'player', v: self });
-  if (opp !== 0) out.push({ k: 'ip', who: 'ai', v: opp });
-  return out;
-}
-
 function readStat(gs: any, stat: string): number {
   switch (stat) {
     case 'truth':
@@ -65,6 +49,20 @@ function readStat(gs: any, stat: string): number {
     default:
       return 0;
   }
+}
+
+function normalizeIpDelta(ip: any): Effect[] {
+  const out: Effect[] = [];
+  if (ip == null) return out;
+  if (typeof ip === 'number') {
+    out.push({ k: 'ip', who: 'player', v: ip });
+    return out;
+  }
+  const self = ip.self ?? 0;
+  const opp = ip.opponent ?? 0;
+  if (self) out.push({ k: 'ip', who: 'player', v: self });
+  if (opp) out.push({ k: 'ip', who: 'ai', v: opp });
+  return out;
 }
 
 function normalizeConditional(obj: any): Effect | null {
@@ -98,70 +96,45 @@ function normalizeConditional(obj: any): Effect | null {
   };
 }
 
-export function isLegacyFlat(obj: any): boolean {
-  if (!obj || Array.isArray(obj)) return false;
-  return (
-    'truthDelta' in obj ||
-    'draw' in obj ||
-    'ipDelta' in obj ||
-    'pressureDelta' in obj ||
-    'defenseDelta' in obj ||
-    'discardRandom' in obj ||
-    'discardChoice' in obj ||
-    'addCardId' in obj ||
-    'if' in obj
-  );
-}
-
-/** Normalize any effects value (array/new, or legacy flat object) to Effect[] */
 export function normalizeEffects(effects: LegacyEffects): Effect[] {
   if (!effects) return [];
-  if (Array.isArray(effects)) return effects as Effect[];
+  if (Array.isArray(effects)) return effects;
 
   const out: Effect[] = [];
   const e: any = effects;
 
-  if (typeof e.truthDelta === 'number' && e.truthDelta !== 0) {
+  if (typeof e.truthDelta === 'number' && e.truthDelta)
     out.push({ k: 'truth', who: 'player', v: e.truthDelta });
-  }
-  if (typeof e.draw === 'number' && e.draw > 0) {
+  if (typeof e.draw === 'number' && e.draw > 0)
     out.push({ k: 'draw', who: 'player', n: e.draw });
-  }
-  if (e.ipDelta != null) {
-    out.push(...normalizeIpDelta(e.ipDelta));
-  }
-  if (e.pressureDelta) {
-    out.push({
-      k: 'pressure',
-      who: toWho(e.pressureDelta.who),
-      state: e.pressureDelta.state,
-      v: e.pressureDelta.v,
-    });
-  }
-  if (e.defenseDelta) {
-    out.push({
-      k: 'defense',
-      state: e.defenseDelta.state,
-      v: e.defenseDelta.v,
-    });
-  }
-  if (typeof e.discardRandom === 'number' && e.discardRandom > 0) {
+  if (e.ipDelta != null) out.push(...normalizeIpDelta(e.ipDelta));
+  if (e.pressureDelta)
+    out.push({ k: 'pressure', who: toWho(e.pressureDelta.who), state: e.pressureDelta.state, v: e.pressureDelta.v });
+  if (e.defenseDelta)
+    out.push({ k: 'defense', state: e.defenseDelta.state, v: e.defenseDelta.v });
+  if (e.discardRandom)
     out.push({ k: 'discardRandom', who: 'ai', n: e.discardRandom });
-  }
-  if (typeof e.discardChoice === 'number' && e.discardChoice > 0) {
+  if (e.discardChoice)
     out.push({ k: 'discardChoice', who: 'ai', n: e.discardChoice });
-  }
-  if (typeof e.addCardId === 'string' && e.addCardId) {
+  if (e.addCardId)
     out.push({ k: 'addCard', who: 'player', cardId: e.addCardId });
-  }
 
-  const c = normalizeConditional(e);
-  if (c) out.push(c);
+  const cond = normalizeConditional(e);
+  if (cond) out.push(cond);
 
-  if (out.length === 0) {
-    console.warn('[normalizeEffects] Legacy object produced no effects. Check mapping.', e);
-  }
+  if (!out.length) console.warn('[normalizeEffects] Legacy produced no effects.', e);
   return out;
 }
 
-export default normalizeEffects;
+export function normalizeCard<T extends { effects?: LegacyEffects; text?: string; flavor?: string; id: string }>(
+  card: T,
+): T & { effects: Effect[] } {
+  const nonAscii = (s?: string) => !!s && /[^\x00-\x7F]/.test(s);
+  if (nonAscii(card.text) || nonAscii((card as any).flavor)) console.warn(`[i18n] Non-ASCII text on ${card.id}. In-game text must be English.`);
+  return { ...card, effects: normalizeEffects(card.effects) };
+}
+
+export function normalizeDeck<T extends { effects?: LegacyEffects }>(cards: T[]): (T & { effects: Effect[] })[] {
+  return (cards ?? []).map(normalizeCard);
+}
+

--- a/src/engine/playCard.ts
+++ b/src/engine/playCard.ts
@@ -1,16 +1,15 @@
 import { applyEffects } from './effects';
-import { normalizeEffects } from './normalizeEffects';
+import { normalizeCard } from './normalizeEffects';
 
-export function playCard(gs: any, who: 'player' | 'ai', card: any, target: any) {
-  if (gs[who].ip < card.cost) {
+export function playCard(gs: any, who: 'player' | 'ai', rawCard: any, target: any) {
+  if (gs[who].ip < rawCard.cost) {
     return { ok: false, reason: 'Not enough IP' };
   }
-  gs[who].ip -= card.cost;
+  gs[who].ip -= rawCard.cost;
+
+  const card = normalizeCard(rawCard);
   gs.discards[who].push(card);
-
-  const effects = normalizeEffects(card.effects);
-  applyEffects(gs, effects, { gs, who, target });
-
+  applyEffects(gs, card.effects, { gs, who, target });
   return { ok: true };
 }
 


### PR DESCRIPTION
## Summary
- add normalized Effect schema and helpers
- wire dedicated core loader with bundled, fetch, and fallback paths
- provide build-time core exporter and scripts

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68c65820ae3c8320b3432180a2cbbbec