### PR TITLE
feat: read-only card preview + fullsize layout (no nested scroll)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -12,6 +12,7 @@ import EffectSystemDashboard from "./pages/EffectSystemDashboard";
 import DatabaseRecovery from "./pages/DatabaseRecovery";
 import { initializeExtensionsOnStartup } from './data/extensionIntegration';
 import { AchievementProvider } from './contexts/AchievementContext';
+import { CardPreviewProvider } from './contexts/CardPreviewContext';
 
 const queryClient = new QueryClient();
 
@@ -26,17 +27,19 @@ const App = () => {
       <TooltipProvider>
         <AudioProvider>
           <AchievementProvider>
-            <Toaster />
-            <Sonner />
-            <BrowserRouter>
-              <Routes>
-                <Route path="/" element={<Index />} />
-                <Route path="/dev/effects" element={<EffectSystemDashboard />} />
-                <Route path="/dev/recovery" element={<DatabaseRecovery />} />
-                {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}
-                <Route path="*" element={<NotFound />} />
-              </Routes>
-            </BrowserRouter>
+            <CardPreviewProvider>
+              <Toaster />
+              <Sonner />
+              <BrowserRouter>
+                <Routes>
+                  <Route path="/" element={<Index />} />
+                  <Route path="/dev/effects" element={<EffectSystemDashboard />} />
+                  <Route path="/dev/recovery" element={<DatabaseRecovery />} />
+                  {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}
+                  <Route path="*" element={<NotFound />} />
+                </Routes>
+              </BrowserRouter>
+            </CardPreviewProvider>
           </AchievementProvider>
         </AudioProvider>
       </TooltipProvider>

--- a/src/components/game/CardPreviewModal.tsx
+++ b/src/components/game/CardPreviewModal.tsx
@@ -1,0 +1,108 @@
+import { useState, useEffect, useRef } from 'react';
+import type { SourceZone } from '@/contexts/CardPreviewContext';
+import { isExtensionCard, getCardExtensionInfo } from '@/data/extensionIntegration';
+import type { GameCard } from '@/types/cardTypes';
+
+type Props = {
+  card: GameCard;
+  sourceZone: SourceZone;
+  onClose: () => void;
+};
+
+export default function CardPreviewModal({ card, sourceZone, onClose }: Props) {
+  const [showFullArt, setShowFullArt] = useState(false);
+  const modalRef = useRef<HTMLDivElement>(null);
+
+  const getImagePath = () => {
+    if (isExtensionCard(card.id)) {
+      const extensionInfo = getCardExtensionInfo(card.id);
+      if (extensionInfo?.id?.toLowerCase().includes('cryptids')) {
+        return '/lovable-uploads/c290a92b-014a-4427-8dd2-a78b76dd986e.png';
+      }
+      if (extensionInfo?.id?.toLowerCase().includes('halloween_spooktacular')) {
+        return '/card-art/halloween_spooktacular-Temp-Image.png';
+      }
+    }
+    if (card.id.toLowerCase().startsWith('hallo-')) {
+      return '/card-art/halloween_spooktacular-Temp-Image.png';
+    }
+    if (
+      card.id.toLowerCase().includes('bigfoot') ||
+      card.id.toLowerCase().includes('mothman') ||
+      card.id.toLowerCase().includes('chupacabra') ||
+      card.id.toLowerCase().includes('cryptid') ||
+      card.id.toLowerCase().includes('men_in_black') ||
+      card.id.toLowerCase().includes('area_51') ||
+      card.id.toLowerCase().includes('roswell')
+    ) {
+      return '/lovable-uploads/c290a92b-014a-4427-8dd2-a78b76dd986e.png';
+    }
+    return '/lovable-uploads/e7c952a9-333a-4f6b-b1b5-f5aeb6c3d9c1.png';
+  };
+  const imagePath = getImagePath();
+
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        if (showFullArt) setShowFullArt(false);
+        else onClose();
+      }
+    };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [showFullArt, onClose]);
+
+  return (
+    <div className="sg-card-backdrop" onClick={onClose} role="dialog" aria-modal="true">
+      <div
+        className="sg-card-modal"
+        onClick={(e) => e.stopPropagation()}
+        ref={modalRef}
+        aria-label={`${card.name} preview`}
+      >
+        <header className="sg-card-header">
+          <h3 className="sg-title">{card.name}</h3>
+          <span className="sg-pill">{card.cost} IP</span>
+          <button className="sg-close" aria-label="Close" onClick={onClose}>✕</button>
+        </header>
+
+        <div className="sg-card-meta">
+          <span className="sg-badge">In Play – {sourceZone}</span>
+          <span className="sg-badge">{card.type}</span>
+          {card.rarity && <span className="sg-badge">{card.rarity}</span>}
+        </div>
+
+        <div className="sg-card-content">
+          <aside className="sg-artwork-pane">
+            {imagePath && <img src={imagePath} alt="" />}
+            {imagePath && (
+              <div className="sg-artwork-actions">
+                <button onClick={() => setShowFullArt(true)}>View Full Art</button>
+              </div>
+            )}
+          </aside>
+
+          <main className="sg-text-pane">
+            <section className="sg-text-section">
+              <h4>Effect</h4>
+              <p>{card.text}</p>
+            </section>
+            {((card.faction?.toLowerCase().startsWith('truth') ? card.flavorTruth : card.flavorGov)) && (
+              <section className="sg-text-section">
+                <h4>Lore</h4>
+                <p>{card.faction?.toLowerCase().startsWith('truth') ? card.flavorTruth : card.flavorGov}</p>
+              </section>
+            )}
+          </main>
+        </div>
+
+        {showFullArt && imagePath && (
+          <div className="sg-fullart-overlay" onClick={() => setShowFullArt(false)}>
+            <img src={imagePath} alt={`${card.name} full art`} />
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+

--- a/src/components/game/PlayedCardsDock.tsx
+++ b/src/components/game/PlayedCardsDock.tsx
@@ -3,6 +3,7 @@ import { Card } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import CardImage from '@/components/game/CardImage';
 import type { GameCard } from '@/types/cardTypes';
+import { useCardPreview } from '@/contexts/CardPreviewContext';
 
 interface PlayedCard {
   card: GameCard;
@@ -16,6 +17,7 @@ interface PlayedCardsDockProps {
 const PlayedCardsDock: React.FC<PlayedCardsDockProps> = ({ playedCards }) => {
   const humanCards = playedCards.filter(pc => pc.player === 'human');
   const aiCards = playedCards.filter(pc => pc.player === 'ai');
+  const { openCardPreview } = useCardPreview();
 
   const getTypeColor = (type: string, isAI: boolean) => {
     const truthColors = {
@@ -73,7 +75,8 @@ const PlayedCardsDock: React.FC<PlayedCardsDockProps> = ({ playedCards }) => {
                   {humanCards.map((playedCard, index) => (
                     <div
                       key={`human-${playedCard.card.id}-${index}`}
-                      className="group relative"
+                      className="group relative cursor-pointer"
+                      onClick={() => openCardPreview(playedCard.card.id, 'board')}
                     >
                       {/* Full card with newspaper styling - doubled size */}
                       <div className={`w-24 h-32 bg-gradient-to-b ${getRarityBg(playedCard.card.rarity)} border rounded shadow-sm animate-scale-in overflow-hidden`}>
@@ -161,7 +164,8 @@ const PlayedCardsDock: React.FC<PlayedCardsDockProps> = ({ playedCards }) => {
                   {aiCards.map((playedCard, index) => (
                     <div
                       key={`ai-${playedCard.card.id}-${index}`}
-                      className="group relative"
+                      className="group relative cursor-pointer"
+                      onClick={() => openCardPreview(playedCard.card.id, 'board')}
                     >
                       {/* Full card with newspaper styling - doubled size */}
                       <div className={`w-24 h-32 bg-gradient-to-b ${getRarityBg(playedCard.card.rarity)} border rounded shadow-sm animate-scale-in overflow-hidden`}>

--- a/src/contexts/CardPreviewContext.tsx
+++ b/src/contexts/CardPreviewContext.tsx
@@ -1,0 +1,43 @@
+import { createContext, useContext, useState, ReactNode } from 'react';
+import { CARD_DATABASE } from '@/data/cardDatabase';
+import type { GameCard } from '@/types/cardTypes';
+import CardPreviewModal from '@/components/game/CardPreviewModal';
+
+export type SourceZone = 'hand' | 'board' | 'discard' | 'zone' | 'timeline';
+
+type Ctx = { openCardPreview: (cardId: string, sourceZone?: SourceZone) => void; };
+const CardPreviewContext = createContext<Ctx | null>(null);
+
+export const useCardPreview = () => {
+  const ctx = useContext(CardPreviewContext);
+  if (!ctx) throw new Error('useCardPreview must be used within CardPreviewProvider');
+  return ctx;
+};
+
+export function CardPreviewProvider({ children }: { children: ReactNode }) {
+  const [card, setCard] = useState<GameCard | null>(null);
+  const [sourceZone, setSourceZone] = useState<SourceZone>('board');
+
+  const openCardPreview = (cardId: string, zone: SourceZone = 'board') => {
+    const found = CARD_DATABASE.find(c => c.id === cardId);
+    if (!found) return;
+    setCard(found);
+    setSourceZone(zone);
+  };
+
+  const handleClose = () => setCard(null);
+
+  return (
+    <CardPreviewContext.Provider value={{ openCardPreview }}>
+      {children}
+      {card && (
+        <CardPreviewModal
+          card={card}
+          sourceZone={sourceZone}
+          onClose={handleClose}
+        />
+      )}
+    </CardPreviewContext.Provider>
+  );
+}
+

--- a/src/index.css
+++ b/src/index.css
@@ -198,6 +198,11 @@ All colors MUST be HSL.
     animation: pulse 1s ease-in-out infinite;
   }
 
+  /* ===== LOCKED: Your Hand mini card dimensions (DO NOT CHANGE) =====
+     Ikke endre width/height/padding/font-size/gap/margins her.
+     Disse verdiene er godkjent og skal forbli identiske.
+  ===== /LOCKED ===== */
+
   /* Enhanced Card Hover Effects */
   .card-hover-glow {
     position: relative;

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,5 +1,6 @@
 import { createRoot } from "react-dom/client";
 import App from "./App.tsx";
 import "./index.css";
+import "./styles/card-preview.css";
 
 createRoot(document.getElementById("root")!).render(<App />);

--- a/src/styles/card-preview.css
+++ b/src/styles/card-preview.css
@@ -1,0 +1,56 @@
+/* Backdrop + modal. Kun MODALEN scroller ved behov – ingen nested scroll. */
+.sg-card-backdrop{
+  position:fixed; inset:0; background:rgba(0,0,0,.55);
+  display:flex; align-items:center; justify-content:center; z-index:1000;
+}
+.sg-card-modal{
+  display:grid; grid-template-rows:auto auto 1fr;
+  width:min(92vw, 960px);
+  max-height:92vh;
+  overflow:auto;
+  background:var(--panel, #131722);
+  color:var(--paper, #f5f4ef);
+  border-radius:16px;
+  box-shadow:0 10px 40px rgba(0,0,0,.45);
+}
+
+/* Header + meta */
+.sg-card-header{padding:12px 16px; display:flex; gap:12px; align-items:center;}
+.sg-title{flex:1; font-family:var(--font-head, serif); font-size:1.15rem;}
+.sg-pill{padding:4px 10px; border-radius:999px; background:#0b223a; color:#fff; font-weight:700;}
+.sg-close{margin-left:8px;}
+.sg-card-meta{padding:0 16px 8px; display:flex; gap:8px; flex-wrap:wrap; color:var(--muted,#97a0b5);}
+.sg-badge{padding:2px 8px; border-radius:999px; background:rgba(255,255,255,.08);}
+
+/* Innhold: artwork + tekst. Kortinnhold beholder 63:88 proporsjoner, men vi låser IKKE høyde. */
+.sg-card-content{display:grid; gap:16px; padding:8px 16px 16px;}
+@media (min-width: 900px){
+  .sg-card-content{ grid-template-columns: 320px 1fr; align-items:start; }
+}
+
+/* Artwork kompakt, full art on demand */
+.sg-artwork-pane img{
+  width:100%; height:auto;
+  max-height: clamp(160px, 28vh, 260px);
+  object-fit: cover;
+  border-radius:12px;
+}
+.sg-artwork-actions{margin-top:8px; display:flex; gap:8px;}
+
+/* Tekst – ingen egen scroll. Sticky seksjonsoverskrift for lang tekst. */
+.sg-text-pane{min-height:200px;}
+.sg-text-section{margin-bottom:12px;}
+.sg-text-section h4{
+  position: sticky; top: 0; padding:6px 0;
+  background: linear-gradient(var(--panel,#131722),var(--panel,#131722));
+  font-family:var(--font-head, serif);
+  letter-spacing:.02em; font-size:1rem;
+}
+
+/* Full Art overlay (inne i modalen) */
+.sg-fullart-overlay{
+  position:fixed; inset:0; z-index:1100; background:rgba(0,0,0,.75);
+  display:flex; align-items:center; justify-content:center;
+}
+.sg-fullart-overlay img{max-width:92vw; max-height:92vh; object-fit:contain; border-radius:12px;}
+


### PR DESCRIPTION
## Summary
- add CardPreview context/provider and full-size modal with non-nested scroll
- integrate provider in app and board card clicks
- lock hand mini-card dimensions via comment and add scoped card preview styles

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68c6d8422d3083208e6f7dadb8e08795