### PR TITLE
Adjust card detail overlay width breakpoints

### DIFF
--- a/src/components/game/CardDetailOverlay.tsx
+++ b/src/components/game/CardDetailOverlay.tsx
@@ -33,7 +33,7 @@ const CardDetailOverlay: React.FC<CardDetailOverlayProps> = ({
       {...swipeHandlers}
     >
       <div
-        className="h-[90vh] sm:h-[70vh] lg:h-[60vh]"
+        className="w-[min(92vw,420px)] md:w-[min(86vw,640px)] lg:w-[min(80vw,820px)] max-h-[90vh] sm:max-h-[70vh] lg:max-h-[60vh]"
         style={{ aspectRatio: '63 / 88' }}
         onClick={(e) => e.stopPropagation()}
       >


### PR DESCRIPTION
## Summary
- Tweak card detail overlay to scale widths from mobile to desktop while capping height
- Preserve 63:88 aspect ratio across breakpoints for consistent card rendering

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68c6a5b2a284832093fb29ba7d2ebd5d