### PR TITLE
fix: unlock body scroll for menus

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -28,15 +28,22 @@ const App = () => {
           <AchievementProvider>
             <Toaster />
             <Sonner />
-            <BrowserRouter>
-              <Routes>
-                <Route path="/" element={<Index />} />
-                <Route path="/dev/effects" element={<EffectSystemDashboard />} />
-                <Route path="/dev/recovery" element={<DatabaseRecovery />} />
-                {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}
-                <Route path="*" element={<NotFound />} />
-              </Routes>
-            </BrowserRouter>
+            {/* layout-fix no-cut v21E */}
+            <div className="grid min-h-[100svh] grid-rows-[auto,1fr,auto] w-full">
+              <header className="shrink-0 h-[var(--masthead-h)]" />
+              <main className="min-h-0 min-w-0 overflow-y-auto">
+                <BrowserRouter>
+                  <Routes>
+                    <Route path="/" element={<Index />} />
+                    <Route path="/dev/effects" element={<EffectSystemDashboard />} />
+                    <Route path="/dev/recovery" element={<DatabaseRecovery />} />
+                    {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}
+                    <Route path="*" element={<NotFound />} />
+                  </Routes>
+                </BrowserRouter>
+              </main>
+              <footer className="shrink-0 h-[var(--tray-h)]" />
+            </div>
           </AchievementProvider>
         </AudioProvider>
       </TooltipProvider>

--- a/src/index.css
+++ b/src/index.css
@@ -78,7 +78,11 @@ All colors MUST be HSL.
     --newspaper-border: 0 0% 30%;
     --newspaper-accent: 0 75% 45%;
     --newspaper-headline: 0 0% 0%;
-    
+
+    /* layout-fix no-cut v21E */
+    --masthead-h: clamp(56px, 6svh, 72px); /* layout-fix no-cut v21E */
+    --tray-h: clamp(64px, 8svh, 96px); /* layout-fix no-cut v21E */
+
     /* Enhanced animation colors */
     --warning: 45 93% 58%;
     --warning-foreground: 0 0% 9%;
@@ -154,6 +158,22 @@ All colors MUST be HSL.
     --rarity-rare: 221 83% 63%;
     --rarity-legendary: 25 95% 63%;
   }
+
+  /* layout-fix no-cut v21E */
+  html,
+  body,
+  #root {
+    height: 100%;
+  }
+  body {
+    overflow: auto;
+  }
+  .masthead {
+    height: var(--masthead-h);
+  }
+  .tray {
+    height: var(--tray-h);
+  }
 }
 
 @layer base {
@@ -163,6 +183,15 @@ All colors MUST be HSL.
 
   body {
     @apply bg-background text-foreground;
+  }
+}
+
+@layer utilities {
+  .h-svh { /* layout-fix no-cut v21E */
+    height: 100svh;
+  }
+  .min-h-svh { /* layout-fix no-cut v21E */
+    min-height: 100svh;
   }
 }
 

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -865,7 +865,8 @@ const Index = () => {
   // Desktop layout (existing design)
   console.log('🔍 Rendering Desktop Layout');
   return (
-    <div className="min-h-screen bg-newspaper-bg">
+    <div className="min-h-0 min-w-0 h-full overflow-visible"> {/* layout-fix no-cut v21E */}
+      <div className="h-full bg-newspaper-bg">{/* layout-fix no-cut v21E */}
       {/* Newspaper Header */}
       <div className="bg-newspaper-bg border-b-4 border-newspaper-border">
         <div className="container mx-auto px-4 py-2">
@@ -1273,6 +1274,7 @@ const Index = () => {
         />
       )}
 
+      </div>{/* layout-fix no-cut v21E */}
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- allow root element to use full safe viewport without locking body scroll
- restructure app layout with scrollable main area and fixed header/footer slots
- adjust game screen wrapper to rely on parent scroll area

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*


------
https://chatgpt.com/codex/tasks/task_e_68c7f5c4021c83208523215a6766a84d