### PR TITLE
Fix UI state subscription without useSyncExternalStore

### DIFF
--- a/src/bindings/trayInspect.ts
+++ b/src/bindings/trayInspect.ts
@@ -1,0 +1,75 @@
+import { openInspector } from '@/ui/Inspector';
+import {
+  getTrayCardByGuid,
+  getTrayMetaByGuid,
+  type InspectSource,
+} from '@/state/uiState';
+
+const BOUND_ATTR = 'data-inspect-bound';
+const LONG_PRESS_DELAY = 350;
+
+type InspectableElement = HTMLElement & { dataset: DOMStringMap };
+
+function bindElements(root: ParentNode, selector: string, source: InspectSource) {
+  if (!('querySelectorAll' in root)) return;
+
+  const elements = Array.from(root.querySelectorAll<InspectableElement>(selector));
+
+  elements.forEach(element => {
+    if (element.getAttribute(BOUND_ATTR) === 'true') return;
+
+    const guid = element.dataset.guid;
+    if (!guid) return;
+
+    const open = () => {
+      const card = getTrayCardByGuid(guid);
+      if (!card) return;
+
+      const meta = getTrayMetaByGuid(guid);
+      openInspector(card, { source, interactive: false, meta });
+    };
+
+    element.addEventListener('click', open);
+    addLongPress(element, open);
+    element.setAttribute(BOUND_ATTR, 'true');
+  });
+}
+
+export function bindTrayInspectHandlers(root: ParentNode = document) {
+  if (typeof window === 'undefined' || typeof document === 'undefined') return;
+
+  bindElements(root, '.tray .card-mini.me[data-guid]', 'playerTray');
+  bindElements(root, '.tray .card-mini.opponent[data-guid]', 'opponentTray');
+}
+
+function addLongPress(element: InspectableElement, onLongPress: () => void) {
+  let timer: number | null = null;
+
+  const clear = () => {
+    if (timer !== null) {
+      window.clearTimeout(timer);
+      timer = null;
+    }
+  };
+
+  element.addEventListener(
+    'touchstart',
+    () => {
+      clear();
+      timer = window.setTimeout(() => {
+        onLongPress();
+      }, LONG_PRESS_DELAY);
+    },
+    { passive: true }
+  );
+
+  ['touchend', 'touchcancel', 'touchmove'].forEach(eventName => {
+    element.addEventListener(
+      eventName,
+      () => {
+        clear();
+      },
+      { passive: true }
+    );
+  });
+}

--- a/src/components/game/PlayedCardsDock.tsx
+++ b/src/components/game/PlayedCardsDock.tsx
@@ -1,8 +1,9 @@
-import React from 'react';
-import { Card } from '@/components/ui/card';
+import React, { useEffect, useMemo, useRef } from 'react';
 import { Badge } from '@/components/ui/badge';
 import CardImage from '@/components/game/CardImage';
 import type { GameCard } from '@/types/cardTypes';
+import { bindTrayInspectHandlers } from '@/bindings/trayInspect';
+import { syncTrayRegistry, type InspectMeta } from '@/state/uiState';
 
 interface PlayedCard {
   card: GameCard;
@@ -11,51 +12,174 @@ interface PlayedCard {
 
 interface PlayedCardsDockProps {
   playedCards: PlayedCard[];
+  round?: number;
 }
 
-const PlayedCardsDock: React.FC<PlayedCardsDockProps> = ({ playedCards }) => {
+const buildGuid = (card: GameCard, owner: 'human' | 'ai', index: number) => `${card.id}-${owner}-${index}`;
+
+const PlayedCardsDock: React.FC<PlayedCardsDockProps> = ({ playedCards, round }) => {
   const humanCards = playedCards.filter(pc => pc.player === 'human');
   const aiCards = playedCards.filter(pc => pc.player === 'ai');
+  const dockRef = useRef<HTMLDivElement>(null);
+
+  const registryEntries = useMemo(() => {
+    let humanIndex = 0;
+    let aiIndex = 0;
+
+    return playedCards.map(entry => {
+      const index = entry.player === 'human' ? humanIndex++ : aiIndex++;
+      const guid = buildGuid(entry.card, entry.player, index);
+      const meta: InspectMeta = {
+        playedBy: entry.player === 'human' ? 'You' : 'Opponent',
+        round,
+        summary: entry.card.text,
+      };
+      return { guid, card: entry.card, meta };
+    });
+  }, [playedCards, round]);
+
+  useEffect(() => {
+    syncTrayRegistry(registryEntries);
+    const root = dockRef.current ?? (typeof document !== 'undefined' ? document : undefined);
+    if (root) {
+      bindTrayInspectHandlers(root);
+    }
+  }, [registryEntries]);
+
+  useEffect(() => {
+    return () => {
+      syncTrayRegistry([]);
+    };
+  }, []);
 
   const getTypeColor = (type: string, isAI: boolean) => {
     const truthColors = {
-      'MEDIA': 'text-truth-red border-truth-red',
-      'ZONE': 'text-yellow-600 border-yellow-600',
-      'ATTACK': 'text-red-600 border-red-600',
-      'DEFENSIVE': 'text-blue-600 border-blue-600',
-      'TECH': 'text-purple-600 border-purple-600',
-      'DEVELOPMENT': 'text-green-600 border-green-600'
-    };
-    
+      MEDIA: 'text-truth-red border-truth-red',
+      ZONE: 'text-yellow-600 border-yellow-600',
+      ATTACK: 'text-red-600 border-red-600',
+      DEFENSIVE: 'text-blue-600 border-blue-600',
+      TECH: 'text-purple-600 border-purple-600',
+      DEVELOPMENT: 'text-green-600 border-green-600',
+    } as const;
+
     const govColors = {
-      'MEDIA': 'text-government-blue border-government-blue',
-      'ZONE': 'text-yellow-600 border-yellow-600',
-      'ATTACK': 'text-red-600 border-red-600',
-      'DEFENSIVE': 'text-blue-600 border-blue-600',
-      'TECH': 'text-purple-600 border-purple-600',
-      'DEVELOPMENT': 'text-green-600 border-green-600'
-    };
-    
-    return isAI ? govColors[type as keyof typeof govColors] || 'text-government-blue border-government-blue' 
-                : truthColors[type as keyof typeof truthColors] || 'text-truth-red border-truth-red';
+      MEDIA: 'text-government-blue border-government-blue',
+      ZONE: 'text-yellow-600 border-yellow-600',
+      ATTACK: 'text-red-600 border-red-600',
+      DEFENSIVE: 'text-blue-600 border-blue-600',
+      TECH: 'text-purple-600 border-purple-600',
+      DEVELOPMENT: 'text-green-600 border-green-600',
+    } as const;
+
+    return isAI
+      ? govColors[type as keyof typeof govColors] || 'text-government-blue border-government-blue'
+      : truthColors[type as keyof typeof truthColors] || 'text-truth-red border-truth-red';
   };
 
   const getRarityBg = (rarity: string) => {
     switch (rarity) {
-      case 'legendary': return 'from-yellow-600/20 to-orange-600/20 border-yellow-500/30';
-      case 'rare': return 'from-purple-600/20 to-blue-600/20 border-purple-500/30';
-      case 'uncommon': return 'from-green-600/20 to-blue-600/20 border-green-500/30';
-      default: return 'from-gray-600/20 to-gray-500/20 border-gray-500/30';
+      case 'legendary':
+        return 'from-yellow-600/20 to-orange-600/20 border-yellow-500/30';
+      case 'rare':
+        return 'from-purple-600/20 to-blue-600/20 border-purple-500/30';
+      case 'uncommon':
+        return 'from-green-600/20 to-blue-600/20 border-green-500/30';
+      default:
+        return 'from-gray-600/20 to-gray-500/20 border-gray-500/30';
     }
   };
 
+  const renderPlayedCard = (playedCard: PlayedCard, index: number, owner: 'human' | 'ai') => {
+    const guid = buildGuid(playedCard.card, owner, index);
+    const ariaLabel = `View details: ${playedCard.card.name} (${playedCard.card.type}, cost ${playedCard.card.cost} IP, ${String(playedCard.card.faction)})`;
+
+    return (
+      <button
+        key={`${owner}-${playedCard.card.id}-${index}`}
+        type="button"
+        data-guid={guid}
+        className={`card-mini ${owner === 'human' ? 'me' : 'opponent'} group relative p-0 bg-transparent border-0 focus:outline-none focus-visible:ring-2 focus-visible:ring-warning focus-visible:ring-offset-2 focus-visible:ring-offset-newspaper-bg transition-transform`}
+        aria-label={ariaLabel}
+        title={ariaLabel}
+      >
+        <div
+          className={`w-24 h-32 bg-gradient-to-b ${getRarityBg(playedCard.card.rarity)} border rounded shadow-sm animate-scale-in overflow-hidden`}
+        >
+          {/* Card header with newspaper styling */}
+          <div className="bg-newspaper-text text-newspaper-bg text-center py-0.5 border-b">
+            <div className="text-[6px] font-bold leading-none">PARANOID TIMES</div>
+          </div>
+
+          {/* Card name */}
+          <div className="px-1 py-0.5 bg-gradient-to-r from-card to-card/80">
+            <div className="text-[7px] font-bold text-center line-clamp-1 leading-tight">
+              {playedCard.card.name}
+            </div>
+          </div>
+
+          {/* Art area - smaller */}
+          <div className="h-8 overflow-hidden border-y">
+            <CardImage cardId={playedCard.card.id} className="w-full h-full object-cover" />
+          </div>
+
+          {/* Effect section */}
+          <div className="px-1 py-0.5 flex-1">
+            <div className="text-[5px] font-semibold mb-0.5">Effect</div>
+            <div className="text-[4px] text-muted-foreground line-clamp-2 leading-tight">
+              {playedCard.card.text}
+            </div>
+          </div>
+
+          {/* Classified Intelligence section */}
+          <div className={`${owner === 'ai' ? 'bg-government-blue/10 border-government-blue/20' : 'bg-truth-red/10 border-truth-red/20'} border-t px-1 py-0.5`}>
+            <div className="text-[4px] font-bold text-muted-foreground mb-0.5">CLASSIFIED INTELLIGENCE</div>
+            <div className="text-[4px] italic line-clamp-1 leading-tight">
+              "{playedCard.card.flavor ?? playedCard.card.flavorGov ?? playedCard.card.flavorTruth}"
+            </div>
+          </div>
+
+          {/* Card type and cost */}
+          <div className="absolute top-5 left-0.5">
+            <Badge variant="outline" className={`text-[5px] px-0.5 py-0 ${getTypeColor(playedCard.card.type, owner === 'ai')}`}>
+              {playedCard.card.type}
+            </Badge>
+          </div>
+          <div className={`absolute top-5 right-0.5 ${owner === 'ai' ? 'bg-government-blue text-white' : 'bg-primary text-primary-foreground'} text-[6px] font-bold px-1 py-0.5 rounded`}>
+            {playedCard.card.cost}
+          </div>
+        </div>
+
+        <span
+          className="absolute right-1 bottom-1 text-[10px] opacity-0 transition-opacity duration-150 select-none pointer-events-none group-hover:opacity-100 group-focus-visible:opacity-100"
+          aria-hidden="true"
+        >
+          🔍
+        </span>
+
+        {/* Enhanced tooltip on hover */}
+        <div className="absolute bottom-full left-1/2 transform -translate-x-1/2 mb-2 opacity-0 group-hover:opacity-100 group-focus-visible:opacity-100 transition-opacity duration-200 pointer-events-none z-50">
+          <div className="bg-popover border border-border rounded-lg p-3 shadow-xl max-w-xs">
+            <div className="font-bold text-sm text-foreground mb-1">{playedCard.card.name}</div>
+            <div className="text-xs text-muted-foreground mb-2">
+              {playedCard.card.type} • Cost: {playedCard.card.cost} IP
+            </div>
+            <div className="text-xs text-foreground mb-2">{playedCard.card.text}</div>
+            <div className={`text-xs italic text-muted-foreground border-l-4 ${owner === 'ai' ? 'border-government-blue bg-government-blue/10' : 'border-truth-red bg-truth-red/10'} rounded-r border border-border/60 pl-2 pr-2 py-1`}>
+              "{playedCard.card.flavor ?? playedCard.card.flavorGov ?? playedCard.card.flavorTruth}"
+            </div>
+          </div>
+        </div>
+      </button>
+    );
+  };
+
   return (
-    <div className="h-full flex flex-col">
+    <div className="h-full flex flex-col tray" ref={dockRef}>
       <div className="flex-1 p-2 overflow-y-auto">
         <h4 className="text-xs font-semibold text-newspaper-text mb-2 font-mono">
           CARDS IN PLAY THIS ROUND
         </h4>
-        
+
         <div className="flex gap-2">
           {/* Human Player Cards */}
           <div className="flex-1">
@@ -70,76 +194,7 @@ const PlayedCardsDock: React.FC<PlayedCardsDockProps> = ({ playedCards }) => {
                   </span>
                 </div>
                 <div className="flex flex-wrap gap-2">
-                  {humanCards.map((playedCard, index) => (
-                    <div
-                      key={`human-${playedCard.card.id}-${index}`}
-                      className="group relative"
-                    >
-                      {/* Full card with newspaper styling - doubled size */}
-                      <div className={`w-24 h-32 bg-gradient-to-b ${getRarityBg(playedCard.card.rarity)} border rounded shadow-sm animate-scale-in overflow-hidden`}>
-                        {/* Card header with newspaper styling */}
-                        <div className="bg-newspaper-text text-newspaper-bg text-center py-0.5 border-b">
-                          <div className="text-[6px] font-bold leading-none">PARANOID TIMES</div>
-                        </div>
-                        
-                        {/* Card name */}
-                        <div className="px-1 py-0.5 bg-gradient-to-r from-card to-card/80">
-                          <div className="text-[7px] font-bold text-center line-clamp-1 leading-tight">
-                            {playedCard.card.name}
-                          </div>
-                        </div>
-                        
-                        {/* Art area - smaller */}
-                        <div className="h-8 overflow-hidden border-y">
-                          <CardImage cardId={playedCard.card.id} className="w-full h-full object-cover" />
-                        </div>
-                        
-                        {/* Effect section */}
-                        <div className="px-1 py-0.5 flex-1">
-                          <div className="text-[5px] font-semibold mb-0.5">Effect</div>
-                          <div className="text-[4px] text-muted-foreground line-clamp-2 leading-tight">
-                            {playedCard.card.text}
-                          </div>
-                        </div>
-                        
-                        {/* Classified Intelligence section */}
-                        <div className="bg-truth-red/10 border-t border-truth-red/20 px-1 py-0.5">
-                          <div className="text-[4px] font-bold text-muted-foreground mb-0.5">CLASSIFIED INTELLIGENCE</div>
-                          <div className="text-[4px] italic line-clamp-1 leading-tight">
-                            "{playedCard.card.flavor ?? playedCard.card.flavorGov ?? playedCard.card.flavorTruth}"
-                          </div>
-                        </div>
-                        
-                        {/* Card type and cost */}
-                        <div className="absolute top-5 left-0.5">
-                          <Badge variant="outline" className={`text-[5px] px-0.5 py-0 ${getTypeColor(playedCard.card.type, false)}`}>
-                            {playedCard.card.type}
-                          </Badge>
-                        </div>
-                        <div className="absolute top-5 right-0.5 bg-primary text-primary-foreground text-[6px] font-bold px-1 py-0.5 rounded">
-                          {playedCard.card.cost}
-                        </div>
-                      </div>
-                      
-                      {/* Enhanced tooltip on hover */}
-                      <div className="absolute bottom-full left-1/2 transform -translate-x-1/2 mb-2 opacity-0 group-hover:opacity-100 transition-opacity duration-200 pointer-events-none z-50">
-                        <div className="bg-popover border border-border rounded-lg p-3 shadow-xl max-w-xs">
-                          <div className="font-bold text-sm text-foreground mb-1">
-                            {playedCard.card.name}
-                          </div>
-                          <div className="text-xs text-muted-foreground mb-2">
-                            {playedCard.card.type} • Cost: {playedCard.card.cost} IP
-                          </div>
-                          <div className="text-xs text-foreground mb-2">
-                            {playedCard.card.text}
-                          </div>
-                          <div className="text-xs italic text-muted-foreground border-l-4 border-truth-red bg-truth-red/10 rounded-r border border-truth-red/20 pl-2 pr-2 py-1">
-                            "{playedCard.card.flavor ?? playedCard.card.flavorGov ?? playedCard.card.flavorTruth}"
-                          </div>
-                        </div>
-                      </div>
-                    </div>
-                  ))}
+                  {humanCards.map((playedCard, index) => renderPlayedCard(playedCard, index, 'human'))}
                 </div>
               </div>
             )}
@@ -158,88 +213,19 @@ const PlayedCardsDock: React.FC<PlayedCardsDockProps> = ({ playedCards }) => {
                   </span>
                 </div>
                 <div className="flex flex-wrap gap-2">
-                  {aiCards.map((playedCard, index) => (
-                    <div
-                      key={`ai-${playedCard.card.id}-${index}`}
-                      className="group relative"
-                    >
-                      {/* Full card with newspaper styling - doubled size */}
-                      <div className={`w-24 h-32 bg-gradient-to-b ${getRarityBg(playedCard.card.rarity)} border rounded shadow-sm animate-scale-in overflow-hidden`}>
-                        {/* Card header with newspaper styling */}
-                        <div className="bg-newspaper-text text-newspaper-bg text-center py-0.5 border-b">
-                          <div className="text-[6px] font-bold leading-none">PARANOID TIMES</div>
-                        </div>
-                        
-                        {/* Card name */}
-                        <div className="px-1 py-0.5 bg-gradient-to-r from-card to-card/80">
-                          <div className="text-[7px] font-bold text-center line-clamp-1 leading-tight">
-                            {playedCard.card.name}
-                          </div>
-                        </div>
-                        
-                        {/* Art area - smaller */}
-                        <div className="h-8 overflow-hidden border-y">
-                          <CardImage cardId={playedCard.card.id} className="w-full h-full object-cover" />
-                        </div>
-                        
-                        {/* Effect section */}
-                        <div className="px-1 py-0.5 flex-1">
-                          <div className="text-[5px] font-semibold mb-0.5">Effect</div>
-                          <div className="text-[4px] text-muted-foreground line-clamp-2 leading-tight">
-                            {playedCard.card.text}
-                          </div>
-                        </div>
-                        
-                        {/* Classified Intelligence section */}
-                        <div className="bg-government-blue/10 border-t border-government-blue/20 px-1 py-0.5">
-                          <div className="text-[4px] font-bold text-muted-foreground mb-0.5">CLASSIFIED INTELLIGENCE</div>
-                          <div className="text-[4px] italic line-clamp-1 leading-tight">
-                            "{playedCard.card.flavor ?? playedCard.card.flavorGov ?? playedCard.card.flavorTruth}"
-                          </div>
-                        </div>
-                        
-                        {/* Card type and cost */}
-                        <div className="absolute top-5 left-0.5">
-                          <Badge variant="outline" className={`text-[5px] px-0.5 py-0 ${getTypeColor(playedCard.card.type, true)}`}>
-                            {playedCard.card.type}
-                          </Badge>
-                        </div>
-                        <div className="absolute top-5 right-0.5 bg-primary text-primary-foreground text-[6px] font-bold px-1 py-0.5 rounded">
-                          {playedCard.card.cost}
-                        </div>
-                      </div>
-                      
-                      {/* Enhanced tooltip on hover */}
-                      <div className="absolute bottom-full left-1/2 transform -translate-x-1/2 mb-2 opacity-0 group-hover:opacity-100 transition-opacity duration-200 pointer-events-none z-50">
-                        <div className="bg-popover border border-border rounded-lg p-3 shadow-xl max-w-xs">
-                          <div className="font-bold text-sm text-foreground mb-1">
-                            {playedCard.card.name}
-                          </div>
-                          <div className="text-xs text-muted-foreground mb-2">
-                            {playedCard.card.type} • Cost: {playedCard.card.cost} IP
-                          </div>
-                          <div className="text-xs text-foreground mb-2">
-                            {playedCard.card.text}
-                          </div>
-                          <div className="text-xs italic text-muted-foreground border-l-4 border-government-blue bg-government-blue/10 rounded-r border border-government-blue/20 pl-2 pr-2 py-1">
-                            "{playedCard.card.flavor ?? playedCard.card.flavorGov ?? playedCard.card.flavorTruth}"
-                          </div>
-                        </div>
-                      </div>
-                    </div>
-                  ))}
+                  {aiCards.map((playedCard, index) => renderPlayedCard(playedCard, index, 'ai'))}
                 </div>
               </div>
             )}
           </div>
-
-          {/* Empty state */}
-          {humanCards.length === 0 && aiCards.length === 0 && (
-            <div className="flex-1 text-center py-2 text-newspaper-text/50">
-              <div className="text-xs">No cards played this round</div>
-            </div>
-          )}
         </div>
+
+        {/* Empty state */}
+        {humanCards.length === 0 && aiCards.length === 0 && (
+          <div className="flex-1 text-center py-2 text-newspaper-text/50">
+            <div className="text-xs">No cards played this round</div>
+          </div>
+        )}
       </div>
     </div>
   );

--- a/src/components/game/ReviewPhaseBanner.tsx
+++ b/src/components/game/ReviewPhaseBanner.tsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import { Button } from '@/components/ui/button';
+import { useUIState } from '@/hooks/useUIState';
+import { continueToNewspaper } from '@/phase/phaseController';
+
+const ReviewPhaseBanner: React.FC = () => {
+  const { showReviewBanner, phase } = useUIState();
+
+  if (!showReviewBanner || phase !== 'REVIEW') {
+    return null;
+  }
+
+  return (
+    <div className="fixed inset-x-0 bottom-6 flex justify-center pointer-events-none z-[9998]">
+      <div className="pointer-events-auto bg-newspaper-text text-newspaper-bg border-2 border-newspaper-border px-4 py-3 rounded-xl shadow-2xl flex flex-col sm:flex-row items-center gap-3">
+        <span className="font-mono text-sm uppercase tracking-wide text-center">
+          Review played cards → Continue to Newspaper
+        </span>
+        <Button
+          onClick={continueToNewspaper}
+          size="sm"
+          className="bg-newspaper-bg text-newspaper-text hover:bg-newspaper-bg/80 text-xs font-bold px-4 py-2"
+        >
+          Continue to Newspaper
+        </Button>
+      </div>
+    </div>
+  );
+};
+
+export default ReviewPhaseBanner;

--- a/src/hooks/useUIState.ts
+++ b/src/hooks/useUIState.ts
@@ -1,0 +1,16 @@
+import { useEffect, useState } from 'react';
+import { getUIStateSnapshot, subscribeUIState, type UIStateSnapshot } from '@/state/uiState';
+
+export const useUIState = (): UIStateSnapshot => {
+  const [snapshot, setSnapshot] = useState<UIStateSnapshot>(() => getUIStateSnapshot());
+
+  useEffect(() => {
+    const unsubscribe = subscribeUIState(() => {
+      setSnapshot(getUIStateSnapshot());
+    });
+
+    return unsubscribe;
+  }, []);
+
+  return snapshot;
+};

--- a/src/phase/phaseController.ts
+++ b/src/phase/phaseController.ts
@@ -1,0 +1,79 @@
+import { bindTrayInspectHandlers } from '@/bindings/trayInspect';
+import { closeInspector } from '@/ui/Inspector';
+import {
+  UIState,
+  setBoardFrozen,
+  setPhase,
+  setReviewBannerVisible,
+} from '@/state/uiState';
+
+let reviewKeyHandler: ((event: KeyboardEvent) => void) | null = null;
+
+function freezeBoardInteractions(freeze: boolean) {
+  setBoardFrozen(freeze);
+}
+
+function showReviewBanner() {
+  setReviewBannerVisible(true);
+}
+
+function hideReviewBanner() {
+  setReviewBannerVisible(false);
+}
+
+function addReviewShortcuts() {
+  if (reviewKeyHandler) return;
+  if (typeof document === 'undefined') return;
+
+  reviewKeyHandler = (event: KeyboardEvent) => {
+    if (event.key === 'Escape' && UIState.inspectingCard) {
+      closeInspector();
+      return;
+    }
+
+    if (UIState.phase === 'REVIEW' && /^[1-9]$/.test(event.key)) {
+      const index = parseInt(event.key, 10) - 1;
+      const elements = document.querySelectorAll<HTMLButtonElement>('.tray .card-mini.me[data-guid]');
+      const target = elements[index];
+      if (target) {
+        target.focus();
+        target.click();
+      }
+    }
+  };
+
+  document.addEventListener('keydown', reviewKeyHandler, { passive: true });
+}
+
+function removeReviewShortcuts() {
+  if (!reviewKeyHandler) return;
+  if (typeof document !== 'undefined') {
+    document.removeEventListener('keydown', reviewKeyHandler);
+  }
+  reviewKeyHandler = null;
+}
+
+export function enterReviewPhase() {
+  if (UIState.phase === 'REVIEW') return;
+  setPhase('REVIEW');
+  freezeBoardInteractions(true);
+  showReviewBanner();
+  bindTrayInspectHandlers();
+  addReviewShortcuts();
+}
+
+export function continueToNewspaper() {
+  if (UIState.phase !== 'REVIEW') return;
+  hideReviewBanner();
+  freezeBoardInteractions(false);
+  setPhase('NEWSPAPER');
+  removeReviewShortcuts();
+  console.log('Phase: REVIEW → NEWSPAPER (Continue pressed)');
+}
+
+export function exitToMainPhase() {
+  hideReviewBanner();
+  freezeBoardInteractions(false);
+  setPhase('MAIN');
+  removeReviewShortcuts();
+}

--- a/src/state/uiState.ts
+++ b/src/state/uiState.ts
@@ -1,0 +1,115 @@
+import type { GameCard } from '@/types/cardTypes';
+
+export type Phase = 'MAIN' | 'REVIEW' | 'RESOLVE' | 'NEWSPAPER';
+export type InspectSource = 'playerTray' | 'opponentTray' | 'hand' | 'discard' | 'deckPreview';
+
+export interface InspectMeta {
+  round?: number;
+  playedBy?: string;
+  target?: string | null;
+  summary?: string;
+}
+
+export interface InspectOptions {
+  interactive?: boolean;
+  source: InspectSource;
+  meta?: InspectMeta;
+}
+
+export interface UIStateSnapshot {
+  phase: Phase;
+  inspectingCard: GameCard | null;
+  inspectOptions: InspectOptions;
+  boardFrozen: boolean;
+  showReviewBanner: boolean;
+}
+
+const listeners = new Set<() => void>();
+
+const trayCardRegistry = new Map<string, GameCard>();
+const trayMetaRegistry = new Map<string, InspectMeta>();
+
+export const UIState: UIStateSnapshot = {
+  phase: 'MAIN',
+  inspectingCard: null,
+  inspectOptions: { interactive: false, source: 'playerTray' },
+  boardFrozen: false,
+  showReviewBanner: false,
+};
+
+function emit() {
+  listeners.forEach(listener => listener());
+}
+
+export function subscribeUIState(listener: () => void) {
+  listeners.add(listener);
+  return () => {
+    listeners.delete(listener);
+  };
+}
+
+export function getUIStateSnapshot(): UIStateSnapshot {
+  return {
+    phase: UIState.phase,
+    inspectingCard: UIState.inspectingCard,
+    inspectOptions: { ...UIState.inspectOptions },
+    boardFrozen: UIState.boardFrozen,
+    showReviewBanner: UIState.showReviewBanner,
+  };
+}
+
+export function setPhase(phase: Phase) {
+  if (UIState.phase === phase) return;
+  UIState.phase = phase;
+  emit();
+}
+
+export function setInspectingCard(card: GameCard | null, options?: InspectOptions) {
+  UIState.inspectingCard = card;
+  if (options) {
+    UIState.inspectOptions = {
+      interactive: options.interactive ?? false,
+      source: options.source,
+      meta: options.meta,
+    };
+  } else {
+    UIState.inspectOptions = { interactive: false, source: 'playerTray' };
+  }
+  emit();
+}
+
+export function setBoardFrozen(frozen: boolean) {
+  if (UIState.boardFrozen === frozen) return;
+  UIState.boardFrozen = frozen;
+  emit();
+}
+
+export function setReviewBannerVisible(visible: boolean) {
+  if (UIState.showReviewBanner === visible) return;
+  UIState.showReviewBanner = visible;
+  emit();
+}
+
+export function syncTrayRegistry(entries: Array<{ guid: string; card: GameCard; meta?: InspectMeta }>) {
+  trayCardRegistry.clear();
+  trayMetaRegistry.clear();
+  entries.forEach(({ guid, card, meta }) => {
+    trayCardRegistry.set(guid, card);
+    if (meta) {
+      trayMetaRegistry.set(guid, meta);
+    }
+  });
+}
+
+export function clearTrayRegistry() {
+  trayCardRegistry.clear();
+  trayMetaRegistry.clear();
+}
+
+export function getTrayCardByGuid(guid: string): GameCard | null {
+  return trayCardRegistry.get(guid) ?? null;
+}
+
+export function getTrayMetaByGuid(guid: string): InspectMeta | undefined {
+  return trayMetaRegistry.get(guid);
+}

--- a/src/ui/Inspector.tsx
+++ b/src/ui/Inspector.tsx
@@ -1,0 +1,71 @@
+import { useEffect } from 'react';
+import { createPortal } from 'react-dom';
+import CardDetailOverlay from '@/components/game/CardDetailOverlay';
+import {
+  UIState,
+  setInspectingCard,
+  type InspectOptions,
+} from '@/state/uiState';
+import { useUIState } from '@/hooks/useUIState';
+
+export function openInspector(card: NonNullable<typeof UIState.inspectingCard>, opts: InspectOptions) {
+  setInspectingCard(card, { interactive: false, ...opts });
+  if (typeof document !== 'undefined') {
+    document.body.classList.add('modal-open');
+  }
+  console.log(`UI: Inspect open (source=${opts.source}, id=${card.id})`);
+}
+
+export function closeInspector() {
+  setInspectingCard(null);
+  if (typeof document !== 'undefined') {
+    document.body.classList.remove('modal-open');
+  }
+}
+
+export const InspectorOverlay = () => {
+  const uiState = useUIState();
+  const { inspectingCard, inspectOptions } = uiState;
+
+  useEffect(() => {
+    if (typeof document === 'undefined') {
+      return;
+    }
+
+    if (!inspectingCard) {
+      document.body.classList.remove('modal-open');
+      return;
+    }
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        closeInspector();
+      }
+    };
+
+    document.body.classList.add('modal-open');
+    document.addEventListener('keydown', handleKeyDown);
+
+    return () => {
+      document.removeEventListener('keydown', handleKeyDown);
+      document.body.classList.remove('modal-open');
+    };
+  }, [inspectingCard]);
+
+  if (!inspectingCard) return null;
+
+  const interactive = inspectOptions.interactive === true;
+
+  return createPortal(
+    <CardDetailOverlay
+      card={inspectingCard}
+      canAfford
+      disabled={!interactive}
+      interactive={interactive}
+      playedMeta={inspectOptions.meta}
+      onClose={closeInspector}
+      onPlayCard={() => {}}
+    />,
+    document.body
+  );
+};


### PR DESCRIPTION
## Summary
- add a shared UI state store and inspector overlay so tray cards can be reopened in a read-only modal
- convert played-card tray items into accessible buttons with hover/long-press bindings and display metadata in the inspector
- introduce a review phase before the newspaper that freezes gameplay, adds keyboard shortcuts, and surfaces a continue banner
- replace the `useSyncExternalStore` hook with a plain effect-driven subscription so the UI state store works without invalid hook errors

## Testing
- `npm run lint` *(fails: missing `@eslint/js` because npm install cannot download dependencies in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ca710158648320a8ecda1d0d3fa9ca