### PR TITLE
feat: add card preview and theme tokens

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -12,6 +12,7 @@ import EffectSystemDashboard from "./pages/EffectSystemDashboard";
 import DatabaseRecovery from "./pages/DatabaseRecovery";
 import { initializeExtensionsOnStartup } from './data/extensionIntegration';
 import { AchievementProvider } from './contexts/AchievementContext';
+import { CardPreviewProvider } from './contexts/CardPreviewContext';
 
 const queryClient = new QueryClient();
 
@@ -26,17 +27,19 @@ const App = () => {
       <TooltipProvider>
         <AudioProvider>
           <AchievementProvider>
-            <Toaster />
-            <Sonner />
-            <BrowserRouter>
-              <Routes>
-                <Route path="/" element={<Index />} />
-                <Route path="/dev/effects" element={<EffectSystemDashboard />} />
-                <Route path="/dev/recovery" element={<DatabaseRecovery />} />
-                {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}
-                <Route path="*" element={<NotFound />} />
-              </Routes>
-            </BrowserRouter>
+            <CardPreviewProvider>
+              <Toaster />
+              <Sonner />
+              <BrowserRouter>
+                <Routes>
+                  <Route path="/" element={<Index />} />
+                  <Route path="/dev/effects" element={<EffectSystemDashboard />} />
+                  <Route path="/dev/recovery" element={<DatabaseRecovery />} />
+                  {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}
+                  <Route path="*" element={<NotFound />} />
+                </Routes>
+              </BrowserRouter>
+            </CardPreviewProvider>
           </AchievementProvider>
         </AudioProvider>
       </TooltipProvider>

--- a/src/components/game/CardDetailOverlay.tsx
+++ b/src/components/game/CardDetailOverlay.tsx
@@ -15,6 +15,7 @@ interface CardDetailOverlayProps {
   onClose: () => void;
   onPlayCard: () => void;
   swipeHandlers?: any;
+  sourceZone?: 'hand' | 'board' | 'discard' | 'zone' | 'timeline';
 }
 
 const CardDetailOverlay: React.FC<CardDetailOverlayProps> = ({
@@ -23,7 +24,8 @@ const CardDetailOverlay: React.FC<CardDetailOverlayProps> = ({
   disabled,
   onClose,
   onPlayCard,
-  swipeHandlers
+  swipeHandlers,
+  sourceZone = 'hand'
 }) => {
   const isMobile = useIsMobile();
   
@@ -90,18 +92,32 @@ const CardDetailOverlay: React.FC<CardDetailOverlayProps> = ({
 
   const faction = getCardFaction(card);
 
+  const zoneLabel = () => {
+    switch (sourceZone) {
+      case 'board':
+        return 'In Play – Board';
+      case 'discard':
+        return 'Discard Pile';
+      case 'zone':
+        return 'Zone';
+      case 'timeline':
+        return 'Timeline';
+      default:
+        return null;
+    }
+  };
+
   return (
     <div 
       className="fixed inset-0 bg-black/80 flex items-center justify-center z-[9999] p-4"
       onClick={onClose}
       {...(isMobile ? swipeHandlers : {})}
     >
-      <div 
-        className={`bg-card transform animate-fade-in flex flex-col overflow-hidden ${
-          isMobile 
-            ? 'w-full max-w-sm max-h-[90vh] rounded-xl' 
-            : 'w-full max-w-md h-[85vh] rounded-2xl'
-        } ${getRarityFrameClass(card.rarity)} ${getRarityGlowClass(card.rarity)}`}
+      <div
+        className={`bg-card transform animate-fade-in flex flex-col overflow-hidden rounded-2xl ${
+          getRarityFrameClass(card.rarity)
+        } ${getRarityGlowClass(card.rarity)}`}
+        style={{ width: 'var(--card-w)', height: 'var(--card-h)', aspectRatio: '63 / 88' }}
         onClick={(e) => e.stopPropagation()}
       >
         {/* Top Bar - Sticky */}
@@ -109,9 +125,14 @@ const CardDetailOverlay: React.FC<CardDetailOverlayProps> = ({
           <div className="flex items-start justify-between gap-3">
             <div className="flex-1 min-w-0">
               {/* Title */}
-              <h2 className="font-bold text-foreground leading-tight mb-2 truncate">
+              <h2 className="font-bold text-foreground leading-tight mb-1 truncate" style={{ fontFamily: 'var(--font-head)' }}>
                 {card.name}
               </h2>
+              {zoneLabel() && (
+                <div className="text-xs text-muted-foreground" style={{ fontFamily: 'var(--font-ui)' }}>
+                  {zoneLabel()}
+                </div>
+              )}
               
               {/* Type Badge */}
               <Badge 
@@ -159,10 +180,10 @@ const CardDetailOverlay: React.FC<CardDetailOverlayProps> = ({
           <div>
             <h4 className="text-sm font-bold mb-2 text-foreground">Effect</h4>
             <div className="bg-card/60 rounded-lg border border-border p-3 space-y-2">
-              <p className="text-sm font-medium text-foreground leading-relaxed">
+              <p className="text-sm font-medium text-foreground leading-snug" style={{ fontFamily: 'var(--font-ui)' }}>
                 {card.text}
               </p>
-              <div className="text-xs text-muted-foreground bg-muted/50 rounded px-2 py-1">
+              <div className="text-xs text-muted-foreground bg-muted/50 rounded px-2 py-1" style={{ fontFamily: 'var(--font-ui)' }}>
                 {getEffectDescription(card)}
               </div>
             </div>
@@ -173,7 +194,7 @@ const CardDetailOverlay: React.FC<CardDetailOverlayProps> = ({
             <h4 className="text-xs font-bold mb-2 text-muted-foreground tracking-wider">
               CLASSIFIED INTELLIGENCE
             </h4>
-            <div className="italic text-sm text-foreground border-l-4 border-truth-red bg-truth-red/10 rounded-r border border-truth-red/20 pl-3 pr-3 py-2 leading-relaxed">
+            <div className="italic text-sm text-foreground border-l-4 border-truth-red bg-truth-red/10 rounded-r border border-truth-red/20 pl-3 pr-3 py-2 leading-snug" style={{ fontFamily: 'var(--font-ui)' }}>
               "{faction === 'truth' ? (card.flavorTruth ?? 'No intelligence available.') : (card.flavorGov ?? 'No intelligence available.')}"
             </div>
           </div>
@@ -192,32 +213,34 @@ const CardDetailOverlay: React.FC<CardDetailOverlayProps> = ({
         </div>
 
         {/* Bottom CTA */}
-        <div className="flex-shrink-0 p-4 border-t border-border bg-card/95">
-          <Button
-            onClick={onPlayCard}
-            disabled={disabled || !canAfford}
-            className={`enhanced-button w-full font-mono relative overflow-hidden transition-all duration-300 ${
-              isMobile ? 'text-base py-4' : 'text-sm py-3'
-            } ${
-              !canAfford ? 'opacity-50 cursor-not-allowed' : 'hover:shadow-lg'
-            }`}
-          >
-            <span className="relative z-10 flex items-center justify-center gap-2">
-              {card.type === 'ZONE' && <Target className={isMobile ? 'w-5 h-5' : 'w-4 h-4'} />}
-              {card.type === 'ATTACK' && <Zap className={isMobile ? 'w-5 h-5' : 'w-4 h-4'} />}
-              {card.type === 'DEFENSIVE' && <Shield className={isMobile ? 'w-5 h-5' : 'w-4 h-4'} />}
-              {card.type === 'ZONE' ? 'SELECT & TARGET' : 'DEPLOY ASSET'}
-            </span>
-            
-            {!canAfford && (
-              <div className="absolute inset-0 flex items-center justify-center bg-destructive/10">
-                <span className="text-xs text-destructive font-medium">
-                  Need {card.cost} IP
-                </span>
-              </div>
-            )}
-          </Button>
-        </div>
+        {!disabled && (
+          <div className="flex-shrink-0 p-4 border-t border-border bg-card/95">
+            <Button
+              onClick={onPlayCard}
+              disabled={disabled || !canAfford}
+              className={`enhanced-button w-full font-mono relative overflow-hidden transition-all duration-300 ${
+                isMobile ? 'text-base py-4' : 'text-sm py-3'
+              } ${
+                !canAfford ? 'opacity-50 cursor-not-allowed' : 'hover:shadow-lg'
+              }`}
+            >
+              <span className="relative z-10 flex items-center justify-center gap-2">
+                {card.type === 'ZONE' && <Target className={isMobile ? 'w-5 h-5' : 'w-4 h-4'} />}
+                {card.type === 'ATTACK' && <Zap className={isMobile ? 'w-5 h-5' : 'w-4 h-4'} />}
+                {card.type === 'DEFENSIVE' && <Shield className={isMobile ? 'w-5 h-5' : 'w-4 h-4'} />}
+                {card.type === 'ZONE' ? 'SELECT & TARGET' : 'DEPLOY ASSET'}
+              </span>
+
+              {!canAfford && (
+                <div className="absolute inset-0 flex items-center justify-center bg-destructive/10">
+                  <span className="text-xs text-destructive font-medium">
+                    Need {card.cost} IP
+                  </span>
+                </div>
+              )}
+            </Button>
+          </div>
+        )}
       </div>
     </div>
   );

--- a/src/components/game/PlayedCardsDock.tsx
+++ b/src/components/game/PlayedCardsDock.tsx
@@ -3,6 +3,7 @@ import { Card } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import CardImage from '@/components/game/CardImage';
 import type { GameCard } from '@/types/cardTypes';
+import { useCardPreview } from '@/contexts/CardPreviewContext';
 
 interface PlayedCard {
   card: GameCard;
@@ -16,6 +17,12 @@ interface PlayedCardsDockProps {
 const PlayedCardsDock: React.FC<PlayedCardsDockProps> = ({ playedCards }) => {
   const humanCards = playedCards.filter(pc => pc.player === 'human');
   const aiCards = playedCards.filter(pc => pc.player === 'ai');
+  const { openCardPreview } = useCardPreview();
+  let pressTimer: number;
+  const startPress = (id: string) => {
+    pressTimer = window.setTimeout(() => openCardPreview(id, 'board'), 350);
+  };
+  const cancelPress = () => clearTimeout(pressTimer);
 
   const getTypeColor = (type: string, isAI: boolean) => {
     const truthColors = {
@@ -74,6 +81,13 @@ const PlayedCardsDock: React.FC<PlayedCardsDockProps> = ({ playedCards }) => {
                     <div
                       key={`human-${playedCard.card.id}-${index}`}
                       className="group relative"
+                      tabIndex={0}
+                      onClick={() => openCardPreview(playedCard.card.id, 'board')}
+                      onKeyDown={e => e.key === 'Enter' && openCardPreview(playedCard.card.id, 'board')}
+                      onTouchStart={() => startPress(playedCard.card.id)}
+                      onTouchEnd={cancelPress}
+                      onTouchMove={cancelPress}
+                      onTouchCancel={cancelPress}
                     >
                       {/* Full card with newspaper styling - doubled size */}
                       <div className={`w-24 h-32 bg-gradient-to-b ${getRarityBg(playedCard.card.rarity)} border rounded shadow-sm animate-scale-in overflow-hidden`}>
@@ -162,6 +176,13 @@ const PlayedCardsDock: React.FC<PlayedCardsDockProps> = ({ playedCards }) => {
                     <div
                       key={`ai-${playedCard.card.id}-${index}`}
                       className="group relative"
+                      tabIndex={0}
+                      onClick={() => openCardPreview(playedCard.card.id, 'board')}
+                      onKeyDown={e => e.key === 'Enter' && openCardPreview(playedCard.card.id, 'board')}
+                      onTouchStart={() => startPress(playedCard.card.id)}
+                      onTouchEnd={cancelPress}
+                      onTouchMove={cancelPress}
+                      onTouchCancel={cancelPress}
                     >
                       {/* Full card with newspaper styling - doubled size */}
                       <div className={`w-24 h-32 bg-gradient-to-b ${getRarityBg(playedCard.card.rarity)} border rounded shadow-sm animate-scale-in overflow-hidden`}>

--- a/src/contexts/CardPreviewContext.tsx
+++ b/src/contexts/CardPreviewContext.tsx
@@ -1,0 +1,50 @@
+import React, { createContext, useContext, useState, ReactNode } from 'react';
+import { CARD_DATABASE } from '@/data/cardDatabase';
+import type { GameCard } from '@/types/cardTypes';
+import CardDetailOverlay from '@/components/game/CardDetailOverlay';
+
+export type SourceZone = 'board' | 'discard' | 'zone' | 'timeline';
+
+interface CardPreviewContextValue {
+  openCardPreview: (cardId: string, sourceZone: SourceZone) => void;
+}
+
+const CardPreviewContext = createContext<CardPreviewContextValue | undefined>(undefined);
+
+export const CardPreviewProvider = ({ children }: { children: ReactNode }) => {
+  const [card, setCard] = useState<GameCard | null>(null);
+  const [sourceZone, setSourceZone] = useState<SourceZone>('board');
+
+  const openCardPreview = (cardId: string, zone: SourceZone) => {
+    const found = CARD_DATABASE.find(c => c.id === cardId);
+    if (found) {
+      setCard(found);
+      setSourceZone(zone);
+    }
+  };
+
+  const handleClose = () => setCard(null);
+
+  return (
+    <CardPreviewContext.Provider value={{ openCardPreview }}>
+      {children}
+      <CardDetailOverlay
+        card={card}
+        canAfford={true}
+        disabled={sourceZone !== 'hand'}
+        sourceZone={sourceZone}
+        onClose={handleClose}
+        onPlayCard={() => {}}
+      />
+    </CardPreviewContext.Provider>
+  );
+};
+
+export const useCardPreview = () => {
+  const ctx = useContext(CardPreviewContext);
+  if (!ctx) {
+    throw new Error('useCardPreview must be used within CardPreviewProvider');
+  }
+  return ctx;
+};
+

--- a/src/index.css
+++ b/src/index.css
@@ -44,12 +44,41 @@ All colors MUST be HSL.
     --sidebar-primary-foreground: 0 0% 98%;
 
     /* Tabloid newspaper theme tokens */
-    --ink: 0 0% 0%;
-    --paper: 0 0% 96.5%;
+    --ink: 240 12% 5%;
+    --paper: 50 23% 95%;
     --line: 0 0% 6.7%;
     --lineSoft: 0 0% 13.3%;
     --grey: 0 0% 80%;
     --grey2: 0 0% 91.4%;
+
+    /* Layout tokens */
+    --masthead-h: 64px;
+    --tray-h-sm: 96px;
+    --tray-h-md: 120px;
+    --tray-h-lg: 140px;
+    --gap-sm: 8px;
+    --gap-md: 12px;
+    --gap-lg: 16px;
+
+    /* Fullsize card (63:88) */
+    --card-w-min: 220px;
+    --card-w-max: 340px;
+    --card-w: clamp(var(--card-w-min), 24vw, var(--card-w-max));
+    --card-h: calc(var(--card-w) * (88 / 63));
+
+    /* Theme colors */
+    --bg: 223 21% 6%;
+    --panel: 224 28% 10%;
+    --muted: 219 12% 54%;
+    --accent: 347 77% 50%;
+
+    /* Faction colors */
+    --truth: 194 100% 88%;
+    --gov: 32 100% 83%;
+
+    /* Typography */
+    --font-head: "Newsreader", serif;
+    --font-ui: "Inter", system-ui, sans-serif;
 
   --sidebar-accent: 240 4.8% 95.9%;
 
@@ -86,10 +115,10 @@ All colors MUST be HSL.
     --success-foreground: 355 7% 97%;
     
     /* Card rarity colors */
-    --rarity-common: 0 0% 60%;
-    --rarity-uncommon: 142 76% 36%;
-    --rarity-rare: 221 83% 53%;
-    --rarity-legendary: 25 95% 53%;
+    --rarity-common: 214 12% 65%;
+    --rarity-uncommon: 213 94% 68%;
+    --rarity-rare: 38 92% 50%;
+    --rarity-legendary: 0 84% 60%;
   }
   .dark {
     --background: 222.2 84% 4.9%;
@@ -488,6 +517,14 @@ All colors MUST be HSL.
     .synergy-unlock {
       animation: none !important;
     }
+  }
+}
+
+@layer components {
+  .card-full {
+    width: var(--card-w);
+    height: var(--card-h);
+    aspect-ratio: 63 / 88;
   }
 }
 


### PR DESCRIPTION
## Summary
- define design tokens for layout, colors, typography and full-size card sizing
- introduce global card preview context and modal
- enable previewing played cards with click, keyboard or long-press

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68c6af8f55708320874f66b0a3e401d2