### PR TITLE
Add missing closing brace to cryptids extension

### DIFF
--- a/public/extensions/cryptids.json
+++ b/public/extensions/cryptids.json
@@ -5264,3 +5264,4 @@
     "flavor": "\"CLASSIFIED INTELLIGENCE: Standard operating procedure, nothing to see.\""
   }
 ]
+}


### PR DESCRIPTION
## Summary
- add the closing brace for the Cryptids extension definition so the JSON is well-formed

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68ca5da230b88320a82ac98fb4f57cdf