### PR TITLE
feat: add per-state pressure tracking

### DIFF
--- a/src/engine/demo.ts
+++ b/src/engine/demo.ts
@@ -96,7 +96,9 @@ export function createDemoGameState(): GameState {
         zoneDefenseBonus: 0,
         pressureTotal: 0
       }
-    }
+    },
+    pressureByState: {},
+    stateAliases: {}
   };
 }
 
@@ -105,26 +107,26 @@ export function runEngineDemo(): string {
   const gameState = createDemoGameState();
   const log: string[] = [];
   
-  const context: Context = {
-    state: gameState,
-    log: (msg) => log.push(msg),
-    turnFlags: {},
-    openReaction: (attackCard, attacker, defender) => {
-      log.push(`🚨 Reaction window opened: ${attacker} played ${attackCard.name}, ${defender} can defend`);
-      
-      // Simulate AI defense selection
-      const defense = pickDefenseForAI(context, defender, attackCard);
-      if (defense) {
-        log.push(`🛡️ ${defender} chooses to defend with: ${defense.name}`);
-      } else {
-        log.push(`❌ ${defender} has no defensive options`);
+    const context: Context = {
+      state: gameState,
+      log: (msg) => log.push(msg),
+      turnFlags: {},
+      openReaction: (attackCard, attacker, defender, targetStateId) => {
+        log.push(`🚨 Reaction window opened: ${attacker} played ${attackCard.name}, ${defender} can defend`);
+
+        // Simulate AI defense selection
+        const defense = pickDefenseForAI(context, defender, attackCard);
+        if (defense) {
+          log.push(`🛡️ ${defender} chooses to defend with: ${defense.name}`);
+        } else {
+          log.push(`❌ ${defender} has no defensive options`);
+        }
+
+        // Resolve reaction
+        const outcome = resolveReaction(context, { card: attackCard, attacker, targetStateId }, defense);
+        log.push(`⚔️ Reaction resolved: ${outcome}`);
       }
-      
-      // Resolve reaction
-      const outcome = resolveReaction(context, { card: attackCard, attacker }, defense);
-      log.push(`⚔️ Reaction resolved: ${outcome}`);
-    }
-  };
+    };
   
   log.push("=== ENGINE DEMO START ===");
   log.push(`Initial state: Truth=${gameState.truth}%, P1 IP=${gameState.players.P1.ip}, P2 IP=${gameState.players.P2.ip}`);

--- a/src/engine/effects.ts
+++ b/src/engine/effects.ts
@@ -1,7 +1,17 @@
 import { Context } from "./types";
 import { normalizeEffects } from "./normalize";
+import { addPressure, aliasToStateId } from "./statePressure";
 
 const clamp = (v: number, lo: number, hi: number) => Math.max(lo, Math.min(hi, v));
+
+function discardRandom(hand: any[], n: number): any[] {
+  const moved: any[] = [];
+  for (let i = 0; i < n && hand.length > 0; i++) {
+    const idx = Math.floor(Math.random() * hand.length);
+    moved.push(...hand.splice(idx, 1));
+  }
+  return moved;
+}
 
 export function applyEffects(ctx: Context, owner: "P1" | "P2", rawEffects: any, targetStateId?: string) {
   console.log(`[Engine] applyEffects for ${owner}:`, rawEffects);
@@ -44,33 +54,33 @@ export function applyEffects(ctx: Context, owner: "P1" | "P2", rawEffects: any, 
     }
   }
   
-  if (eff.discardOpponent) {
+  if ((eff.discardOpponent || 0) > 0) {
     console.log(`[Engine] Forcing opponent to discard ${eff.discardOpponent} cards`);
-    for (let i = 0; i < eff.discardOpponent; i++) {
-      const c = opp.hand.shift();
-      if (c) {
-        opp.discard.push(c);
-        console.log(`[Engine] Opponent discarded: ${c.name}`);
-      }
-    }
+    const moved = discardRandom(opp.hand, eff.discardOpponent);
+    opp.discard.push(...moved);
   }
-  
-  if (eff.discardRandom) {
+
+  if ((eff.discardRandom || 0) > 0) {
     console.log(`[Engine] ${owner} discarding ${eff.discardRandom} random cards`);
-    for (let i = 0; i < eff.discardRandom; i++) {
-      if (you.hand.length > 0) {
-        const randomIndex = Math.floor(Math.random() * you.hand.length);
-        const c = you.hand.splice(randomIndex, 1)[0];
-        if (c) {
-          you.discard.push(c);
-          console.log(`[Engine] ${owner} randomly discarded: ${c.name}`);
-        }
+    const moved = discardRandom(you.hand, eff.discardRandom);
+    you.discard.push(...moved);
+  }
+
+  // Pressure (liste-basert)
+  if (eff.pressureOps?.length) {
+    for (const p of eff.pressureOps) {
+      if (p.scope === "all") {
+        for (const sid of Object.keys(s.pressureByState)) addPressure(ctx, owner, sid, p.amount);
+      } else if (targetStateId) {
+        addPressure(ctx, owner, targetStateId, p.amount);
       }
     }
   }
 
-  if (typeof eff.pressureDelta === "number") {
-    you.pressureTotal = (you.pressureTotal || 0) + eff.pressureDelta;
+  // Pressure (flatt v2.1E): alltid til valgt stat
+  const flatPressure = typeof (rawEffects?.pressureDelta) === "number" ? rawEffects.pressureDelta : (eff as any).pressureDelta;
+  if (typeof flatPressure === "number" && targetStateId) {
+    addPressure(ctx, owner, targetStateId, Number(flatPressure));
   }
   
   if (eff.zoneDefense) {
@@ -82,7 +92,11 @@ export function applyEffects(ctx: Context, owner: "P1" | "P2", rawEffects: any, 
     let ok = true;
     if (cond.ifTruthAtLeast !== undefined) ok &&= s.truth >= cond.ifTruthAtLeast;
     if (cond.ifZonesControlledAtLeast !== undefined) ok &&= you.zones.length >= cond.ifZonesControlledAtLeast;
-    if (cond.ifTargetStateIs !== undefined) ok &&= (targetStateId && targetStateId === cond.ifTargetStateIs);
+    if (cond.ifTargetStateIs !== undefined) {
+      const wanted = aliasToStateId(ctx, String(cond.ifTargetStateIs));
+      const chosen = aliasToStateId(ctx, targetStateId);
+      ok &&= !!wanted && !!chosen && wanted === chosen;
+    }
     applyEffects(ctx, owner, ok ? cond.then : (cond.else || {}), targetStateId);
   }
 
@@ -94,11 +108,9 @@ export function applyEffects(ctx: Context, owner: "P1" | "P2", rawEffects: any, 
     }
   }
   
-  if (eff.flags?.forceDiscard) {
-    for (let i = 0; i < eff.flags.forceDiscard; i++) {
-      const c = opp.hand.shift();
-      if (c) opp.discard.push(c);
-    }
+  if ((eff.flags?.forceDiscard || 0) > 0) {
+    const moved = discardRandom(opp.hand, eff.flags.forceDiscard!);
+    opp.discard.push(...moved);
   }
 
   if (eff.flags?.zoneCostReduction) {

--- a/src/engine/flow.ts
+++ b/src/engine/flow.ts
@@ -47,7 +47,7 @@ export function playCard(ctx: Context, owner: "P1" | "P2", card: Card, targetSta
   const needsReaction = (card.type === "ATTACK" || card.type === "MEDIA");
   
   if (needsReaction && ctx.openReaction) {
-    ctx.openReaction(card, owner, defender); // UI opens ReactionModal for human, AI can auto
+    ctx.openReaction(card, owner, defender, targetStateId); // UI opens ReactionModal for human, AI can auto
     return "reaction-pending";
   }
 
@@ -60,7 +60,7 @@ export function resolveReaction(
   ctx: Context, 
   attack: { card: Card, attacker: "P1" | "P2", targetStateId?: string }, 
   defenseCard: Card | null
-): PlayOutcome {
+  ): PlayOutcome {
   const { card: attackCard, attacker, targetStateId } = attack;
   const defender = attacker === "P1" ? "P2" : "P1";
 
@@ -91,9 +91,16 @@ export function resolveReaction(
     // Fix: Use ID-based filtering here too
     you.hand = you.hand.filter(c => c.id !== attackCard.id);
     you.discard.push(attackCard);
+    ctx.turnFlags = {};
     return "blocked";
   }
 
   resolveCard(ctx, attacker, attackCard, targetStateId);
+  ctx.turnFlags = {};
   return "played";
+}
+
+export function endTurn(ctx: Context) {
+  ctx.turnFlags = {};
+  if (ctx.state.skipAIActionNext) delete ctx.state.skipAIActionNext;
 }

--- a/src/engine/normalize.ts
+++ b/src/engine/normalize.ts
@@ -5,6 +5,8 @@ export type Normalized = {
   discardOpponent?: number;
   discardRandom?: number; // Support for legacy random discard
   pressureDelta?: number;
+  // NEW: eksplisitte pressure-operasjoner
+  pressureOps?: Array<{ amount: number; scope: "target" | "all" }>;
   zoneDefense?: number;
   reduceFactor?: number; // For partial blocking defensive cards (0-1)
   conditional?: any;
@@ -80,7 +82,8 @@ export function normalizeEffects(effectsField: any): Normalized {
         break;
       }
       case "pressure": {
-        out.pressureDelta = (out.pressureDelta || 0) + Number(item.v || item.value || 0);
+        const scope = item.target === "all" ? "all" : "target";
+        (out.pressureOps ||= []).push({ amount: Number(item.v || item.value || 0), scope });
         break;
       }
       case "zoneDefense": {

--- a/src/engine/statePressure.ts
+++ b/src/engine/statePressure.ts
@@ -1,0 +1,18 @@
+import { Context } from "./types";
+
+export function aliasToStateId(ctx: Context, s?: string): string | undefined {
+  if (!s) return undefined;
+  const key = s.trim().toLowerCase();
+  const a = ctx.state.stateAliases || {};
+  return a[s] || a[key] || a[s.toUpperCase()] || a[capitalizeWords(key)] || s; // fallbacks
+}
+function capitalizeWords(x: string) {
+  return x.replace(/\b\w/g, c => c.toUpperCase());
+}
+
+export function addPressure(ctx: Context, owner: "P1" | "P2", stateId: string, amt: number) {
+  const rec = (ctx.state.pressureByState[stateId] ||= { P1: 0, P2: 0 });
+  rec[owner] = Math.max(0, (rec[owner] || 0) + amt);
+  const player = ctx.state.players[owner];
+  player.pressureTotal = Math.max(0, (player.pressureTotal || 0) + amt);
+}

--- a/src/engine/types.ts
+++ b/src/engine/types.ts
@@ -38,7 +38,11 @@ export interface GameState {
   truth: number; // 0..100
   currentPlayer: "P1" | "P2";
   players: Record<"P1" | "P2", PlayerState>;
+  // NEW: trykk per stat per side
+  pressureByState: Record<string, { P1: number; P2: number }>;
   skipAIActionNext?: boolean;
+  // optional: map med statnavn/aliaser -> id
+  stateAliases?: Record<string, string>; // "Minnesota"|"MN" -> "MN"
 }
 
 export interface Context {
@@ -46,7 +50,12 @@ export interface Context {
   rng?: () => number;
   log?: (m: string) => void;
   // Reaction hook – UI sets this to open modal when needed
-  openReaction?: (attackCard: Card, attacker: "P1" | "P2", defender: "P1" | "P2") => void;
+  openReaction?: (
+    attackCard: Card,
+    attacker: "P1" | "P2",
+    defender: "P1" | "P2",
+    targetStateId?: string
+  ) => void;
   // Turn flags (immune/block) – per side
   turnFlags?: Partial<Record<"P1" | "P2", { immune?: boolean; blockAttack?: boolean }>>;
 }


### PR DESCRIPTION
## Summary
- track pressure per player per state and resolve using aliases
- normalize pressure operations with `target` scope
- reset reaction flags after resolution and randomize forced discards

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68c80ee30b8083208a0e2f48f0e5d2f8