### PR TITLE
Add faction metadata to Halloween extension

### DIFF
--- a/public/extensions/halloween_spooktacular_with_temp_image.json
+++ b/public/extensions/halloween_spooktacular_with_temp_image.json
@@ -4,6 +4,10 @@
   "version": "1.0.0",
   "author": "ShadowGov Team",
   "description": "Halloween Spooktacular — MVP-compliant pack (ATTACK/MEDIA/ZONE only, table costs, simple flavor).",
+  "factions": [
+    "government"
+  ],
+  "count": 200,
   "cards": [
     {
       "id": "hallo-gov-graveyard-flyer-protocol-001",


### PR DESCRIPTION
## Summary
- add the missing factions metadata to the Halloween Spooktacular extension definition
- include the card count so the pack matches the expected schema

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ca5f98073883208de81c1932c135ef