### PR TITLE
Add MVP rules engine with validation

### DIFF
--- a/scripts/migrate_to_mvp.ts
+++ b/scripts/migrate_to_mvp.ts
@@ -1,0 +1,181 @@
+#!/usr/bin/env bun
+import { glob } from 'glob';
+import { readFile, writeFile } from 'node:fs/promises';
+import { relative } from 'node:path';
+import process from 'node:process';
+import { sanitizeCard, validateCard } from '../src/mvp/validator';
+
+const DEFAULT_PATTERNS = ['src/**/*.json', 'public/**/*.json', 'assets/**/*.json'];
+const GLOB_OPTIONS = {
+  ignore: ['**/node_modules/**', '**/dist/**', '**/coverage/**', '**/.git/**'],
+  absolute: true,
+};
+
+type ProcessResult = {
+  file: string;
+  status: 'ok' | 'fixed' | 'failed';
+  messages: string[];
+};
+
+type CardExtraction = {
+  cards: unknown[];
+  type: 'array' | 'object';
+  key?: string;
+  source: unknown;
+};
+
+const looksLikeCard = (value: unknown): value is Record<string, unknown> => {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    'id' in value &&
+    'type' in value &&
+    'rarity' in value &&
+    'faction' in value
+  );
+};
+
+const extractCardArray = (data: unknown): CardExtraction | null => {
+  if (Array.isArray(data) && data.every(looksLikeCard)) {
+    return { cards: data, type: 'array', source: data };
+  }
+  if (typeof data === 'object' && data !== null) {
+    const value = (data as Record<string, unknown>).cards;
+    if (Array.isArray(value) && value.every(looksLikeCard)) {
+      return { cards: value, type: 'object', key: 'cards', source: data };
+    }
+  }
+  return null;
+};
+
+const ensureTrailingNewline = (value: string): string => (value.endsWith('\n') ? value : `${value}\n`);
+
+async function gatherFiles(patterns: string[]): Promise<string[]> {
+  const files = new Set<string>();
+  for (const pattern of patterns) {
+    const matches = await glob(pattern, GLOB_OPTIONS);
+    for (const file of matches) {
+      files.add(file);
+    }
+  }
+  return Array.from(files).sort();
+}
+
+async function processFile(file: string): Promise<ProcessResult | null> {
+  const originalContent = await readFile(file, 'utf8');
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(originalContent);
+  } catch (error) {
+    return {
+      file,
+      status: 'failed',
+      messages: [`invalid JSON: ${(error as Error).message}`],
+    };
+  }
+
+  const extraction = extractCardArray(parsed);
+  if (!extraction) {
+    return null;
+  }
+
+  const sanitizedCards: unknown[] = [];
+  const messages: string[] = [];
+  let hasErrors = false;
+
+  extraction.cards.forEach((raw, index) => {
+    const { card, errors, changes } = sanitizeCard(raw);
+    const hasId =
+      typeof raw === 'object' && raw !== null && 'id' in raw && (raw as { id?: unknown }).id != null;
+    const label = hasId ? String((raw as { id: unknown }).id) : `index ${index}`;
+
+    if (!card || errors.length > 0) {
+      hasErrors = true;
+      messages.push(`${label}: ${errors.join('; ')}`);
+      return;
+    }
+
+    const validation = validateCard(card);
+    if (!validation.ok) {
+      hasErrors = true;
+      messages.push(`${label}: ${validation.errors.join('; ')}`);
+    }
+
+    if (changes.length > 0) {
+      messages.push(`${card.id}: ${changes.join('; ')}`);
+    }
+
+    sanitizedCards.push(card);
+  });
+
+  if (hasErrors) {
+    return { file, status: 'failed', messages };
+  }
+
+  const outputData =
+    extraction.type === 'array'
+      ? sanitizedCards
+      : { ...(extraction.source as Record<string, unknown>), [extraction.key as string]: sanitizedCards };
+
+  const newContent = JSON.stringify(outputData, null, 2) + '\n';
+  const changed = newContent !== ensureTrailingNewline(originalContent);
+
+  if (changed) {
+    await writeFile(file, newContent, 'utf8');
+  }
+
+  return {
+    file,
+    status: changed ? 'fixed' : 'ok',
+    messages,
+  };
+}
+
+async function main() {
+  const patterns = process.argv.slice(2);
+  const files = await gatherFiles(patterns.length > 0 ? patterns : DEFAULT_PATTERNS);
+
+  if (files.length === 0) {
+    console.warn('No JSON files matched the provided patterns.');
+    return;
+  }
+
+  const reports: ProcessResult[] = [];
+  for (const file of files) {
+    const result = await processFile(file);
+    if (result) {
+      reports.push(result);
+    }
+  }
+
+  const cwd = process.cwd();
+  let hasFailures = false;
+
+  for (const report of reports) {
+    if (report.status === 'failed') {
+      hasFailures = true;
+    }
+    const relPath = relative(cwd, report.file);
+    console.log(`\n${relPath}: ${report.status.toUpperCase()}`);
+    if (report.messages.length > 0) {
+      for (const message of report.messages) {
+        console.log(`  - ${message}`);
+      }
+    }
+  }
+
+  if (reports.length === 0) {
+    console.log('No card JSON files found.');
+  }
+
+  if (hasFailures) {
+    process.exitCode = 1;
+  }
+}
+
+if (import.meta.main) {
+  main().catch(error => {
+    console.error('Migration failed:', error);
+    process.exitCode = 1;
+  });
+}

--- a/src/game/hooks/useRules.ts
+++ b/src/game/hooks/useRules.ts
@@ -1,0 +1,39 @@
+import { useMemo } from 'react';
+import {
+  USE_MVP_RULES,
+  canPlay as canPlayMvp,
+  endTurn as endTurnMvp,
+  playCard as playCardMvp,
+  resolve as resolveMvp,
+  startTurn as startTurnMvp,
+  winCheck as winCheckMvp,
+  type Card,
+} from '@/mvp';
+import { fromEngineState, toEngineState, type UIGameState } from '@/state/gameState';
+
+type RulesAdapter = {
+  startTurn: (state: UIGameState) => UIGameState;
+  canPlay: (state: UIGameState, card: Card, targetStateId?: string) => { ok: boolean; reason?: string };
+  playCard: (state: UIGameState, cardId: string, targetStateId?: string) => UIGameState;
+  resolve: (state: UIGameState, owner: 'P1' | 'P2', card: Card, targetStateId?: string) => UIGameState;
+  endTurn: (state: UIGameState, discards: string[]) => UIGameState;
+  winCheck: (state: UIGameState) => ReturnType<typeof winCheckMvp>;
+};
+
+const createMvpAdapter = (): RulesAdapter => ({
+  startTurn: state => fromEngineState(startTurnMvp(toEngineState(state))),
+  canPlay: (state, card, targetStateId) => canPlayMvp(toEngineState(state), card, targetStateId),
+  playCard: (state, cardId, targetStateId) =>
+    fromEngineState(playCardMvp(toEngineState(state), cardId, targetStateId)),
+  resolve: (state, owner, card, targetStateId) =>
+    fromEngineState(resolveMvp(toEngineState(state), owner, card, targetStateId)),
+  endTurn: (state, discards) => fromEngineState(endTurnMvp(toEngineState(state), discards)),
+  winCheck: state => winCheckMvp(toEngineState(state)),
+});
+
+export const useRules = (): RulesAdapter => {
+  return useMemo(() => {
+    const adapter = createMvpAdapter();
+    return USE_MVP_RULES ? adapter : adapter;
+  }, []);
+};

--- a/src/mvp/engine.test.ts
+++ b/src/mvp/engine.test.ts
@@ -1,0 +1,228 @@
+import { describe, expect, it } from 'bun:test';
+import { canPlay, endTurn, resolve, winCheck } from './engine';
+import type { Card, GameState, PlayerState } from './types';
+
+const createPlayer = (id: 'P1' | 'P2', overrides: Partial<PlayerState> = {}): PlayerState => ({
+  id,
+  faction: overrides.faction ?? (id === 'P1' ? 'truth' : 'government'),
+  deck: overrides.deck ?? [],
+  hand: overrides.hand ?? [],
+  discard: overrides.discard ?? [],
+  ip: overrides.ip ?? 0,
+  states: overrides.states ?? [],
+});
+
+const createState = (overrides: Partial<GameState> = {}): GameState => ({
+  turn: overrides.turn ?? 1,
+  currentPlayer: overrides.currentPlayer ?? 'P1',
+  truth: overrides.truth ?? 50,
+  players: overrides.players ?? {
+    P1: createPlayer('P1', overrides.players?.P1),
+    P2: createPlayer('P2', overrides.players?.P2),
+  },
+  pressureByState: overrides.pressureByState ?? { CA: { P1: 0, P2: 0 } },
+  stateDefense: overrides.stateDefense ?? { CA: 2 },
+  playsThisTurn: overrides.playsThisTurn ?? 0,
+});
+
+const attackCard: Card = {
+  id: 'attack',
+  name: 'Attack',
+  faction: 'truth',
+  type: 'ATTACK',
+  rarity: 'common',
+  cost: 2,
+  effects: { ipDelta: { opponent: 3 } },
+};
+
+const mediaCard: Card = {
+  id: 'media',
+  name: 'Media',
+  faction: 'truth',
+  type: 'MEDIA',
+  rarity: 'common',
+  cost: 3,
+  effects: { truthDelta: 5 },
+};
+
+const zoneCard: Card = {
+  id: 'zone',
+  name: 'Zone',
+  faction: 'truth',
+  type: 'ZONE',
+  rarity: 'common',
+  cost: 4,
+  effects: { pressureDelta: 3 },
+};
+
+describe('canPlay', () => {
+  it('blocks playing more than three cards per turn', () => {
+    const state = createState({ playsThisTurn: 3 });
+    const result = canPlay(state, attackCard);
+    expect(result.ok).toBeFalse();
+    expect(result.reason).toBe('play-limit');
+  });
+
+  it('requires enough IP to play a card', () => {
+    const state = createState({
+      players: {
+        P1: createPlayer('P1', { ip: 1 }),
+        P2: createPlayer('P2'),
+      },
+    });
+    const result = canPlay(state, attackCard);
+    expect(result.ok).toBeFalse();
+    expect(result.reason).toBe('insufficient-ip');
+  });
+
+  it('requires a valid target state for ZONE cards', () => {
+    const state = createState({
+      players: {
+        P1: createPlayer('P1', { ip: 10 }),
+        P2: createPlayer('P2'),
+      },
+    });
+    const result = canPlay(state, zoneCard);
+    expect(result.ok).toBeFalse();
+    expect(result.reason).toBe('missing-target');
+  });
+});
+
+describe('resolve', () => {
+  it('prevents opponent IP from dropping below zero', () => {
+    const state = createState({
+      players: {
+        P1: createPlayer('P1', { ip: 10 }),
+        P2: createPlayer('P2', { ip: 2 }),
+      },
+    });
+
+    const result = resolve(state, 'P1', attackCard);
+    expect(result.players.P2.ip).toBe(0);
+    expect(state.players.P2.ip).toBe(2);
+  });
+
+  it('discards the correct number of opponent cards', () => {
+    const originalRandom = Math.random;
+    Math.random = () => 0;
+    try {
+      const opponentHand: Card[] = [
+        { ...attackCard, id: 'opp-1' },
+        { ...attackCard, id: 'opp-2' },
+      ];
+      const attackWithDiscard: Card = {
+        ...attackCard,
+        effects: { ipDelta: { opponent: 1 }, discardOpponent: 2 },
+      };
+      const state = createState({
+        players: {
+          P1: createPlayer('P1'),
+          P2: createPlayer('P2', { hand: opponentHand, discard: [] }),
+        },
+      });
+
+      const result = resolve(state, 'P1', attackWithDiscard);
+      expect(result.players.P2.hand.length).toBe(0);
+      expect(result.players.P2.discard.length).toBe(2);
+    } finally {
+      Math.random = originalRandom;
+    }
+  });
+
+  it('clamps truth between 0 and 100 for MEDIA cards', () => {
+    const state = createState({ truth: 98 });
+    const result = resolve(state, 'P1', mediaCard);
+    expect(result.truth).toBe(100);
+    const lowerState = createState({ truth: 3 });
+    const negativeMedia: Card = { ...mediaCard, effects: { truthDelta: -10 } };
+    const lowerResult = resolve(lowerState, 'P1', negativeMedia);
+    expect(lowerResult.truth).toBe(0);
+  });
+
+  it('captures a state when pressure meets or exceeds defense', () => {
+    const state = createState({
+      pressureByState: { CA: { P1: 0, P2: 0 } },
+      stateDefense: { CA: 2 },
+      players: {
+        P1: createPlayer('P1', { states: [] }),
+        P2: createPlayer('P2', { states: ['CA'] }),
+      },
+    });
+
+    const result = resolve(state, 'P1', zoneCard, 'CA');
+    expect(result.pressureByState.CA).toEqual({ P1: 0, P2: 0 });
+    expect(result.players.P1.states).toContain('CA');
+    expect(result.players.P2.states).not.toContain('CA');
+  });
+});
+
+describe('endTurn', () => {
+  const cardA: Card = { ...attackCard, id: 'A' };
+  const cardB: Card = { ...attackCard, id: 'B' };
+
+  it('allows one free discard without IP cost', () => {
+    const state = createState({
+      players: {
+        P1: createPlayer('P1', { hand: [cardA, cardB], discard: [], ip: 5 }),
+        P2: createPlayer('P2'),
+      },
+    });
+
+    const result = endTurn(state, ['A']);
+    expect(result.players.P1.ip).toBe(5);
+    expect(result.players.P1.hand.map(card => card.id)).toEqual(['B']);
+    expect(result.players.P1.discard.map(card => card.id)).toContain('A');
+    expect(result.currentPlayer).toBe('P2');
+  });
+
+  it('charges IP for additional discards', () => {
+    const state = createState({
+      players: {
+        P1: createPlayer('P1', { hand: [cardA, cardB], discard: [], ip: 5 }),
+        P2: createPlayer('P2'),
+      },
+    });
+
+    const result = endTurn(state, ['A', 'B']);
+    expect(result.players.P1.ip).toBe(4);
+    expect(result.players.P1.hand.length).toBe(0);
+    expect(result.players.P1.discard.length).toBe(2);
+  });
+});
+
+describe('winCheck', () => {
+  it('detects a state-control victory', () => {
+    const state = createState({
+      players: {
+        P1: createPlayer('P1', { states: Array.from({ length: 10 }, (_, idx) => `S${idx}`) }),
+        P2: createPlayer('P2'),
+      },
+    });
+    const result = winCheck(state);
+    expect(result).toEqual({ winner: 'P1', reason: 'states' });
+  });
+
+  it('detects a truth-track victory for the truth faction', () => {
+    const state = createState({ truth: 92 });
+    const result = winCheck(state);
+    expect(result).toEqual({ winner: 'P1', reason: 'truth' });
+  });
+
+  it('detects a truth-track victory for the government faction', () => {
+    const state = createState({
+      truth: 8,
+      players: {
+        P1: createPlayer('P1', { faction: 'truth' }),
+        P2: createPlayer('P2', { faction: 'government' }),
+      },
+    });
+    const result = winCheck(state);
+    expect(result).toEqual({ winner: 'P2', reason: 'truth' });
+  });
+
+  it('detects an IP victory', () => {
+    const state = createState({ players: { P1: createPlayer('P1'), P2: createPlayer('P2', { ip: 205 }) } });
+    const result = winCheck(state);
+    expect(result).toEqual({ winner: 'P2', reason: 'ip' });
+  });
+});

--- a/src/mvp/engine.ts
+++ b/src/mvp/engine.ts
@@ -1,0 +1,287 @@
+import { cloneGameState } from './validator';
+import type { Card, EffectsATTACK, EffectsMEDIA, EffectsZONE, GameState, PlayerState } from './types';
+
+const clamp = (value: number, min: number, max: number): number =>
+  Math.max(min, Math.min(max, value));
+
+const otherPlayer = (id: 'P1' | 'P2'): 'P1' | 'P2' => (id === 'P1' ? 'P2' : 'P1');
+
+const drawUpToFive = (player: PlayerState): PlayerState => {
+  const deck = [...player.deck];
+  const hand = [...player.hand];
+  while (hand.length < 5 && deck.length > 0) {
+    hand.push(deck.shift()!);
+  }
+  return {
+    ...player,
+    deck,
+    hand,
+  };
+};
+
+export function startTurn(state: GameState): GameState {
+  const cloned = cloneGameState(state);
+  const currentId = cloned.currentPlayer;
+  const me = cloned.players[currentId];
+  const ipGain = 5 + me.states.length;
+  const updatedPlayer: PlayerState = {
+    ...drawUpToFive(me),
+    ip: me.ip + ipGain,
+  };
+
+  return {
+    ...cloned,
+    players: {
+      ...cloned.players,
+      [currentId]: updatedPlayer,
+    },
+    playsThisTurn: 0,
+  };
+}
+
+export function canPlay(
+  state: GameState,
+  card: Card,
+  targetStateId?: string,
+): { ok: boolean; reason?: string } {
+  if (state.playsThisTurn >= 3) {
+    return { ok: false, reason: 'play-limit' };
+  }
+
+  const player = state.players[state.currentPlayer];
+  if (!player) {
+    return { ok: false, reason: 'invalid-player' };
+  }
+
+  if (player.ip < card.cost) {
+    return { ok: false, reason: 'insufficient-ip' };
+  }
+
+  if (card.type === 'ZONE') {
+    if (!targetStateId) {
+      return { ok: false, reason: 'missing-target' };
+    }
+    if (!state.pressureByState[targetStateId]) {
+      return { ok: false, reason: 'invalid-target' };
+    }
+  }
+
+  return { ok: true };
+}
+
+export function playCard(state: GameState, cardId: string, targetStateId?: string): GameState {
+  const cloned = cloneGameState(state);
+  const currentId = cloned.currentPlayer;
+  const player = cloned.players[currentId];
+  const cardIndex = player.hand.findIndex(card => card.id === cardId);
+  if (cardIndex === -1) {
+    throw new Error(`card ${cardId} not found in hand`);
+  }
+
+  const card = player.hand[cardIndex];
+  const eligibility = canPlay(cloned, card, targetStateId);
+  if (!eligibility.ok) {
+    throw new Error(eligibility.reason ?? 'cannot-play');
+  }
+
+  const newHand = [...player.hand];
+  newHand.splice(cardIndex, 1);
+
+  const updatedPlayer: PlayerState = {
+    ...player,
+    hand: newHand,
+    discard: [...player.discard, card],
+    ip: player.ip - card.cost,
+  };
+
+  const interimState: GameState = {
+    ...cloned,
+    players: {
+      ...cloned.players,
+      [currentId]: updatedPlayer,
+    },
+    playsThisTurn: cloned.playsThisTurn + 1,
+  };
+
+  return resolve(interimState, currentId, card, targetStateId);
+}
+
+export function resolve(
+  state: GameState,
+  owner: 'P1' | 'P2',
+  card: Card,
+  targetStateId?: string,
+): GameState {
+  const cloned = cloneGameState(state);
+  const opponentId = otherPlayer(owner);
+  const me = cloned.players[owner];
+  const opponent = cloned.players[opponentId];
+
+  if (card.type === 'ATTACK') {
+    const effects = card.effects as EffectsATTACK;
+    const opponentLoss = effects.ipDelta.opponent;
+    const newOpponentIP = Math.max(0, opponent.ip - opponentLoss);
+
+    let updatedHand = [...opponent.hand];
+    let updatedDiscard = [...opponent.discard];
+
+    const discardCount = effects.discardOpponent ?? 0;
+    for (let i = 0; i < discardCount && updatedHand.length > 0; i += 1) {
+      const index = Math.floor(Math.random() * updatedHand.length);
+      const [discarded] = updatedHand.splice(index, 1);
+      updatedDiscard = [...updatedDiscard, discarded];
+    }
+
+    return {
+      ...cloned,
+      players: {
+        ...cloned.players,
+        [owner]: { ...me },
+        [opponentId]: {
+          ...opponent,
+          ip: newOpponentIP,
+          hand: updatedHand,
+          discard: updatedDiscard,
+        },
+      },
+    };
+  }
+
+  if (card.type === 'MEDIA') {
+    const effects = card.effects as EffectsMEDIA;
+    const newTruth = clamp(cloned.truth + effects.truthDelta, 0, 100);
+    return {
+      ...cloned,
+      truth: newTruth,
+    };
+  }
+
+  if (!targetStateId) {
+    throw new Error('ZONE card requires target state');
+  }
+
+  const effects = card.effects as EffectsZONE;
+  const currentPressure = cloned.pressureByState[targetStateId] ?? { P1: 0, P2: 0 };
+  const ownerPressure = currentPressure[owner] + effects.pressureDelta;
+  let pressureByState = {
+    ...cloned.pressureByState,
+    [targetStateId]: { ...currentPressure, [owner]: ownerPressure },
+  };
+
+  let updatedPlayers: Record<'P1' | 'P2', PlayerState> = {
+    ...cloned.players,
+    [owner]: { ...me },
+    [opponentId]: { ...opponent },
+  };
+
+  const defense = cloned.stateDefense[targetStateId] ?? Infinity;
+  if (ownerPressure >= defense) {
+    pressureByState = {
+      ...pressureByState,
+      [targetStateId]: { P1: 0, P2: 0 },
+    };
+
+    const ownerStates = new Set(updatedPlayers[owner].states);
+    ownerStates.add(targetStateId);
+    const opponentStates = updatedPlayers[opponentId].states.filter(stateId => stateId !== targetStateId);
+
+    updatedPlayers = {
+      ...updatedPlayers,
+      [owner]: {
+        ...updatedPlayers[owner],
+        states: Array.from(ownerStates),
+      },
+      [opponentId]: {
+        ...updatedPlayers[opponentId],
+        states: opponentStates,
+      },
+    };
+  }
+
+  return {
+    ...cloned,
+    players: updatedPlayers,
+    pressureByState,
+  };
+}
+
+export function endTurn(state: GameState, discards: string[]): GameState {
+  const cloned = cloneGameState(state);
+  const currentId = cloned.currentPlayer;
+  const player = cloned.players[currentId];
+
+  const discardCounts = new Map<string, number>();
+  for (const id of discards) {
+    discardCounts.set(id, (discardCounts.get(id) ?? 0) + 1);
+  }
+
+  const newHand: Card[] = [];
+  const newDiscard = [...player.discard];
+  let discarded = 0;
+
+  for (const card of player.hand) {
+    const count = discardCounts.get(card.id) ?? 0;
+    if (count > 0) {
+      discardCounts.set(card.id, count - 1);
+      newDiscard.push(card);
+      discarded += 1;
+    } else {
+      newHand.push(card);
+    }
+  }
+
+  const extraDiscards = Math.max(0, discarded - 1);
+  const ipCost = extraDiscards;
+  const updatedIP = Math.max(0, player.ip - ipCost);
+
+  const updatedPlayer: PlayerState = {
+    ...player,
+    hand: newHand,
+    discard: newDiscard,
+    ip: updatedIP,
+  };
+
+  const nextPlayer = otherPlayer(currentId);
+
+  return {
+    ...cloned,
+    currentPlayer: nextPlayer,
+    turn: cloned.turn + 1,
+    playsThisTurn: 0,
+    players: {
+      ...cloned.players,
+      [currentId]: updatedPlayer,
+    },
+  };
+}
+
+export function winCheck(
+  state: GameState,
+): { winner?: 'P1' | 'P2'; reason?: 'states' | 'truth' | 'ip' } {
+  const { players } = state;
+  if (players.P1.states.length >= 10) {
+    return { winner: 'P1', reason: 'states' };
+  }
+  if (players.P2.states.length >= 10) {
+    return { winner: 'P2', reason: 'states' };
+  }
+
+  if (state.truth >= 90) {
+    const truthPlayer = players.P1.faction === 'truth' ? 'P1' : 'P2';
+    return { winner: truthPlayer, reason: 'truth' };
+  }
+
+  if (state.truth <= 10) {
+    const governmentPlayer = players.P1.faction === 'government' ? 'P1' : 'P2';
+    return { winner: governmentPlayer, reason: 'truth' };
+  }
+
+  if (players.P1.ip >= 200) {
+    return { winner: 'P1', reason: 'ip' };
+  }
+  if (players.P2.ip >= 200) {
+    return { winner: 'P2', reason: 'ip' };
+  }
+
+  return {};
+}

--- a/src/mvp/index.ts
+++ b/src/mvp/index.ts
@@ -1,0 +1,5 @@
+export const USE_MVP_RULES = true;
+
+export * from './types';
+export * from './validator';
+export * from './engine';

--- a/src/mvp/types.ts
+++ b/src/mvp/types.ts
@@ -1,0 +1,40 @@
+export type Faction = "truth" | "government";
+export type CardType = "ATTACK" | "MEDIA" | "ZONE";
+export type Rarity = "common" | "uncommon" | "rare" | "legendary";
+
+export type EffectsATTACK = { ipDelta: { opponent: number }; discardOpponent?: 0 | 1 | 2 };
+export type EffectsMEDIA = { truthDelta: number };
+export type EffectsZONE = { pressureDelta: number };
+
+export type Card = {
+  id: string;
+  name: string;
+  faction: Faction;
+  type: CardType;
+  rarity: Rarity;
+  cost: number;
+  effects: EffectsATTACK | EffectsMEDIA | EffectsZONE;
+  artId?: string;
+  flavor?: string;
+  tags?: string[];
+};
+
+export type PlayerState = {
+  id: "P1" | "P2";
+  faction: Faction;
+  deck: Card[];
+  hand: Card[];
+  discard: Card[];
+  ip: number;
+  states: string[];
+};
+
+export type GameState = {
+  turn: number;
+  currentPlayer: "P1" | "P2";
+  truth: number;
+  players: Record<"P1" | "P2", PlayerState>;
+  pressureByState: Record<string, { P1: number; P2: number }>;
+  stateDefense: Record<string, number>;
+  playsThisTurn: number;
+};

--- a/src/mvp/validator.ts
+++ b/src/mvp/validator.ts
@@ -1,0 +1,312 @@
+import type {
+  Card,
+  CardType,
+  EffectsATTACK,
+  EffectsMEDIA,
+  EffectsZONE,
+  Faction,
+  GameState,
+  PlayerState,
+  Rarity,
+} from './types';
+
+export const ALLOWED_FACTIONS: readonly Faction[] = ['truth', 'government'];
+export const ALLOWED_TYPES: readonly CardType[] = ['ATTACK', 'MEDIA', 'ZONE'];
+export const ALLOWED_RARITIES: readonly Rarity[] = ['common', 'uncommon', 'rare', 'legendary'];
+
+export const COST_TABLE: Record<CardType, Record<Rarity, number>> = {
+  ATTACK: { common: 2, uncommon: 3, rare: 4, legendary: 5 },
+  MEDIA: { common: 3, uncommon: 4, rare: 5, legendary: 6 },
+  ZONE: { common: 4, uncommon: 5, rare: 6, legendary: 7 },
+};
+
+export function expectedCost(type: CardType, rarity: Rarity): number {
+  return COST_TABLE[type][rarity];
+}
+
+const isNonEmptyString = (value: unknown): value is string =>
+  typeof value === 'string' && value.trim().length > 0;
+
+const toNumber = (value: unknown): number | null => {
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return value;
+  }
+  if (typeof value === 'string' && value.trim().length > 0) {
+    const parsed = Number(value);
+    if (!Number.isNaN(parsed) && Number.isFinite(parsed)) {
+      return parsed;
+    }
+  }
+  return null;
+};
+
+const CARD_ALLOWED_KEYS = new Set([
+  'id',
+  'name',
+  'faction',
+  'type',
+  'rarity',
+  'cost',
+  'effects',
+  'artId',
+  'flavor',
+  'tags',
+]);
+
+const ATTACK_EFFECT_KEYS = new Set(['ipDelta', 'discardOpponent']);
+const MEDIA_EFFECT_KEYS = new Set(['truthDelta']);
+const ZONE_EFFECT_KEYS = new Set(['pressureDelta']);
+
+export type CardValidationResult = {
+  card?: Card;
+  errors: string[];
+  changes: string[];
+};
+
+export function sanitizeCard(raw: unknown): CardValidationResult {
+  const errors: string[] = [];
+  const changes: string[] = [];
+
+  if (typeof raw !== 'object' || raw === null) {
+    return { errors: ['card is not an object'], changes };
+  }
+
+  const input = raw as Record<string, unknown>;
+
+  if (!isNonEmptyString(input.id)) {
+    errors.push('missing id');
+  }
+  if (!isNonEmptyString(input.name)) {
+    errors.push('missing name');
+  }
+
+  const faction = input.faction;
+  if (!ALLOWED_FACTIONS.includes(faction as Faction)) {
+    errors.push(`invalid faction: ${faction}`);
+  }
+
+  const type = input.type;
+  if (!ALLOWED_TYPES.includes(type as CardType)) {
+    errors.push(`invalid type: ${type}`);
+  }
+
+  const rarity = input.rarity;
+  if (!ALLOWED_RARITIES.includes(rarity as Rarity)) {
+    errors.push(`invalid rarity: ${rarity}`);
+  }
+
+  if (errors.length > 0) {
+    return { errors, changes };
+  }
+
+  const typedType = type as CardType;
+  const typedRarity = rarity as Rarity;
+  const typedFaction = faction as Faction;
+
+  const extraCardKeys = Object.keys(input).filter(key => !CARD_ALLOWED_KEYS.has(key));
+  if (extraCardKeys.length > 0) {
+    changes.push(`removed unsupported card keys: ${extraCardKeys.join(', ')}`);
+  }
+
+  const sanitizeAttack = (value: unknown): EffectsATTACK | null => {
+    if (typeof value !== 'object' || value === null) {
+      errors.push('ATTACK card requires effects object');
+      return null;
+    }
+    const effects = value as Record<string, unknown>;
+
+    let opponentDelta: number | null = null;
+    if (typeof effects.ipDelta === 'number') {
+      opponentDelta = effects.ipDelta;
+      changes.push('normalized ipDelta to object form');
+    } else if (typeof effects.ipDelta === 'object' && effects.ipDelta !== null) {
+      opponentDelta = toNumber((effects.ipDelta as Record<string, unknown>).opponent);
+      const extra = Object.keys(effects.ipDelta as Record<string, unknown>).filter(
+        key => key !== 'opponent',
+      );
+      if (extra.length > 0) {
+        changes.push(`removed unsupported ipDelta keys: ${extra.join(', ')}`);
+      }
+    }
+
+    if (opponentDelta === null || opponentDelta <= 0) {
+      errors.push('ATTACK card requires ipDelta.opponent > 0');
+      return null;
+    }
+
+    const extraKeys = Object.keys(effects).filter(key => !ATTACK_EFFECT_KEYS.has(key));
+    if (extraKeys.length > 0) {
+      changes.push(`removed unsupported ATTACK effect keys: ${extraKeys.join(', ')}`);
+    }
+
+    const attackEffects: EffectsATTACK = {
+      ipDelta: { opponent: opponentDelta },
+    };
+
+    if (Object.prototype.hasOwnProperty.call(effects, 'discardOpponent')) {
+      const discard = toNumber(effects.discardOpponent);
+      if (discard === null || !Number.isInteger(discard) || discard < 0 || discard > 2) {
+        errors.push('discardOpponent must be 0, 1 or 2');
+      } else if (discard > 0) {
+        attackEffects.discardOpponent = discard as 0 | 1 | 2;
+      }
+    }
+
+    return attackEffects;
+  };
+
+  const sanitizeMedia = (value: unknown): EffectsMEDIA | null => {
+    const delta = toNumber((value as Record<string, unknown>)?.truthDelta);
+    if (delta === null) {
+      errors.push('MEDIA card requires truthDelta');
+      return null;
+    }
+    const extraKeys =
+      value && typeof value === 'object'
+        ? Object.keys(value as Record<string, unknown>).filter(
+            key => !MEDIA_EFFECT_KEYS.has(key),
+          )
+        : [];
+    if (extraKeys.length > 0) {
+      changes.push(`removed unsupported MEDIA effect keys: ${extraKeys.join(', ')}`);
+    }
+    return { truthDelta: delta };
+  };
+
+  const sanitizeZone = (value: unknown): EffectsZONE | null => {
+    const delta = toNumber((value as Record<string, unknown>)?.pressureDelta);
+    if (delta === null || delta <= 0) {
+      errors.push('ZONE card requires pressureDelta > 0');
+      return null;
+    }
+    const extraKeys =
+      value && typeof value === 'object'
+        ? Object.keys(value as Record<string, unknown>).filter(
+            key => !ZONE_EFFECT_KEYS.has(key),
+          )
+        : [];
+    if (extraKeys.length > 0) {
+      changes.push(`removed unsupported ZONE effect keys: ${extraKeys.join(', ')}`);
+    }
+    return { pressureDelta: delta };
+  };
+
+  let effects: EffectsATTACK | EffectsMEDIA | EffectsZONE | null = null;
+  if (typedType === 'ATTACK') {
+    effects = sanitizeAttack(input.effects);
+  } else if (typedType === 'MEDIA') {
+    effects = sanitizeMedia(input.effects);
+  } else {
+    effects = sanitizeZone(input.effects);
+  }
+
+  if (effects === null) {
+    return { errors, changes };
+  }
+
+  const card: Card = {
+    id: (input.id as string).trim(),
+    name: (input.name as string).trim(),
+    faction: typedFaction,
+    type: typedType,
+    rarity: typedRarity,
+    cost: expectedCost(typedType, typedRarity),
+    effects,
+  };
+
+  if (input.cost !== card.cost) {
+    changes.push(`cost set to ${card.cost}`);
+  }
+
+  if (isNonEmptyString(input.artId)) {
+    card.artId = input.artId;
+  }
+  if (isNonEmptyString(input.flavor)) {
+    card.flavor = input.flavor;
+  }
+  if (Array.isArray(input.tags)) {
+    const tags = input.tags.filter(tag => typeof tag === 'string' && tag.trim().length > 0);
+    if (tags.length > 0) {
+      card.tags = tags;
+    }
+  }
+
+  return { card, errors, changes };
+}
+
+export function validateCard(card: Card): { ok: boolean; errors: string[] } {
+  const errors: string[] = [];
+
+  if (!ALLOWED_FACTIONS.includes(card.faction)) {
+    errors.push(`invalid faction: ${card.faction}`);
+  }
+
+  if (!ALLOWED_TYPES.includes(card.type)) {
+    errors.push(`invalid type: ${card.type}`);
+  }
+
+  if (!ALLOWED_RARITIES.includes(card.rarity)) {
+    errors.push(`invalid rarity: ${card.rarity}`);
+  }
+
+  const expected = expectedCost(card.type, card.rarity);
+  if (card.cost !== expected) {
+    errors.push(`cost should be ${expected}`);
+  }
+
+  switch (card.type) {
+    case 'ATTACK': {
+      const effects = card.effects as EffectsATTACK;
+      if (!effects?.ipDelta || effects.ipDelta.opponent <= 0) {
+        errors.push('ATTACK cards require ipDelta.opponent > 0');
+      }
+      if (
+        typeof effects.discardOpponent !== 'undefined' &&
+        ![0, 1, 2].includes(effects.discardOpponent)
+      ) {
+        errors.push('discardOpponent must be 0, 1 or 2 when present');
+      }
+      break;
+    }
+    case 'MEDIA': {
+      const effects = card.effects as EffectsMEDIA;
+      if (typeof effects.truthDelta !== 'number' || Number.isNaN(effects.truthDelta)) {
+        errors.push('MEDIA cards require numeric truthDelta');
+      }
+      break;
+    }
+    case 'ZONE': {
+      const effects = card.effects as EffectsZONE;
+      if (!effects || effects.pressureDelta <= 0) {
+        errors.push('ZONE cards require pressureDelta > 0');
+      }
+      break;
+    }
+  }
+
+  return { ok: errors.length === 0, errors };
+}
+
+export function clonePlayer(player: PlayerState): PlayerState {
+  return {
+    ...player,
+    deck: [...player.deck],
+    hand: [...player.hand],
+    discard: [...player.discard],
+    states: [...player.states],
+  };
+}
+
+export function cloneGameState(state: GameState): GameState {
+  return {
+    ...state,
+    players: {
+      P1: clonePlayer(state.players.P1),
+      P2: clonePlayer(state.players.P2),
+    },
+    pressureByState: Object.fromEntries(
+      Object.entries(state.pressureByState).map(([id, value]) => [id, { ...value }]),
+    ),
+    stateDefense: { ...state.stateDefense },
+  };
+}

--- a/src/state/gameState.ts
+++ b/src/state/gameState.ts
@@ -1,0 +1,7 @@
+import type { GameState } from '@/mvp';
+
+export type UIGameState = GameState;
+
+export const toEngineState = (state: UIGameState): GameState => state;
+
+export const fromEngineState = (state: GameState): UIGameState => state;


### PR DESCRIPTION
## Summary
- define MVP card, player, and game state types along with validator helpers and the feature flag export
- implement the MVP rules engine plus hook adapter and automated tests that cover turn flow, resolution, and win checks
- add a migration script for normalising card JSON to the MVP constraints

## Testing
- bun test

------
https://chatgpt.com/codex/tasks/task_e_68c985699c388320b0361f079aaa2220