### PR TITLE
Add MVP validator utility and share cost helpers

### DIFF
--- a/scripts/fix-attack-ip.ts
+++ b/scripts/fix-attack-ip.ts
@@ -1,15 +1,21 @@
 import fs from "node:fs";
 import path from "node:path";
 
+import { expectedCost, type Rarity } from "../src/rules/mvp";
+
 const DATA_ROOT = path.join(process.cwd(), "src", "data");
 const LOG_PATH = path.join(process.cwd(), "tools", "logs", "fix-attack-ip.json");
 
-const AMOUNT_BY_RARITY = { common: 1, uncommon: 2, rare: 3, legendary: 4 } as const;
-const COST_BY_RARITY = { common: 2, uncommon: 3, rare: 4, legendary: 5 } as const;
+const AMOUNT_BY_RARITY: Record<Rarity, number> = {
+  common: 1,
+  uncommon: 2,
+  rare: 3,
+  legendary: 4
+};
 
 const INDENT_STEP = "  ";
 
-type RarityKey = keyof typeof AMOUNT_BY_RARITY;
+type RarityKey = Rarity;
 type CardRecord = Record<string, unknown> & {
   id?: string;
   rarity?: RarityKey;
@@ -316,7 +322,7 @@ function processCard(cardText: string, indent: string, filePath: string): { upda
   }
 
   const amount = AMOUNT_BY_RARITY[rarity];
-  parsed.cost = COST_BY_RARITY[rarity];
+  parsed.cost = expectedCost("ATTACK", rarity);
   parsed.effects = parsed.effects ?? {};
   normalizeEffects(parsed.effects as EffectRecord, amount);
 

--- a/scripts/validate-attack-ip.ts
+++ b/scripts/validate-attack-ip.ts
@@ -1,11 +1,17 @@
 import fs from "node:fs";
 import path from "node:path";
 
-const DATA_ROOT = path.join(process.cwd(), "src", "data");
-const AMOUNT_BY_RARITY = { common: 1, uncommon: 2, rare: 3, legendary: 4 } as const;
-const COST_BY_RARITY = { common: 2, uncommon: 3, rare: 4, legendary: 5 } as const;
+import { expectedCost, type Rarity } from "../src/rules/mvp";
 
-type RarityKey = keyof typeof AMOUNT_BY_RARITY;
+const DATA_ROOT = path.join(process.cwd(), "src", "data");
+const AMOUNT_BY_RARITY: Record<Rarity, number> = {
+  common: 1,
+  uncommon: 2,
+  rare: 3,
+  legendary: 4
+};
+
+type RarityKey = Rarity;
 type CardRecord = {
   id?: string;
   rarity?: RarityKey;
@@ -158,7 +164,7 @@ for (const file of files) {
     }
 
     const expectedAmount = AMOUNT_BY_RARITY[rarity];
-    const expectedCost = COST_BY_RARITY[rarity];
+    const expectedCostValue = expectedCost("ATTACK", rarity);
 
     const ipDelta = card.effects?.ipDelta as Record<string, unknown> | undefined;
     if (!ipDelta) {
@@ -178,8 +184,8 @@ for (const file of files) {
       }
     }
 
-    if (card.cost !== expectedCost) {
-      errors.push(`${id}: cost=${card.cost} expected ${expectedCost}`);
+    if (card.cost !== expectedCostValue) {
+      errors.push(`${id}: cost=${card.cost} expected ${expectedCostValue}`);
     }
 
     const flavor = card.flavor ?? card.flavorGov ?? card.flavorTruth;

--- a/src/systems/CardEffectValidator.ts
+++ b/src/systems/CardEffectValidator.ts
@@ -1,112 +1,45 @@
 import type { GameCard } from '@/rules/mvp';
-import type { CardEffects } from '@/types/cardEffects';
+import {
+  validateMvpCard,
+  validateMvpCards,
+  type ValidationResult,
+  type ValidationSummary,
+} from '@/utils/validate-mvp';
 
-const WHITELIST_KEYS = new Set([
-  'truthDelta',
-  'ipDelta', 
-  'draw',
-  'discardOpponent',
-  'pressureDelta',
-  'zoneDefense',
-  'conditional'
-]);
-
-export interface ValidationResult {
-  cardId: string;
-  cardName: string;
-  factionOk: boolean;
-  whitelistOk: boolean;
-  zoneOk: boolean;
-  legendaryOk: boolean;
-  isValid: boolean;
-  issues: string[];
-}
+export type { ValidationResult, ValidationSummary } from '@/utils/validate-mvp';
 
 export function validateCard(card: GameCard): ValidationResult {
-  const issues: string[] = [];
-  
-  // 1) faction casing - must be lowercase 'truth' or 'government'
-  const factionOk = ['truth', 'government'].includes((card.faction ?? '').toLowerCase());
-  if (!factionOk) {
-    issues.push(`Invalid faction: "${card.faction}". Must be "truth" or "government" (lowercase)`);
-  }
-  
-  // 2) whitelist - only allowed effect keys
-  const effectKeys = Object.keys(card.effects ?? {});
-  const whitelistOk = effectKeys.every(k => WHITELIST_KEYS.has(k));
-  if (!whitelistOk) {
-    const invalidKeys = effectKeys.filter(k => !WHITELIST_KEYS.has(k));
-    issues.push(`Invalid effect keys: ${invalidKeys.join(', ')}. Allowed: ${Array.from(WHITELIST_KEYS).join(', ')}`);
-  }
-  
-  // 3) zone target - ZONE cards must have state targeting
-  const zoneOk = card.type === 'ZONE'
-    ? card.target?.scope === 'state' && card.target?.count === 1
-    : true;
-  if (!zoneOk) {
-    issues.push(`ZONE card "${card.name}" must have target: {scope: "state", count: 1}`);
-  }
-  
-  // 4) legendary minimum cost - legendary cards must cost at least 25 IP
-  const legendaryOk = card.rarity !== 'legendary' || (card.cost ?? 0) >= 25;
-  if (!legendaryOk) {
-    issues.push(`Legendary card "${card.name}" must cost at least 25 IP (currently ${card.cost})`);
-  }
-  
-  const isValid = factionOk && whitelistOk && zoneOk && legendaryOk;
-  
-  return {
-    cardId: card.id,
-    cardName: card.name,
-    factionOk,
-    whitelistOk,
-    zoneOk,
-    legendaryOk,
-    isValid,
-    issues
-  };
+  return validateMvpCard(card);
 }
 
-export function validateCards(cards: GameCard[]): {
-  totalCards: number;
-  validCards: number;
-  invalidCards: number;
-  results: ValidationResult[];
-} {
-  const results = cards.map(validateCard);
-  
-  return {
-    totalCards: cards.length,
-    validCards: results.filter(r => r.isValid).length,
-    invalidCards: results.filter(r => !r.isValid).length,
-    results: results.filter(r => !r.isValid) // Only return problematic cards
-  };
+export function validateCards(cards: GameCard[]): ValidationSummary {
+  return validateMvpCards(cards);
 }
 
 export function createValidationReport(cards: GameCard[]): string {
-  const validation = validateCards(cards);
-  
-  let report = `\n=== CARD VALIDATION REPORT (v2.1E) ===\n`;
-  report += `Total Cards: ${validation.totalCards}\n`;
-  report += `Valid Cards: ${validation.validCards}\n`;
-  report += `Invalid Cards: ${validation.invalidCards}\n\n`;
-  
-  if (validation.invalidCards === 0) {
-    report += `✅ All cards passed v2.1E validation!\n`;
+  const summary = validateCards(cards);
+
+  let report = `\n=== CARD VALIDATION REPORT (MVP) ===\n`;
+  report += `Total Cards: ${summary.totalCards}\n`;
+  report += `Valid Cards: ${summary.validCards}\n`;
+  report += `Invalid Cards: ${summary.invalidCards}\n\n`;
+
+  if (summary.invalidCards === 0) {
+    report += '✅ All cards passed MVP validation!\n';
     return report;
   }
-  
-  report += `VALIDATION ISSUES:\n`;
+
+  report += 'VALIDATION ISSUES:\n';
   report += `${'='.repeat(50)}\n`;
-  
-  for (const result of validation.results) {
+
+  for (const result of summary.results) {
     report += `\n❌ ${result.cardId}: ${result.cardName}\n`;
     report += `${'-'.repeat(result.cardName.length + result.cardId.length + 2)}\n`;
-    
+
     for (const issue of result.issues) {
-      report += `   • ${issue}\n`;
+      report += `   • ${issue.message}\n`;
     }
   }
-  
+
   return report;
 }

--- a/src/utils/validate-mvp.ts
+++ b/src/utils/validate-mvp.ts
@@ -1,0 +1,300 @@
+import type { GameCard, MVPCardType, Rarity } from '@/rules/mvp';
+import { MVP_CARD_TYPES, expectedCost } from '@/rules/mvp';
+
+const MVP_FACTIONS = ['truth', 'government'] as const;
+const MVP_RARITIES: readonly Rarity[] = ['common', 'uncommon', 'rare', 'legendary'];
+
+export const EFFECT_WHITELIST: Record<MVPCardType, ReadonlySet<string>> = {
+  ATTACK: new Set(['ipDelta', 'discardOpponent']),
+  MEDIA: new Set(['truthDelta']),
+  ZONE: new Set(['pressureDelta']),
+};
+
+type IssueCode =
+  | 'invalid-faction'
+  | 'invalid-type'
+  | 'invalid-rarity'
+  | 'missing-effects'
+  | 'invalid-effect-key'
+  | 'invalid-effect-value'
+  | 'invalid-zone-target'
+  | 'invalid-cost';
+
+export interface ValidationIssue {
+  code: IssueCode;
+  message: string;
+}
+
+export interface ValidationResult {
+  cardId: string;
+  cardName: string;
+  cardType: string | undefined;
+  rarity: string | undefined;
+  faction: string | undefined;
+  ok: boolean;
+  issues: ValidationIssue[];
+  checks: {
+    factionOk: boolean;
+    typeOk: boolean;
+    rarityOk: boolean;
+    effectWhitelistOk: boolean;
+    effectValuesOk: boolean;
+    targetOk: boolean;
+    costOk: boolean;
+  };
+}
+
+export interface ValidationSummary {
+  totalCards: number;
+  validCards: number;
+  invalidCards: number;
+  successCount: number;
+  errorCount: number;
+  successRate: number;
+  results: ValidationResult[];
+  allResults: ValidationResult[];
+}
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object' && value !== null;
+
+const normalizeFaction = (value: unknown): (typeof MVP_FACTIONS)[number] | null => {
+  if (typeof value !== 'string') {
+    return null;
+  }
+  const normalized = value.toLowerCase();
+  return MVP_FACTIONS.includes(normalized as (typeof MVP_FACTIONS)[number])
+    ? (normalized as (typeof MVP_FACTIONS)[number])
+    : null;
+};
+
+const normalizeType = (value: unknown): MVPCardType | null => {
+  if (typeof value !== 'string') {
+    return null;
+  }
+  const normalized = value.toUpperCase();
+  return MVP_CARD_TYPES.includes(normalized as MVPCardType)
+    ? (normalized as MVPCardType)
+    : null;
+};
+
+const normalizeRarity = (value: unknown): Rarity | null => {
+  if (typeof value !== 'string') {
+    return null;
+  }
+  const normalized = value.toLowerCase();
+  return MVP_RARITIES.includes(normalized as Rarity) ? (normalized as Rarity) : null;
+};
+
+const toNumber = (value: unknown): number | null => {
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return value;
+  }
+  if (typeof value === 'string') {
+    const parsed = Number(value);
+    if (Number.isFinite(parsed)) {
+      return parsed;
+    }
+  }
+  return null;
+};
+
+export function validateMvpCard(card: GameCard): ValidationResult {
+  const issues: ValidationIssue[] = [];
+
+  const faction = normalizeFaction(card.faction);
+  const type = normalizeType(card.type);
+  const rarity = normalizeRarity(card.rarity);
+
+  const factionOk = faction !== null;
+  if (!factionOk) {
+    issues.push({
+      code: 'invalid-faction',
+      message: `Invalid faction "${card.faction ?? 'unknown'}". Expected: truth or government.`,
+    });
+  }
+
+  const typeOk = type !== null;
+  if (!typeOk) {
+    issues.push({
+      code: 'invalid-type',
+      message: `Invalid type "${card.type ?? 'unknown'}". MVP allows ATTACK, MEDIA or ZONE.`,
+    });
+  }
+
+  const rarityOk = rarity !== null;
+  if (!rarityOk) {
+    issues.push({
+      code: 'invalid-rarity',
+      message: `Invalid rarity "${card.rarity ?? 'unknown'}". Expected: common, uncommon, rare or legendary.`,
+    });
+  }
+
+  const effects = card.effects;
+  const hasEffects = isRecord(effects) && Object.keys(effects).length > 0;
+  let effectWhitelistOk = true;
+  let effectValuesOk = true;
+  let targetOk = true;
+
+  if (!hasEffects) {
+    effectValuesOk = false;
+    issues.push({
+      code: 'missing-effects',
+      message: 'Card is missing MVP effects.',
+    });
+  }
+
+  if (hasEffects && typeOk) {
+    const allowedKeys = EFFECT_WHITELIST[type as MVPCardType];
+    const effectKeys = Object.keys(effects as Record<string, unknown>);
+    const invalidKeys = effectKeys.filter(key => !allowedKeys.has(key));
+    if (invalidKeys.length > 0) {
+      effectWhitelistOk = false;
+      issues.push({
+        code: 'invalid-effect-key',
+        message: `Invalid effect keys: ${invalidKeys.join(', ')}. Allowed: ${Array.from(allowedKeys).join(', ')}.`,
+      });
+    }
+
+    switch (type) {
+      case 'ATTACK': {
+        const ipDelta = isRecord((effects as Record<string, unknown>).ipDelta)
+          ? ((effects as Record<string, unknown>).ipDelta as Record<string, unknown>)
+          : null;
+        if (!ipDelta) {
+          effectValuesOk = false;
+          issues.push({
+            code: 'invalid-effect-value',
+            message: 'ATTACK cards require effects.ipDelta with opponent damage.',
+          });
+          break;
+        }
+
+        const extraKeys = Object.keys(ipDelta).filter(key => key !== 'opponent');
+        if (extraKeys.length > 0) {
+          effectValuesOk = false;
+          issues.push({
+            code: 'invalid-effect-key',
+            message: `ipDelta may only include "opponent". Found: ${extraKeys.join(', ')}.`,
+          });
+        }
+
+        const opponentDelta = toNumber(ipDelta.opponent);
+        if (opponentDelta === null || opponentDelta <= 0 || !Number.isInteger(opponentDelta)) {
+          effectValuesOk = false;
+          issues.push({
+            code: 'invalid-effect-value',
+            message: `ipDelta.opponent must be a positive integer. Found: ${ipDelta.opponent ?? 'missing'}.`,
+          });
+        }
+
+        if ('discardOpponent' in (effects as Record<string, unknown>)) {
+          const discardValue = toNumber((effects as Record<string, unknown>).discardOpponent);
+          if (discardValue === null || ![0, 1, 2].includes(discardValue)) {
+            effectValuesOk = false;
+            issues.push({
+              code: 'invalid-effect-value',
+              message: `discardOpponent must be 0, 1 or 2 when present. Found: ${(effects as Record<string, unknown>).discardOpponent ?? 'missing'}.`,
+            });
+          }
+        }
+        break;
+      }
+      case 'MEDIA': {
+        const truthDelta = toNumber((effects as Record<string, unknown>).truthDelta);
+        if (truthDelta === null) {
+          effectValuesOk = false;
+          issues.push({
+            code: 'invalid-effect-value',
+            message: 'MEDIA cards require numeric truthDelta.',
+          });
+        }
+        break;
+      }
+      case 'ZONE': {
+        const pressureDelta = toNumber((effects as Record<string, unknown>).pressureDelta);
+        if (pressureDelta === null || pressureDelta <= 0) {
+          effectValuesOk = false;
+          issues.push({
+            code: 'invalid-effect-value',
+            message: 'ZONE cards require pressureDelta > 0.',
+          });
+        }
+        targetOk = card.target?.scope === 'state' && card.target?.count === 1;
+        if (!targetOk) {
+          issues.push({
+            code: 'invalid-zone-target',
+            message: 'ZONE cards must target a single state: { scope: "state", count: 1 }.',
+          });
+        }
+        break;
+      }
+      default:
+        break;
+    }
+  }
+
+  const costValue = toNumber(card.cost);
+  let costOk = costValue !== null;
+  if (!costOk) {
+    issues.push({
+      code: 'invalid-cost',
+      message: `Invalid cost "${card.cost ?? 'missing'}". MVP cards require numeric cost.`,
+    });
+  } else if (typeOk && rarityOk) {
+    const expected = expectedCost(type as MVPCardType, rarity as Rarity);
+    if (costValue !== expected) {
+      costOk = false;
+      issues.push({
+        code: 'invalid-cost',
+        message: `Cost ${costValue} does not match MVP expectation ${expected} for ${type} ${rarity}.`,
+      });
+    }
+  }
+
+  const ok =
+    factionOk &&
+    typeOk &&
+    rarityOk &&
+    effectWhitelistOk &&
+    effectValuesOk &&
+    targetOk &&
+    costOk;
+
+  return {
+    cardId: card.id,
+    cardName: card.name ?? 'Unnamed Card',
+    cardType: card.type,
+    rarity: card.rarity as string | undefined,
+    faction: card.faction as string | undefined,
+    ok,
+    issues,
+    checks: {
+      factionOk,
+      typeOk,
+      rarityOk,
+      effectWhitelistOk,
+      effectValuesOk,
+      targetOk,
+      costOk,
+    },
+  };
+}
+
+export function validateMvpCards(cards: GameCard[]): ValidationSummary {
+  const results = cards.map(validateMvpCard);
+  const validCards = results.filter(result => result.ok).length;
+  const invalidCards = results.length - validCards;
+  const successRate = cards.length === 0 ? 100 : (validCards / cards.length) * 100;
+
+  return {
+    totalCards: cards.length,
+    validCards,
+    invalidCards,
+    successCount: validCards,
+    errorCount: invalidCards,
+    successRate,
+    results: results.filter(result => !result.ok),
+    allResults: results,
+  };
+}


### PR DESCRIPTION
## Summary
- add a reusable MVP validation module that enforces faction/type rules, effect whitelisting, and cost checks
- update the card effect validator wrapper to use the new utility when producing reports
- reuse the shared MVP cost table in ATTACK card maintenance scripts to keep expected costs in sync

## Testing
- `npm run test`
- `npm run lint` *(fails: Cannot find package '@eslint/js' imported from eslint.config.js)*

------
https://chatgpt.com/codex/tasks/task_e_68cab2741e488320934d30c2853cda6c