### PR TITLE
refactor: pivot core card pipeline to MVP

### DIFF
--- a/README-core-recovery.md
+++ b/README-core-recovery.md
@@ -8,7 +8,7 @@ The system is now active! The `src/data/core/index.ts` collector automatically g
 
 ### Current Status
 - ✅ Core collector active
-- ✅ Runtime normalization (v2.1E format)
+- ✅ MVP repair + validation (`repairToMVP` → `validateCardMVP`)
 - ✅ Fallback protection (20 minimal cards if batches fail)
 - ✅ Enhanced Balancing Dashboard updated with proper counts
 
@@ -18,29 +18,26 @@ Place your batch files in `src/data/core/` with this structure:
 
 ```typescript
 // src/data/core/truth-batch-X.ts
-import type { GameCard } from '../../types/cardTypes';
+import type { GameCard } from '@/rules/mvp';
 
 export const CORE_BATCH_TRUTH_X: GameCard[] = [
   {
-    id: "unique-id",
-    faction: "truth", // or "government"
-    name: "Card Name",
-    type: "MEDIA", // MEDIA, ZONE, ATTACK, DEFENSIVE
-    rarity: "common", // common, uncommon, rare, legendary
-    cost: 5, // Will be recalculated by v2.1E engine
-    text: "Card effect description",
-    flavorTruth: "Flavor text for truth perspective",
-    flavorGov: "Flavor text for government perspective", 
-    target: { scope: "global", count: 0 }, // or state targeting for ZONE
+    id: 'unique-id',
+    faction: 'truth', // or 'government'
+    name: 'Card Name',
+    type: 'MEDIA', // MEDIA, ZONE, ATTACK
+    rarity: 'common', // common, uncommon, rare, legendary
     effects: {
-      truthDelta: 3,
-      draw: 1,
-      // ... other v2.1E effects
-    }
-  }
+      truthDelta: 1,
+    },
+    flavor: 'Optional shared flavor line',
+    // For ZONE cards include: target: { scope: 'state', count: 1 }, effects: { pressureDelta: N }
+  },
   // ... more cards
 ];
 ```
+- `repairToMVP` fills in MVP costs automatically based on type/rarity.
+- Skip legacy `text` fields—only the MVP effect whitelist is preserved.
 
 ## 🔧 Manual Recovery (CLI)
 
@@ -75,7 +72,7 @@ Your batch files aren't being found. Check:
 
 ### "Build errors"
 - Ensure all cards have required fields (id, faction, name, type, rarity)
-- Use proper v2.1E effect structure
+- Stick to MVP effects: `truthDelta`, `pressureDelta`, `ipDelta.opponent` (+ optional `discardOpponent`)
 - Check TypeScript syntax in batch files
 
 ### "Duplicates or validation fails"

--- a/scripts/migrate_to_mvp.ts
+++ b/scripts/migrate_to_mvp.ts
@@ -3,7 +3,7 @@ import { glob } from 'glob';
 import { readFile, writeFile } from 'node:fs/promises';
 import { relative } from 'node:path';
 import process from 'node:process';
-import { sanitizeCard, validateCard } from '../src/mvp/validator';
+import { repairToMVP, validateCardMVP } from '../src/mvp/validator';
 
 const DEFAULT_PATTERNS = ['src/**/*.json', 'public/**/*.json', 'assets/**/*.json'];
 const GLOB_OPTIONS = {
@@ -84,18 +84,18 @@ async function processFile(file: string): Promise<ProcessResult | null> {
   let hasErrors = false;
 
   extraction.cards.forEach((raw, index) => {
-    const { card, errors, changes } = sanitizeCard(raw);
+    const { card, errors, changes } = repairToMVP(raw);
     const hasId =
       typeof raw === 'object' && raw !== null && 'id' in raw && (raw as { id?: unknown }).id != null;
     const label = hasId ? String((raw as { id: unknown }).id) : `index ${index}`;
 
-    if (!card || errors.length > 0) {
+    if (errors.length > 0) {
       hasErrors = true;
       messages.push(`${label}: ${errors.join('; ')}`);
       return;
     }
 
-    const validation = validateCard(card);
+    const validation = validateCardMVP(card);
     if (!validation.ok) {
       hasErrors = true;
       messages.push(`${label}: ${validation.errors.join('; ')}`);

--- a/scripts/splitCoreToBatches.ts
+++ b/scripts/splitCoreToBatches.ts
@@ -26,7 +26,7 @@ const CORE_DIR = path.resolve(ROOT, 'src', 'data', 'core');
 
 const TRUTH_SOURCE = path.join(CORE_DIR, 'core_truth_MVP_balanced.json');
 const GOVERNMENT_SOURCE = path.join(CORE_DIR, 'core_government_MVP_balanced.json');
-const IMPORT_PATH = '../../types/cardTypes';
+const IMPORT_PATH = '@/rules/mvp';
 const CARDS_PER_BATCH = 50;
 const EXPECTED_BATCHES = 4;
 

--- a/src/data/cardBalancing.ts
+++ b/src/data/cardBalancing.ts
@@ -165,19 +165,20 @@ const COST_CURVES = {
   }
 };
 
-export function extractEffectValue(cardText: string, cardType: string): number {
+export function extractEffectValue(cardText: string | undefined, cardType: string): number {
+  const text = cardText ?? '';
   // Extract numerical values from card text
-  const truthMatch = cardText.match(/Truth ([+-])(\d+)/);
+  const truthMatch = text.match(/Truth ([+-])(\d+)/);
   if (truthMatch) {
     return parseInt(truthMatch[2]);
   }
-  
-  const pressureMatch = cardText.match(/\+(\d+) Pressure/);
+
+  const pressureMatch = text.match(/\+(\d+) Pressure/);
   if (pressureMatch) {
     return parseInt(pressureMatch[1]);
   }
-  
-  const damageMatch = cardText.match(/(\d+) (?:damage|IP)/i);
+
+  const damageMatch = text.match(/(\d+) (?:damage|IP)/i);
   if (damageMatch) {
     return parseInt(damageMatch[1]);
   }

--- a/src/data/core/_archive/truth-batch-5.ts
+++ b/src/data/core/_archive/truth-batch-5.ts
@@ -1,7 +1,7 @@
 // Truth Batch 5 - v2.1E Compliant Cards  
 // TRUTH-101 to TRUTH-125
 
-import type { GameCard } from '../../../types/cardTypes';
+import type { GameCard } from '@/rules/mvp';
 
 export const CORE_BATCH_TRUTH_5: GameCard[] = [
   {

--- a/src/data/core/_archive/truth-batch-6.ts
+++ b/src/data/core/_archive/truth-batch-6.ts
@@ -1,7 +1,7 @@
 // Truth Batch 6 - v2.1E Compliant Cards
 // TRUTH-126 to TRUTH-150
 
-import type { GameCard } from '../../../types/cardTypes';
+import type { GameCard } from '@/rules/mvp';
 
 export const CORE_BATCH_TRUTH_6: GameCard[] = [
   {

--- a/src/data/core/_archive/truth-batch-7.ts
+++ b/src/data/core/_archive/truth-batch-7.ts
@@ -1,7 +1,7 @@
 // Truth Batch 7 - v2.1E Compliant Cards
 // TRUTH-151 to TRUTH-200
 
-import type { GameCard } from '../../../types/cardTypes';
+import type { GameCard } from '@/rules/mvp';
 
 export const CORE_BATCH_TRUTH_7: GameCard[] = [
   {

--- a/src/data/core/government-batch-1.ts
+++ b/src/data/core/government-batch-1.ts
@@ -1,4 +1,4 @@
-import type { GameCard } from '../../types/cardTypes';
+import type { GameCard } from '@/rules/mvp';
 
 export const governmentBatch1: GameCard[] = [
   {

--- a/src/data/core/government-batch-2.ts
+++ b/src/data/core/government-batch-2.ts
@@ -1,4 +1,4 @@
-import type { GameCard } from '../../types/cardTypes';
+import type { GameCard } from '@/rules/mvp';
 
 export const governmentBatch2: GameCard[] = [
   {

--- a/src/data/core/government-batch-3.ts
+++ b/src/data/core/government-batch-3.ts
@@ -1,4 +1,4 @@
-import type { GameCard } from '../../types/cardTypes';
+import type { GameCard } from '@/rules/mvp';
 
 export const governmentBatch3: GameCard[] = [
   {

--- a/src/data/core/government-batch-4.ts
+++ b/src/data/core/government-batch-4.ts
@@ -1,4 +1,4 @@
-import type { GameCard } from '../../types/cardTypes';
+import type { GameCard } from '@/rules/mvp';
 
 export const governmentBatch4: GameCard[] = [
   {

--- a/src/data/core/index.ts
+++ b/src/data/core/index.ts
@@ -1,4 +1,4 @@
-import type { GameCard } from '../../types/cardTypes';
+import type { GameCard } from '@/rules/mvp';
 
 // TRUTH (4 × 50)
 import { truthBatch1 } from './truth-batch-1';

--- a/src/data/core/truth-batch-1.ts
+++ b/src/data/core/truth-batch-1.ts
@@ -1,4 +1,4 @@
-import type { GameCard } from '../../types/cardTypes';
+import type { GameCard } from '@/rules/mvp';
 
 export const truthBatch1: GameCard[] = [
   {

--- a/src/data/core/truth-batch-2.ts
+++ b/src/data/core/truth-batch-2.ts
@@ -1,4 +1,4 @@
-import type { GameCard } from '../../types/cardTypes';
+import type { GameCard } from '@/rules/mvp';
 
 export const truthBatch2: GameCard[] = [
   {

--- a/src/data/core/truth-batch-3.ts
+++ b/src/data/core/truth-batch-3.ts
@@ -1,4 +1,4 @@
-import type { GameCard } from '../../types/cardTypes';
+import type { GameCard } from '@/rules/mvp';
 
 export const truthBatch3: GameCard[] = [
   {

--- a/src/data/core/truth-batch-4.ts
+++ b/src/data/core/truth-batch-4.ts
@@ -1,4 +1,4 @@
-import type { GameCard } from '../../types/cardTypes';
+import type { GameCard } from '@/rules/mvp';
 
 export const truthBatch4: GameCard[] = [
   {

--- a/src/mvp/validator.ts
+++ b/src/mvp/validator.ts
@@ -1,5 +1,5 @@
-import type { CardType, Faction, Rarity } from '@/rules/mvp';
-import { expectedCost } from '@/rules/mvp';
+import type { Faction, GameCard, MVPCardType, Rarity } from '@/rules/mvp';
+import { expectedCost, MVP_CARD_TYPES } from '@/rules/mvp';
 
 export type EffectsATTACK = {
   ipDelta: { opponent: number };
@@ -14,18 +14,13 @@ export type EffectsZONE = {
   pressureDelta: number;
 };
 
-export type Card = {
-  id: string;
-  name: string;
-  faction: Faction;
-  type: CardType;
+export type MVPGameCard = GameCard & {
   rarity: Rarity;
-  cost: number;
+  type: MVPCardType;
   effects: EffectsATTACK | EffectsMEDIA | EffectsZONE;
-  artId?: string;
-  flavor?: string;
-  tags?: string[];
 };
+
+export type Card = MVPGameCard;
 
 export type PlayerId = 'P1' | 'P2';
 
@@ -51,270 +46,413 @@ export type GameState = {
 };
 
 export const ALLOWED_FACTIONS: readonly Faction[] = ['truth', 'government'];
-export const ALLOWED_TYPES: readonly CardType[] = ['ATTACK', 'MEDIA', 'ZONE'];
+export const ALLOWED_TYPES: readonly MVPCardType[] = MVP_CARD_TYPES;
 export const ALLOWED_RARITIES: readonly Rarity[] = ['common', 'uncommon', 'rare', 'legendary'];
 
-const isNonEmptyString = (value: unknown): value is string =>
-  typeof value === 'string' && value.trim().length > 0;
+const DEV = typeof import.meta !== 'undefined' && (import.meta as any)?.env?.DEV;
+
+const toTrimmedString = (value: unknown): string | null => {
+  if (typeof value === 'string') {
+    const trimmed = value.trim();
+    return trimmed.length > 0 ? trimmed : null;
+  }
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return String(value);
+  }
+  return null;
+};
+
+const toFaction = (value: unknown, changes: string[]): Faction => {
+  const text = toTrimmedString(value)?.toLowerCase();
+  if (text === 'government') {
+    return 'government';
+  }
+  if (text === 'truth') {
+    return 'truth';
+  }
+  if (text === 'Truth' || text === 'Government') {
+    changes.push(`coerced faction '${value}' to lowercase`);
+  } else if (value !== undefined) {
+    changes.push(`replaced invalid faction '${value}' with 'truth'`);
+  }
+  return 'truth';
+};
+
+const toType = (value: unknown, changes: string[]): MVPCardType => {
+  const text = toTrimmedString(value)?.toUpperCase();
+  if (text && ALLOWED_TYPES.includes(text as MVPCardType)) {
+    return text as MVPCardType;
+  }
+  if (value !== undefined && value !== null) {
+    changes.push(`replaced invalid type '${value}' with 'MEDIA'`);
+  }
+  return 'MEDIA';
+};
+
+const toRarity = (value: unknown, changes: string[]): Rarity => {
+  const text = toTrimmedString(value)?.toLowerCase();
+  if (text && ALLOWED_RARITIES.includes(text as Rarity)) {
+    return text as Rarity;
+  }
+  if (value !== undefined && value !== null) {
+    changes.push(`replaced invalid rarity '${value}' with 'common'`);
+  }
+  return 'common';
+};
 
 const toNumber = (value: unknown): number | null => {
   if (typeof value === 'number' && Number.isFinite(value)) {
     return value;
   }
-  if (typeof value === 'string' && value.trim().length > 0) {
+  if (typeof value === 'string') {
     const parsed = Number(value);
-    if (!Number.isNaN(parsed) && Number.isFinite(parsed)) {
-      return parsed;
-    }
+    return Number.isFinite(parsed) ? parsed : null;
   }
   return null;
 };
 
-const CARD_ALLOWED_KEYS = new Set([
-  'id',
-  'name',
-  'faction',
-  'type',
-  'rarity',
-  'cost',
-  'effects',
-  'artId',
-  'flavor',
-  'tags',
-]);
+const clampInteger = (value: number, min: number, max: number): number => {
+  if (!Number.isFinite(value)) {
+    return min;
+  }
+  const rounded = Math.round(value);
+  return Math.max(min, Math.min(max, rounded));
+};
 
-const ATTACK_EFFECT_KEYS = new Set(['ipDelta', 'discardOpponent']);
-const MEDIA_EFFECT_KEYS = new Set(['truthDelta']);
-const ZONE_EFFECT_KEYS = new Set(['pressureDelta']);
+const sanitizeAttackEffects = (
+  rawEffects: unknown,
+  changes: string[],
+  warnings: string[],
+): EffectsATTACK => {
+  const source = (typeof rawEffects === 'object' && rawEffects !== null
+    ? (rawEffects as Record<string, unknown>)
+    : {}) as Record<string, unknown>;
 
-export type CardValidationResult = {
-  card?: Card;
+  let opponentDelta: number | null = null;
+
+  if (typeof source.ipDelta === 'number') {
+    opponentDelta = source.ipDelta;
+    changes.push('normalized ATTACK ipDelta from number to object form');
+  } else if (typeof source.ipDelta === 'object' && source.ipDelta !== null) {
+    opponentDelta = toNumber((source.ipDelta as Record<string, unknown>).opponent);
+  }
+
+  if (opponentDelta === null || opponentDelta <= 0) {
+    warnings.push('ATTACK cards require ipDelta.opponent > 0; defaulting to 1');
+    opponentDelta = 1;
+  }
+
+  const attack: EffectsATTACK = {
+    ipDelta: { opponent: clampInteger(opponentDelta, 1, 9) },
+  };
+
+  if (Object.prototype.hasOwnProperty.call(source, 'discardOpponent')) {
+    const discard = toNumber(source.discardOpponent);
+    if (discard === null) {
+      warnings.push('discardOpponent must be a number; removing value');
+    } else {
+      const normalized = clampInteger(discard, 0, 2) as 0 | 1 | 2;
+      if (normalized !== discard) {
+        changes.push(`clamped discardOpponent from ${discard} to ${normalized}`);
+      }
+      if (normalized > 0) {
+        attack.discardOpponent = normalized;
+      }
+    }
+  }
+
+  const allowedKeys = new Set(['ipDelta', 'discardOpponent']);
+  const extraKeys = Object.keys(source).filter(key => !allowedKeys.has(key));
+  if (extraKeys.length > 0) {
+    changes.push(`removed unsupported ATTACK effect keys: ${extraKeys.join(', ')}`);
+  }
+
+  return attack;
+};
+
+const sanitizeMediaEffects = (
+  rawEffects: unknown,
+  changes: string[],
+  warnings: string[],
+): EffectsMEDIA => {
+  let delta: number | null = null;
+
+  if (typeof rawEffects === 'number') {
+    delta = rawEffects;
+    changes.push('normalized MEDIA effects from number to object form');
+  } else if (typeof rawEffects === 'object' && rawEffects !== null) {
+    delta = toNumber((rawEffects as Record<string, unknown>).truthDelta);
+  }
+
+  if (delta === null) {
+    warnings.push('MEDIA cards require truthDelta; defaulting to 1');
+    delta = 1;
+  }
+
+  const media: EffectsMEDIA = { truthDelta: Math.round(delta) };
+
+  const extraKeys =
+    rawEffects && typeof rawEffects === 'object'
+      ? Object.keys(rawEffects as Record<string, unknown>).filter(key => key !== 'truthDelta')
+      : [];
+  if (extraKeys.length > 0) {
+    changes.push(`removed unsupported MEDIA effect keys: ${extraKeys.join(', ')}`);
+  }
+
+  return media;
+};
+
+const sanitizeZoneEffects = (
+  rawEffects: unknown,
+  changes: string[],
+  warnings: string[],
+): EffectsZONE => {
+  let delta: number | null = null;
+
+  if (typeof rawEffects === 'number') {
+    delta = rawEffects;
+    changes.push('normalized ZONE effects from number to object form');
+  } else if (typeof rawEffects === 'object' && rawEffects !== null) {
+    delta = toNumber((rawEffects as Record<string, unknown>).pressureDelta);
+    const extraKeys = Object.keys(rawEffects as Record<string, unknown>).filter(
+      key => key !== 'pressureDelta',
+    );
+    if (extraKeys.length > 0) {
+      changes.push(`removed unsupported ZONE effect keys: ${extraKeys.join(', ')}`);
+    }
+  }
+
+  if (delta === null || delta <= 0) {
+    warnings.push('ZONE cards require pressureDelta > 0; defaulting to 1');
+    delta = 1;
+  }
+
+  return { pressureDelta: clampInteger(delta, 1, 9) };
+};
+
+const normalizeFlavor = (value: unknown): string | undefined => {
+  const text = toTrimmedString(value);
+  return text ?? undefined;
+};
+
+const normalizeTarget = (type: MVPCardType, value: unknown, changes: string[]) => {
+  if (type !== 'ZONE') {
+    return undefined;
+  }
+
+  if (typeof value === 'object' && value !== null) {
+    const scope = toTrimmedString((value as Record<string, unknown>).scope)?.toLowerCase();
+    const count = toNumber((value as Record<string, unknown>).count);
+
+    const normalizedScope = scope === 'state' ? 'state' : 'state';
+    if (scope !== 'state' && scope !== undefined) {
+      changes.push(`normalized ZONE target scope from '${scope}' to 'state'`);
+    }
+
+    const normalizedCount = clampInteger(count ?? 1, 1, 3);
+    if (!count || normalizedCount !== count) {
+      changes.push(`normalized ZONE target count to ${normalizedCount}`);
+    }
+
+    return { scope: normalizedScope as 'state', count: normalizedCount };
+  }
+
+  changes.push('added default ZONE target { scope: "state", count: 1 }');
+  return { scope: 'state' as const, count: 1 };
+};
+
+const createMvpText = (
+  type: MVPCardType,
+  effects: EffectsATTACK | EffectsMEDIA | EffectsZONE,
+): string | undefined => {
+  switch (type) {
+    case 'ATTACK': {
+      const attack = effects as EffectsATTACK;
+      const parts = [`Opponent -${attack.ipDelta.opponent} IP`];
+      if (attack.discardOpponent && attack.discardOpponent > 0) {
+        parts.push(
+          attack.discardOpponent === 1
+            ? 'Opponent discards 1 card'
+            : `Opponent discards ${attack.discardOpponent} cards`,
+        );
+      }
+      return `${parts.join('. ')}.`;
+    }
+    case 'MEDIA': {
+      const media = effects as EffectsMEDIA;
+      const value = media.truthDelta;
+      const sign = value >= 0 ? '+' : '';
+      return `${sign}${value}% Truth.`;
+    }
+    case 'ZONE': {
+      const zone = effects as EffectsZONE;
+      return `+${zone.pressureDelta} Pressure to a state.`;
+    }
+    default:
+      return undefined;
+  }
+};
+
+export type MVPRepairResult = {
+  card: MVPGameCard;
   errors: string[];
   changes: string[];
 };
 
-export function sanitizeCard(raw: unknown): CardValidationResult {
-  const errors: string[] = [];
+export function repairToMVP(raw: unknown): MVPRepairResult {
   const changes: string[] = [];
+  const errors: string[] = [];
 
   if (typeof raw !== 'object' || raw === null) {
-    return { errors: ['card is not an object'], changes };
-  }
-
-  const input = raw as Record<string, unknown>;
-
-  if (!isNonEmptyString(input.id)) {
-    errors.push('missing id');
-  }
-  if (!isNonEmptyString(input.name)) {
-    errors.push('missing name');
-  }
-
-  const faction = input.faction;
-  if (!ALLOWED_FACTIONS.includes(faction as Faction)) {
-    errors.push(`invalid faction: ${faction}`);
-  }
-
-  const type = input.type;
-  if (!ALLOWED_TYPES.includes(type as CardType)) {
-    errors.push(`invalid type: ${type}`);
-  }
-
-  const rarity = input.rarity;
-  if (!ALLOWED_RARITIES.includes(rarity as Rarity)) {
-    errors.push(`invalid rarity: ${rarity}`);
-  }
-
-  if (errors.length > 0) {
-    return { errors, changes };
-  }
-
-  const typedType = type as CardType;
-  const typedRarity = rarity as Rarity;
-  const typedFaction = faction as Faction;
-
-  const extraCardKeys = Object.keys(input).filter(key => !CARD_ALLOWED_KEYS.has(key));
-  if (extraCardKeys.length > 0) {
-    changes.push(`removed unsupported card keys: ${extraCardKeys.join(', ')}`);
-  }
-
-  const sanitizeAttack = (value: unknown): EffectsATTACK | null => {
-    if (typeof value !== 'object' || value === null) {
-      errors.push('ATTACK card requires effects object');
-      return null;
-    }
-    const effects = value as Record<string, unknown>;
-
-    let opponentDelta: number | null = null;
-    if (typeof effects.ipDelta === 'number') {
-      opponentDelta = effects.ipDelta;
-      changes.push('normalized ipDelta to object form');
-    } else if (typeof effects.ipDelta === 'object' && effects.ipDelta !== null) {
-      opponentDelta = toNumber((effects.ipDelta as Record<string, unknown>).opponent);
-      const extra = Object.keys(effects.ipDelta as Record<string, unknown>).filter(
-        key => key !== 'opponent',
-      );
-      if (extra.length > 0) {
-        changes.push(`removed unsupported ipDelta keys: ${extra.join(', ')}`);
-      }
-    }
-
-    if (opponentDelta === null || opponentDelta <= 0) {
-      errors.push('ATTACK card requires ipDelta.opponent > 0');
-      return null;
-    }
-
-    const extraKeys = Object.keys(effects).filter(key => !ATTACK_EFFECT_KEYS.has(key));
-    if (extraKeys.length > 0) {
-      changes.push(`removed unsupported ATTACK effect keys: ${extraKeys.join(', ')}`);
-    }
-
-    const attackEffects: EffectsATTACK = {
-      ipDelta: { opponent: opponentDelta },
+    errors.push('card is not an object');
+    const card: MVPGameCard = {
+      id: `mvp-card-${Math.random().toString(36).slice(2, 10)}`,
+      name: 'Unknown Card',
+      faction: 'truth',
+      type: 'MEDIA',
+      rarity: 'common',
+      cost: expectedCost('MEDIA', 'common'),
+      effects: { truthDelta: 1 },
     };
+    return { card, errors, changes };
+  }
 
-    if (Object.prototype.hasOwnProperty.call(effects, 'discardOpponent')) {
-      const discard = toNumber(effects.discardOpponent);
-      if (discard === null || !Number.isInteger(discard) || discard < 0 || discard > 2) {
-        errors.push('discardOpponent must be 0, 1 or 2');
-      } else if (discard > 0) {
-        attackEffects.discardOpponent = discard as 0 | 1 | 2;
-      }
-    }
+  const source = raw as Record<string, unknown>;
 
-    return attackEffects;
-  };
+  const id = toTrimmedString(source.id) ?? `mvp-card-${Math.random().toString(36).slice(2, 10)}`;
+  if (!toTrimmedString(source.id)) {
+    errors.push('missing id; generated placeholder id');
+    changes.push(`generated id ${id}`);
+  }
 
-  const sanitizeMedia = (value: unknown): EffectsMEDIA | null => {
-    const delta = toNumber((value as Record<string, unknown>)?.truthDelta);
-    if (delta === null) {
-      errors.push('MEDIA card requires truthDelta');
-      return null;
-    }
-    const extraKeys =
-      value && typeof value === 'object'
-        ? Object.keys(value as Record<string, unknown>).filter(
-            key => !MEDIA_EFFECT_KEYS.has(key),
-          )
-        : [];
-    if (extraKeys.length > 0) {
-      changes.push(`removed unsupported MEDIA effect keys: ${extraKeys.join(', ')}`);
-    }
-    return { truthDelta: delta };
-  };
+  const name = toTrimmedString(source.name) ?? 'Unnamed Card';
+  if (!toTrimmedString(source.name)) {
+    errors.push('missing name; defaulted to "Unnamed Card"');
+  }
 
-  const sanitizeZone = (value: unknown): EffectsZONE | null => {
-    const delta = toNumber((value as Record<string, unknown>)?.pressureDelta);
-    if (delta === null || delta <= 0) {
-      errors.push('ZONE card requires pressureDelta > 0');
-      return null;
-    }
-    const extraKeys =
-      value && typeof value === 'object'
-        ? Object.keys(value as Record<string, unknown>).filter(
-            key => !ZONE_EFFECT_KEYS.has(key),
-          )
-        : [];
-    if (extraKeys.length > 0) {
-      changes.push(`removed unsupported ZONE effect keys: ${extraKeys.join(', ')}`);
-    }
-    return { pressureDelta: delta };
-  };
+  const faction = toFaction(source.faction, changes);
+  const type = toType(source.type, changes);
+  const rarity = toRarity(source.rarity, changes);
 
-  let effects: EffectsATTACK | EffectsMEDIA | EffectsZONE | null = null;
-  if (typedType === 'ATTACK') {
-    effects = sanitizeAttack(input.effects);
-  } else if (typedType === 'MEDIA') {
-    effects = sanitizeMedia(input.effects);
+  const warnings: string[] = [];
+  let effects: EffectsATTACK | EffectsMEDIA | EffectsZONE;
+  if (type === 'ATTACK') {
+    effects = sanitizeAttackEffects(source.effects, changes, warnings);
+  } else if (type === 'MEDIA') {
+    effects = sanitizeMediaEffects(source.effects, changes, warnings);
   } else {
-    effects = sanitizeZone(input.effects);
+    effects = sanitizeZoneEffects(source.effects, changes, warnings);
   }
 
-  if (effects === null) {
-    return { errors, changes };
+  warnings.forEach(message => {
+    errors.push(message);
+  });
+
+  const flavor = normalizeFlavor(source.flavor);
+  const flavorTruth = normalizeFlavor(source.flavorTruth) ?? flavor;
+  const flavorGov = normalizeFlavor(source.flavorGov) ?? flavor;
+
+  const target = normalizeTarget(type, source.target, changes);
+
+  if (source.text) {
+    changes.push('removed deprecated text field');
   }
 
-  const card: Card = {
-    id: (input.id as string).trim(),
-    name: (input.name as string).trim(),
-    faction: typedFaction,
-    type: typedType,
-    rarity: typedRarity,
-    cost: expectedCost(typedType, typedRarity),
+  const card: MVPGameCard = {
+    id,
+    name,
+    faction,
+    type,
+    rarity,
+    cost: expectedCost(type, rarity),
     effects,
   };
 
-  if (input.cost !== card.cost) {
-    changes.push(`cost set to ${card.cost}`);
+  if (flavor) {
+    card.flavor = flavor;
+  }
+  if (flavorTruth) {
+    card.flavorTruth = flavorTruth;
+  }
+  if (flavorGov) {
+    card.flavorGov = flavorGov;
+  }
+  if (target) {
+    card.target = target;
   }
 
-  if (isNonEmptyString(input.artId)) {
-    card.artId = input.artId;
+  if (typeof source.extId === 'string' && source.extId.trim().length > 0) {
+    card.extId = source.extId.trim();
   }
-  if (isNonEmptyString(input.flavor)) {
-    card.flavor = input.flavor;
-  }
-  if (Array.isArray(input.tags)) {
-    const tags = input.tags.filter(tag => typeof tag === 'string' && tag.trim().length > 0);
-    if (tags.length > 0) {
-      card.tags = tags;
-    }
+
+  const autoText = createMvpText(type, effects);
+  if (autoText) {
+    card.text = autoText;
   }
 
   return { card, errors, changes };
 }
 
-export function validateCard(card: Card): { ok: boolean; errors: string[] } {
-  const errors: string[] = [];
+export function validateCardMVP(card: MVPGameCard): { ok: boolean; errors: string[] } {
+  const validationErrors: string[] = [];
 
   if (!ALLOWED_FACTIONS.includes(card.faction)) {
-    errors.push(`invalid faction: ${card.faction}`);
+    validationErrors.push(`invalid faction: ${card.faction}`);
   }
 
   if (!ALLOWED_TYPES.includes(card.type)) {
-    errors.push(`invalid type: ${card.type}`);
+    validationErrors.push(`invalid type: ${card.type}`);
   }
 
   if (!ALLOWED_RARITIES.includes(card.rarity)) {
-    errors.push(`invalid rarity: ${card.rarity}`);
+    validationErrors.push(`invalid rarity: ${card.rarity}`);
   }
 
-  const expected = expectedCost(card.type, card.rarity);
-  if (card.cost !== expected) {
-    errors.push(`cost should be ${expected}`);
+  if (ALLOWED_TYPES.includes(card.type) && ALLOWED_RARITIES.includes(card.rarity)) {
+    const expected = expectedCost(card.type, card.rarity);
+    if (card.cost !== expected) {
+      validationErrors.push(`cost should be ${expected}`);
+    }
   }
 
   switch (card.type) {
     case 'ATTACK': {
       const effects = card.effects as EffectsATTACK;
-      if (!effects?.ipDelta || effects.ipDelta.opponent <= 0) {
-        errors.push('ATTACK cards require ipDelta.opponent > 0');
+      if (effects.ipDelta.opponent <= 0) {
+        validationErrors.push('ATTACK cards require ipDelta.opponent > 0');
       }
       if (
         typeof effects.discardOpponent !== 'undefined' &&
         ![0, 1, 2].includes(effects.discardOpponent)
       ) {
-        errors.push('discardOpponent must be 0, 1 or 2 when present');
+        validationErrors.push('discardOpponent must be 0, 1 or 2 when present');
       }
       break;
     }
     case 'MEDIA': {
       const effects = card.effects as EffectsMEDIA;
       if (typeof effects.truthDelta !== 'number' || Number.isNaN(effects.truthDelta)) {
-        errors.push('MEDIA cards require numeric truthDelta');
+        validationErrors.push('MEDIA cards require numeric truthDelta');
       }
       break;
     }
     case 'ZONE': {
       const effects = card.effects as EffectsZONE;
-      if (!effects || effects.pressureDelta <= 0) {
-        errors.push('ZONE cards require pressureDelta > 0');
+      if (effects.pressureDelta <= 0) {
+        validationErrors.push('ZONE cards require pressureDelta > 0');
+      }
+      if (!card.target || card.target.scope !== 'state') {
+        validationErrors.push('ZONE cards require state target');
       }
       break;
     }
   }
 
-  return { ok: errors.length === 0, errors };
+  if (DEV && validationErrors.length > 0) {
+    console.warn('[MVP VALIDATOR]', card.id, validationErrors);
+  }
+
+  return { ok: validationErrors.length === 0, errors: validationErrors };
 }
 
 export function clonePlayer(player: PlayerState): PlayerState {
@@ -341,3 +479,4 @@ export function cloneGameState(state: GameState): GameState {
     stateDefense: { ...state.stateDefense },
   };
 }
+

--- a/src/systems/__tests__/cardResolution.test.ts
+++ b/src/systems/__tests__/cardResolution.test.ts
@@ -6,7 +6,7 @@ import {
   type GameSnapshot,
   type AchievementTracker,
 } from '../cardResolution';
-import type { GameCard } from '../../types/cardTypes';
+import type { GameCard } from '@/rules/mvp';
 import type { PlayerStats } from '../../data/achievementSystem';
 
 const createBaseState = (): GameSnapshot => ({


### PR DESCRIPTION
## Summary
- replace legacy card sanitizer with repairToMVP/validateCardMVP to enforce MVP schema and generate baseline rules text
- load core and extension cards through the MVP repair pipeline, exposing helpers to inspect sanitized core/all cards
- streamline weighted deck generation and extension ingestion to operate purely on MVP ATTACK/MEDIA/ZONE cards and update docs/tooling for the new flow

## Testing
- npm run lint *(fails: missing @eslint/js dependency in workspace)*
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cab698b43483209c66f24f20471149