### PR TITLE
Add v2.1E strict effect engine and validator

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,12 +5,15 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build": "vite build",
+    "validate:core": "tsx scripts/validate-core-v21e-strict.ts",
+    "build": "bun run validate:core && vite build",
+    "build:npm": "npm run validate:core && vite build",
     "build:dev": "vite build --mode development",
     "lint": "eslint .",
     "preview": "vite preview",
     "export:core": "tsx scripts/export-core-json.ts",
-    "build:core": "CORE_SEED=2025-09-14 tsx scripts/export-core-json.ts"
+    "build:core": "CORE_SEED=2025-09-14 tsx scripts/export-core-json.ts",
+    "snapshot:core": "tsx scripts/snapshot-core-v21e-strict.ts"
   },
   "dependencies": {
     "@hookform/resolvers": "^3.10.0",

--- a/scripts/snapshot-core-v21e-strict.ts
+++ b/scripts/snapshot-core-v21e-strict.ts
@@ -1,0 +1,24 @@
+// Run: bunx tsx scripts/snapshot-core-v21e-strict.ts
+import fs from "fs";
+import path from "path";
+import { validateCanonicalEffects } from "../src/rules/validateEffects";
+
+(async function main(){
+  const mod = await import("../src/data/core/index.ts");
+  const cards: any[] = (mod as any).CARD_DATABASE_CORE || [];
+
+  const noncompliant = cards
+    .map(c => ({ id:c.id, errs: validateCanonicalEffects(c.effects || {}, `${c.id}.effects`) }))
+    .filter(x => x.errs.length>0);
+
+  const dir = "src/data/exports";
+  fs.mkdirSync(dir, { recursive:true });
+  fs.writeFileSync(path.join(dir,"card-effects-core.strict.json"), JSON.stringify(cards,null,2));
+  if (noncompliant.length) {
+    fs.writeFileSync(path.join(dir,"card-effects-core.noncompliant.txt"),
+      noncompliant.map(x=>`${x.id}\n${x.errs.map(e=>"  - "+e).join("\n")}`).join("\n"));
+    console.warn(`⚠ Some core cards violate v2.1E-Strict. See ${dir}/card-effects-core.noncompliant.txt`);
+  } else {
+    console.log("✓ All core cards canonical (snapshot)");
+  }
+})();

--- a/scripts/validate-core-v21e-strict.ts
+++ b/scripts/validate-core-v21e-strict.ts
@@ -1,0 +1,30 @@
+// Run: bunx tsx scripts/validate-core-v21e-strict.ts
+import { validateCanonicalEffects } from "../src/rules/validateEffects";
+
+type Card = { id:string; name:string; type:string; faction?:string; cost:number; effects:any };
+
+import("../src/data/core/index.ts").then(mod => {
+  const cards: Card[] = (mod as any).CARD_DATABASE_CORE || [];
+  if (!Array.isArray(cards) || cards.length===0) {
+    console.error("✖ No cards found in CARD_DATABASE_CORE");
+    process.exit(1);
+  }
+
+  const errs: string[] = [];
+  for (const c of cards) {
+    const e = c.effects;
+    if (typeof e==="string" || Array.isArray(e)) {
+      errs.push(`${c.id}.effects: must be canonical object (found string/array)`);
+      continue;
+    }
+    errs.push(...validateCanonicalEffects(e, `${c.id}.effects`));
+  }
+
+  if (errs.length) {
+    console.error("✖ v2.1E-Strict validation failed for core:");
+    for (const e of errs) console.error(" -", e);
+    process.exit(1);
+  }
+  console.log(`✓ v2.1E-Strict validation OK for ${cards.length} core cards`);
+  process.exit(0);
+});

--- a/src/components/game/ReactionModal.tsx
+++ b/src/components/game/ReactionModal.tsx
@@ -2,55 +2,32 @@ import * as Dialog from "@radix-ui/react-dialog";
 import { Card } from "@/engine/types";
 
 export function ReactionModal({
-  open,
-  onOpenChange,
-  attackCard,
-  defenseHand,
-  onDefend
-}: {
-  open: boolean;
-  onOpenChange: (open: boolean) => void;
+  open, onOpenChange, attackCard, defenseHand, onDefend
+}:{
+  open:boolean;
+  onOpenChange:(open:boolean)=>void;
   attackCard: Card;
   defenseHand: Card[];
-  onDefend: (card: Card | null) => void;
-}) {
+  onDefend:(card: Card | null)=>void;
+}){
   return (
     <Dialog.Root open={open} onOpenChange={onOpenChange}>
       <Dialog.Portal>
-        <Dialog.Overlay className="fixed inset-0 bg-black/60 z-50" />
-        <Dialog.Content className="fixed left-1/2 top-24 -translate-x-1/2 w-[420px] rounded-xl bg-neutral-900 text-neutral-100 p-4 shadow-xl z-50">
+        <Dialog.Overlay className="fixed inset-0 bg-black/60" />
+        <Dialog.Content className="fixed left-1/2 top-24 -translate-x-1/2 w-[420px] rounded-xl bg-neutral-900 text-neutral-100 p-4 shadow-xl">
           <Dialog.Title className="text-lg font-semibold">Defend?</Dialog.Title>
-          <p className="mt-1 opacity-80">
-            Opponent played: <b>{attackCard.name}</b>
-          </p>
-          
+          <p className="mt-1 opacity-80">Opponent played: <b>{attackCard?.name}</b></p>
           <div className="mt-3 space-y-2 max-h-64 overflow-auto">
-            {defenseHand.map(c => (
-              <button 
-                key={c.id} 
-                onClick={() => onDefend(c)}
-                className="w-full text-left rounded-lg border border-white/10 p-2 hover:bg-white/10 transition-colors"
-              >
+            {defenseHand.map(c=>(
+              <button key={c.id} onClick={()=>onDefend(c)}
+                className="w-full text-left rounded-lg border border-white/10 p-2 hover:bg-white/10">
                 {c.name} <span className="opacity-70">— cost {c.cost}</span>
               </button>
             ))}
-            
-            <button 
-              onClick={() => onDefend(null)} 
-              className="w-full rounded-lg border border-white/10 p-2 bg-red-500/20 hover:bg-red-500/30 transition-colors"
-            >
-              Don't Defend
+            <button onClick={()=>onDefend(null)} className="w-full rounded-lg border border-white/10 p-2 bg-red-500/20 hover:bg-red-500/30">
+              Don’t Defend
             </button>
           </div>
-          
-          <Dialog.Close asChild>
-            <button 
-              className="absolute top-2 right-2 w-6 h-6 rounded-full bg-white/10 hover:bg-white/20 flex items-center justify-center text-xs"
-              aria-label="Close"
-            >
-              ×
-            </button>
-          </Dialog.Close>
         </Dialog.Content>
       </Dialog.Portal>
     </Dialog.Root>

--- a/src/engine/applyStrict.ts
+++ b/src/engine/applyStrict.ts
@@ -1,0 +1,60 @@
+import { CanonicalEffects } from "@/rules/v21e-strict";
+import { Context } from "./types";
+
+const clamp = (v:number,lo:number,hi:number)=>Math.max(lo,Math.min(hi,v));
+const discardRandom = (arr: any[], n:number) => {
+  const moved:any[]=[]; for(let i=0;i<n && arr.length;i++){ const idx=Math.floor(Math.random()*arr.length); moved.push(...arr.splice(idx,1)); } return moved;
+};
+
+export function applyCanonical(ctx: Context, owner:"P1"|"P2", e: CanonicalEffects, targetStateId?: string){
+  const s=ctx.state, you=s.players[owner], opp=s.players[owner==="P1"?"P2":"P1"];
+
+  if (e.truthDelta) s.truth = clamp(s.truth + e.truthDelta, 0, 100);
+  if (e.ipDelta?.self)      you.ip = Math.max(0, you.ip + e.ipDelta.self);
+  if (e.ipDelta?.opponent)  opp.ip = Math.max(0, opp.ip + e.ipDelta.opponent);
+
+  if (e.draw) for (let i=0;i<e.draw;i++){ const c=you.deck.shift(); if (c) you.hand.push(c); }
+  if (e.discardOpponent){ const moved=discardRandom(opp.hand, e.discardOpponent); opp.discard.push(...moved); }
+
+  if (e.zoneDefense) you.zoneDefenseBonus += e.zoneDefense;
+
+  if (e.pressureAllDelta){
+    for (const sid of Object.keys(s.pressureByState)) {
+      const rec = (s.pressureByState[sid] ||= { P1:0, P2:0 });
+      rec[owner] = Math.max(0, rec[owner] + e.pressureAllDelta);
+    }
+  }
+  if (e.pressureDelta && targetStateId){
+    const rec = (s.pressureByState[targetStateId] ||= { P1:0, P2:0 });
+    rec[owner] = Math.max(0, rec[owner] + e.pressureDelta);
+  }
+
+  if (e.costModDelta){
+    you.costMods = you.costMods || {};
+    if (typeof e.costModDelta.zone  === "number") you.costMods.zone  = (you.costMods.zone  || 0) + e.costModDelta.zone;
+    if (typeof e.costModDelta.media === "number") you.costMods.media = (you.costMods.media || 0) + e.costModDelta.media;
+  }
+  if (e.ipIncomePerTurn) you.passiveIncome = (you.passiveIncome||0) + e.ipIncomePerTurn;
+
+  if (e.skipOpponentAction){
+    s.skipNextAction = s.skipNextAction || { P1:0, P2:0 } as any;
+    const foe = owner==="P1"?"P2":"P1";
+    s.skipNextAction[foe] = (s.skipNextAction[foe]||0) + e.skipOpponentAction;
+  }
+
+  if (e.conditional){
+    const c = e.conditional; let ok = true;
+    if (c.ifTruthAtLeast !== undefined) ok &&= s.truth >= c.ifTruthAtLeast;
+    if (c.ifZonesControlledAtLeast !== undefined) ok &&= you.zones.length >= c.ifZonesControlledAtLeast;
+    if (c.ifTargetStateIs !== undefined) ok &&= (String(c.ifTargetStateIs).toUpperCase() === String(targetStateId||"").toUpperCase());
+    applyCanonical(ctx, owner, ok ? (c.then||{}) : (c.else||{}), targetStateId);
+  }
+
+  if (e.reaction?.immune || e.reaction?.block) {
+    ctx.turnFlags = { ...(ctx.turnFlags||{}), [owner]: {
+      ...(ctx.turnFlags?.[owner]||{}),
+      immune: Boolean(e.reaction?.immune) || Boolean(ctx.turnFlags?.[owner]?.immune),
+      blockAttack:  Boolean(e.reaction?.block)  || Boolean((ctx.turnFlags as any)?.[owner]?.blockAttack),
+    }};
+  }
+}

--- a/src/engine/flow.ts
+++ b/src/engine/flow.ts
@@ -1,53 +1,39 @@
 import { Card, Context } from "./types";
-import { applyEffects } from "./effects";
+import { applyCanonical } from "./applyStrict";
 
-export type PlayOutcome = "played" | "blocked" | "failed";
+export type PlayOutcome = "played" | "blocked" | "failed" | "reaction-pending";
 
-export function effectiveCostFor(ctx: Context, owner: "P1" | "P2", card: Card) {
+export function effectiveCostFor(ctx:Context, owner:"P1"|"P2", card:Card){
   const mods = ctx.state.players[owner].costMods || {};
   let m = card.cost;
-  if (card.type === "ZONE" && typeof mods.zone === "number") {
-    m = Math.max(0, m + mods.zone);
-  }
-  if (card.type === "MEDIA" && typeof mods.media === "number") {
-    m = Math.max(0, m + mods.media);
-  }
+  if (card.type==="ZONE"  && typeof mods.zone  === "number") m = Math.max(0, m + mods.zone);
+  if (card.type==="MEDIA" && typeof mods.media === "number") m = Math.max(0, m + mods.media);
   return m;
 }
 
-export function canAfford(ctx: Context, owner: "P1" | "P2", card: Card): boolean {
+export function canAfford(ctx: Context, owner:"P1"|"P2", card:Card): boolean {
   return ctx.state.players[owner].ip >= effectiveCostFor(ctx, owner, card);
 }
-
-export function payCost(ctx: Context, owner: "P1" | "P2", card: Card) {
+export function payCost(ctx: Context, owner:"P1"|"P2", card:Card) {
   ctx.state.players[owner].ip -= effectiveCostFor(ctx, owner, card);
 }
 
-export function resolveCard(ctx: Context, owner: "P1" | "P2", card: Card, targetStateId?: string) {
-  applyEffects(ctx, owner, card.effects || {}, targetStateId);
+export function resolveCard(ctx: Context, owner:"P1"|"P2", card:Card, targetStateId?: string){
+  applyCanonical(ctx, owner, card.effects || {}, targetStateId);
   const you = ctx.state.players[owner];
-  
-  // Fix: Use ID-based filtering instead of reference equality
-  console.log(`[Engine] Removing card ${card.id} from ${owner} hand (${you.hand.length} cards)`);
-  const originalHandSize = you.hand.length;
-  you.hand = you.hand.filter(c => c.id !== card.id);
-  console.log(`[Engine] Hand after removal: ${you.hand.length} cards (removed: ${originalHandSize - you.hand.length})`);
-  
+  you.hand = you.hand.filter(c => c !== card);
   you.discard.push(card);
-  if (card.type === "ZONE") {
-    you.zones.push(card.id);
-  }
+  if (card.type === "ZONE") you.zones.push(card.id);
 }
 
-export function playCard(ctx: Context, owner: "P1" | "P2", card: Card, targetStateId?: string): PlayOutcome | "reaction-pending" {
+export function playCard(ctx: Context, owner:"P1"|"P2", card:Card, targetStateId?: string): PlayOutcome {
   if (!canAfford(ctx, owner, card)) return "failed";
   payCost(ctx, owner, card);
 
   const defender = owner === "P1" ? "P2" : "P1";
   const needsReaction = (card.type === "ATTACK" || card.type === "MEDIA");
-  
-  if (needsReaction && ctx.openReaction) {
-    ctx.openReaction(card, owner, defender, targetStateId); // UI opens ReactionModal for human, AI can auto
+  if (needsReaction && ctx.openReaction){
+    ctx.openReaction(card, owner, defender, targetStateId); // UI åpner modal eller AI velger
     return "reaction-pending";
   }
 
@@ -55,52 +41,36 @@ export function playCard(ctx: Context, owner: "P1" | "P2", card: Card, targetSta
   return "played";
 }
 
-// Called from UI when reaction is chosen (defenseCard = null if "Don't Defend")
-export function resolveReaction(
-  ctx: Context, 
-  attack: { card: Card, attacker: "P1" | "P2", targetStateId?: string }, 
-  defenseCard: Card | null
-  ): PlayOutcome {
+// Kalles fra UI når reaction er valgt (defenseCard = null for “Don’t Defend”)
+export function resolveReaction(ctx: Context, attack: {card:Card, attacker:"P1"|"P2", targetStateId?:string}, defenseCard: Card | null): PlayOutcome {
   const { card: attackCard, attacker, targetStateId } = attack;
   const defender = attacker === "P1" ? "P2" : "P1";
 
-  // 1) Defender plays optional defense
   let blocked = false;
-  if (defenseCard) {
-    if (canAfford(ctx, defender, defenseCard)) {
-      payCost(ctx, defender, defenseCard);
-      resolveCard(ctx, defender, defenseCard, targetStateId);
-      const flags = ctx.turnFlags?.[defender];
-      if (flags?.blockAttack) blocked = true;
-    }
+  if (defenseCard && canAfford(ctx, defender, defenseCard)) {
+    payCost(ctx, defender, defenseCard);
+    resolveCard(ctx, defender, defenseCard, targetStateId);
+    const flags = ctx.turnFlags?.[defender];
+    if (flags?.blockAttack) blocked = true;
   }
 
-  // 2) Attack resolve – check immunity
   if (!blocked) {
     const flags = ctx.turnFlags?.[defender];
-    if (flags?.immune) {
-      // Ignore effects that affect defender (truth/ip/pressure/forceDiscard) – no-op
-      // But for simplicity: mark as blocked
-      blocked = true;
-    }
+    if (flags?.immune) blocked = true;
   }
 
-  if (blocked) {
-    // withdraw cost for attack? No – cost is paid. Only effects are nullified.
-    const you = ctx.state.players[attacker];
-    // Fix: Use ID-based filtering here too
-    you.hand = you.hand.filter(c => c.id !== attackCard.id);
-    you.discard.push(attackCard);
+  // alltid forbruk angrepskortet (kost er allerede betalt)
+  const atk = ctx.state.players[attacker];
+  atk.hand = atk.hand.filter(c => c !== attackCard);
+  atk.discard.push(attackCard);
+
+  if (!blocked) {
+    // vi har allerede lagt det i discard; men må kjøre effekter:
+    applyCanonical(ctx, attacker, attackCard.effects || {}, targetStateId);
+    ctx.turnFlags = {};
+    return "played";
+  } else {
     ctx.turnFlags = {};
     return "blocked";
   }
-
-  resolveCard(ctx, attacker, attackCard, targetStateId);
-  ctx.turnFlags = {};
-  return "played";
-}
-
-export function endTurn(ctx: Context) {
-  ctx.turnFlags = {};
-  if (ctx.state.skipAIActionNext) delete ctx.state.skipAIActionNext;
 }

--- a/src/engine/simpleAI.ts
+++ b/src/engine/simpleAI.ts
@@ -1,26 +1,15 @@
 import { Card, Context } from "./types";
 
-export function pickDefenseForAI(ctx: Context, owner: "P1" | "P2", incoming: Card): Card | null {
+export function pickDefenseForAI(ctx: Context, owner:"P1"|"P2", incoming: Card): Card | null {
   const p = ctx.state.players[owner];
-  const defs = p.hand.filter(c => c.type === "DEFENSIVE" && p.ip >= c.cost);
-  
+  const defs = p.hand.filter(c => c.type==="DEFENSIVE" && p.ip >= c.cost);
   if (!defs.length) return null;
-  
-  const score = (c: Card) => {
-    const eff = c.effects || {};
-    const effectStr = JSON.stringify(eff);
-    
-    // Prioritize cards that can block or provide immunity
-    const s1 = /blockAttack|immune/.test(effectStr) ? 5 : 0;
-    
-    // Secondary: cards that discard opponent cards
-    const s2 = effectStr.includes('"discardOpponent"') ? 2 : 0;
-    
-    // Tertiary: cards that give self IP
-    const s3 = effectStr.includes('"ipDelta":{"self"') ? 1 : 0;
-    
+  const score = (c:Card) => {
+    const e = c.effects || {};
+    const s1 = (e?.reaction?.block || e?.reaction?.immune) ? 5 : 0;
+    const s2 = typeof e.discardOpponent === "number" ? 2 : 0;
+    const s3 = typeof e.ipDelta?.self === "number" ? 1 : 0;
     return s1 + s2 + s3;
   };
-  
-  return defs.sort((a, b) => score(b) - score(a))[0];
+  return defs.sort((a,b)=>score(b)-score(a))[0];
 }

--- a/src/engine/turn.ts
+++ b/src/engine/turn.ts
@@ -1,0 +1,23 @@
+import { Context } from "./types";
+
+export function endTurn(ctx: Context){
+  // passiv inntekt
+  for (const pid of ["P1","P2"] as const) {
+    const p = ctx.state.players[pid];
+    if (p.passiveIncome) p.ip += p.passiveIncome;
+  }
+  // reaction-flags ryddes per tur
+  ctx.turnFlags = {};
+  // bytt spiller
+  const me = ctx.state.currentPlayer;
+  ctx.state.currentPlayer = me === "P1" ? "P2" : "P1";
+  ctx.state.turn += 1;
+
+  // skip neste handling hvis aktiv
+  const cur = ctx.state.currentPlayer;
+  const left = ctx.state.skipNextAction?.[cur] || 0;
+  if (left > 0) {
+    ctx.state.skipNextAction![cur] = left - 1;
+    // markér turn som auto-skipped i UI-logg om ønskelig
+  }
+}

--- a/src/engine/types.ts
+++ b/src/engine/types.ts
@@ -41,6 +41,7 @@ export interface GameState {
   // NEW: trykk per stat per side
   pressureByState: Record<string, { P1: number; P2: number }>;
   skipAIActionNext?: boolean;
+  skipNextAction?: { P1: number; P2: number };
   // optional: map med statnavn/aliaser -> id
   stateAliases?: Record<string, string>; // "Minnesota"|"MN" -> "MN"
 }

--- a/src/rules/v21e-strict.ts
+++ b/src/rules/v21e-strict.ts
@@ -1,0 +1,31 @@
+export type CanonicalEffects = {
+  // Kjerne
+  truthDelta?: number;                              // ±% Truth (global)
+  ipDelta?: { self?: number; opponent?: number };   // ±IP
+  draw?: number;                                    // trekk (self)
+  discardOpponent?: number;                         // motstander kaster (random)
+  zoneDefense?: number;                             // +forsvarsbonus (passivt)
+
+  // Pressure
+  pressureDelta?: number;                           // +/− til TARGET state
+  pressureAllDelta?: number;                        // +/− til ALLE stater
+
+  // Reaction (brukes kun i reaction-vindu)
+  reaction?: { block?: boolean; immune?: boolean };
+
+  // Varige modifikatorer / økonomi
+  costModDelta?: { zone?: number; media?: number }; // +dyrere/−billigere
+  ipIncomePerTurn?: number;                         // passiv IP/turn
+
+  // Tidskontroll
+  skipOpponentAction?: number;                      // hopp over N neste handlinger (typisk 1)
+
+  // Betingelser
+  conditional?: {
+    ifTruthAtLeast?: number;
+    ifZonesControlledAtLeast?: number;
+    ifTargetStateIs?: string;                       // sammenlignes mot stateId (USPS-kode)
+    then?: CanonicalEffects;
+    else?: CanonicalEffects;
+  };
+};

--- a/src/rules/validateEffects.ts
+++ b/src/rules/validateEffects.ts
@@ -1,0 +1,62 @@
+import { CanonicalEffects } from "./v21e-strict";
+
+const ALLOWED = new Set([
+  "truthDelta","ipDelta","draw","discardOpponent","zoneDefense",
+  "pressureDelta","pressureAllDelta","reaction","costModDelta",
+  "ipIncomePerTurn","skipOpponentAction","conditional"
+]);
+
+export function validateCanonicalEffects(e:any, path="effects"):string[] {
+  const errs:string[]=[];
+  if (!e || typeof e!=="object" || Array.isArray(e)) return [`${path}: must be object`];
+
+  for (const k of Object.keys(e)) if (!ALLOWED.has(k)) errs.push(`${path}.${k}: not allowed`);
+
+  if ("truthDelta" in e && typeof e.truthDelta!=="number") errs.push(`${path}.truthDelta: number`);
+  if ("ipDelta" in e) {
+    if (typeof e.ipDelta!=="object") errs.push(`${path}.ipDelta: object`);
+    else {
+      if ("self" in e.ipDelta && !Number.isInteger(e.ipDelta.self)) errs.push(`${path}.ipDelta.self: int`);
+      if ("opponent" in e.ipDelta && !Number.isInteger(e.ipDelta.opponent)) errs.push(`${path}.ipDelta.opponent: int`);
+    }
+  }
+  if ("draw" in e && !Number.isInteger(e.draw)) errs.push(`${path}.draw: int`);
+  if ("discardOpponent" in e && !Number.isInteger(e.discardOpponent)) errs.push(`${path}.discardOpponent: int`);
+  if ("zoneDefense" in e && !Number.isInteger(e.zoneDefense)) errs.push(`${path}.zoneDefense: int`);
+  if ("pressureDelta" in e && !Number.isInteger(e.pressureDelta)) errs.push(`${path}.pressureDelta: int`);
+  if ("pressureAllDelta" in e && !Number.isInteger(e.pressureAllDelta)) errs.push(`${path}.pressureAllDelta: int`);
+
+  if ("reaction" in e) {
+    const r=e.reaction;
+    if (!r || typeof r!=="object") errs.push(`${path}.reaction: object`);
+    else {
+      if ("block" in r && typeof r.block!=="boolean") errs.push(`${path}.reaction.block: boolean`);
+      if ("immune" in r && typeof r.immune!=="boolean") errs.push(`${path}.reaction.immune: boolean`);
+    }
+  }
+
+  if ("costModDelta" in e) {
+    const c=e.costModDelta;
+    if (!c || typeof c!=="object") errs.push(`${path}.costModDelta: object`);
+    else {
+      if ("zone" in c && !Number.isInteger(c.zone)) errs.push(`${path}.costModDelta.zone: int`);
+      if ("media" in c && !Number.isInteger(c.media)) errs.push(`${path}.costModDelta.media: int`);
+    }
+  }
+
+  if ("ipIncomePerTurn" in e && !Number.isInteger(e.ipIncomePerTurn)) errs.push(`${path}.ipIncomePerTurn: int`);
+  if ("skipOpponentAction" in e && !Number.isInteger(e.skipOpponentAction)) errs.push(`${path}.skipOpponentAction: int`);
+
+  if ("conditional" in e) {
+    const c=e.conditional;
+    if (!c || typeof c!=="object") errs.push(`${path}.conditional: object`);
+    else {
+      if ("ifTruthAtLeast" in c && typeof c.ifTruthAtLeast!=="number") errs.push(`${path}.conditional.ifTruthAtLeast: number`);
+      if ("ifZonesControlledAtLeast" in c && !Number.isInteger(c.ifZonesControlledAtLeast)) errs.push(`${path}.conditional.ifZonesControlledAtLeast: int`);
+      if ("ifTargetStateIs" in c && typeof c.ifTargetStateIs!=="string") errs.push(`${path}.conditional.ifTargetStateIs: string`);
+      if ("then" in c) errs.push(...validateCanonicalEffects(c.then, `${path}.conditional.then`));
+      if ("else" in c) errs.push(...validateCanonicalEffects(c.else, `${path}.conditional.else`));
+    }
+  }
+  return errs;
+}


### PR DESCRIPTION
## Summary
- introduce canonical v2.1E effect schema and validator
- wire minimal engine with reaction window and simple defensive AI
- add build-time scripts to validate and snapshot core card effects

## Testing
- `bun run validate:core` *(fails: tsx: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c8197f3ad0832087437ed58f6e4281