### PR TITLE
feat: implement tabloid game layout components

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,9 +7,12 @@
     <meta name="description" content="Lovable Generated Project" />
     <meta name="author" content="Lovable" />
 
-    <link rel="preconnect" href="https://fonts.googleapis.com">
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Anton:wght@400&family=Bebas+Neue:wght@400&display=swap" rel="stylesheet">
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Anton&family=Bebas+Neue&family=Inter:wght@400;500;700&display=swap"
+      rel="stylesheet"
+    />
 
     <meta property="og:title" content="state-shift-strategy" />
     <meta property="og:description" content="Lovable Generated Project" />

--- a/src/components/game/GameLayout.tsx
+++ b/src/components/game/GameLayout.tsx
@@ -1,0 +1,33 @@
+import React from 'react';
+
+interface GameLayoutProps {
+  header?: React.ReactNode;
+  status?: React.ReactNode;
+  left?: React.ReactNode;
+  center?: React.ReactNode;
+  right?: React.ReactNode;
+  tray?: React.ReactNode;
+}
+
+export default function GameLayout({
+  header,
+  status,
+  left,
+  center,
+  right,
+  tray,
+}: GameLayoutProps) {
+  return (
+    <div
+      className="min-h-screen bg-[#f5efe2] text-black grid [grid-template-areas:'masthead''status''left''center''right''tray'] md:[grid-template-areas:'masthead_masthead''status_status''center_right''left_right''tray_tray'] lg:[grid-template-areas:'masthead_masthead_masthead''status_status_status''left_center_right''tray_tray_tray'] lg:grid-cols-[320px_1fr_360px] md:grid-cols-[1fr_340px] grid-rows-[auto_auto_1fr_auto]"
+    >
+      <header className="area-[masthead] sticky top-0 z-40">{header}</header>
+      <div className="area-[status]">{status}</div>
+      <aside className="area-[left] px-3 md:px-4 py-3">{left}</aside>
+      <main className="area-[center] px-3 md:px-4 py-3 overflow-hidden">{center}</main>
+      <aside className="area-[right] px-3 md:px-4 py-3">{right}</aside>
+      <div className="area-[tray] sticky bottom-0 z-30">{tray}</div>
+    </div>
+  );
+}
+

--- a/src/components/game/HandPanel.tsx
+++ b/src/components/game/HandPanel.tsx
@@ -1,0 +1,41 @@
+interface HandCard {
+  id: string | number;
+  name: string;
+  rarity: string;
+  rarityColor: string;
+  cost: number;
+}
+
+interface HandPanelProps {
+  cards: HandCard[];
+  onClick: (card: HandCard) => void;
+}
+
+export function HandPanel({ cards, onClick }: HandPanelProps) {
+  return (
+    <div className="bg-[#0b0c0d] text-white rounded border border-[#2a2d33] p-2 h-full flex flex-col">
+      <div className="font-[anton] uppercase text-sm mb-2 tracking-wide">Your Hand</div>
+      <div className="md:flex-1 md:overflow-auto md:flex md:flex-col md:gap-2 flex overflow-x-auto gap-2">
+        {cards.map((c) => (
+          <button
+            key={c.id}
+            onClick={() => onClick(c)}
+            className="bg-white text-black rounded-lg border border-[#d1d5db] px-3 py-2 flex items-center justify-between hover:shadow-md"
+          >
+            <span className="font-medium truncate">{c.name}</span>
+            <div className="flex items-center gap-2">
+              <span
+                className="px-2 py-0.5 rounded text-white text-xs"
+                style={{ background: c.rarityColor }}
+              >
+                {c.rarity.toUpperCase()}
+              </span>
+              <span className="bg-[#dc2626] text-white px-2 py-0.5 rounded text-xs">{c.cost} IP</span>
+            </div>
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+}
+

--- a/src/components/game/Header.tsx
+++ b/src/components/game/Header.tsx
@@ -1,0 +1,37 @@
+export function Masthead() {
+  return (
+    <div className="bg-black text-white font-[anton] tracking-wide px-4 py-2 text-2xl md:text-3xl border-b-4 border-[#1a1a1a]">
+      THE PARANOID TIMES
+    </div>
+  );
+}
+
+interface StatusBarProps {
+  round: number;
+  yourIp: number;
+  truth: number;
+  yourStates: number;
+  aiIp: number;
+  aiStates: number;
+}
+
+export function StatusBar({
+  round,
+  yourIp,
+  truth,
+  yourStates,
+  aiIp,
+  aiStates,
+}: StatusBarProps) {
+  return (
+    <div className="bg-[#111] text-[#f1f5f9] px-3 py-2 text-xs md:text-sm flex gap-6 overflow-x-auto border-b border-[#2a2a2a]">
+      <span>ROUND {round}</span>
+      <span>YOUR IP {yourIp}</span>
+      <span>TRUTH {truth}%</span>
+      <span>YOUR STATES {yourStates}</span>
+      <span>AI IP {aiIp}</span>
+      <span>AI STATES {aiStates}</span>
+    </div>
+  );
+}
+

--- a/src/components/game/LeftColumn.tsx
+++ b/src/components/game/LeftColumn.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+
+interface ColumnBox {
+  title: string;
+  content: React.ReactNode;
+}
+
+interface LeftColumnProps {
+  victory: ColumnBox;
+  agenda: ColumnBox;
+  intel: ColumnBox;
+}
+
+export function LeftColumn({ victory, agenda, intel }: LeftColumnProps) {
+  return (
+    <div className="flex flex-col gap-3">
+      {[victory, agenda, intel].map((box, i) => (
+        <section
+          key={i}
+          className="bg-[#fff] border-2 border-black shadow-[4px_4px_0_#000] p-3"
+        >
+          <h3 className="font-[anton] text-lg uppercase mb-1">{box.title}</h3>
+          <div className="text-sm leading-snug">{box.content}</div>
+        </section>
+      ))}
+    </div>
+  );
+}
+

--- a/src/components/game/MapPanel.tsx
+++ b/src/components/game/MapPanel.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+
+interface MapPanelProps {
+  children: React.ReactNode;
+  title?: string;
+}
+
+export function MapPanel({ children, title = 'USA Territory Control' }: MapPanelProps) {
+  return (
+    <div className="h-full flex flex-col">
+      <div className="inline-block bg-white border-2 border-black px-3 py-1 font-[anton] uppercase mb-2">
+        {title}
+      </div>
+      <div className="flex-1 bg-[#f7f7f7] border-2 border-black shadow-[6px_6px_0_#000] overflow-hidden rounded">
+        {children}
+      </div>
+    </div>
+  );
+}
+

--- a/src/components/game/Tray.tsx
+++ b/src/components/game/Tray.tsx
@@ -1,0 +1,39 @@
+interface TrayCard {
+  id: string | number;
+  name: string;
+  cost: number;
+  image: string;
+  effectShort: string;
+}
+
+interface TrayProps {
+  cards: TrayCard[];
+  onInspect: (card: TrayCard) => void;
+}
+
+export function Tray({ cards, onInspect }: TrayProps) {
+  return (
+    <div className="bg-[#0b0c0d] border-t-4 border-black px-3 py-2">
+      <div className="max-w-[1400px] mx-auto">
+        <div className="font-[anton] text-white uppercase text-sm mb-2">Cards in Play</div>
+        <div className="grid grid-flow-col auto-cols-[220px] gap-12 overflow-x-auto pb-2">
+          {cards.map((c) => (
+            <button
+              key={c.id}
+              onClick={() => onInspect(c)}
+              className="bg-[#fff] border-2 border-black shadow-[6px_6px_0_#000] rounded text-left p-2"
+            >
+              <div className="font-[anton] text-xs uppercase flex justify-between mb-1">
+                <span className="truncate">{c.name}</span>
+                <span className="bg-[#dc2626] text-white px-2 rounded">{c.cost} IP</span>
+              </div>
+              <img src={c.image} alt="" className="w-full h-24 object-cover mb-2" />
+              <div className="border border-black bg-white text-xs p-1">{c.effectShort}</div>
+            </button>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}
+

--- a/src/index.css
+++ b/src/index.css
@@ -87,11 +87,23 @@ All colors MUST be HSL.
     --success-foreground: 355 7% 97%;
     
     /* Card rarity colors */
-    --rarity-common: #cfd8e3;
-    --rarity-uncommon: #7ce4b2;
-    --rarity-rare: #8fb7ff;
-    --rarity-legendary: #ffc86b;
+    --rarity-common: #d1d5db;
+    --rarity-uncommon: #6ee7b7;
+    --rarity-rare: #60a5fa;
+    --rarity-legendary: #facc15;
     --rarity-epic: #d59bff;
+
+    /* Masthead and tray */
+    --masthead-height: 60px;
+    --masthead-bg: #000000;
+    --masthead-color: #ffffff;
+    --tray-height-desktop: 28vh;
+    --tray-height-tablet: 30vh;
+    --tray-height-mobile: 34vh;
+
+    /* Font families */
+    --font-headline: 'Anton', 'Bebas Neue', sans-serif;
+    --font-body: 'Inter', 'Roboto', sans-serif;
 
     /* Shared card styling */
     --card-bg: #0e0f11;
@@ -156,16 +168,28 @@ All colors MUST be HSL.
     --success-foreground: 355 7% 97%;
     
     /* Dark card rarity colors */
-    --rarity-common: #cfd8e3;
-    --rarity-uncommon: #7ce4b2;
-    --rarity-rare: #8fb7ff;
-    --rarity-legendary: #ffc86b;
+    --rarity-common: #d1d5db;
+    --rarity-uncommon: #6ee7b7;
+    --rarity-rare: #60a5fa;
+    --rarity-legendary: #facc15;
     --rarity-epic: #d59bff;
 
     /* Shared card styling */
     --card-bg: #0e0f11;
     --card-border: #2a2d33;
     --card-text: #e9edf1;
+  }
+}
+
+@media (max-width: 1023px) {
+  :root {
+    --masthead-height: 48px;
+  }
+}
+
+@media (max-width: 767px) {
+  :root {
+    --masthead-height: 40px;
   }
 }
 
@@ -180,10 +204,47 @@ All colors MUST be HSL.
 }
 
 @layer components {
-  .rarity-common     { --rarity-accent: var(--rarity-common); }
-  .rarity-uncommon   { --rarity-accent: var(--rarity-uncommon); }
-  .rarity-rare       { --rarity-accent: var(--rarity-rare); }
-  .rarity-legendary  { --rarity-accent: var(--rarity-legendary); }
+  .rarity-common {
+    --rarity-accent: var(--rarity-common);
+    border: 2px solid var(--rarity-common);
+    box-shadow: 0 0 0 2px color-mix(in oklab, var(--rarity-common) 40%, transparent);
+  }
+  .rarity-uncommon {
+    --rarity-accent: var(--rarity-uncommon);
+    border: 2px solid var(--rarity-uncommon);
+    box-shadow: 0 0 0 2px color-mix(in oklab, var(--rarity-uncommon) 40%, transparent);
+  }
+  .rarity-rare {
+    --rarity-accent: var(--rarity-rare);
+    border: 2px solid var(--rarity-rare);
+    box-shadow: 0 0 0 2px color-mix(in oklab, var(--rarity-rare) 40%, transparent);
+  }
+  .rarity-legendary {
+    --rarity-accent: var(--rarity-legendary);
+    border: 2px solid var(--rarity-legendary);
+    box-shadow: 0 0 6px 3px color-mix(in oklab, var(--rarity-legendary) 50%, transparent);
+  }
+
+  .masthead {
+    height: var(--masthead-height);
+    background: var(--masthead-bg);
+    color: var(--masthead-color);
+    font-family: var(--font-headline);
+  }
+
+  .card-tray {
+    height: var(--tray-height-desktop);
+  }
+  @media (max-width: 1023px) {
+    .card-tray {
+      height: var(--tray-height-tablet);
+    }
+  }
+  @media (max-width: 767px) {
+    .card-tray {
+      height: var(--tray-height-mobile);
+    }
+  }
 
   .card-base {
     @apply rounded-xl border p-4 shadow-md hover:shadow-lg transition-shadow;

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -67,6 +67,22 @@ export default {
         "newspaper-border": "hsl(var(--newspaper-border))",
         "newspaper-accent": "hsl(var(--newspaper-accent))",
         "newspaper-headline": "hsl(var(--newspaper-headline))",
+        "rarity-common": "var(--rarity-common)",
+        "rarity-uncommon": "var(--rarity-uncommon)",
+        "rarity-rare": "var(--rarity-rare)",
+        "rarity-legendary": "var(--rarity-legendary)",
+        "masthead-bg": "var(--masthead-bg)",
+        "masthead-color": "var(--masthead-color)",
+      },
+      fontFamily: {
+        headline: "var(--font-headline)",
+        body: "var(--font-body)",
+      },
+      height: {
+        masthead: "var(--masthead-height)",
+        "tray-desktop": "var(--tray-height-desktop)",
+        "tray-tablet": "var(--tray-height-tablet)",
+        "tray-mobile": "var(--tray-height-mobile)",
       },
       borderRadius: {
         lg: "var(--radius)",


### PR DESCRIPTION
## Summary
- add global Anton, Bebas Neue and Inter font imports
- extend Tailwind theme with rarity colors and layout variables
- introduce tabloid game layout components for grid, hand, map and tray

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/date-fns)*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68c69352ccc88320b35c380f688dcfc9