### PR TITLE
Remove reaction window references from docs

### DIFF
--- a/DESIGN_DOC_MVP.md
+++ b/DESIGN_DOC_MVP.md
@@ -110,7 +110,7 @@ Trekk: Trekk opp til 5 kort på hånd (fyll opp).
 
 Spillfase
 
-3\) Spill opptil 3 kort i valgfri rekkefølge. Betal IP-kost, kortet resolves umiddelbart. (Ingen reactions i MVP.)
+3\) Spill opptil 3 kort i valgfri rekkefølge. Betal IP-kost, kortet resolves umiddelbart.
 
 
 
@@ -671,10 +671,6 @@ A: Staten blir din, og Pressures i den staten nullstilles (0/0).
 
 
 12\. Videreutvikling (etter MVP)
-
-
-
-Reactions (enkel DEFENSIVE) mot ATTACK senere.
 
 
 

--- a/ShadowGov-Rules-v2.1.md
+++ b/ShadowGov-Rules-v2.1.md
@@ -62,11 +62,8 @@ Each round has two turns: player → opponent.
 - Draw until hand = 5 cards (if possible).  
 - Gain +5 base IP + IP from states owned.  
 
-**Action Phase**  
-- Play up to 3 cards, paying IP cost.  
-- **ATTACK** triggers Defense reaction:  
-  - Opponent may play 1 DEFENSIVE within 4s.  
-  - If none, Attack resolves.  
+**Action Phase**
+- Play up to 3 cards, paying IP cost. **ATTACK** cards resolve immediately; opponents cannot respond defensively during the action phase.
 
 **Resolution**  
 - Apply card effects.  


### PR DESCRIPTION
## Summary
- remove mention of reaction windows from the MVP design doc, leaving immediate resolution rules intact
- drop the planned defensive reactions note from the post-MVP roadmap and clarify attacks resolve without responses in the v2.1 rules

## Testing
- not run (docs only)


------
https://chatgpt.com/codex/tasks/task_e_68c95181c32c83208b88daad2848747b