### PR TITLE
feat: apply responsive base layout

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -28,15 +28,18 @@ const App = () => {
           <AchievementProvider>
             <Toaster />
             <Sonner />
-            <BrowserRouter>
-              <Routes>
-                <Route path="/" element={<Index />} />
-                <Route path="/dev/effects" element={<EffectSystemDashboard />} />
-                <Route path="/dev/recovery" element={<DatabaseRecovery />} />
-                {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}
-                <Route path="*" element={<NotFound />} />
-              </Routes>
-            </BrowserRouter>
+            {/* responsive-v21E */}
+            <div className="grid grid-rows-[auto,1fr,auto] h-[100dvh] w-full overflow-hidden">
+              <BrowserRouter>
+                <Routes>
+                  <Route path="/" element={<Index />} />
+                  <Route path="/dev/effects" element={<EffectSystemDashboard />} />
+                  <Route path="/dev/recovery" element={<DatabaseRecovery />} />
+                  {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}
+                  <Route path="*" element={<NotFound />} />
+                </Routes>
+              </BrowserRouter>
+            </div>
           </AchievementProvider>
         </AudioProvider>
       </TooltipProvider>

--- a/src/index.css
+++ b/src/index.css
@@ -78,7 +78,11 @@ All colors MUST be HSL.
     --newspaper-border: 0 0% 30%;
     --newspaper-accent: 0 75% 45%;
     --newspaper-headline: 0 0% 0%;
-    
+
+    /* responsive-v21E */
+    --masthead-h: clamp(56px, 6svh, 72px);
+    --tray-h: clamp(72px, 10svh, 112px);
+
     /* Enhanced animation colors */
     --warning: 45 93% 58%;
     --warning-foreground: 0 0% 9%;
@@ -153,6 +157,26 @@ All colors MUST be HSL.
     --rarity-uncommon: 142 84% 44%;
     --rarity-rare: 221 83% 63%;
     --rarity-legendary: 25 95% 63%;
+  }
+
+  /* responsive-v21E */
+  html,
+  body {
+    height: 100%;
+  }
+  body {
+    overflow: auto;
+  }
+  @screen lg {
+    body {
+      overflow: hidden;
+    }
+  }
+  .masthead {
+    height: var(--masthead-h);
+  }
+  .tray {
+    height: var(--tray-h);
   }
 }
 

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -865,7 +865,8 @@ const Index = () => {
   // Desktop layout (existing design)
   console.log('🔍 Rendering Desktop Layout');
   return (
-    <div className="min-h-screen bg-newspaper-bg">
+    <div className="contents"> {/* responsive-v21E */}
+      <div className="overflow-auto lg:overflow-hidden h-full bg-newspaper-bg">{/* responsive-v21E */}
       {/* Newspaper Header */}
       <div className="bg-newspaper-bg border-b-4 border-newspaper-border">
         <div className="container mx-auto px-4 py-2">
@@ -1273,6 +1274,7 @@ const Index = () => {
         />
       )}
 
+      </div>{/* responsive-v21E */}
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- add masthead/tray CSS variables and desktop body overflow rules
- wrap app with grid-based full-height layout
- ensure main game page uses content grid with constrained scrolling

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68c7f5c4021c83208523215a6766a84d