### PR TITLE
Use body font and paper background for game cards

### DIFF
--- a/src/components/game/card.css
+++ b/src/components/game/card.css
@@ -11,7 +11,7 @@
 .rarity-legendary { --rarity-color: var(--rarity-legendary); }
 
 .card-base {
-  @apply rounded-xl border shadow-md font-sans flex flex-col;
+  @apply rounded-xl border shadow-md font-body flex flex-col;
   background: #fafafa;
   color: #111;
   border-color: var(--rarity-color, #e5e7eb);
@@ -35,7 +35,7 @@
 }
 
 .card-effect {
-  @apply border border-black bg-white p-2 text-sm;
+  @apply border border-black bg-paper p-2 text-sm;
 }
 
 .card-flavor {


### PR DESCRIPTION
## Summary
- switch card base to `font-body` for better typography
- use `bg-paper` color on card effects

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm ci` *(fails: 403 Forbidden for date-fns)*
- `npm run build` *(fails: vite: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c6a3740d308320a158782dcfa6aacc