### PR TITLE
Strip clash field from saved game data

### DIFF
--- a/src/hooks/useGameState.ts
+++ b/src/hooks/useGameState.ts
@@ -83,12 +83,14 @@ interface GameState {
 
 const generateInitialEvents = (eventManager: EventManager): GameEvent[] => {
   // Start with some common events for the first newspaper
-  const initialEvents = EVENT_DATABASE.filter(event => 
+  const initialEvents = EVENT_DATABASE.filter(event =>
     event.rarity === 'common' && !event.conditions
   ).slice(0, 3);
-  
+
   return initialEvents;
 };
+
+const omitClashKey = (key: string, value: unknown) => (key === 'clash' ? undefined : value);
 
 export const useGameState = (aiDifficulty: AIDifficulty = 'medium') => {
   const [eventManager] = useState(() => new EventManager());
@@ -735,9 +737,9 @@ export const useGameState = (aiDifficulty: AIDifficulty = 'medium') => {
       timestamp: Date.now(),
       version: '1.0'
     };
-    
+
     try {
-      localStorage.setItem('shadowgov-savegame', JSON.stringify(saveData));
+      localStorage.setItem('shadowgov-savegame', JSON.stringify(saveData, omitClashKey));
       return true;
     } catch (error) {
       console.error('Failed to save game:', error);
@@ -749,9 +751,9 @@ export const useGameState = (aiDifficulty: AIDifficulty = 'medium') => {
     try {
       const savedData = localStorage.getItem('shadowgov-savegame');
       if (!savedData) return false;
-      
-      const saveData = JSON.parse(savedData);
-      
+
+      const saveData = JSON.parse(savedData, omitClashKey);
+
       // Validate save data structure
       if (!saveData.faction || !saveData.phase || saveData.version !== '1.0') {
         console.warn('Invalid or incompatible save data');
@@ -778,8 +780,8 @@ export const useGameState = (aiDifficulty: AIDifficulty = 'medium') => {
     try {
       const savedData = localStorage.getItem('shadowgov-savegame');
       if (!savedData) return null;
-      
-      const saveData = JSON.parse(savedData);
+
+      const saveData = JSON.parse(savedData, omitClashKey);
       return {
         faction: saveData.faction,
         turn: saveData.turn,


### PR DESCRIPTION
## Summary
- add a JSON replacer/reviver that omits the `clash` field from serialized game data
- use the helper when saving to localStorage so new saves never persist `clash`
- parse saves with the same helper to gracefully ignore `clash` from older save files and when reading save metadata

## Testing
- npm run lint *(fails: missing @eslint/js because dependencies could not be installed in the sandbox)*

------
https://chatgpt.com/codex/tasks/task_e_68c967514bd8832093944df62c6dd086