### PR TITLE
Add difficulty persistence helpers and AI turn sequencing

### DIFF
--- a/src/hooks/useGameState.ts
+++ b/src/hooks/useGameState.ts
@@ -12,6 +12,8 @@ import { getStartingHandSize, type DrawMode, type CardDrawState } from '@/data/c
 import { useAchievements } from '@/contexts/AchievementContext';
 import { resolveCardEffects as resolveCardEffectsCore, type CardPlayResolution } from '@/systems/cardResolution';
 import { computeMediaTruthDelta_MVP, warnIfMediaScaling } from '@/mvp/media';
+import type { Difficulty } from '@/ai';
+import { getDifficulty } from '@/state/settings';
 
 interface GameState {
   faction: 'government' | 'truth';
@@ -95,6 +97,25 @@ const omitClashKey = (key: string, value: unknown) => (key === 'clash' ? undefin
 
 const HAND_LIMIT = 5;
 
+const DIFFICULTY_TO_AI_DIFFICULTY: Record<Difficulty, AIDifficulty> = {
+  EASY: 'easy',
+  NORMAL: 'medium',
+  HARD: 'hard',
+  TOP_SECRET_PLUS: 'legendary',
+};
+
+const resolveAiDifficulty = (override?: AIDifficulty): AIDifficulty => {
+  if (override) {
+    return override;
+  }
+
+  try {
+    return DIFFICULTY_TO_AI_DIFFICULTY[getDifficulty()];
+  } catch {
+    return 'medium';
+  }
+};
+
 const drawCardsFromDeck = (
   deck: GameCard[],
   count: number,
@@ -126,7 +147,8 @@ const drawCardsFromDeck = (
   return { drawn, deck: nextDeck };
 };
 
-export const useGameState = (aiDifficulty: AIDifficulty = 'medium') => {
+export const useGameState = (aiDifficultyOverride?: AIDifficulty) => {
+  const aiDifficulty = resolveAiDifficulty(aiDifficultyOverride);
   const [eventManager] = useState(() => new EventManager());
   const achievements = useAchievements();
   

--- a/src/state/settings.ts
+++ b/src/state/settings.ts
@@ -1,0 +1,27 @@
+import type { Difficulty } from "../ai";
+
+export function getDifficulty(): Difficulty {
+  const storage = typeof localStorage !== "undefined" ? localStorage : null;
+  const raw = storage?.getItem("shadowgov:difficulty") ?? "NORMAL";
+  switch (raw) {
+    case "EASY":
+    case "NORMAL":
+    case "HARD":
+    case "TOP_SECRET_PLUS":
+      return raw as Difficulty;
+    default:
+      return "NORMAL";
+  }
+}
+
+export function setDifficultyFromLabel(label: string) {
+  const map: Record<string, string> = {
+    "EASY - Intelligence Leak": "EASY",
+    "NORMAL - Classified": "NORMAL",
+    "HARD - Top Secret": "HARD",
+    "TOP SECRET+ - Meta-Cheating": "TOP_SECRET_PLUS",
+  };
+  if (typeof localStorage !== "undefined") {
+    localStorage.setItem("shadowgov:difficulty", map[label] ?? "NORMAL");
+  }
+}

--- a/src/systems/turns/takeAiTurn.ts
+++ b/src/systems/turns/takeAiTurn.ts
@@ -1,0 +1,36 @@
+import { chooseTurnActions } from '@/ai';
+import { endTurn, playCard, type GameState } from '@/mvp';
+import { getDifficulty } from '@/state/settings';
+
+type PlayCardAction = {
+  type: 'play-card';
+  cardId: string;
+  targetStateId?: string;
+};
+
+type EndTurnAction = {
+  type: 'end-turn';
+  discards?: string[];
+};
+
+type Action = PlayCardAction | EndTurnAction;
+
+function applyAction(state: GameState, action: Action): GameState {
+  if (action.type === 'play-card') {
+    return playCard(state, action.cardId, action.targetStateId);
+  }
+  if (action.type === 'end-turn') {
+    return endTurn(state, action.discards ?? []);
+  }
+  return state;
+}
+
+export async function takeAiTurn(state: GameState): Promise<GameState> {
+  const level = getDifficulty();
+  const seq = chooseTurnActions(state, level) as Action[];
+  for (const action of seq) {
+    state = applyAction(state, action);
+    await new Promise(resolve => setTimeout(resolve, 150));
+  }
+  return state;
+}


### PR DESCRIPTION
## Summary
- add difficulty label mapping in the options menu with a TOP SECRET+ setting
- persist the selected difficulty via new helpers and map it into the active AI difficulty
- implement an async AI turn helper that executes the policy sequence using the stored difficulty

## Testing
- npm run lint *(fails: cannot find package '@eslint/js' from eslint.config.js)*

------
https://chatgpt.com/codex/tasks/task_e_68ca937836a48320ade32876badd8eec