### PR TITLE
Normalize attack IP handling

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,9 @@
     "lint": "eslint .",
     "test": "bun test --coverage --coverage-reporter=text",
     "preview": "vite preview",
-    "ingest:core": "ts-node scripts/splitCoreToBatches.ts"
+    "ingest:core": "ts-node scripts/splitCoreToBatches.ts",
+    "fix:attack-ip": "bun scripts/fix-attack-ip.ts",
+    "validate:attack-ip": "bun scripts/validate-attack-ip.ts"
   },
   "dependencies": {
     "@hookform/resolvers": "^3.10.0",

--- a/scripts/fix-attack-ip.ts
+++ b/scripts/fix-attack-ip.ts
@@ -1,0 +1,394 @@
+import fs from "node:fs";
+import path from "node:path";
+
+const DATA_ROOT = path.join(process.cwd(), "src", "data");
+const LOG_PATH = path.join(process.cwd(), "tools", "logs", "fix-attack-ip.json");
+
+const AMOUNT_BY_RARITY = { common: 1, uncommon: 2, rare: 3, legendary: 4 } as const;
+const COST_BY_RARITY = { common: 2, uncommon: 3, rare: 4, legendary: 5 } as const;
+
+const INDENT_STEP = "  ";
+
+type RarityKey = keyof typeof AMOUNT_BY_RARITY;
+type CardRecord = Record<string, unknown> & {
+  id?: string;
+  rarity?: RarityKey;
+  type?: string;
+  cost?: number;
+  flavor?: string;
+  flavorTruth?: string;
+  flavorGov?: string;
+  text?: string;
+  effects?: any;
+};
+
+type EffectRecord = Record<string, unknown> & {
+  ipDelta?: Record<string, unknown> & { opponent?: number };
+  conditional?: unknown;
+};
+
+type ChangeLog = { file: string; id: string; rarity?: string; fix: string };
+
+const changes: ChangeLog[] = [];
+
+function walkFiles(dir: string, collector: string[]): void {
+  const entries = fs.readdirSync(dir, { withFileTypes: true });
+  for (const entry of entries) {
+    if (entry.name.startsWith(".")) continue;
+    const fullPath = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      walkFiles(fullPath, collector);
+    } else if (entry.isFile() && (entry.name.endsWith(".ts") || entry.name.endsWith(".tsx"))) {
+      collector.push(fullPath);
+    }
+  }
+}
+
+function findObjectBounds(content: string, matchIndex: number): { start: number; end: number; indent: string } | null {
+  let start = -1;
+  let depth = 0;
+  let inString = false;
+  let stringChar = "";
+  let escaped = false;
+
+  for (let i = matchIndex; i >= 0; i--) {
+    const char = content[i];
+    if (inString) {
+      if (escaped) {
+        escaped = false;
+        continue;
+      }
+      if (char === "\\") {
+        escaped = true;
+        continue;
+      }
+      if (char === stringChar) {
+        inString = false;
+      }
+      continue;
+    }
+    if (char === '"' || char === "'") {
+      inString = true;
+      stringChar = char;
+      continue;
+    }
+    if (char === '}') {
+      depth++;
+      continue;
+    }
+    if (char === '{') {
+      if (depth === 0) {
+        start = i;
+        break;
+      }
+      depth--;
+    }
+  }
+
+  if (start === -1) return null;
+
+  depth = 0;
+  inString = false;
+  stringChar = "";
+  escaped = false;
+  let end = -1;
+
+  for (let i = start; i < content.length; i++) {
+    const char = content[i];
+    if (inString) {
+      if (escaped) {
+        escaped = false;
+        continue;
+      }
+      if (char === "\\") {
+        escaped = true;
+        continue;
+      }
+      if (char === stringChar) {
+        inString = false;
+      }
+      continue;
+    }
+    if (char === '"' || char === "'") {
+      inString = true;
+      stringChar = char;
+      continue;
+    }
+    if (char === '{') {
+      depth++;
+      continue;
+    }
+    if (char === '}') {
+      depth--;
+      if (depth === 0) {
+        end = i + 1;
+        break;
+      }
+    }
+  }
+
+  if (end === -1) return null;
+
+  const lineStart = content.lastIndexOf("\n", start) + 1;
+  const indent = content.slice(lineStart, start);
+
+  return { start, end, indent };
+}
+
+function parseObject(text: string): CardRecord {
+  return Function("return (" + text + ");")();
+}
+
+function clone<T>(value: T): T {
+  return JSON.parse(JSON.stringify(value));
+}
+
+function ensureFlavor(card: CardRecord): boolean {
+  if (typeof card.flavor === "string" && card.flavor.length > 0) {
+    if (/Opponent\s+gains/i.test(card.flavor)) {
+      card.flavor = card.flavor.replace(/Opponent\s+gains/gi, "Opponent loses");
+      return true;
+    }
+    return false;
+  }
+
+  const source = card.flavorTruth || card.flavorGov || "—";
+  card.flavor = source;
+  return true;
+}
+
+function sanitizeText(card: CardRecord): boolean {
+  if (typeof card.text !== "string") return false;
+  if (!/Opponent\s+gains/i.test(card.text)) return false;
+  card.text = card.text.replace(/Opponent\s+gains/gi, "Opponent loses");
+  return true;
+}
+
+function sanitizeFlavorSources(card: CardRecord): boolean {
+  let updated = false;
+  if (typeof card.flavorTruth === "string" && /Opponent\s+gains/i.test(card.flavorTruth)) {
+    card.flavorTruth = card.flavorTruth.replace(/Opponent\s+gains/gi, "Opponent loses");
+    updated = true;
+  }
+  if (typeof card.flavorGov === "string" && /Opponent\s+gains/i.test(card.flavorGov)) {
+    card.flavorGov = card.flavorGov.replace(/Opponent\s+gains/gi, "Opponent loses");
+    updated = true;
+  }
+  return updated;
+}
+
+function normalizeEffects(effects: EffectRecord | undefined, amount: number, enforceAmount: boolean = true): void {
+  if (!effects || typeof effects !== "object") return;
+
+  const ipDelta = (effects.ipDelta && typeof effects.ipDelta === "object") ? effects.ipDelta : {};
+  for (const key of Object.keys(ipDelta)) {
+    if (key !== "opponent") {
+      delete (ipDelta as Record<string, unknown>)[key];
+    }
+  }
+  const existing = typeof ipDelta.opponent === "number" ? Math.abs(ipDelta.opponent) : undefined;
+  (ipDelta as Record<string, unknown>).opponent = enforceAmount ? amount : (existing ?? amount);
+  effects.ipDelta = ipDelta;
+
+  if (Array.isArray(effects.conditional)) {
+    for (const cond of effects.conditional) {
+      if (cond && typeof cond === "object") {
+        normalizeConditional(cond as Record<string, unknown>, amount);
+      }
+    }
+  } else if (effects.conditional && typeof effects.conditional === "object") {
+    normalizeConditional(effects.conditional as Record<string, unknown>, amount);
+  }
+}
+
+function normalizeConditional(conditional: Record<string, unknown>, amount: number): void {
+  const thenEffects = conditional.then as EffectRecord | undefined;
+  const elseEffects = conditional.else as EffectRecord | undefined;
+  if (thenEffects) normalizeEffects(thenEffects, amount, false);
+  if (elseEffects) normalizeEffects(elseEffects, amount, false);
+}
+
+function formatAny(value: unknown, indent: string, preferredKeys?: string[]): string {
+  if (Array.isArray(value)) {
+    if (value.length === 0) return "[]";
+    const innerIndent = indent + INDENT_STEP;
+    const items = value.map((item) => `${innerIndent}${formatAny(item, innerIndent)}`);
+    return `[
+${items.join(",\n")}\n${indent}]`;
+  }
+
+  if (value && typeof value === "object") {
+    return formatObject(value as Record<string, unknown>, indent, preferredKeys);
+  }
+
+  if (typeof value === "string") {
+    return JSON.stringify(value);
+  }
+
+  return String(value);
+}
+
+const CARD_KEY_ORDER = [
+  "id",
+  "faction",
+  "name",
+  "type",
+  "rarity",
+  "cost",
+  "text",
+  "flavor",
+  "flavorTruth",
+  "flavorGov",
+  "target",
+  "effects",
+  "extId",
+];
+
+const EFFECT_KEY_ORDER = [
+  "truthDelta",
+  "ipDelta",
+  "draw",
+  "discardSelf",
+  "discardOpponent",
+  "pressureDelta",
+  "zoneDefense",
+  "captureBonus",
+  "damage",
+  "incomeBonus",
+  "conditional",
+  "duration",
+  "repeatable",
+  "requiresTarget",
+  "tags",
+];
+
+function sortKeys(keys: string[], preferred: string[] = []): string[] {
+  return keys.sort((a, b) => {
+    const ai = preferred.indexOf(a);
+    const bi = preferred.indexOf(b);
+    if (ai === -1 && bi === -1) return a.localeCompare(b);
+    if (ai === -1) return 1;
+    if (bi === -1) return -1;
+    return ai - bi;
+  });
+}
+
+function formatObject(obj: Record<string, unknown>, indent: string, preferredOrder?: string[]): string {
+  const keys = sortKeys(Object.keys(obj), preferredOrder ?? []);
+  if (keys.length === 0) {
+    return "{}";
+  }
+
+  const innerIndent = indent + INDENT_STEP;
+  const lines: string[] = [];
+
+  for (const key of keys) {
+    const value = (obj as Record<string, unknown>)[key];
+    if (value === undefined) continue;
+    let childOrder: string[] | undefined;
+    if (key === "effects") {
+      childOrder = EFFECT_KEY_ORDER;
+    } else if (key === "ipDelta") {
+      childOrder = ["opponent"];
+    }
+    lines.push(`${innerIndent}${key}: ${formatAny(value, innerIndent, childOrder)}`);
+  }
+
+  if (lines.length === 0) {
+    return "{}";
+  }
+
+  return `{
+${lines.join(",\n")}\n${indent}}`;
+}
+
+function processCard(cardText: string, indent: string, filePath: string): { updatedText: string; changed: boolean; card: CardRecord } {
+  const parsed = parseObject(cardText);
+  const original = clone(parsed);
+
+  if (parsed.type !== "ATTACK") {
+    return { updatedText: indent + cardText.trimStart(), changed: false, card: parsed };
+  }
+
+  const rarity = parsed.rarity as RarityKey | undefined;
+  if (!rarity || !(rarity in AMOUNT_BY_RARITY)) {
+    return { updatedText: indent + cardText.trimStart(), changed: false, card: parsed };
+  }
+
+  const amount = AMOUNT_BY_RARITY[rarity];
+  parsed.cost = COST_BY_RARITY[rarity];
+  parsed.effects = parsed.effects ?? {};
+  normalizeEffects(parsed.effects as EffectRecord, amount);
+
+  ensureFlavor(parsed);
+  sanitizeFlavorSources(parsed);
+  sanitizeText(parsed);
+
+  if (parsed.flavor && /Opponent\s+gains/i.test(parsed.flavor)) {
+    parsed.flavor = parsed.flavor.replace(/Opponent\s+gains/gi, "Opponent loses");
+  }
+
+  const formatted = `${indent}${formatObject(parsed as Record<string, unknown>, indent, CARD_KEY_ORDER)}`;
+  const existingFormatted = `${indent}${cardText.trimStart()}`;
+  const dataChanged = JSON.stringify(parsed) !== JSON.stringify(original);
+  const formattedChanged = existingFormatted !== formatted;
+  const changed = dataChanged || formattedChanged;
+
+  if (changed) {
+    changes.push({
+      file: path.relative(process.cwd(), filePath),
+      id: parsed.id ?? "UNKNOWN",
+      rarity,
+      fix: "attack-ip-normalized",
+    });
+  }
+
+  return { updatedText: formatted, changed, card: parsed };
+}
+
+function processFile(filePath: string): void {
+  const original = fs.readFileSync(filePath, "utf8");
+  const pattern = /type\s*:\s*['"]ATTACK['"]/g;
+  const matches: Array<{ start: number; end: number; indent: string }> = [];
+  let match: RegExpExecArray | null;
+
+  while ((match = pattern.exec(original)) !== null) {
+    const bounds = findObjectBounds(original, match.index);
+    if (bounds) {
+      matches.push(bounds);
+    }
+  }
+
+  if (matches.length === 0) return;
+
+  let content = original;
+  let fileChanged = false;
+
+  for (let i = matches.length - 1; i >= 0; i--) {
+    const { start, end, indent } = matches[i];
+    const replaceStart = Math.max(0, start - indent.length);
+    const cardText = content.slice(start, end);
+    const { updatedText, changed } = processCard(cardText, indent, filePath);
+    if (changed) {
+      fileChanged = true;
+      content = content.slice(0, replaceStart) + updatedText + content.slice(end);
+    }
+  }
+
+  if (fileChanged) {
+    fs.writeFileSync(filePath, content, "utf8");
+  }
+}
+
+const files: string[] = [];
+walkFiles(DATA_ROOT, files);
+files.sort();
+
+for (const file of files) {
+  processFile(file);
+}
+
+fs.mkdirSync(path.dirname(LOG_PATH), { recursive: true });
+fs.writeFileSync(LOG_PATH, JSON.stringify(changes, null, 2));
+
+console.log(`Done. Changes: ${changes.length}`);

--- a/scripts/validate-attack-ip.ts
+++ b/scripts/validate-attack-ip.ts
@@ -1,0 +1,208 @@
+import fs from "node:fs";
+import path from "node:path";
+
+const DATA_ROOT = path.join(process.cwd(), "src", "data");
+const AMOUNT_BY_RARITY = { common: 1, uncommon: 2, rare: 3, legendary: 4 } as const;
+const COST_BY_RARITY = { common: 2, uncommon: 3, rare: 4, legendary: 5 } as const;
+
+type RarityKey = keyof typeof AMOUNT_BY_RARITY;
+type CardRecord = {
+  id?: string;
+  rarity?: RarityKey;
+  type?: string;
+  cost?: number;
+  flavor?: string;
+  flavorTruth?: string;
+  flavorGov?: string;
+  text?: string;
+  effects?: {
+    ipDelta?: Record<string, unknown>;
+  } & Record<string, unknown>;
+};
+
+function walkFiles(dir: string, collector: string[]): void {
+  const entries = fs.readdirSync(dir, { withFileTypes: true });
+  for (const entry of entries) {
+    if (entry.name.startsWith(".")) continue;
+    const fullPath = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      walkFiles(fullPath, collector);
+    } else if (entry.isFile() && (entry.name.endsWith(".ts") || entry.name.endsWith(".tsx"))) {
+      collector.push(fullPath);
+    }
+  }
+}
+
+function findObjectBounds(content: string, matchIndex: number): { start: number; end: number } | null {
+  let start = -1;
+  let depth = 0;
+  let inString = false;
+  let stringChar = "";
+  let escaped = false;
+
+  for (let i = matchIndex; i >= 0; i--) {
+    const char = content[i];
+    if (inString) {
+      if (escaped) {
+        escaped = false;
+        continue;
+      }
+      if (char === "\\") {
+        escaped = true;
+        continue;
+      }
+      if (char === stringChar) {
+        inString = false;
+      }
+      continue;
+    }
+    if (char === '"' || char === "'") {
+      inString = true;
+      stringChar = char;
+      continue;
+    }
+    if (char === '}') {
+      depth++;
+      continue;
+    }
+    if (char === '{') {
+      if (depth === 0) {
+        start = i;
+        break;
+      }
+      depth--;
+    }
+  }
+
+  if (start === -1) return null;
+
+  depth = 0;
+  inString = false;
+  stringChar = "";
+  escaped = false;
+  let end = -1;
+
+  for (let i = start; i < content.length; i++) {
+    const char = content[i];
+    if (inString) {
+      if (escaped) {
+        escaped = false;
+        continue;
+      }
+      if (char === "\\") {
+        escaped = true;
+        continue;
+      }
+      if (char === stringChar) {
+        inString = false;
+      }
+      continue;
+    }
+    if (char === '"' || char === "'") {
+      inString = true;
+      stringChar = char;
+      continue;
+    }
+    if (char === '{') {
+      depth++;
+      continue;
+    }
+    if (char === '}') {
+      depth--;
+      if (depth === 0) {
+        end = i + 1;
+        break;
+      }
+    }
+  }
+
+  if (end === -1) return null;
+  return { start, end };
+}
+
+function parseObject(text: string): CardRecord {
+  return Function("return (" + text + ");")();
+}
+
+const files: string[] = [];
+walkFiles(DATA_ROOT, files);
+files.sort();
+
+const errors: string[] = [];
+
+for (const file of files) {
+  const content = fs.readFileSync(file, "utf8");
+  const pattern = /type\s*:\s*['"]ATTACK['"]/g;
+  let match: RegExpExecArray | null;
+
+  while ((match = pattern.exec(content)) !== null) {
+    const bounds = findObjectBounds(content, match.index);
+    if (!bounds) continue;
+    const { start, end } = bounds;
+    const cardText = content.slice(start, end);
+
+    let card: CardRecord;
+    try {
+      card = parseObject(cardText);
+    } catch (error) {
+      errors.push(`${path.relative(process.cwd(), file)}: Failed to parse ATTACK card at index ${start}`);
+      continue;
+    }
+
+    if (card.type !== "ATTACK") continue;
+    const rarity = card.rarity;
+    const id = card.id ?? "UNKNOWN";
+    if (!rarity || !(rarity in AMOUNT_BY_RARITY)) {
+      errors.push(`${id} (${path.relative(process.cwd(), file)}): missing or invalid rarity`);
+      continue;
+    }
+
+    const expectedAmount = AMOUNT_BY_RARITY[rarity];
+    const expectedCost = COST_BY_RARITY[rarity];
+
+    const ipDelta = card.effects?.ipDelta as Record<string, unknown> | undefined;
+    if (!ipDelta) {
+      errors.push(`${id}: missing effects.ipDelta`);
+    } else {
+      const keys = Object.keys(ipDelta);
+      for (const key of keys) {
+        if (key !== "opponent") {
+          errors.push(`${id}: illegal ipDelta.${key}`);
+        }
+      }
+
+      const valueRaw = ipDelta.opponent;
+      const value = typeof valueRaw === "number" ? valueRaw : Number(valueRaw);
+      if (!Number.isFinite(value) || value !== expectedAmount) {
+        errors.push(`${id}: ipDelta.opponent=${valueRaw} expected ${expectedAmount}`);
+      }
+    }
+
+    if (card.cost !== expectedCost) {
+      errors.push(`${id}: cost=${card.cost} expected ${expectedCost}`);
+    }
+
+    const flavor = card.flavor ?? card.flavorGov ?? card.flavorTruth;
+    if (!flavor || typeof flavor !== "string" || flavor.trim().length === 0) {
+      errors.push(`${id}: missing flavor`);
+    }
+
+    const textFields = [card.text, card.flavor, card.flavorTruth, card.flavorGov];
+    for (const field of textFields) {
+      if (typeof field === "string" && /Opponent\s+gains/i.test(field)) {
+        errors.push(`${id}: contains forbidden phrase 'Opponent gains'`);
+        break;
+      }
+    }
+  }
+}
+
+if (errors.length > 0) {
+  console.error("❌ ATTACK IP validation failed:");
+  for (const err of errors) {
+    console.error(` - ${err}`);
+  }
+  process.exit(1);
+}
+
+console.log("✅ All ATTACK cards have normalized IP and cost values.");

--- a/src/components/game/CardCollection.tsx
+++ b/src/components/game/CardCollection.tsx
@@ -55,9 +55,9 @@ const CardCollection = ({ open, onOpenChange }: CardCollectionProps) => {
           <span>Played: {cardStats.timesPlayed} times</span>
         </div>
         
-        {card.flavorGov && (
+        {(card.flavor ?? card.flavorGov ?? card.flavorTruth) && (
           <div className="mt-2 p-2 bg-accent/30 rounded text-xs italic text-muted-foreground">
-            "{card.flavorGov}"
+            "{card.flavor ?? card.flavorGov ?? card.flavorTruth}"
           </div>
         )}
       </div>

--- a/src/components/game/CardCollectionTabloid.tsx
+++ b/src/components/game/CardCollectionTabloid.tsx
@@ -73,9 +73,9 @@ const CardCollectionTabloid = ({ open, onOpenChange }: CardCollectionTabloidProp
           </div>
         </div>
         
-        {card.flavorGov && (
+        {(card.flavor ?? card.flavorGov ?? card.flavorTruth) && (
           <div className="mt-2 p-2 bg-[#e9e9e9] border border-black text-[10px] italic">
-            "{card.flavorGov}"
+            "{card.flavor ?? card.flavorGov ?? card.flavorTruth}"
           </div>
         )}
       </div>

--- a/src/components/game/CardDetailOverlay.tsx
+++ b/src/components/game/CardDetailOverlay.tsx
@@ -89,6 +89,7 @@ const CardDetailOverlay: React.FC<CardDetailOverlayProps> = ({
   };
 
   const faction = getCardFaction(card);
+  const flavorText = card.flavor ?? card.flavorGov ?? card.flavorTruth ?? 'No intelligence available.';
 
   return (
     <div 
@@ -174,7 +175,7 @@ const CardDetailOverlay: React.FC<CardDetailOverlayProps> = ({
               CLASSIFIED INTELLIGENCE
             </h4>
             <div className="italic text-sm text-foreground border-l-4 border-truth-red bg-truth-red/10 rounded-r border border-truth-red/20 pl-3 pr-3 py-2 leading-relaxed">
-              "{faction === 'truth' ? (card.flavorTruth ?? 'No intelligence available.') : (card.flavorGov ?? 'No intelligence available.')}"
+              "{flavorText}"
             </div>
           </div>
 

--- a/src/components/game/GameHand.tsx
+++ b/src/components/game/GameHand.tsx
@@ -84,7 +84,7 @@ const GameHand = ({ cards, onPlayCard, disabled }: GameHandProps) => {
                 </div>
                 
                 <div className="text-xs italic text-muted-foreground text-center mb-3 min-h-6 border-t pt-2">
-                  "{card.faction === 'truth' ? card.flavorTruth : card.flavorGov}"
+                  "{card.flavor ?? card.flavorGov ?? card.flavorTruth}"
                 </div>
                 
                 <Button

--- a/src/components/game/MinimizedHand.tsx
+++ b/src/components/game/MinimizedHand.tsx
@@ -115,7 +115,7 @@ const MinimizedHand = ({
                 
                 <div className="pt-2 border-t border-newspaper-text/20">
                   <p className="text-xs italic text-newspaper-text/60">
-                    {card.flavorGov || card.flavorTruth}
+                    {card.flavor ?? card.flavorGov ?? card.flavorTruth}
                   </p>
                 </div>
                 
@@ -234,7 +234,7 @@ const MinimizedHand = ({
                 
                 <div className="border-t border-newspaper-text/20 pt-2">
                   <p className="text-xs italic text-newspaper-text/60">
-                    "{card.flavorGov || card.flavorTruth}"
+                    "{card.flavor ?? card.flavorGov ?? card.flavorTruth}"
                   </p>
                 </div>
                 

--- a/src/components/game/Newspaper.tsx
+++ b/src/components/game/Newspaper.tsx
@@ -117,7 +117,7 @@ const Newspaper = ({ events, playedCards, faction, onClose }: NewspaperProps) =>
     const headline = tabloidHeadlines[Math.floor(Math.random() * tabloidHeadlines.length)];
     
     // Use flavor text or generate Weekly World News style content
-    const flavorText = card.flavorTruth || card.flavorGov;
+    const flavorText = card.flavor ?? card.flavorGov ?? card.flavorTruth;
     const tabloidContent = flavorText || 
       `Local sources report bizarre activities linked to what witnesses describe as "${card.name}". Government officials refuse comment, but experts claim this could change everything. "I've never seen anything like it," said one anonymous whistleblower. Full story inside – if the Men in Black don't stop us first!`;
 

--- a/src/components/game/PlayedCardsDock.tsx
+++ b/src/components/game/PlayedCardsDock.tsx
@@ -106,7 +106,7 @@ const PlayedCardsDock: React.FC<PlayedCardsDockProps> = ({ playedCards }) => {
                         <div className="bg-truth-red/10 border-t border-truth-red/20 px-1 py-0.5">
                           <div className="text-[4px] font-bold text-muted-foreground mb-0.5">CLASSIFIED INTELLIGENCE</div>
                           <div className="text-[4px] italic line-clamp-1 leading-tight">
-                            "{playedCard.card.faction === 'truth' ? playedCard.card.flavorTruth : playedCard.card.flavorGov}"
+                            "{playedCard.card.flavor ?? playedCard.card.flavorGov ?? playedCard.card.flavorTruth}"
                           </div>
                         </div>
                         
@@ -134,7 +134,7 @@ const PlayedCardsDock: React.FC<PlayedCardsDockProps> = ({ playedCards }) => {
                             {playedCard.card.text}
                           </div>
                           <div className="text-xs italic text-muted-foreground border-l-4 border-truth-red bg-truth-red/10 rounded-r border border-truth-red/20 pl-2 pr-2 py-1">
-                            "{playedCard.card.faction === 'truth' ? playedCard.card.flavorTruth : playedCard.card.flavorGov}"
+                            "{playedCard.card.flavor ?? playedCard.card.flavorGov ?? playedCard.card.flavorTruth}"
                           </div>
                         </div>
                       </div>
@@ -194,7 +194,7 @@ const PlayedCardsDock: React.FC<PlayedCardsDockProps> = ({ playedCards }) => {
                         <div className="bg-government-blue/10 border-t border-government-blue/20 px-1 py-0.5">
                           <div className="text-[4px] font-bold text-muted-foreground mb-0.5">CLASSIFIED INTELLIGENCE</div>
                           <div className="text-[4px] italic line-clamp-1 leading-tight">
-                            "{playedCard.card.faction === 'truth' ? playedCard.card.flavorTruth : playedCard.card.flavorGov}"
+                            "{playedCard.card.flavor ?? playedCard.card.flavorGov ?? playedCard.card.flavorTruth}"
                           </div>
                         </div>
                         
@@ -222,7 +222,7 @@ const PlayedCardsDock: React.FC<PlayedCardsDockProps> = ({ playedCards }) => {
                             {playedCard.card.text}
                           </div>
                           <div className="text-xs italic text-muted-foreground border-l-4 border-government-blue bg-government-blue/10 rounded-r border border-government-blue/20 pl-2 pr-2 py-1">
-                            "{playedCard.card.faction === 'truth' ? playedCard.card.flavorTruth : playedCard.card.flavorGov}"
+                            "{playedCard.card.flavor ?? playedCard.card.flavorGov ?? playedCard.card.flavorTruth}"
                           </div>
                         </div>
                       </div>

--- a/src/components/game/TabloidNewspaper.tsx
+++ b/src/components/game/TabloidNewspaper.tsx
@@ -116,7 +116,7 @@ const TabloidNewspaper = ({ events, playedCards, faction, truth, onClose }: Tabl
       const headline = tabloidHeadlines[Math.floor(Math.random() * tabloidHeadlines.length)];
       
       // Use flavor text or generate Weekly World News style content
-      const flavorText = pc.card.flavorTruth || pc.card.flavorGov;
+      const flavorText = pc.card.flavor ?? pc.card.flavorGov ?? pc.card.flavorTruth;
       const baseContent = flavorText || 
         `Local sources report bizarre activities linked to what witnesses describe as "${pc.card.name}". Government officials refuse comment, but experts claim this could change everything. "I've never seen anything like it," said one anonymous whistleblower.`;
 

--- a/src/data/cardDatabase.ts
+++ b/src/data/cardDatabase.ts
@@ -107,14 +107,24 @@ async function loadCoreCards(): Promise<GameCard[]> {
           id: "truth-4",
           faction: "truth",
           name: "Freedom Rally",
-          type: "ATTACK", 
+          type: "ATTACK",
           rarity: "common",
-          cost: 7,
+          cost: 2,
           text: "+5% Truth. Target a state; reduce its Defense by 2.",
+          flavor: "The people unite for transparency.",
           flavorTruth: "The people unite for transparency.",
           flavorGov: "Domestic unrest contained.",
-          target: { scope: "state", count: 1 },
-          effects: { truthDelta: 5, zoneDefense: -2 }
+          target: {
+            count: 1,
+            scope: "state"
+          },
+          effects: {
+            truthDelta: 5,
+            ipDelta: {
+              opponent: 1
+            },
+            zoneDefense: -2
+          }
         },
         {
           id: "truth-5",
@@ -167,12 +177,23 @@ async function loadCoreCards(): Promise<GameCard[]> {
           name: "Protest Movement",
           type: "ATTACK",
           rarity: "uncommon",
-          cost: 8,
+          cost: 3,
           text: "+6% Truth. Target a state; reduce its Defense by 1. Opponent discards 1 card.",
+          flavor: "Voices cannot be silenced forever.",
           flavorTruth: "Voices cannot be silenced forever.",
           flavorGov: "Civil disturbance contained.",
-          target: { scope: "state", count: 1 },
-          effects: { truthDelta: 6, zoneDefense: -1, discardOpponent: 1 }
+          target: {
+            count: 1,
+            scope: "state"
+          },
+          effects: {
+            truthDelta: 6,
+            ipDelta: {
+              opponent: 2
+            },
+            discardOpponent: 1,
+            zoneDefense: -1
+          }
         },
         {
           id: "truth-9",
@@ -246,13 +267,23 @@ async function loadCoreCards(): Promise<GameCard[]> {
           faction: "government",
           name: "Federal Raid",
           type: "ATTACK",
-          rarity: "common", 
-          cost: 7,
+          rarity: "common",
+          cost: 2,
           text: "-5% Truth. Target a state; reduce its Defense by 2.",
+          flavor: "Authority silences dissent.",
           flavorTruth: "Authority silences dissent.",
           flavorGov: "National security maintained.",
-          target: { scope: "state", count: 1 },
-          effects: { truthDelta: -5, zoneDefense: -2 }
+          target: {
+            count: 1,
+            scope: "state"
+          },
+          effects: {
+            truthDelta: -5,
+            ipDelta: {
+              opponent: 1
+            },
+            zoneDefense: -2
+          }
         },
         {
           id: "gov-5", 
@@ -305,12 +336,23 @@ async function loadCoreCards(): Promise<GameCard[]> {
           name: "Surveillance State",
           type: "ATTACK",
           rarity: "uncommon",
-          cost: 8,
+          cost: 3,
           text: "-6% Truth. Target a state; reduce its Defense by 1. Opponent discards 1 card.",
+          flavor: "Big Brother is always watching.",
           flavorTruth: "Big Brother is always watching.",
           flavorGov: "Enhanced monitoring operational.",
-          target: { scope: "state", count: 1 },
-          effects: { truthDelta: -6, zoneDefense: -1, discardOpponent: 1 }
+          target: {
+            count: 1,
+            scope: "state"
+          },
+          effects: {
+            truthDelta: -6,
+            ipDelta: {
+              opponent: 2
+            },
+            discardOpponent: 1,
+            zoneDefense: -1
+          }
         },
         {
           id: "gov-9",

--- a/src/data/core/_archive/truth-batch-6.ts
+++ b/src/data/core/_archive/truth-batch-6.ts
@@ -88,12 +88,21 @@ export const CORE_BATCH_TRUTH_6: GameCard[] = [
     name: "Data Breach Whistle",
     type: "ATTACK",
     rarity: "uncommon",
-    cost: 10,
+    cost: 3,
     text: "Opponent discards 1 card.",
+    flavor: "The loudest tiny whistle ever printed.",
     flavorTruth: "The loudest tiny whistle ever printed.",
     flavorGov: "The loudest tiny whistle ever printed.",
-    target: { scope: "global", count: 0 },
-    effects: { discardOpponent: 1 }
+    target: {
+      count: 0,
+      scope: "global"
+    },
+    effects: {
+      ipDelta: {
+        opponent: 2
+      },
+      discardOpponent: 1
+    }
   },
   {
     id: "TRUTH-133",
@@ -101,12 +110,20 @@ export const CORE_BATCH_TRUTH_6: GameCard[] = [
     name: "Press Conference Ambush",
     type: "ATTACK",
     rarity: "uncommon",
-    cost: 9,
+    cost: 3,
     text: "Opponent -2 IP.",
+    flavor: "First question, final answer.",
     flavorTruth: "First question, final answer.",
     flavorGov: "First question, final answer.",
-    target: { scope: "global", count: 0 },
-    effects: { ipDelta: { opponent: -2 } }
+    target: {
+      count: 0,
+      scope: "global"
+    },
+    effects: {
+      ipDelta: {
+        opponent: 2
+      }
+    }
   },
   {
     id: "TRUTH-134",
@@ -114,12 +131,21 @@ export const CORE_BATCH_TRUTH_6: GameCard[] = [
     name: "FOIA Lightning Round",
     type: "ATTACK",
     rarity: "rare",
-    cost: 12,
+    cost: 4,
     text: "Draw 2. Opponent -2 IP.",
+    flavor: "Redaction ink runs in the rain.",
     flavorTruth: "Redaction ink runs in the rain.",
     flavorGov: "Redaction ink runs in the rain.",
-    target: { scope: "global", count: 0 },
-    effects: { draw: 2, ipDelta: { opponent: -2 } }
+    target: {
+      count: 0,
+      scope: "global"
+    },
+    effects: {
+      ipDelta: {
+        opponent: 3
+      },
+      draw: 2
+    }
   },
   {
     id: "TRUTH-135",
@@ -127,12 +153,22 @@ export const CORE_BATCH_TRUTH_6: GameCard[] = [
     name: "Infiltrate the Briefing",
     type: "ATTACK",
     rarity: "uncommon",
-    cost: 10,
+    cost: 3,
     text: "Target state: reduce its Defense by 1. Draw 1.",
+    flavor: "Credentials printed on recycled secrets.",
     flavorTruth: "Credentials printed on recycled secrets.",
     flavorGov: "Credentials printed on recycled secrets.",
-    target: { scope: "state", count: 1 },
-    effects: { pressureDelta: 1, draw: 1 }
+    target: {
+      count: 1,
+      scope: "state"
+    },
+    effects: {
+      ipDelta: {
+        opponent: 2
+      },
+      draw: 1,
+      pressureDelta: 1
+    }
   },
   {
     id: "TRUTH-136",
@@ -140,12 +176,20 @@ export const CORE_BATCH_TRUTH_6: GameCard[] = [
     name: "Crowdsourced Fact Storm",
     type: "ATTACK",
     rarity: "uncommon",
-    cost: 9,
+    cost: 3,
     text: "Gain +1 IP.",
+    flavor: "1,000 comments, one conclusion.",
     flavorTruth: "1,000 comments, one conclusion.",
     flavorGov: "1,000 comments, one conclusion.",
-    target: { scope: "global", count: 0 },
-    effects: { ipDelta: { self: 1 } }
+    target: {
+      count: 0,
+      scope: "global"
+    },
+    effects: {
+      ipDelta: {
+        opponent: 2
+      }
+    }
   },
   {
     id: "TRUTH-137",
@@ -153,12 +197,22 @@ export const CORE_BATCH_TRUTH_6: GameCard[] = [
     name: "Operation Spotlight",
     type: "ATTACK",
     rarity: "rare",
-    cost: 12,
+    cost: 4,
     text: "Opponent discards 1 card. +4% Truth.",
+    flavor: "Stage lights melt alibis.",
     flavorTruth: "Stage lights melt alibis.",
     flavorGov: "Stage lights melt alibis.",
-    target: { scope: "global", count: 0 },
-    effects: { discardOpponent: 1, truthDelta: 4 }
+    target: {
+      count: 0,
+      scope: "global"
+    },
+    effects: {
+      truthDelta: 4,
+      ipDelta: {
+        opponent: 3
+      },
+      discardOpponent: 1
+    }
   },
   {
     id: "TRUTH-138",
@@ -166,12 +220,21 @@ export const CORE_BATCH_TRUTH_6: GameCard[] = [
     name: "Emergency Broadcast Override",
     type: "ATTACK",
     rarity: "uncommon",
-    cost: 11,
+    cost: 3,
     text: "Draw 1 card.",
+    flavor: "We interrupt your regularly scheduled denial.",
     flavorTruth: "We interrupt your regularly scheduled denial.",
     flavorGov: "We interrupt your regularly scheduled denial.",
-    target: { scope: "global", count: 0 },
-    effects: { draw: 1 }
+    target: {
+      count: 0,
+      scope: "global"
+    },
+    effects: {
+      ipDelta: {
+        opponent: 2
+      },
+      draw: 1
+    }
   },
   {
     id: "TRUTH-139",
@@ -179,12 +242,22 @@ export const CORE_BATCH_TRUTH_6: GameCard[] = [
     name: "Street Reporter Blitz",
     type: "ATTACK",
     rarity: "uncommon",
-    cost: 9,
+    cost: 3,
     text: "Target state: +1 Pressure. +3% Truth.",
+    flavor: "Microphones swarm like bees.",
     flavorTruth: "Microphones swarm like bees.",
     flavorGov: "Microphones swarm like bees.",
-    target: { scope: "state", count: 1 },
-    effects: { pressureDelta: 1, truthDelta: 3 }
+    target: {
+      count: 1,
+      scope: "state"
+    },
+    effects: {
+      truthDelta: 3,
+      ipDelta: {
+        opponent: 2
+      },
+      pressureDelta: 1
+    }
   },
   {
     id: "TRUTH-140",
@@ -192,12 +265,21 @@ export const CORE_BATCH_TRUTH_6: GameCard[] = [
     name: "Subpoena Surprise",
     type: "ATTACK",
     rarity: "rare",
-    cost: 12,
+    cost: 4,
     text: "Opponent -3 IP. Draw 1.",
+    flavor: "Signed by Judge Public Opinion.",
     flavorTruth: "Signed by Judge Public Opinion.",
     flavorGov: "Signed by Judge Public Opinion.",
-    target: { scope: "global", count: 0 },
-    effects: { ipDelta: { opponent: -3 }, draw: 1 }
+    target: {
+      count: 0,
+      scope: "global"
+    },
+    effects: {
+      ipDelta: {
+        opponent: 3
+      },
+      draw: 1
+    }
   },
   {
     id: "TRUTH-141",
@@ -205,12 +287,21 @@ export const CORE_BATCH_TRUTH_6: GameCard[] = [
     name: "Elvis Press Pass",
     type: "ATTACK",
     rarity: "uncommon",
-    cost: 10,
+    cost: 3,
     text: "Opponent discards 1 card.",
+    flavor: "Laminate of destiny.",
     flavorTruth: "Laminate of destiny.",
     flavorGov: "Laminate of destiny.",
-    target: { scope: "global", count: 0 },
-    effects: { discardOpponent: 1 }
+    target: {
+      count: 0,
+      scope: "global"
+    },
+    effects: {
+      ipDelta: {
+        opponent: 2
+      },
+      discardOpponent: 1
+    }
   },
   {
     id: "TRUTH-142",
@@ -218,16 +309,27 @@ export const CORE_BATCH_TRUTH_6: GameCard[] = [
     name: "Flash-Truth Rally",
     type: "ATTACK",
     rarity: "uncommon",
-    cost: 10,
+    cost: 3,
     text: "+4% Truth. If you control 2+ zones, gain +1 IP.",
+    flavor: "Chants harmonize with sirens.",
     flavorTruth: "Chants harmonize with sirens.",
     flavorGov: "Chants harmonize with sirens.",
-    target: { scope: "global", count: 0 },
-    effects: { 
+    target: {
+      count: 0,
+      scope: "global"
+    },
+    effects: {
       truthDelta: 4,
+      ipDelta: {
+        opponent: 2
+      },
       conditional: {
         ifZonesControlledAtLeast: 2,
-        then: { ipDelta: { self: 1 } }
+        then: {
+          ipDelta: {
+            opponent: 2
+          }
+        }
       }
     }
   },

--- a/src/data/core/_archive/truth-batch-7.ts
+++ b/src/data/core/_archive/truth-batch-7.ts
@@ -450,12 +450,21 @@ export const CORE_BATCH_TRUTH_7: GameCard[] = [
     name: "Open Mic Press Briefing",
     type: "ATTACK",
     rarity: "uncommon",
-    cost: 10,
+    cost: 3,
     text: "Draw 1 card.",
+    flavor: "Mic check, lie wreck.",
     flavorTruth: "Mic check, lie wreck.",
     flavorGov: "Mic check, lie wreck.",
-    target: { scope: "global", count: 0 },
-    effects: { draw: 1 }
+    target: {
+      count: 0,
+      scope: "global"
+    },
+    effects: {
+      ipDelta: {
+        opponent: 2
+      },
+      draw: 1
+    }
   },
   {
     id: "TRUTH-184",
@@ -463,12 +472,22 @@ export const CORE_BATCH_TRUTH_7: GameCard[] = [
     name: "Neighborhood Drone Surge",
     type: "ATTACK",
     rarity: "uncommon",
-    cost: 10,
+    cost: 3,
     text: "Target state: +1 Pressure. Draw 1.",
+    flavor: "Eyes in the sky, pies on the porch.",
     flavorTruth: "Eyes in the sky, pies on the porch.",
     flavorGov: "Eyes in the sky, pies on the porch.",
-    target: { scope: "state", count: 1 },
-    effects: { pressureDelta: 1, draw: 1 }
+    target: {
+      count: 1,
+      scope: "state"
+    },
+    effects: {
+      ipDelta: {
+        opponent: 2
+      },
+      draw: 1,
+      pressureDelta: 1
+    }
   },
   {
     id: "TRUTH-185",
@@ -476,12 +495,21 @@ export const CORE_BATCH_TRUTH_7: GameCard[] = [
     name: "Leaks to Local Paper",
     type: "ATTACK",
     rarity: "uncommon",
-    cost: 9,
+    cost: 3,
     text: "Opponent discards 1 card.",
+    flavor: "Ink beats intimidation.",
     flavorTruth: "Ink beats intimidation.",
     flavorGov: "Ink beats intimidation.",
-    target: { scope: "global", count: 0 },
-    effects: { discardOpponent: 1 }
+    target: {
+      count: 0,
+      scope: "global"
+    },
+    effects: {
+      ipDelta: {
+        opponent: 2
+      },
+      discardOpponent: 1
+    }
   },
   {
     id: "TRUTH-186",
@@ -489,16 +517,26 @@ export const CORE_BATCH_TRUTH_7: GameCard[] = [
     name: "Citizen Audit",
     type: "ATTACK",
     rarity: "rare",
-    cost: 12,
+    cost: 4,
     text: "Opponent -3 IP. If Truth ≥ 60%, opponent -5 IP instead.",
+    flavor: "Receipts stapled to reality.",
     flavorTruth: "Receipts stapled to reality.",
     flavorGov: "Receipts stapled to reality.",
-    target: { scope: "global", count: 0 },
-    effects: { 
-      ipDelta: { opponent: -3 },
+    target: {
+      count: 0,
+      scope: "global"
+    },
+    effects: {
+      ipDelta: {
+        opponent: 3
+      },
       conditional: {
         ifTruthAtLeast: 60,
-        then: { ipDelta: { opponent: -5 } }
+        then: {
+          ipDelta: {
+            opponent: 5
+          }
+        }
       }
     }
   },
@@ -508,12 +546,21 @@ export const CORE_BATCH_TRUTH_7: GameCard[] = [
     name: "Midnight Signal Boost",
     type: "ATTACK",
     rarity: "uncommon",
-    cost: 9,
+    cost: 3,
     text: "+4% Truth. Opponent -1 IP.",
+    flavor: "Static speaks volumes.",
     flavorTruth: "Static speaks volumes.",
     flavorGov: "Static speaks volumes.",
-    target: { scope: "global", count: 0 },
-    effects: { truthDelta: 4, ipDelta: { opponent: -1 } }
+    target: {
+      count: 0,
+      scope: "global"
+    },
+    effects: {
+      truthDelta: 4,
+      ipDelta: {
+        opponent: 2
+      }
+    }
   },
   {
     id: "TRUTH-188",
@@ -521,12 +568,20 @@ export const CORE_BATCH_TRUTH_7: GameCard[] = [
     name: "Counter-Spin Workshop",
     type: "ATTACK",
     rarity: "uncommon",
-    cost: 9,
+    cost: 3,
     text: "Gain +1 IP.",
+    flavor: "Spin class for facts.",
     flavorTruth: "Spin class for facts.",
     flavorGov: "Spin class for facts.",
-    target: { scope: "global", count: 0 },
-    effects: { ipDelta: { self: 1 } }
+    target: {
+      count: 0,
+      scope: "global"
+    },
+    effects: {
+      ipDelta: {
+        opponent: 2
+      }
+    }
   },
   {
     id: "TRUTH-189",
@@ -534,12 +589,21 @@ export const CORE_BATCH_TRUTH_7: GameCard[] = [
     name: "FOIA Blitz Marathon",
     type: "ATTACK",
     rarity: "rare",
-    cost: 12,
+    cost: 4,
     text: "Draw 2. Opponent -2 IP.",
+    flavor: "Paper cuts to the narrative.",
     flavorTruth: "Paper cuts to the narrative.",
     flavorGov: "Paper cuts to the narrative.",
-    target: { scope: "global", count: 0 },
-    effects: { draw: 2, ipDelta: { opponent: -2 } }
+    target: {
+      count: 0,
+      scope: "global"
+    },
+    effects: {
+      ipDelta: {
+        opponent: 3
+      },
+      draw: 2
+    }
   },
   {
     id: "TRUTH-190",
@@ -547,12 +611,22 @@ export const CORE_BATCH_TRUTH_7: GameCard[] = [
     name: "Flash Mob Fact-Check",
     type: "ATTACK",
     rarity: "uncommon",
-    cost: 10,
+    cost: 3,
     text: "Target state: reduce its Defense by 1. Draw 1.",
+    flavor: "Synchronised citations.",
     flavorTruth: "Synchronised citations.",
     flavorGov: "Synchronised citations.",
-    target: { scope: "state", count: 1 },
-    effects: { pressureDelta: 1, draw: 1 }
+    target: {
+      count: 1,
+      scope: "state"
+    },
+    effects: {
+      ipDelta: {
+        opponent: 2
+      },
+      draw: 1,
+      pressureDelta: 1
+    }
   },
   {
     id: "TRUTH-191",
@@ -560,12 +634,21 @@ export const CORE_BATCH_TRUTH_7: GameCard[] = [
     name: "Mothman Siren",
     type: "ATTACK",
     rarity: "uncommon",
-    cost: 10,
+    cost: 3,
     text: "Target state: +1 Pressure.",
+    flavor: "Wings over weak points.",
     flavorTruth: "Wings over weak points.",
     flavorGov: "Wings over weak points.",
-    target: { scope: "state", count: 1 },
-    effects: { pressureDelta: 1 }
+    target: {
+      count: 1,
+      scope: "state"
+    },
+    effects: {
+      ipDelta: {
+        opponent: 2
+      },
+      pressureDelta: 1
+    }
   },
   {
     id: "TRUTH-192",

--- a/src/hooks/useCardAnimation.ts
+++ b/src/hooks/useCardAnimation.ts
@@ -229,7 +229,7 @@ export const useCardAnimation = () => {
             ${cardData.text || 'Effect unknown'}
           </div>
           <div class="text-xs italic text-muted-foreground text-center min-h-6 border-t border-border pt-2">
-            "${cardData.flavorTruth || 'No flavor text'}"
+            "${cardData.flavor ?? cardData.flavorGov ?? cardData.flavorTruth || 'No flavor text'}"
           </div>
           <div class="text-xs text-center font-bold text-primary">
             DEPLOYED

--- a/src/systems/CardEffectProcessor.ts
+++ b/src/systems/CardEffectProcessor.ts
@@ -69,10 +69,22 @@ export class CardEffectProcessor {
         result.ipDelta.self += effects.ipDelta.self;
         result.logMessages.push(`IP ${effects.ipDelta.self >= 0 ? '+' : ''}${effects.ipDelta.self}`);
       }
-      
+
       if (effects.ipDelta.opponent !== undefined) {
-        result.ipDelta.opponent += effects.ipDelta.opponent;
-        result.logMessages.push(`Opponent IP ${effects.ipDelta.opponent >= 0 ? '+' : ''}${effects.ipDelta.opponent}`);
+        const amount = effects.ipDelta.opponent;
+        result.ipDelta.self += amount;
+        result.ipDelta.opponent -= amount;
+
+        if (amount > 0) {
+          result.logMessages.push(`Opponent loses ${amount} IP`);
+          result.logMessages.push(`You gain ${amount} IP`);
+        } else if (amount < 0) {
+          const abs = Math.abs(amount);
+          result.logMessages.push(`Opponent gains ${abs} IP`);
+          result.logMessages.push(`You lose ${abs} IP`);
+        } else {
+          result.logMessages.push('No IP change');
+        }
       }
     }
     

--- a/src/systems/CardTextGenerator.ts
+++ b/src/systems/CardTextGenerator.ts
@@ -7,8 +7,19 @@ import type { CardEffects, Card } from '@/types/cardEffects';
 const renderEffects = (e: CardEffects): string[] => {
   const parts: string[] = [];
   if (typeof e.truthDelta === 'number') parts.push(`${e.truthDelta >= 0 ? '+' : ''}${e.truthDelta}% Truth`);
-  if (e.ipDelta?.self) parts.push(`${e.ipDelta.self >= 0 ? '+' : ''}${e.ipDelta.self} IP (you)`);
-  if (e.ipDelta?.opponent) parts.push(`${e.ipDelta.opponent >= 0 ? '+' : ''}${e.ipDelta.opponent} IP (opponent)`);
+  if (typeof e.ipDelta?.self === 'number') {
+    parts.push(`${e.ipDelta.self >= 0 ? '+' : ''}${e.ipDelta.self} IP (you)`);
+  }
+  if (typeof e.ipDelta?.opponent === 'number') {
+    const n = e.ipDelta.opponent;
+    if (n > 0) {
+      parts.push(`Opponent loses ${n} IP`);
+    } else if (n < 0) {
+      parts.push(`Opponent gains ${Math.abs(n)} IP`);
+    } else {
+      parts.push('No IP change');
+    }
+  }
   if (typeof e.draw === 'number') parts.push(`Draw ${e.draw}`);
   if (typeof e.discardOpponent === 'number') parts.push(`Opponent discards ${e.discardOpponent}`);
   if (typeof e.pressureDelta === 'number') parts.push(`${e.pressureDelta >= 0 ? '+' : ''}${e.pressureDelta} Pressure`);
@@ -40,12 +51,14 @@ export class CardTextGenerator {
         const sign = effects.ipDelta.self >= 0 ? '+' : '';
         parts.push(`${sign}${effects.ipDelta.self} IP`);
       }
-      
+
       if (effects.ipDelta.opponent !== undefined) {
-        if (effects.ipDelta.opponent < 0) {
-          parts.push(`Opponent loses ${Math.abs(effects.ipDelta.opponent)} IP`);
+        if (effects.ipDelta.opponent > 0) {
+          parts.push(`Opponent loses ${effects.ipDelta.opponent} IP`);
+        } else if (effects.ipDelta.opponent < 0) {
+          parts.push(`Opponent gains ${Math.abs(effects.ipDelta.opponent)} IP`);
         } else {
-          parts.push(`Opponent gains ${effects.ipDelta.opponent} IP`);
+          parts.push('No IP change');
         }
       }
     }

--- a/src/systems/__tests__/cardResolution.test.ts
+++ b/src/systems/__tests__/cardResolution.test.ts
@@ -65,16 +65,16 @@ describe('resolveCardEffects - direct attack resolution', () => {
       text: '',
       flavorTruth: '',
       flavorGov: '',
-      effects: { ipDelta: { opponent: -4 } },
+      effects: { ipDelta: { opponent: 4 } },
     };
 
     const resolution = resolveCardEffects(gameState, attackCard, null, tracker);
 
     expect(resolution.aiIP).toBe(16);
-    expect(resolution.ip).toBe(7);
+    expect(resolution.ip).toBe(11);
     expect(resolution.damageDealt).toBe(0);
     expect(updates.length).toBe(1);
-    expect(updates[0]?.max_ip_reached).toBe(7);
+    expect(updates[0]?.max_ip_reached).toBe(11);
     expect(updates[0]?.max_truth_reached).toBe(60);
     expect(updates[0]?.min_truth_reached).toBe(60);
     // Ensure the original game state remains unchanged
@@ -120,7 +120,7 @@ describe('resolveCardEffects - direct attack resolution', () => {
       text: '',
       flavorTruth: '',
       flavorGov: '',
-      effects: { ipDelta: { opponent: -2 } },
+      effects: { ipDelta: { opponent: 2 } },
     };
 
     const resolution = resolveCardEffects(gameState, attackCard, null);

--- a/src/systems/cost/v21e/scorer.ts
+++ b/src/systems/cost/v21e/scorer.ts
@@ -27,7 +27,8 @@ export function scoreEffectsV21E(effects: CardEffects): number {
       score += effects.ipDelta.self > 0 ? effects.ipDelta.self * 0.5 : 0;
     }
     if (effects.ipDelta.opponent) {
-      score += effects.ipDelta.opponent < 0 ? Math.abs(effects.ipDelta.opponent) * 0.7 : 0;
+      const opponent = effects.ipDelta.opponent;
+      score += opponent > 0 ? opponent * 0.7 : 0;
     }
   }
   

--- a/src/types/cardTypes.ts
+++ b/src/types/cardTypes.ts
@@ -43,6 +43,7 @@ export interface GameCard {
   
   // Text fields - both must exist for flavor routing
   text?: string;
+  flavor?: string;
   flavorTruth: string;  // Required
   flavorGov: string;    // Required
   

--- a/src/types/enhancedCardEffects.ts
+++ b/src/types/enhancedCardEffects.ts
@@ -152,6 +152,7 @@ export interface EnhancedCard {
   
   // Text fields
   text?: string;
+  flavor?: string;
   flavorTruth?: string;
   flavorGov?: string;
   

--- a/tools/logs/fix-attack-ip.json
+++ b/tools/logs/fix-attack-ip.json
@@ -1,0 +1,146 @@
+[
+  {
+    "file": "src/data/cardDatabase.ts",
+    "id": "gov-8",
+    "rarity": "uncommon",
+    "fix": "attack-ip-normalized"
+  },
+  {
+    "file": "src/data/cardDatabase.ts",
+    "id": "gov-4",
+    "rarity": "common",
+    "fix": "attack-ip-normalized"
+  },
+  {
+    "file": "src/data/cardDatabase.ts",
+    "id": "truth-8",
+    "rarity": "uncommon",
+    "fix": "attack-ip-normalized"
+  },
+  {
+    "file": "src/data/cardDatabase.ts",
+    "id": "truth-4",
+    "rarity": "common",
+    "fix": "attack-ip-normalized"
+  },
+  {
+    "file": "src/data/core/_archive/truth-batch-6.ts",
+    "id": "TRUTH-142",
+    "rarity": "uncommon",
+    "fix": "attack-ip-normalized"
+  },
+  {
+    "file": "src/data/core/_archive/truth-batch-6.ts",
+    "id": "TRUTH-141",
+    "rarity": "uncommon",
+    "fix": "attack-ip-normalized"
+  },
+  {
+    "file": "src/data/core/_archive/truth-batch-6.ts",
+    "id": "TRUTH-140",
+    "rarity": "rare",
+    "fix": "attack-ip-normalized"
+  },
+  {
+    "file": "src/data/core/_archive/truth-batch-6.ts",
+    "id": "TRUTH-139",
+    "rarity": "uncommon",
+    "fix": "attack-ip-normalized"
+  },
+  {
+    "file": "src/data/core/_archive/truth-batch-6.ts",
+    "id": "TRUTH-138",
+    "rarity": "uncommon",
+    "fix": "attack-ip-normalized"
+  },
+  {
+    "file": "src/data/core/_archive/truth-batch-6.ts",
+    "id": "TRUTH-137",
+    "rarity": "rare",
+    "fix": "attack-ip-normalized"
+  },
+  {
+    "file": "src/data/core/_archive/truth-batch-6.ts",
+    "id": "TRUTH-136",
+    "rarity": "uncommon",
+    "fix": "attack-ip-normalized"
+  },
+  {
+    "file": "src/data/core/_archive/truth-batch-6.ts",
+    "id": "TRUTH-135",
+    "rarity": "uncommon",
+    "fix": "attack-ip-normalized"
+  },
+  {
+    "file": "src/data/core/_archive/truth-batch-6.ts",
+    "id": "TRUTH-134",
+    "rarity": "rare",
+    "fix": "attack-ip-normalized"
+  },
+  {
+    "file": "src/data/core/_archive/truth-batch-6.ts",
+    "id": "TRUTH-133",
+    "rarity": "uncommon",
+    "fix": "attack-ip-normalized"
+  },
+  {
+    "file": "src/data/core/_archive/truth-batch-6.ts",
+    "id": "TRUTH-132",
+    "rarity": "uncommon",
+    "fix": "attack-ip-normalized"
+  },
+  {
+    "file": "src/data/core/_archive/truth-batch-7.ts",
+    "id": "TRUTH-191",
+    "rarity": "uncommon",
+    "fix": "attack-ip-normalized"
+  },
+  {
+    "file": "src/data/core/_archive/truth-batch-7.ts",
+    "id": "TRUTH-190",
+    "rarity": "uncommon",
+    "fix": "attack-ip-normalized"
+  },
+  {
+    "file": "src/data/core/_archive/truth-batch-7.ts",
+    "id": "TRUTH-189",
+    "rarity": "rare",
+    "fix": "attack-ip-normalized"
+  },
+  {
+    "file": "src/data/core/_archive/truth-batch-7.ts",
+    "id": "TRUTH-188",
+    "rarity": "uncommon",
+    "fix": "attack-ip-normalized"
+  },
+  {
+    "file": "src/data/core/_archive/truth-batch-7.ts",
+    "id": "TRUTH-187",
+    "rarity": "uncommon",
+    "fix": "attack-ip-normalized"
+  },
+  {
+    "file": "src/data/core/_archive/truth-batch-7.ts",
+    "id": "TRUTH-186",
+    "rarity": "rare",
+    "fix": "attack-ip-normalized"
+  },
+  {
+    "file": "src/data/core/_archive/truth-batch-7.ts",
+    "id": "TRUTH-185",
+    "rarity": "uncommon",
+    "fix": "attack-ip-normalized"
+  },
+  {
+    "file": "src/data/core/_archive/truth-batch-7.ts",
+    "id": "TRUTH-184",
+    "rarity": "uncommon",
+    "fix": "attack-ip-normalized"
+  },
+  {
+    "file": "src/data/core/_archive/truth-batch-7.ts",
+    "id": "TRUTH-183",
+    "rarity": "uncommon",
+    "fix": "attack-ip-normalized"
+  }
+]


### PR DESCRIPTION
## Summary
- add Bun scripts to normalize ATTACK card IP deltas, costs, flavor fields and log the touched cards
- update data sets so ATTACK cards steal IP based on rarity while preserving conditional magnitudes, and expose the new `flavor` field in UI components
- adjust renderer, resolver, costing, and tests to treat positive opponent deltas as steals and fall back to unified flavor text

## Testing
- bun run fix:attack-ip
- bun run validate:attack-ip
- bun test

------
https://chatgpt.com/codex/tasks/task_e_68ca3bf71e0083208fc82471bb07edb4