### PR TITLE
Fix MVP media truth scaling for AI and human resolution

### DIFF
--- a/src/mvp/media.ts
+++ b/src/mvp/media.ts
@@ -1,0 +1,48 @@
+import type { Card, EffectsMEDIA, Faction, PlayerState } from './types';
+
+export interface MediaResolutionOptions {
+  overrideSign?: 1 | -1;
+}
+
+export interface MediaActor {
+  faction: Faction;
+  isAI?: boolean;
+}
+
+type MediaCardLike = Pick<Card, 'id' | 'type' | 'effects'>;
+
+const getMediaEffects = (card?: MediaCardLike | null): EffectsMEDIA | undefined => {
+  if (!card || card.type !== 'MEDIA') return undefined;
+  return card.effects as EffectsMEDIA | undefined;
+};
+
+export function computeMediaTruthDelta_MVP(
+  acting: MediaActor | Pick<PlayerState, 'faction'>,
+  card: MediaCardLike | null | undefined,
+  opts: MediaResolutionOptions = {},
+): number {
+  const effects = getMediaEffects(card);
+  const base = Math.abs(effects?.truthDelta ?? 0);
+  if (!base) return 0;
+
+  if (opts.overrideSign === 1 || opts.overrideSign === -1) {
+    return opts.overrideSign * base;
+  }
+
+  const sign = acting.faction === 'truth' ? 1 : -1;
+  return sign * base;
+}
+
+let _mvpWarned = false;
+
+export function warnIfMediaScaling(card: MediaCardLike | null | undefined, delta: number): void {
+  if (!card) return;
+  const effects = getMediaEffects(card);
+  const magnitude = Math.abs(effects?.truthDelta ?? 0);
+  if (!_mvpWarned && magnitude > 0 && Math.abs(delta) > magnitude) {
+    console.warn(
+      `[MVP] MEDIA scaling detected on ${card.id}. Expected ±${magnitude}, got ${delta}. Stripping multipliers.`,
+    );
+    _mvpWarned = true;
+  }
+}


### PR DESCRIPTION
## Summary
- add a shared MVP media truth delta calculator and warning helper
- update core MVP engine/card resolution flows to use the helper and forward override options
- adjust AI media plays to rely on the helper and log accurate truth adjustments

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68ca7e264bb483208865daca51b93b46