### PR TITLE
refactor: adjust base grid layout

### DIFF
--- a/src/components/game/GameLayout.tsx
+++ b/src/components/game/GameLayout.tsx
@@ -19,7 +19,7 @@ export default function GameLayout({
 }: GameLayoutProps) {
   return (
     <div
-      className="min-h-screen bg-[#f5efe2] text-black grid [grid-template-areas:'masthead''status''left''center''right''tray'] md:[grid-template-areas:'masthead_masthead''status_status''center_right''left_right''tray_tray'] lg:[grid-template-areas:'masthead_masthead_masthead''status_status_status''left_center_right''tray_tray_tray'] lg:grid-cols-[320px_1fr_360px] md:grid-cols-[1fr_340px] grid-rows-[auto_auto_1fr_auto]"
+      className="min-h-screen bg-[#f5efe2] text-black grid [grid-template-areas:'masthead''status''center''right''left''tray'] md:[grid-template-areas:'masthead_masthead''status_status''center_right''left_right''tray_tray'] lg:[grid-template-areas:'masthead_masthead_masthead''status_status_status''left_center_right''tray_tray_tray'] lg:grid-cols-[320px_1fr_360px] md:grid-cols-[1fr_340px] grid-rows-[auto_auto_1fr_auto]"
     >
       <header className="area-[masthead] sticky top-0 z-40">{header}</header>
       <div className="area-[status]">{status}</div>


### PR DESCRIPTION
## Summary
- reorder base grid areas so center and right appear before left in mobile layout

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*


------
https://chatgpt.com/codex/tasks/task_e_68c6a19e809c8320a89bb9f7af5438e5