### PR TITLE
Ensure truth adjustments use helper

### DIFF
--- a/src/mvp/engine.ts
+++ b/src/mvp/engine.ts
@@ -1,5 +1,6 @@
 import { cloneGameState } from './validator';
 import { computeMediaTruthDelta_MVP, warnIfMediaScaling, type MediaResolutionOptions } from './media';
+import { applyTruthDelta } from '@/utils/truth';
 import type {
   Card,
   EffectsATTACK,
@@ -7,9 +8,6 @@ import type {
   GameState,
   PlayerState,
 } from './types';
-
-const clamp = (value: number, min: number, max: number): number =>
-  Math.max(min, Math.min(max, value));
 
 const otherPlayer = (id: 'P1' | 'P2'): 'P1' | 'P2' => (id === 'P1' ? 'P2' : 'P1');
 
@@ -182,11 +180,12 @@ export function resolve(
   if (card.type === 'MEDIA') {
     const delta = computeMediaTruthDelta_MVP(me, card, opts);
     warnIfMediaScaling(card, delta);
-    const newTruth = clamp(cloned.truth + delta, 0, 100);
-    return {
+    const updated = {
       ...cloned,
-      truth: newTruth,
+      log: [...cloned.log],
     };
+    applyTruthDelta(updated, delta, owner);
+    return updated;
   }
 
   if (!targetStateId) {

--- a/src/systems/cardResolution.ts
+++ b/src/systems/cardResolution.ts
@@ -4,6 +4,7 @@ import type { Card } from '@/types/cardEffects';
 import type { GameCard } from '@/types/cardTypes';
 import { setStateOccupation } from '@/data/usaStates';
 import type { PlayerStats } from '@/data/achievementSystem';
+import { applyTruthDelta } from '@/utils/truth';
 
 type Faction = 'government' | 'truth';
 
@@ -112,7 +113,9 @@ export function resolveCardEffects(
     effectResult.truthDelta = truthDelta;
   }
 
-  const truthAfterEffects = Math.max(0, Math.min(100, gameState.truth + truthDelta));
+  const truthTracker = { truth: gameState.truth, log: logEntries };
+  applyTruthDelta(truthTracker, truthDelta, 'player');
+  const truthAfterEffects = truthTracker.truth;
   const playerIPAfterEffects = Math.max(0, ipAfterCost + effectResult.ipDelta.self);
   const damageDealt = effectResult.damage ?? 0;
   const aiIPAfterEffects = Math.max(

--- a/src/utils/truth.ts
+++ b/src/utils/truth.ts
@@ -1,0 +1,32 @@
+export type TruthActorId = 'human' | 'ai' | 'player' | 'P1' | 'P2';
+
+export interface TruthMutable {
+  truth: number;
+  log: string[];
+}
+
+export function clampTruth(x: number): number {
+  return Math.max(0, Math.min(100, Math.round(x)));
+}
+
+export function applyTruthDelta<T extends TruthMutable>(
+  gs: T,
+  delta: number,
+  _who: TruthActorId,
+): T {
+  if (!Number.isFinite(delta)) {
+    return gs;
+  }
+
+  if (delta === 0) {
+    gs.truth = clampTruth(gs.truth);
+    return gs;
+  }
+
+  const before = gs.truth;
+  const after = clampTruth(before + delta);
+  gs.truth = after;
+  const arrow = delta >= 0 ? '↑' : '↓';
+  gs.log.push(`Truth manipulation ${arrow} (${before}% → ${after}%)`);
+  return gs;
+}


### PR DESCRIPTION
## Summary
- add a shared truth utility that clamps percentage changes and emits consistent log entries
- route MEDIA resolution, human turn events, and AI media plays through the new helper so truth shifts stay additive
- update the MVP engine media branch to reuse the helper when adjusting truth

## Testing
- npm run lint *(fails: cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68ca9c33aa4483209d1d6bad16866cfb