### PR TITLE
Add card effect export for Enhanced Balancing

### DIFF
--- a/src/balance/exportEffects.ts
+++ b/src/balance/exportEffects.ts
@@ -1,0 +1,56 @@
+import type { Card, ExportRow } from "./types";
+import { getAllCards } from "./getCards";
+
+function toExportRow(card: Card): ExportRow {
+  return {
+    id: card.id,
+    name: card.name,
+    faction: card.faction ?? "",
+    type: card.type,
+    rarity: card.rarity ?? "",
+    cost: card.cost,
+    effects: JSON.stringify(card.effects ?? {}),
+  };
+}
+
+function toCSV(rows: ExportRow[]): string {
+  const header = ["id","name","faction","type","rarity","cost","effects"].join(",");
+  const body = rows
+    .map(r => [
+      r.id,
+      (r.name ?? "").replaceAll('"','""'),
+      r.faction ?? "",
+      r.type ?? "",
+      r.rarity ?? "",
+      String(r.cost ?? ""),
+      (r.effects ?? "").replaceAll('"','""'),
+    ].map(v => `"${v}"`).join(","))
+    .join("\n");
+  return header + "\n" + body;
+}
+
+function download(filename: string, content: string, mime = "application/octet-stream") {
+  const blob = new Blob([content], { type: mime });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement("a");
+  a.href = url;
+  a.download = filename;
+  document.body.appendChild(a);
+  a.click();
+  a.remove();
+  URL.revokeObjectURL(url);
+}
+
+export function exportEffectsFiles(includeExtensions: boolean) {
+  const cards = getAllCards(includeExtensions);
+  const rows = cards.map(toExportRow);
+
+  const anomalies = rows.filter(r => !r.id || !r.name || !r.effects);
+  if (anomalies.length) {
+    // eslint-disable-next-line no-console
+    console.warn("[Export Data] Noen rader har mangler:", anomalies.slice(0, 5));
+  }
+
+  download("card-effects-v21E.json", JSON.stringify(rows, null, 2), "application/json");
+  download("card-effects-v21E.csv", toCSV(rows), "text/csv");
+}

--- a/src/balance/getCards.ts
+++ b/src/balance/getCards.ts
@@ -1,0 +1,37 @@
+import type { Card } from "./types";
+
+// Import core batches
+import { CORE_BATCH_TRUTH_1 } from "../data/core/truth-batch-1";
+import { CORE_BATCH_TRUTH_2 } from "../data/core/truth-batch-2";
+import { CORE_BATCH_TRUTH_3 } from "../data/core/truth-batch-3";
+import { CORE_BATCH_TRUTH_4 } from "../data/core/truth-batch-4";
+import { CORE_BATCH_GOV_1 } from "../data/core/government-batch-1";
+import { CORE_BATCH_GOV_2 } from "../data/core/government-batch-2";
+import { CORE_BATCH_GOV_3 } from "../data/core/government-batch-3";
+import { CORE_BATCH_GOV_4 } from "../data/core/government-batch-4";
+
+function getExtensionCardsSafe(): Card[] {
+  // @ts-ignore - read from global if available
+  const reg: Card[] = (window as any)?.ShadowGovExtensions?.cards ?? [];
+  return Array.isArray(reg) ? (reg as Card[]) : [];
+}
+
+export function getAllCoreCards(): Card[] {
+  return [
+    ...CORE_BATCH_TRUTH_1,
+    ...CORE_BATCH_TRUTH_2,
+    ...CORE_BATCH_TRUTH_3,
+    ...CORE_BATCH_TRUTH_4,
+    ...CORE_BATCH_GOV_1,
+    ...CORE_BATCH_GOV_2,
+    ...CORE_BATCH_GOV_3,
+    ...CORE_BATCH_GOV_4,
+  ] as Card[];
+}
+
+export function getAllCards(includeExtensions: boolean): Card[] {
+  const core = getAllCoreCards();
+  if (!includeExtensions) return core;
+  const ext = getExtensionCardsSafe();
+  return [...core, ...ext];
+}

--- a/src/balance/types.ts
+++ b/src/balance/types.ts
@@ -1,0 +1,37 @@
+export type Faction = "Truth" | "Government";
+export type CardType =
+  | "MEDIA"
+  | "ZONE"
+  | "ATTACK"
+  | "TECH"
+  | "DEVELOPMENT"
+  | "DEFENSIVE"
+  | "INSTANT"
+  | "LEGENDARY";
+export type Rarity = "common" | "uncommon" | "rare" | "legendary";
+
+export interface Card {
+  id: string;
+  name: string;
+  type: CardType;
+  faction?: Faction;
+  rarity?: Rarity;
+  cost: number;
+  text?: string;
+  flavor?: string;
+  flavorTruth?: string;
+  flavorGov?: string;
+  target?: any;
+  effects: Record<string, any>;
+  art?: string; // optional, used by other exporters
+}
+
+export interface ExportRow {
+  id: string;
+  name: string;
+  faction: string;
+  type: string;
+  rarity: string;
+  cost: number;
+  effects: string; // JSON-stringify
+}

--- a/src/components/game/EnhancedBalancingDashboard.tsx
+++ b/src/components/game/EnhancedBalancingDashboard.tsx
@@ -5,6 +5,7 @@ import { Badge } from '@/components/ui/badge';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { EnhancedCardBalancer } from '@/data/enhancedCardBalancing';
 import { Download, RefreshCw, Image, FileText, BarChart3 } from 'lucide-react';
+import { exportEffectsFiles } from '@/balance/exportEffects';
 import { PieChart, Pie, Cell, BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer, LineChart, Line, Area, AreaChart } from 'recharts';
 
 interface EnhancedBalancingDashboardProps {
@@ -142,7 +143,14 @@ const EnhancedBalancingDashboard = ({ onClose }: EnhancedBalancingDashboardProps
             >
               {includeExtensions ? "Med Extensions" : "Kun Base Cards"}
             </Button>
-            <Button onClick={exportData} variant="outline" size="sm">
+            <Button
+              onClick={() => {
+                exportData();
+                exportEffectsFiles(includeExtensions);
+              }}
+              variant="outline"
+              size="sm"
+            >
               <Download size={16} className="mr-1" />
               Export Data
             </Button>


### PR DESCRIPTION
## Summary
- add balance utilities for card types and export rows
- implement card aggregation with optional extension inclusion
- export card effects to JSON and CSV and hook into existing Export Data button

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Cannot find package '@eslint/js'; `npm install` also failed with 403)*

------
https://chatgpt.com/codex/tasks/task_e_68c6dc82cb048320b2daef15f3d32cfb