### PR TITLE
feat: apply theme colors to card UI

### DIFF
--- a/src/components/game/HandPanel.tsx
+++ b/src/components/game/HandPanel.tsx
@@ -20,7 +20,7 @@ export function HandPanel({ cards, onClick }: HandPanelProps) {
           <button
             key={c.id}
             onClick={() => onClick(c)}
-            className="bg-white text-black rounded-lg border border-[#d1d5db] px-3 py-2 flex items-center justify-between hover:shadow-md"
+            className="bg-paper text-ink rounded-lg border border-[#d1d5db] px-3 py-2 flex items-center justify-between hover:shadow-md"
           >
             <span className="font-medium truncate">{c.name}</span>
             <div className="flex items-center gap-2">

--- a/src/components/game/Tray.tsx
+++ b/src/components/game/Tray.tsx
@@ -21,14 +21,14 @@ export function Tray({ cards, onInspect }: TrayProps) {
             <button
               key={c.id}
               onClick={() => onInspect(c)}
-              className="bg-[#fff] border-2 border-black shadow-[6px_6px_0_#000] rounded text-left p-2"
+              className="bg-paper border-2 border-black shadow-[6px_6px_0_black] rounded text-left p-2"
             >
               <div className="font-[anton] text-xs uppercase flex justify-between mb-1">
                 <span className="truncate">{c.name}</span>
                 <span className="bg-[#dc2626] text-white px-2 rounded">{c.cost} IP</span>
               </div>
               <img src={c.image} alt="" className="w-full h-24 object-cover mb-2" />
-              <div className="border border-black bg-white text-xs p-1">{c.effectShort}</div>
+              <div className="border border-black bg-paper text-xs p-1">{c.effectShort}</div>
             </button>
           ))}
         </div>


### PR DESCRIPTION
## Summary
- use `bg-paper`/`text-ink` for hand card buttons
- switch tray cards to `bg-paper` and remove hex color shadow

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: Cannot find package '@eslint/js')

------
https://chatgpt.com/codex/tasks/task_e_68c6a25255448320b3c8c8ff8fe23ff9