### PR TITLE
Switch game state flow to MVP resolver

### DIFF
--- a/src/data/cardDatabase.ts
+++ b/src/data/cardDatabase.ts
@@ -176,6 +176,10 @@ export function getAllCardsSnapshot(): GameCard[] {
   return getAllCards();
 }
 
+export async function loadCardPool(): Promise<GameCard[]> {
+  return loadCoreCards();
+}
+
 export const CARD_DATABASE: GameCard[] = new Proxy([], {
   get(_target, prop) {
     const cards = getAllCards();

--- a/src/data/weightedCardDistribution.ts
+++ b/src/data/weightedCardDistribution.ts
@@ -1,6 +1,5 @@
 import type { GameCard } from '@/rules/mvp';
 import { ensureMvpCosts, getCoreCards, isMvpCard } from './cardDatabase';
-import { extensionManager } from './extensionSystem';
 
 export const MVP_TYPE_WEIGHTS: Record<'ATTACK' | 'MEDIA' | 'ZONE', number> = {
   ATTACK: 0.33,
@@ -149,9 +148,9 @@ interface CardSet {
 class WeightedCardDistribution {
   private settings: DistributionSettings = { ...DEFAULT_DISTRIBUTION_SETTINGS };
   
-  // Get all available card sets (core + enabled extensions)
+  // Get available card sets (core only in MVP)
   private getAvailableCardSets(): CardSet[] {
-    const sets: CardSet[] = [
+    return [
       {
         id: 'core',
         name: 'Core Set',
@@ -159,26 +158,6 @@ class WeightedCardDistribution {
         isCore: true,
       },
     ];
-
-    const allExtensionCards = extensionManager.getAllExtensionCards();
-    const enabledExtensions = extensionManager.getEnabledExtensions();
-    enabledExtensions.forEach(ext => {
-      const extensionCards = sanitizeSetCards(
-        allExtensionCards.filter(card => card.extId === ext.id),
-        ext.id,
-      );
-
-      if (extensionCards.length > 0) {
-        sets.push({
-          id: ext.id,
-          name: ext.name,
-          cards: extensionCards,
-          isCore: false,
-        });
-      }
-    });
-
-    return sets;
   }
 
   // MVP: Remove keyword heuristics - exact faction match only


### PR DESCRIPTION
## Summary
- add a unified `resolveCardMVP` adapter that handles both human and AI MVP card plays and keeps AI control/pressure in sync
- update `useGameState` to use the MVP resolver, drop extension-era card logic, and run AI turns through the same effect system
- expose a simple loader in the card database and scope weighted deck generation to the core MVP set

## Testing
- `npm run lint` *(fails: missing @eslint/js dependency in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cac0db2d588320a96864276150748c