### PR TITLE
Align MVP UI with streamlined rules

### DIFF
--- a/src/components/game/CardCollection.tsx
+++ b/src/components/game/CardCollection.tsx
@@ -5,8 +5,9 @@ import { Input } from '@/components/ui/input';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { Progress } from '@/components/ui/progress';
 import { useCardCollection } from '@/hooks/useCardCollection';
-import type { GameCard } from '@/rules/mvp';
+import type { GameCard, MVPCardType } from '@/rules/mvp';
 import { CARD_DATABASE } from '@/data/cardDatabase';
+import { MVP_CARD_TYPES } from '@/rules/mvp';
 
 interface CardCollectionProps {
   open: boolean;
@@ -22,13 +23,17 @@ const CardCollection = ({ open, onOpenChange }: CardCollectionProps) => {
   const stats = getCollectionStats();
   const discoveredCards = getDiscoveredCards();
   
+  const normalizeCardType = (type: string): MVPCardType => {
+    return MVP_CARD_TYPES.includes(type as MVPCardType) ? type as MVPCardType : 'MEDIA';
+  };
+
   // Filter cards based on search and filters
   const filteredCards = discoveredCards.filter(card => {
     const matchesSearch = card.name.toLowerCase().includes(searchTerm.toLowerCase()) ||
                          card.text.toLowerCase().includes(searchTerm.toLowerCase());
-    const matchesType = filterType === 'all' || card.type === filterType;
+    const matchesType = filterType === 'all' || normalizeCardType(card.type) === filterType;
     const matchesRarity = filterRarity === 'all' || card.rarity === filterRarity;
-    
+
     return matchesSearch && matchesType && matchesRarity;
   });
 
@@ -44,7 +49,7 @@ const CardCollection = ({ open, onOpenChange }: CardCollectionProps) => {
                            card.rarity === 'rare' ? 'secondary' : 'outline'}>
               {card.rarity}
             </Badge>
-            <Badge variant="outline">{card.type}</Badge>
+            <Badge variant="outline">{normalizeCardType(card.type)}</Badge>
           </div>
         </div>
         
@@ -111,7 +116,6 @@ const CardCollection = ({ open, onOpenChange }: CardCollectionProps) => {
               <SelectItem value="MEDIA">Media</SelectItem>
               <SelectItem value="ZONE">Zone</SelectItem>
               <SelectItem value="ATTACK">Attack</SelectItem>
-              <SelectItem value="DEFENSIVE">Defensive</SelectItem>
             </SelectContent>
           </Select>
           <Select value={filterRarity} onValueChange={setFilterRarity}>

--- a/src/components/game/CardCollectionTabloid.tsx
+++ b/src/components/game/CardCollectionTabloid.tsx
@@ -6,7 +6,8 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@
 import { Progress } from '@/components/ui/progress';
 import { Button } from '@/components/ui/button';
 import { useCardCollection } from '@/hooks/useCardCollection';
-import type { GameCard } from '@/rules/mvp';
+import type { GameCard, MVPCardType } from '@/rules/mvp';
+import { MVP_CARD_TYPES } from '@/rules/mvp';
 
 interface CardCollectionTabloidProps {
   open: boolean;
@@ -22,13 +23,17 @@ const CardCollectionTabloid = ({ open, onOpenChange }: CardCollectionTabloidProp
   const stats = getCollectionStats();
   const discoveredCards = getDiscoveredCards();
   
+  const normalizeCardType = (type: string): MVPCardType => {
+    return MVP_CARD_TYPES.includes(type as MVPCardType) ? type as MVPCardType : 'MEDIA';
+  };
+
   // Filter cards based on search and filters
   const filteredCards = discoveredCards.filter(card => {
     const matchesSearch = card.name.toLowerCase().includes(searchTerm.toLowerCase()) ||
                          card.text.toLowerCase().includes(searchTerm.toLowerCase());
-    const matchesType = filterType === 'all' || card.type === filterType;
+    const matchesType = filterType === 'all' || normalizeCardType(card.type) === filterType;
     const matchesRarity = filterRarity === 'all' || card.rarity === filterRarity;
-    
+
     return matchesSearch && matchesType && matchesRarity;
   });
 
@@ -55,7 +60,7 @@ const CardCollectionTabloid = ({ open, onOpenChange }: CardCollectionTabloidProp
           </h3>
           <div className="flex gap-1 mt-1">
             <div className="text-[10px] uppercase font-black px-1 py-0.5 bg-black text-white">
-              {card.type}
+              {normalizeCardType(card.type)}
             </div>
             <div className="text-[10px] uppercase font-black px-1 py-0.5 border border-black">
               {card.rarity}
@@ -147,7 +152,6 @@ const CardCollectionTabloid = ({ open, onOpenChange }: CardCollectionTabloidProp
                   <SelectItem value="MEDIA">MEDIA</SelectItem>
                   <SelectItem value="ZONE">ZONE</SelectItem>
                   <SelectItem value="ATTACK">ATTACK</SelectItem>
-                  <SelectItem value="DEFENSIVE">DEFENSIVE</SelectItem>
                 </SelectContent>
               </Select>
               <Select value={filterRarity} onValueChange={setFilterRarity}>

--- a/src/components/game/CardDetailOverlay.tsx
+++ b/src/components/game/CardDetailOverlay.tsx
@@ -1,8 +1,9 @@
 import React from 'react';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
-import { X, Target, Zap, Shield } from 'lucide-react';
+import { X, Target, Zap, Megaphone } from 'lucide-react';
 import type { GameCard } from '@/rules/mvp';
+import { MVP_CARD_TYPES, type MVPCardType } from '@/rules/mvp';
 import CardImage from '@/components/game/CardImage';
 import { ExtensionCardBadge } from '@/components/game/ExtensionCardBadge';
 import { useIsMobile } from '@/hooks/use-mobile';
@@ -57,26 +58,21 @@ const CardDetailOverlay: React.FC<CardDetailOverlayProps> = ({
     return `rarity-glow-${rarityLevel}`;
   };
 
-  const getTypeColor = (type: string, faction: 'government' | 'truth') => {
+  const normalizeCardType = (type: string): MVPCardType => {
+    return MVP_CARD_TYPES.includes(type as MVPCardType) ? type as MVPCardType : 'MEDIA';
+  };
+
+  const getTypeColor = (type: MVPCardType, faction: 'government' | 'truth') => {
     switch (type) {
       case 'MEDIA':
-        return faction === 'truth' 
+        return faction === 'truth'
           ? 'bg-truth-red/20 border-truth-red text-truth-red'
           : 'bg-government-blue/20 border-government-blue text-government-blue';
       case 'ZONE':
         return 'bg-accent/20 border-accent text-accent-foreground';
       case 'ATTACK':
-        return 'bg-destructive/20 border-destructive text-destructive';
-      case 'DEFENSIVE':
-        return 'bg-success/20 border-success text-success-foreground';
-      case 'TECH':
-        return 'bg-primary/20 border-primary text-primary';
-      case 'DEVELOPMENT':
-        return 'bg-secondary/20 border-secondary text-secondary-foreground';
-      case 'INSTANT':
-        return 'bg-warning/20 border-warning text-warning-foreground';
       default:
-        return 'bg-muted/20 border-muted text-muted-foreground';
+        return 'bg-destructive/20 border-destructive text-destructive';
     }
   };
 
@@ -89,6 +85,7 @@ const CardDetailOverlay: React.FC<CardDetailOverlayProps> = ({
   };
 
   const faction = getCardFaction(card);
+  const displayType = normalizeCardType(card.type);
   const flavorText = card.flavor ?? card.flavorGov ?? card.flavorTruth ?? 'No intelligence available.';
 
   return (
@@ -115,11 +112,11 @@ const CardDetailOverlay: React.FC<CardDetailOverlayProps> = ({
               </h2>
               
               {/* Type Badge */}
-              <Badge 
-                variant="outline" 
-                className={`text-xs px-2 py-0.5 ${getTypeColor(card.type, faction)}`}
+              <Badge
+                variant="outline"
+                className={`text-xs px-2 py-0.5 ${getTypeColor(displayType, faction)}`}
               >
-                {card.type}
+                {displayType}
               </Badge>
             </div>
             
@@ -204,10 +201,10 @@ const CardDetailOverlay: React.FC<CardDetailOverlayProps> = ({
             }`}
           >
             <span className="relative z-10 flex items-center justify-center gap-2">
-              {card.type === 'ZONE' && <Target className={isMobile ? 'w-5 h-5' : 'w-4 h-4'} />}
-              {card.type === 'ATTACK' && <Zap className={isMobile ? 'w-5 h-5' : 'w-4 h-4'} />}
-              {card.type === 'DEFENSIVE' && <Shield className={isMobile ? 'w-5 h-5' : 'w-4 h-4'} />}
-              {card.type === 'ZONE' ? 'SELECT & TARGET' : 'DEPLOY ASSET'}
+              {displayType === 'ZONE' && <Target className={isMobile ? 'w-5 h-5' : 'w-4 h-4'} />}
+              {displayType === 'ATTACK' && <Zap className={isMobile ? 'w-5 h-5' : 'w-4 h-4'} />}
+              {displayType === 'MEDIA' && <Megaphone className={isMobile ? 'w-5 h-5' : 'w-4 h-4'} />}
+              {displayType === 'ZONE' ? 'SELECT & TARGET' : 'DEPLOY ASSET'}
             </span>
             
             {!canAfford && (

--- a/src/components/game/EnhancedBalancingDashboard.tsx
+++ b/src/components/game/EnhancedBalancingDashboard.tsx
@@ -1,503 +1,137 @@
-import { useState, useMemo } from 'react';
 import { Card } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
-import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
-import { EnhancedCardBalancer } from '@/data/enhancedCardBalancing';
-import { extensionManager } from '@/data/extensionSystem';
-import { Download, RefreshCw, Image, FileText, BarChart3 } from 'lucide-react';
-import { PieChart, Pie, Cell, BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer, LineChart, Line, Area, AreaChart } from 'recharts';
+import {
+  MVP_COST_TABLE_ROWS,
+  MVP_RULES_SECTIONS,
+  MVP_RULES_TITLE,
+} from '@/content/mvpRules';
 
 interface EnhancedBalancingDashboardProps {
   onClose: () => void;
 }
 
 const EnhancedBalancingDashboard = ({ onClose }: EnhancedBalancingDashboardProps) => {
-  const [includeExtensions, setIncludeExtensions] = useState(true);
-  
-  const enhancedBalancer = useMemo(() => new EnhancedCardBalancer(includeExtensions), [includeExtensions]);
-  const report = useMemo(() => enhancedBalancer.generateEnhancedReport(), [enhancedBalancer]);
-  const simulation = useMemo(() => enhancedBalancer.runEnhancedSimulation(500), [enhancedBalancer]);
-
-  // Get actual card counts from the balancer
-  const actualCardCount = report.totalCards;
-  const extensionCardCount = includeExtensions ? extensionManager.getAllExtensionCards().length : 0;
-  const coreCardCount = actualCardCount - extensionCardCount;
-
-  console.log(`🔢 Enhanced Balancing Card Counts:
-  - Core Database: ${coreCardCount} cards
-  - Extension Cards: ${extensionCardCount} cards  
-  - Total Cards: ${actualCardCount} cards
-  - Include Extensions: ${includeExtensions}`);
-
-  const exportData = () => {
-    const data = enhancedBalancer.exportFullAnalysis();
-    const blob = new Blob([JSON.stringify(data, null, 2)], { type: 'application/json' });
-    const url = URL.createObjectURL(blob);
-    const link = document.createElement('a');
-    link.href = url;
-    link.download = `balance-report-mvp-${new Date().toISOString().split('T')[0]}.json`;
-    link.click();
-    URL.revokeObjectURL(url);
-  };
-
-  const exportCardIdsNeedingArt = () => {
-    const cardsNeedingArt = report.cardAnalysis.filter(card => 
-      !card.cardId.includes('temp') && // Cards with temp images
-      (card.classification === 'Undercosted' || card.severity === 'Severe')
-    );
-    
-    const artExport = {
-      timestamp: new Date().toISOString(),
-      totalCards: cardsNeedingArt.length,
-      categories: {
-        undercosted: cardsNeedingArt.filter(c => c.classification === 'Undercosted').map(c => ({
-          id: c.cardId,
-          name: c.name,
-          faction: c.faction,
-          rarity: c.rarity,
-          reason: 'Undercosted - needs better art to justify power'
-        })),
-        severe: cardsNeedingArt.filter(c => c.severity === 'Severe').map(c => ({
-          id: c.cardId,
-          name: c.name,
-          faction: c.faction,
-          rarity: c.rarity,
-          reason: 'Severe balance issues - high priority art needed'
-        }))
-      },
-      cardIds: cardsNeedingArt.map(c => c.cardId)
-    };
-
-    const blob = new Blob([JSON.stringify(artExport, null, 2)], { type: 'application/json' });
-    const url = URL.createObjectURL(blob);
-    const link = document.createElement('a');
-    link.href = url;
-    link.download = `cards-needing-art-${new Date().toISOString().split('T')[0]}.json`;
-    link.click();
-    URL.revokeObjectURL(url);
-  };
-
-  // Chart data preparation
-  const factionPieData = [
-    { name: 'Truth Seeker', value: report.truthCards, color: '#3b82f6' },
-    { name: 'Government', value: report.governmentCards, color: '#ef4444' },
-    { name: 'Misaligned', value: report.misalignedCards, color: '#f97316' }
-  ];
-
-  const balancePieData = [
-    { name: 'Balanserte', value: report.onCurve, color: '#10b981' },
-    { name: 'Underpriset', value: report.undercosted, color: '#ef4444' },
-    { name: 'Overpriset', value: report.overcosted, color: '#f59e0b' }
-  ];
-
-  const costDistributionData = useMemo(() => {
-    const costs: { [key: number]: number } = {};
-    report.cardAnalysis.forEach(card => {
-      costs[card.cost] = (costs[card.cost] || 0) + 1;
-    });
-    return Object.entries(costs).map(([cost, count]) => ({
-      cost: parseInt(cost),
-      count,
-      name: `${cost} IP`
-    })).sort((a, b) => a.cost - b.cost);
-  }, [report.cardAnalysis]);
-
-  const rarityDistributionData = useMemo(() => {
-    const rarities: { [key: string]: number } = {};
-    report.cardAnalysis.forEach(card => {
-      rarities[card.rarity] = (rarities[card.rarity] || 0) + 1;
-    });
-    return Object.entries(rarities).map(([rarity, count]) => ({
-      rarity,
-      count,
-      color: rarity === 'Legendary' ? '#8b5cf6' : 
-             rarity === 'Rare' ? '#3b82f6' : 
-             rarity === 'Common' ? '#10b981' : '#6b7280'
-    }));
-  }, [report.cardAnalysis]);
-
-  const utilityVsCostData = useMemo(() => {
-    return report.cardAnalysis.map(card => ({
-      name: card.name,
-      cost: card.cost,
-      utility: card.totalUtility,
-      faction: card.faction,
-      classification: card.classification
-    }));
-  }, [report.cardAnalysis]);
+  const effectSection = MVP_RULES_SECTIONS.find((section) => section.title === 'Effect Whitelist (MVP)');
+  const cardRolesSection = MVP_RULES_SECTIONS.find((section) => section.title === 'Card Roles');
 
   return (
     <div className="fixed inset-0 z-50 bg-black/80 flex items-center justify-center p-4">
-      <Card className="w-full max-w-6xl h-[90vh] bg-gray-900 border-gray-700 overflow-hidden">
-        <div className="flex items-center justify-between p-4 border-b border-gray-700">
+      <Card className="w-full max-w-4xl max-h-[90vh] bg-gray-950 border border-gray-700 overflow-hidden flex flex-col">
+        <div className="flex items-center justify-between p-4 border-b border-gray-800 bg-gray-900/80">
           <div>
-            <h2 className="text-xl font-bold text-white font-mono">ENHANCED BALANCING (MVP)</h2>
-            <div className="text-xs text-green-400 mt-1">Oppdatert for strukturerte card effects</div>
+            <h2 className="text-lg font-semibold text-white font-mono tracking-wide">
+              MVP BALANCING BRIEFING
+            </h2>
+            <p className="text-xs text-emerald-400 mt-1 font-mono">
+              Focused analytics for ATTACK • MEDIA • ZONE cards
+            </p>
           </div>
-          <div className="flex items-center gap-2">
-            <Button
-              onClick={() => setIncludeExtensions(!includeExtensions)}
-              variant={includeExtensions ? "default" : "outline"}
-              size="sm"
-            >
-              {includeExtensions ? "Med Extensions" : "Kun Base Cards"}
-            </Button>
-            <Button onClick={exportData} variant="outline" size="sm">
-              <Download size={16} className="mr-1" />
-              Export Data
-            </Button>
-            <Button onClick={exportCardIdsNeedingArt} variant="outline" size="sm">
-              <Image size={16} className="mr-1" />
-              Export Art List
-            </Button>
-            <Button 
-              onClick={() => window.open('/dev/recovery', '_blank')} 
-              variant="outline" 
-              size="sm"
-              className="text-orange-400 border-orange-600 hover:bg-orange-900/20"
-            >
-              <RefreshCw size={16} className="mr-1" />
-              Database Recovery
-            </Button>
-            <Button onClick={onClose} variant="outline" size="sm">Lukk</Button>
-          </div>
+          <Button onClick={onClose} variant="outline" size="sm">
+            Close
+          </Button>
         </div>
 
-        <div className="p-4 h-full overflow-auto">
-          <Tabs defaultValue="overview" className="h-full">
-            <TabsList className="w-full bg-gray-800">
-              <TabsTrigger value="overview">Oversikt</TabsTrigger>
-              <TabsTrigger value="charts">Grafer & Diagrammer</TabsTrigger>
-              <TabsTrigger value="cards">Kort Analyse</TabsTrigger>
-              <TabsTrigger value="simulation">Simulering</TabsTrigger>
-            </TabsList>
+        <div className="flex-1 overflow-y-auto p-6 space-y-6 text-sm text-slate-200">
+          <section className="space-y-3">
+            <h3 className="text-xl font-semibold text-white font-mono">{MVP_RULES_TITLE}</h3>
+            <p className="text-slate-300 leading-relaxed">
+              This dashboard summarises the minimal effect surface used for the ShadowGov MVP build. Anything outside this whitelist is hidden from analysis until it is migrated to the new ATTACK/MEDIA/ZONE framework.
+            </p>
+            <div className="flex flex-wrap gap-2">
+              {['ATTACK', 'MEDIA', 'ZONE'].map((type) => (
+                <Badge key={type} variant="outline" className="uppercase tracking-wide text-xs border-emerald-500 text-emerald-300">
+                  {type}
+                </Badge>
+              ))}
+              <Badge variant="outline" className="uppercase tracking-wide text-xs border-cyan-500 text-cyan-300">
+                RARITIES: Common → Legendary
+              </Badge>
+            </div>
+          </section>
 
-            <TabsContent value="overview" className="mt-4 space-y-4">
-              <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
-                <Card className="p-4 bg-gray-800">
-                  <h3 className="text-lg font-semibold text-white mb-2">Balance Status</h3>
-                  <div className="space-y-2">
-                    <div className="flex justify-between">
-                      <span>Balanserte kort:</span>
-                      <Badge className="bg-green-600">{report.onCurve}</Badge>
-                    </div>
-                    <div className="flex justify-between">
-                      <span>Underpriset:</span>
-                      <Badge className="bg-red-600">{report.undercosted}</Badge>
-                    </div>
-                    <div className="flex justify-between">
-                      <span>Overpriset:</span>
-                      <Badge className="bg-yellow-600">{report.overcosted}</Badge>
-                    </div>
-                  </div>
-                </Card>
+          {effectSection && (
+            <section className="space-y-3">
+              <h3 className="text-lg font-semibold text-white font-mono">{effectSection.title}</h3>
+              <ul className="space-y-2 text-slate-300">
+                {effectSection.bullets?.map((bullet) => (
+                  <li key={bullet} className="pl-4 relative">
+                    <span className="absolute left-0 text-emerald-400">•</span>
+                    <span>{bullet}</span>
+                  </li>
+                ))}
+              </ul>
+              <p className="text-xs text-slate-500">
+                Legacy keywords such as DEFENSIVE, TECH, or INSTANT are ignored during MVP imports and will return once their effects are modelled with these primitives.
+              </p>
+            </section>
+          )}
 
-                <Card className="p-4 bg-gray-800">
-                  <h3 className="text-lg font-semibold text-white mb-2">Faction Fordeling</h3>
-                  <div className="space-y-2">
-                    <div className="flex justify-between">
-                      <span>Truth kort:</span>
-                      <Badge className="bg-blue-600">{report.truthCards}</Badge>
+          {cardRolesSection && (
+            <section className="space-y-3">
+              <h3 className="text-lg font-semibold text-white font-mono">{cardRolesSection.title}</h3>
+              <div className="grid gap-3 md:grid-cols-3">
+                {cardRolesSection.bullets?.map((bullet) => {
+                  const [label, summary] = bullet.split(':');
+                  return (
+                    <div key={bullet} className="bg-gray-900/60 border border-gray-800 rounded-lg p-3">
+                      <div className="text-xs font-semibold text-emerald-300 uppercase tracking-wide">{label?.trim()}</div>
+                      <div className="text-sm text-slate-200 mt-1 leading-relaxed">{summary?.trim()}</div>
                     </div>
-                    <div className="flex justify-between">
-                      <span>Government kort:</span>
-                      <Badge className="bg-red-600">{report.governmentCards}</Badge>
-                    </div>
-                    <div className="flex justify-between">
-                      <span>Misaligned:</span>
-                      <Badge className="bg-orange-600">{report.misalignedCards}</Badge>
-                    </div>
-                  </div>
-                </Card>
-
-                <Card className="p-4 bg-gray-800">
-                  <h3 className="text-lg font-semibold text-white mb-2">Statistikk</h3>
-                  <div className="space-y-2">
-                    <div className="flex justify-between">
-                      <span>Totalt kort:</span>
-                      <span className="text-white font-mono">{actualCardCount}</span>
-                    </div>
-                    {includeExtensions && (
-                      <>
-                        <div className="flex justify-between text-sm">
-                          <span className="text-gray-400">- Core kort:</span>
-                          <span className="text-gray-300 font-mono">{coreCardCount}</span>
-                        </div>
-                        <div className="flex justify-between text-sm">
-                          <span className="text-gray-400">- Extension kort:</span>
-                          <span className="text-gray-300 font-mono">{extensionCardCount}</span>
-                        </div>
-                      </>
-                    )}
-                    <div className="flex justify-between">
-                      <span>Snitt kostnad:</span>
-                      <span className="text-white">{report.averageCost.toFixed(1)} IP</span>
-                    </div>
-                    <div className="flex justify-between">
-                      <span>Snitt utility:</span>
-                      <span className="text-white">{report.averageUtility.toFixed(1)}</span>
-                    </div>
-                  </div>
-                </Card>
+                  );
+                })}
               </div>
-            </TabsContent>
+            </section>
+          )}
 
-            <TabsContent value="charts" className="mt-4 space-y-6">
-              {/* Pie Charts Row */}
-              <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
-                <Card className="p-4 bg-gray-800">
-                  <h3 className="text-lg font-semibold text-white mb-4">Faction Fordeling</h3>
-                  <ResponsiveContainer width="100%" height={200}>
-                    <PieChart>
-                      <Pie
-                        data={factionPieData}
-                        cx="50%"
-                        cy="50%"
-                        innerRadius={40}
-                        outerRadius={80}
-                        dataKey="value"
-                        label={({name, value}) => `${name}: ${value}`}
-                      >
-                        {factionPieData.map((entry, index) => (
-                          <Cell key={`cell-${index}`} fill={entry.color} />
-                        ))}
-                      </Pie>
-                      <Tooltip />
-                    </PieChart>
-                  </ResponsiveContainer>
-                </Card>
+          <section className="space-y-3">
+            <h3 className="text-lg font-semibold text-white font-mono">MVP Cost Table</h3>
+            <p className="text-slate-300 leading-relaxed">
+              Compare candidate designs against the fixed IP budgets below. Deviations from these baselines should come with narrative or mechanical justification.
+            </p>
+            <div className="overflow-x-auto">
+              <table className="w-full text-left border-collapse text-xs md:text-sm">
+                <thead>
+                  <tr className="bg-gray-900 text-slate-200">
+                    <th className="border border-gray-800 px-3 py-2 font-mono uppercase tracking-wide">Rarity</th>
+                    <th className="border border-gray-800 px-3 py-2 font-mono uppercase tracking-wide">Attack</th>
+                    <th className="border border-gray-800 px-3 py-2 font-mono uppercase tracking-wide">Media</th>
+                    <th className="border border-gray-800 px-3 py-2 font-mono uppercase tracking-wide">Zone</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {MVP_COST_TABLE_ROWS.map((row) => (
+                    <tr key={row.rarity} className="odd:bg-gray-900/40">
+                      <td className="border border-gray-800 px-3 py-2 font-semibold uppercase text-slate-100">
+                        {row.rarity}
+                      </td>
+                      <td className="border border-gray-800 px-3 py-2 text-slate-200">
+                        <div className="font-semibold text-emerald-300">{row.attack.effect}</div>
+                        <div className="text-xs text-slate-400">Cost {row.attack.cost}</div>
+                      </td>
+                      <td className="border border-gray-800 px-3 py-2 text-slate-200">
+                        <div className="font-semibold text-sky-300">{row.media.effect}</div>
+                        <div className="text-xs text-slate-400">Cost {row.media.cost}</div>
+                      </td>
+                      <td className="border border-gray-800 px-3 py-2 text-slate-200">
+                        <div className="font-semibold text-amber-300">{row.zone.effect}</div>
+                        <div className="text-xs text-slate-400">Cost {row.zone.cost}</div>
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          </section>
 
-                <Card className="p-4 bg-gray-800">
-                  <h3 className="text-lg font-semibold text-white mb-4">Balance Status</h3>
-                  <ResponsiveContainer width="100%" height={200}>
-                    <PieChart>
-                      <Pie
-                        data={balancePieData}
-                        cx="50%"
-                        cy="50%"
-                        innerRadius={40}
-                        outerRadius={80}
-                        dataKey="value"
-                        label={({name, value}) => `${name}: ${value}`}
-                      >
-                        {balancePieData.map((entry, index) => (
-                          <Cell key={`cell-${index}`} fill={entry.color} />
-                        ))}
-                      </Pie>
-                      <Tooltip />
-                    </PieChart>
-                  </ResponsiveContainer>
-                </Card>
-
-                <Card className="p-4 bg-gray-800">
-                  <h3 className="text-lg font-semibold text-white mb-4">Rarity Fordeling</h3>
-                  <ResponsiveContainer width="100%" height={200}>
-                    <PieChart>
-                      <Pie
-                        data={rarityDistributionData}
-                        cx="50%"
-                        cy="50%"
-                        innerRadius={40}
-                        outerRadius={80}
-                        dataKey="count"
-                        label={({rarity, count}) => `${rarity}: ${count}`}
-                      >
-                        {rarityDistributionData.map((entry, index) => (
-                          <Cell key={`cell-${index}`} fill={entry.color} />
-                        ))}
-                      </Pie>
-                      <Tooltip />
-                    </PieChart>
-                  </ResponsiveContainer>
-                </Card>
-              </div>
-
-              {/* Bar Charts Row */}
-              <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
-                <Card className="p-4 bg-gray-800">
-                  <h3 className="text-lg font-semibold text-white mb-4">Kostnad Distribusjon</h3>
-                  <ResponsiveContainer width="100%" height={300}>
-                    <BarChart data={costDistributionData}>
-                      <CartesianGrid strokeDasharray="3 3" stroke="#374151" />
-                      <XAxis dataKey="name" stroke="#9ca3af" />
-                      <YAxis stroke="#9ca3af" />
-                      <Tooltip 
-                        contentStyle={{ 
-                          backgroundColor: '#374151', 
-                          border: '1px solid #4b5563',
-                          borderRadius: '6px'
-                        }} 
-                      />
-                      <Bar dataKey="count" fill="#3b82f6" />
-                    </BarChart>
-                  </ResponsiveContainer>
-                </Card>
-
-                <Card className="p-4 bg-gray-800">
-                  <h3 className="text-lg font-semibold text-white mb-4">Utility vs Kostnad</h3>
-                  <ResponsiveContainer width="100%" height={300}>
-                    <AreaChart data={utilityVsCostData}>
-                      <CartesianGrid strokeDasharray="3 3" stroke="#374151" />
-                      <XAxis dataKey="cost" stroke="#9ca3af" />
-                      <YAxis stroke="#9ca3af" />
-                      <Tooltip 
-                        contentStyle={{ 
-                          backgroundColor: '#374151', 
-                          border: '1px solid #4b5563',
-                          borderRadius: '6px'
-                        }} 
-                      />
-                      <Area type="monotone" dataKey="utility" stroke="#10b981" fill="#10b981" fillOpacity={0.3} />
-                    </AreaChart>
-                  </ResponsiveContainer>
-                </Card>
-              </div>
-
-              {/* Win Rate Trend */}
-              <Card className="p-4 bg-gray-800">
-                <h3 className="text-lg font-semibold text-white mb-4">Simulering Trend</h3>
-                <ResponsiveContainer width="100%" height={300}>
-                  <LineChart data={[
-                    { name: 'Truth Seeker', winRate: simulation.truthWinRate, color: '#3b82f6' },
-                    { name: 'Government', winRate: simulation.governmentWinRate, color: '#ef4444' },
-                    { name: 'Draw', winRate: simulation.drawRate, color: '#6b7280' }
-                  ]}>
-                    <CartesianGrid strokeDasharray="3 3" stroke="#374151" />
-                    <XAxis dataKey="name" stroke="#9ca3af" />
-                    <YAxis stroke="#9ca3af" />
-                    <Tooltip 
-                      contentStyle={{ 
-                        backgroundColor: '#374151', 
-                        border: '1px solid #4b5563',
-                        borderRadius: '6px'
-                      }} 
-                    />
-                    <Line type="monotone" dataKey="winRate" stroke="#10b981" strokeWidth={3} />
-                  </LineChart>
-                </ResponsiveContainer>
-              </Card>
-            </TabsContent>
-
-            <TabsContent value="cards" className="mt-4">
-              <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
-                <Card className="p-4 bg-gray-800">
-                  <div className="flex items-center justify-between mb-4">
-                    <h3 className="text-lg font-semibold text-white">Kort som trenger oppmerksomhet</h3>
-                    <Button onClick={exportCardIdsNeedingArt} variant="outline" size="sm">
-                      <FileText size={16} className="mr-1" />
-                      Export Problem Cards
-                    </Button>
-                  </div>
-                  <div className="grid gap-2 max-h-96 overflow-y-auto">
-                  {report.cardAnalysis
-                    .filter(card => card.classification !== 'On Curve')
-                    .sort((a, b) => b.severity === 'Severe' ? 1 : -1)
-                    .slice(0, 20)
-                    .map(card => (
-                      <div key={card.cardId} className="p-3 bg-gray-700 rounded border border-gray-600">
-                        <div className="flex justify-between items-start">
-                          <div>
-                            <div className="font-medium text-white">{card.name}</div>
-                            <div className="text-sm text-gray-400">
-                              {card.type} | {card.faction} | {card.rarity}
-                            </div>
-                            <div className="text-sm text-yellow-400">
-                              Kostnad: {card.cost} IP | Utility: {card.totalUtility.toFixed(1)}
-                            </div>
-                          </div>
-                          <div className="flex gap-2">
-                            <Badge className={
-                              card.classification === 'Undercosted' ? 'bg-red-600' :
-                              card.classification === 'Overcosted' ? 'bg-yellow-600' : 'bg-green-600'
-                            }>
-                              {card.classification}
-                            </Badge>
-                            <Badge className={
-                              card.severity === 'Severe' ? 'bg-red-600' :
-                              card.severity === 'High' ? 'bg-orange-600' :
-                              card.severity === 'Medium' ? 'bg-yellow-600' : 'bg-green-600'
-                            }>
-                              {card.severity}
-                            </Badge>
-                          </div>
-                        </div>
-                        {card.recommendation.cost && (
-                          <div className="mt-2 text-sm text-blue-400">
-                            Anbefaling: {card.recommendation.cost} IP ({card.recommendation.reasoning})
-                          </div>
-                        )}
-                      </div>
-                    ))}
-                  </div>
-                </Card>
-
-                <Card className="p-4 bg-gray-800">
-                  <h3 className="text-lg font-semibold text-white mb-4">Kort som trenger grafikk</h3>
-                  <div className="grid gap-2 max-h-96 overflow-y-auto">
-                    {report.cardAnalysis
-                      .filter(card => 
-                        !card.cardId.includes('temp') && 
-                        (card.classification === 'Undercosted' || card.severity === 'Severe' || card.cardId.includes('temp-image'))
-                      )
-                      .sort((a, b) => b.severity === 'Severe' ? 1 : -1)
-                      .slice(0, 15)
-                      .map(card => (
-                        <div key={card.cardId} className="p-3 bg-gray-700 rounded border border-gray-600">
-                          <div className="flex justify-between items-start">
-                            <div>
-                              <div className="font-medium text-white">{card.name}</div>
-                              <div className="text-sm text-gray-400">
-                                ID: {card.cardId}
-                              </div>
-                              <div className="text-sm text-gray-400">
-                                {card.type} | {card.faction} | {card.rarity}
-                              </div>
-                              <div className="text-xs text-orange-400">
-                                {card.cardId.includes('temp') ? 'Har midlertidig grafikk' : 'Trenger bedre grafikk'}
-                              </div>
-                            </div>
-                            <div className="flex gap-1 flex-col">
-                              <Badge className="bg-purple-600 text-xs">
-                                Art Needed
-                              </Badge>
-                              {card.severity === 'Severe' && (
-                                <Badge className="bg-red-600 text-xs">
-                                  Priority
-                                </Badge>
-                              )}
-                            </div>
-                          </div>
-                        </div>
-                      ))}
-                  </div>
-                </Card>
-              </div>
-            </TabsContent>
-
-            <TabsContent value="simulation" className="mt-4">
-              <Card className="p-4 bg-gray-800">
-                <h3 className="text-lg font-semibold text-white mb-4">Simulering ({simulation.iterations} spill)</h3>
-                <div className="grid grid-cols-1 md:grid-cols-3 gap-4 mb-4">
-                  <div className="text-center">
-                    <div className="text-2xl font-bold text-blue-400">{simulation.truthWinRate.toFixed(1)}%</div>
-                    <div className="text-sm text-gray-400">Truth Seeker Wins</div>
-                  </div>
-                  <div className="text-center">
-                    <div className="text-2xl font-bold text-red-400">{simulation.governmentWinRate.toFixed(1)}%</div>
-                    <div className="text-sm text-gray-400">Government Wins</div>
-                  </div>
-                  <div className="text-center">
-                    <div className="text-2xl font-bold text-gray-400">{simulation.drawRate.toFixed(1)}%</div>
-                    <div className="text-sm text-gray-400">Draws</div>
-                  </div>
-                </div>
-                <div className="text-sm text-gray-400">
-                  Gjennomsnittlig spillengde: {simulation.averageGameLength.toFixed(1)} runder
-                </div>
-              </Card>
-            </TabsContent>
-          </Tabs>
+          <section className="space-y-2">
+            <h3 className="text-lg font-semibold text-white font-mono">Roadmap</h3>
+            <ul className="list-disc list-inside text-slate-300 space-y-1">
+              <li>Deck simulations, win-rate tracking, and extension analytics will return once cards conform to MVP schemas.</li>
+              <li>Upload or view non-MVP tags by enabling the legacy dashboard in developer tools.</li>
+              <li>Share balance notes via design docs; this overlay stays canonical for playtesters.</li>
+            </ul>
+          </section>
         </div>
       </Card>
     </div>

--- a/src/components/game/GameHand.tsx
+++ b/src/components/game/GameHand.tsx
@@ -3,7 +3,8 @@ import CardImage from './CardImage';
 import { Card } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
-import type { GameCard } from '@/rules/mvp';
+import type { GameCard, MVPCardType } from '@/rules/mvp';
+import { MVP_CARD_TYPES } from '@/rules/mvp';
 
 interface GameHandProps {
   cards: GameCard[];
@@ -22,13 +23,16 @@ const GameHand = ({ cards, onPlayCard, disabled }: GameHandProps) => {
     }
   };
 
-  const getTypeColor = (type: string) => {
+  const normalizeCardType = (type: string): MVPCardType => {
+    return MVP_CARD_TYPES.includes(type as MVPCardType) ? type as MVPCardType : 'MEDIA';
+  };
+
+  const getTypeColor = (type: MVPCardType) => {
     switch (type) {
       case 'MEDIA': return 'border-truth-red bg-truth-red/10';
       case 'ZONE': return 'border-government-blue bg-government-blue/10';
-      case 'ATTACK': return 'border-destructive bg-destructive/10';
-      case 'DEFENSIVE': return 'border-primary bg-primary/10';
-      default: return 'border-muted bg-muted/10';
+      case 'ATTACK':
+      default: return 'border-destructive bg-destructive/10';
     }
   };
 
@@ -40,7 +44,7 @@ const GameHand = ({ cards, onPlayCard, disabled }: GameHandProps) => {
         {cards.map((card, index) => (
           <Card 
             key={card.id} 
-            className={`relative p-0 cursor-pointer transition-all hover:scale-105 hover:-translate-y-2 ${getTypeColor(card.type)} ${
+            className={`relative p-0 cursor-pointer transition-all hover:scale-105 hover:-translate-y-2 ${getTypeColor(normalizeCardType(card.type))} ${
               disabled ? 'opacity-50' : ''
             } overflow-hidden animate-card-deal`}
             style={{ animationDelay: `${index * 0.1}s` }}
@@ -68,14 +72,16 @@ const GameHand = ({ cards, onPlayCard, disabled }: GameHandProps) => {
               {/* Card content */}
               <div className="p-3">
                 <div className="flex justify-center mb-2">
-                  <Badge 
-                    variant="outline" 
-                    className={`text-xs font-mono ${card.type === 'MEDIA' ? 'bg-truth-red/20 border-truth-red text-truth-red' : 
-                      card.type === 'ZONE' ? 'bg-government-blue/20 border-government-blue text-government-blue' :
-                      card.type === 'ATTACK' ? 'bg-destructive/20 border-destructive text-destructive' :
-                      'bg-accent/20 border-accent text-accent-foreground'}`}
+                  <Badge
+                    variant="outline"
+                    className={`text-xs font-mono ${(() => {
+                      const type = normalizeCardType(card.type);
+                      if (type === 'MEDIA') return 'bg-truth-red/20 border-truth-red text-truth-red';
+                      if (type === 'ZONE') return 'bg-government-blue/20 border-government-blue text-government-blue';
+                      return 'bg-destructive/20 border-destructive text-destructive';
+                    })()}`}
                   >
-                    [{card.type}]
+                    [{normalizeCardType(card.type)}]
                   </Badge>
                 </div>
                 

--- a/src/components/game/HowToPlayTabloid.tsx
+++ b/src/components/game/HowToPlayTabloid.tsx
@@ -1,7 +1,12 @@
-import { useState, useRef, useEffect } from 'react';
+import { useState, useRef, useEffect, useCallback } from 'react';
 import { Button } from '@/components/ui/button';
 import { ScrollArea } from '@/components/ui/scroll-area';
 import { ChevronDown, ChevronUp } from 'lucide-react';
+import {
+  MVP_COST_TABLE_ROWS,
+  MVP_RULES_SECTIONS,
+  MVP_RULES_TITLE,
+} from '@/content/mvpRules';
 
 interface HowToPlayTabloidProps {
   onClose: () => void;
@@ -9,144 +14,50 @@ interface HowToPlayTabloidProps {
 
 const HowToPlayTabloid = ({ onClose }: HowToPlayTabloidProps) => {
   const [canScrollUp, setCanScrollUp] = useState(false);
-  const [canScrollDown, setCanScrollDown] = useState(true);
-  const [rulesContent, setRulesContent] = useState<string>('');
+  const [canScrollDown, setCanScrollDown] = useState(false);
   const scrollAreaRef = useRef<HTMLDivElement>(null);
 
-  // Load rules from the markdown file
-  useEffect(() => {
-    const loadRules = async () => {
-      try {
-        const response = await fetch('/how-to-play-mvp.md');
-        if (response.ok) {
-          const content = await response.text();
-          setRulesContent(content);
-        } else {
-          setRulesContent(fallbackRules);
-        }
-      } catch (error) {
-        console.log('Could not load rules file, using fallback');
-        setRulesContent(fallbackRules);
-      }
-    };
-    
-    loadRules();
+  const updateScrollButtons = useCallback(() => {
+    const viewport = scrollAreaRef.current?.querySelector('[data-radix-scroll-area-viewport]') as HTMLElement | null;
+    if (!viewport) return;
+
+    const { scrollTop, scrollHeight, clientHeight } = viewport;
+    setCanScrollUp(scrollTop > 0);
+    setCanScrollDown(scrollTop + clientHeight < scrollHeight - 2);
   }, []);
 
-  const fallbackRules = `# How to Play ShadowGov (MVP Rules)
+  useEffect(() => {
+    const viewport = scrollAreaRef.current?.querySelector('[data-radix-scroll-area-viewport]') as HTMLElement | null;
+    if (!viewport) return;
 
-## Objective
-Win by pushing national Truth to 100 or by reducing your opponent's Influence Points (IP) to zero. Control states with pressure to accelerate your plan.
+    updateScrollButtons();
+    viewport.addEventListener('scroll', updateScrollButtons);
 
-## Turn Structure
-1. **Start of Turn** – Draw up to 5 cards and gain IP (5 + number of states you control).
-2. **Main Phase** – Play up to three cards, targeting states when required.
-3. **End Phase** – Resolve ongoing effects and pass the turn.
+    const resizeObserver = typeof ResizeObserver !== 'undefined'
+      ? new ResizeObserver(() => updateScrollButtons())
+      : null;
 
-## Card Types
-- **MEDIA** – Adjust Truth directly. Costs are fixed by rarity (Common 3, Uncommon 4, Rare 5, Legendary 6).
-- **ATTACK** – Spend IP to damage your opponent's IP or force discards. Costs follow rarity (2/3/4/5).
-- **ZONE** – Add pressure to specific states to claim control. Costs follow rarity (4/5/6/7).
+    resizeObserver?.observe(viewport);
 
-## Effects
-The MVP ruleset supports a focused effect set:
-- \`truthDelta\` for MEDIA cards.
-- \`ipDelta.opponent\` and optional \`discardOpponent\` for ATTACK cards.
-- \`pressureDelta\` for ZONE cards.
-
-Any legacy effect keys are ignored by the sanitiser during import.
-
-## Deck Building Tips
-- Keep a balance of card types so you can react to board state changes.
-- ZONE cards win games when backed by MEDIA momentum.
-- ATTACK cards are most efficient when the opponent banks IP for big plays.
-`;
+    return () => {
+      viewport.removeEventListener('scroll', updateScrollButtons);
+      resizeObserver?.disconnect();
+    };
+  }, [updateScrollButtons]);
 
   const scrollTo = (direction: 'up' | 'down') => {
-    const scrollElement = scrollAreaRef.current?.querySelector('[data-radix-scroll-area-viewport]');
-    if (scrollElement) {
-      const scrollAmount = 300;
-      const currentScroll = scrollElement.scrollTop;
-      const newScroll = direction === 'down' 
-        ? currentScroll + scrollAmount 
-        : currentScroll - scrollAmount;
-      
-      scrollElement.scrollTo({
-        top: newScroll,
-        behavior: 'smooth'
-      });
-    }
-  };
+    const viewport = scrollAreaRef.current?.querySelector('[data-radix-scroll-area-viewport]') as HTMLElement | null;
+    if (!viewport) return;
 
-  const handleScroll = (event: any) => {
-    const scrollElement = event.target;
-    const { scrollTop, scrollHeight, clientHeight } = scrollElement;
-    
-    setCanScrollUp(scrollTop > 0);
-    setCanScrollDown(scrollTop + clientHeight < scrollHeight - 10);
-  };
+    const scrollAmount = 300;
+    const newScroll = direction === 'down'
+      ? viewport.scrollTop + scrollAmount
+      : viewport.scrollTop - scrollAmount;
 
-  // Parse markdown content to tabloid-style HTML
-  const parseMarkdown = (content: string) => {
-    const lines = content.split('\n');
-    const elements: JSX.Element[] = [];
-
-    lines.forEach((line, index) => {
-      if (line.startsWith('# ')) {
-        elements.push(
-          <div key={index} className="border-4 border-black bg-white p-4 mb-4 shadow-[4px_4px_0_#000]">
-            <h1 className="text-3xl md:text-4xl font-black uppercase tracking-tight font-[Oswald,Impact,Arial-Black,system-ui,sans-serif]">
-              {line.substring(2)}
-            </h1>
-          </div>
-        );
-      } else if (line.startsWith('## ')) {
-        elements.push(
-          <div key={index} className="border-2 border-black bg-white p-3 mt-4 mb-2 shadow-[2px_2px_0_#000] relative">
-            <div className="absolute -top-1 -right-1 bg-red-600 text-white px-1 py-0.5 text-[8px] font-black uppercase">
-              SECRET
-            </div>
-            <h2 className="text-xl font-black uppercase tracking-tight font-[Oswald,Impact,Arial-Black,system-ui,sans-serif]">
-              {line.substring(3)}
-            </h2>
-          </div>
-        );
-      } else if (line.startsWith('### ')) {
-        elements.push(
-          <h3 key={index} className="text-lg font-black uppercase tracking-tight mt-4 mb-2 font-[Oswald,Impact,Arial-Black,system-ui,sans-serif]">
-            {line.substring(4)}
-          </h3>
-        );
-      } else if (line.startsWith('- ')) {
-        elements.push(
-          <div key={index} className="ml-4 mb-1 text-sm">
-            <span className="font-black">▪</span> {line.substring(2)}
-          </div>
-        );
-      } else if (line.startsWith('**') && line.endsWith('**')) {
-        elements.push(
-          <div key={index} className="font-black uppercase mt-2 mb-1 text-sm tracking-wide">
-            {line.substring(2, line.length - 2)}
-          </div>
-        );
-      } else if (line.trim() !== '' && !line.startsWith('---')) {
-        elements.push(
-          <p key={index} className="text-sm mb-2 leading-relaxed">
-            {line}
-          </p>
-        );
-      } else if (line.startsWith('---')) {
-        elements.push(
-          <div key={index} className="my-4">
-            <div className="h-2 bg-[#e9e9e9]"></div>
-            <div className="h-2 bg-[#e9e9e9] w-3/4 my-1"></div>
-            <div className="h-2 bg-[#e9e9e9] w-1/2"></div>
-          </div>
-        );
-      }
+    viewport.scrollTo({
+      top: newScroll,
+      behavior: 'smooth'
     });
-
-    return elements;
   };
 
   return (
@@ -157,7 +68,7 @@ Any legacy effect keys are ignored by the sanitiser during import.
           <div className="text-4xl md:text-5xl font-black uppercase tracking-tight font-[Oswald,Impact,Arial-Black,system-ui,sans-serif]">
             LEAKED INSTRUCTIONS!
           </div>
-          <Button 
+          <Button
             onClick={onClose}
             className="w-auto border-2 border-black bg-white text-black text-lg font-extrabold uppercase px-4 py-2 shadow-[4px_4px_0_#000] hover:shadow-[2px_2px_0_#000] transition-transform hover:translate-x-[1px] hover:translate-y-[1px]"
           >
@@ -180,23 +91,91 @@ Any legacy effect keys are ignored by the sanitiser during import.
         </div>
 
         <div className="relative">
-          <ScrollArea 
-            ref={scrollAreaRef} 
+          <ScrollArea
+            ref={scrollAreaRef}
             className="h-[70vh] w-full"
           >
-            <div 
-              className="p-6"
-              onScroll={handleScroll}
-            >
-              {rulesContent ? (
-                <div className="space-y-2">
-                  {parseMarkdown(rulesContent)}
+            <div className="p-6 space-y-4">
+              <div className="border-4 border-black bg-white p-4 shadow-[4px_4px_0_#000]">
+                <h1 className="text-3xl md:text-4xl font-black uppercase tracking-tight font-[Oswald,Impact,Arial-Black,system-ui,sans-serif]">
+                  {MVP_RULES_TITLE}
+                </h1>
+              </div>
+
+              {MVP_RULES_SECTIONS.map((section) => (
+                <section key={section.title} className="border-2 border-black bg-white p-3 shadow-[2px_2px_0_#000]">
+                  <div className="flex items-center justify-between">
+                    <h2 className="text-xl font-black uppercase tracking-tight font-[Oswald,Impact,Arial-Black,system-ui,sans-serif]">
+                      {section.title}
+                    </h2>
+                    <div className="bg-red-600 text-white px-1 py-0.5 text-[8px] font-black uppercase">
+                      VERIFIED
+                    </div>
+                  </div>
+                  {section.description && (
+                    <p className="mt-2 text-sm leading-relaxed">
+                      {section.description}
+                    </p>
+                  )}
+                  {section.bullets && (
+                    <ul className="mt-2 space-y-2 text-sm">
+                      {section.bullets.map((bullet) => (
+                        <li key={bullet} className="flex items-start gap-2">
+                          <span className="font-black text-lg leading-none">▪</span>
+                          <span className="leading-relaxed">{bullet}</span>
+                        </li>
+                      ))}
+                    </ul>
+                  )}
+                </section>
+              ))}
+
+              <section className="border-2 border-black bg-white p-3 shadow-[2px_2px_0_#000] space-y-3">
+                <div className="flex items-center justify-between">
+                  <h2 className="text-xl font-black uppercase tracking-tight font-[Oswald,Impact,Arial-Black,system-ui,sans-serif]">
+                    COST BENCHMARKS BY RARITY
+                  </h2>
+                  <div className="bg-yellow-400 text-black px-1 py-0.5 text-[8px] font-black uppercase">
+                    AUDIT READY
+                  </div>
                 </div>
-              ) : (
-                <div className="text-center py-8 text-gray-600">
-                  Loading classified documents...
+                <p className="text-sm leading-relaxed">
+                  Every MVP card follows a fixed IP cost with predictable baseline effects. Spot anything outside this grid and raise the alarm.
+                </p>
+                <div className="overflow-x-auto">
+                  <table className="w-full text-left border-collapse text-xs md:text-sm">
+                    <thead>
+                      <tr className="bg-black text-white">
+                        <th className="border border-black px-2 py-1 font-black uppercase">RARITY</th>
+                        <th className="border border-black px-2 py-1 font-black uppercase">ATTACK</th>
+                        <th className="border border-black px-2 py-1 font-black uppercase">MEDIA</th>
+                        <th className="border border-black px-2 py-1 font-black uppercase">ZONE</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {MVP_COST_TABLE_ROWS.map((row) => (
+                        <tr key={row.rarity} className="odd:bg-[#f5f5f5]">
+                          <td className="border border-black px-2 py-1 font-black uppercase">
+                            {row.rarity}
+                          </td>
+                          <td className="border border-black px-2 py-1">
+                            <div className="font-black uppercase text-xs md:text-sm">{row.attack.effect}</div>
+                            <div className="text-[10px] md:text-xs uppercase text-gray-600">Cost {row.attack.cost}</div>
+                          </td>
+                          <td className="border border-black px-2 py-1">
+                            <div className="font-black uppercase text-xs md:text-sm">{row.media.effect}</div>
+                            <div className="text-[10px] md:text-xs uppercase text-gray-600">Cost {row.media.cost}</div>
+                          </td>
+                          <td className="border border-black px-2 py-1">
+                            <div className="font-black uppercase text-xs md:text-sm">{row.zone.effect}</div>
+                            <div className="text-[10px] md:text-xs uppercase text-gray-600">Cost {row.zone.cost}</div>
+                          </td>
+                        </tr>
+                      ))}
+                    </tbody>
+                  </table>
                 </div>
-              )}
+              </section>
             </div>
           </ScrollArea>
 
@@ -210,7 +189,7 @@ Any legacy effect keys are ignored by the sanitiser during import.
               <ChevronUp className="w-4 h-4" />
             </Button>
           )}
-          
+
           {canScrollDown && (
             <Button
               onClick={() => scrollTo('down')}

--- a/src/components/game/MinimizedHand.tsx
+++ b/src/components/game/MinimizedHand.tsx
@@ -3,10 +3,11 @@ import { Card } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
-import { Maximize2, Minimize2, Zap, Shield, Target, Megaphone } from 'lucide-react';
+import { Maximize2, Minimize2, Zap, Target, Megaphone } from 'lucide-react';
 import { ExtensionCardBadge } from './ExtensionCardBadge';
 import { isExtensionCard } from '@/data/extensionIntegration';
-import type { GameCard } from '@/rules/mvp';
+import type { GameCard, MVPCardType } from '@/rules/mvp';
+import { MVP_CARD_TYPES } from '@/rules/mvp';
 
 interface MinimizedHandProps {
   cards: GameCard[];
@@ -29,13 +30,17 @@ const MinimizedHand = ({
 }: MinimizedHandProps) => {
   const [hoveredCard, setHoveredCard] = useState<string | null>(null);
 
+  const normalizeCardType = (type: string): MVPCardType => {
+    return MVP_CARD_TYPES.includes(type as MVPCardType) ? type as MVPCardType : 'MEDIA';
+  };
+
   const getCardIcon = (type: string) => {
-    switch (type) {
+    const normalized = normalizeCardType(type);
+    switch (normalized) {
       case 'MEDIA': return <Megaphone className="w-3 h-3" />;
       case 'ZONE': return <Target className="w-3 h-3" />;
-      case 'ATTACK': return <Zap className="w-3 h-3" />;
-      case 'DEFENSIVE': return <Shield className="w-3 h-3" />;
-      default: return null;
+      case 'ATTACK':
+      default: return <Zap className="w-3 h-3" />;
     }
   };
 
@@ -50,12 +55,12 @@ const MinimizedHand = ({
   };
 
   const getTypeColor = (type: string) => {
-    switch (type) {
+    const normalized = normalizeCardType(type);
+    switch (normalized) {
       case 'MEDIA': return 'text-purple-600 bg-purple-100';
       case 'ZONE': return 'text-blue-600 bg-blue-100';
-      case 'ATTACK': return 'text-red-600 bg-red-100';
-      case 'DEFENSIVE': return 'text-green-600 bg-green-100';
-      default: return 'text-gray-600 bg-gray-100';
+      case 'ATTACK':
+      default: return 'text-red-600 bg-red-100';
     }
   };
 
@@ -93,12 +98,12 @@ const MinimizedHand = ({
             >
               <div className="space-y-2">
                 <div className="flex items-center justify-between">
-                  <Badge 
-                    variant="outline" 
+                  <Badge
+                    variant="outline"
                     className={`text-xs ${getTypeColor(card.type)} border-current`}
                   >
                     {getCardIcon(card.type)}
-                    <span className="ml-1">{card.type}</span>
+                    <span className="ml-1">{normalizeCardType(card.type)}</span>
                   </Badge>
                   <Badge variant="outline" className="text-xs font-bold">
                     {card.cost} IP
@@ -213,10 +218,10 @@ const MinimizedHand = ({
                <div className="space-y-2">
                  <div className="flex items-center justify-between gap-2">
                    <div className="flex items-center gap-1">
-                     <Badge className={getTypeColor(card.type)}>
-                       {getCardIcon(card.type)}
-                       <span className="ml-1">{card.type}</span>
-                     </Badge>
+                      <Badge className={getTypeColor(card.type)}>
+                        {getCardIcon(card.type)}
+                        <span className="ml-1">{normalizeCardType(card.type)}</span>
+                      </Badge>
                      <ExtensionCardBadge cardId={card.id} card={card} variant="inline" />
                    </div>
                    <Badge variant="outline" className="font-bold">

--- a/src/components/game/NewCardsPresentation.tsx
+++ b/src/components/game/NewCardsPresentation.tsx
@@ -1,28 +1,10 @@
-import React, { useState, useEffect } from 'react';
+import React from 'react';
 import { Card } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
 import CardImage from './CardImage';
-
-interface GameCard {
-  id: string;
-  name: string;
-  type: 'MEDIA' | 'ZONE' | 'ATTACK' | 'DEFENSIVE' | 'DEVELOPMENT' | 'LEGENDARY';
-  rarity: 'common' | 'uncommon' | 'rare' | 'legendary';
-  text: string;
-  flavor?: string;
-  cost: number;
-  target?: {
-    scope: string;
-    restrict?: string[];
-    requireTag?: string;
-    type?: string;
-    faction?: string;
-    onlyIf?: any;
-  };
-  effects?: any;
-  faction?: string;
-}
+import type { GameCard, MVPCardType } from '@/rules/mvp';
+import { MVP_CARD_TYPES } from '@/rules/mvp';
 
 interface NewCardsPresentationProps {
   cards: GameCard[];
@@ -30,17 +12,11 @@ interface NewCardsPresentationProps {
   onConfirm: () => void;
 }
 
+const normalizeCardType = (type: string): MVPCardType => {
+  return MVP_CARD_TYPES.includes(type as MVPCardType) ? type as MVPCardType : 'MEDIA';
+};
+
 const NewCardsPresentation = ({ cards, isVisible, onConfirm }: NewCardsPresentationProps) => {
-  const [showCards, setShowCards] = useState(false);
-
-  useEffect(() => {
-    if (isVisible && cards.length > 0) {
-      setShowCards(true);
-    } else {
-      setShowCards(false);
-    }
-  }, [isVisible, cards]);
-
   if (!isVisible || cards.length === 0) return null;
 
   const getRarityColor = (rarity: string) => {
@@ -54,14 +30,12 @@ const NewCardsPresentation = ({ cards, isVisible, onConfirm }: NewCardsPresentat
   };
 
   const getTypeColor = (type: string) => {
-    switch (type) {
+    const normalized = normalizeCardType(type);
+    switch (normalized) {
       case 'MEDIA': return 'border-truth-red bg-truth-red/10';
       case 'ZONE': return 'border-government-blue bg-government-blue/10';
-      case 'ATTACK': return 'border-destructive bg-destructive/10';
-      case 'DEFENSIVE': return 'border-accent bg-accent/10';
-      case 'DEVELOPMENT': return 'border-primary bg-primary/10';
-      case 'LEGENDARY': return 'border-secondary bg-secondary/10';
-      default: return 'border-muted bg-muted/10';
+      case 'ATTACK':
+      default: return 'border-destructive bg-destructive/10';
     }
   };
 
@@ -103,19 +77,16 @@ const NewCardsPresentation = ({ cards, isVisible, onConfirm }: NewCardsPresentat
               {/* Card content */}
               <div className="p-3">
                 <div className="flex justify-center mb-2">
-                  <Badge 
-                    variant="outline" 
-                    className={`text-xs font-mono ${
-                      card.type === 'MEDIA' ? 'bg-truth-red/20 border-truth-red text-truth-red' : 
-                      card.type === 'ZONE' ? 'bg-government-blue/20 border-government-blue text-government-blue' :
-                      card.type === 'ATTACK' ? 'bg-destructive/20 border-destructive text-destructive' :
-                      card.type === 'DEFENSIVE' ? 'bg-accent/20 border-accent text-accent-foreground' :
-                      card.type === 'DEVELOPMENT' ? 'bg-primary/20 border-primary text-primary' :
-                      card.type === 'LEGENDARY' ? 'bg-secondary/20 border-secondary text-secondary-foreground' :
-                      'bg-muted/20 border-muted text-muted-foreground'
-                    }`}
+                  <Badge
+                    variant="outline"
+                    className={`text-xs font-mono ${(() => {
+                      const type = normalizeCardType(card.type);
+                      if (type === 'MEDIA') return 'bg-truth-red/20 border-truth-red text-truth-red';
+                      if (type === 'ZONE') return 'bg-government-blue/20 border-government-blue text-government-blue';
+                      return 'bg-destructive/20 border-destructive text-destructive';
+                    })()}`}
                   >
-                    [{card.type}]
+                    [{normalizeCardType(card.type)}]
                   </Badge>
                 </div>
                 

--- a/src/components/game/PlayedCardsDock.tsx
+++ b/src/components/game/PlayedCardsDock.tsx
@@ -2,7 +2,8 @@ import React from 'react';
 import { Card } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import CardImage from '@/components/game/CardImage';
-import type { GameCard } from '@/rules/mvp';
+import type { GameCard, MVPCardType } from '@/rules/mvp';
+import { MVP_CARD_TYPES } from '@/rules/mvp';
 
 interface PlayedCard {
   card: GameCard;
@@ -17,27 +18,25 @@ const PlayedCardsDock: React.FC<PlayedCardsDockProps> = ({ playedCards }) => {
   const humanCards = playedCards.filter(pc => pc.player === 'human');
   const aiCards = playedCards.filter(pc => pc.player === 'ai');
 
+  const normalizeCardType = (type: string): MVPCardType => {
+    return MVP_CARD_TYPES.includes(type as MVPCardType) ? type as MVPCardType : 'MEDIA';
+  };
+
   const getTypeColor = (type: string, isAI: boolean) => {
-    const truthColors = {
-      'MEDIA': 'text-truth-red border-truth-red',
-      'ZONE': 'text-yellow-600 border-yellow-600',
-      'ATTACK': 'text-red-600 border-red-600',
-      'DEFENSIVE': 'text-blue-600 border-blue-600',
-      'TECH': 'text-purple-600 border-purple-600',
-      'DEVELOPMENT': 'text-green-600 border-green-600'
+    const normalized = normalizeCardType(type);
+    const truthColors: Record<MVPCardType, string> = {
+      MEDIA: 'text-truth-red border-truth-red',
+      ZONE: 'text-yellow-600 border-yellow-600',
+      ATTACK: 'text-red-600 border-red-600'
     };
-    
-    const govColors = {
-      'MEDIA': 'text-government-blue border-government-blue',
-      'ZONE': 'text-yellow-600 border-yellow-600',
-      'ATTACK': 'text-red-600 border-red-600',
-      'DEFENSIVE': 'text-blue-600 border-blue-600',
-      'TECH': 'text-purple-600 border-purple-600',
-      'DEVELOPMENT': 'text-green-600 border-green-600'
+
+    const govColors: Record<MVPCardType, string> = {
+      MEDIA: 'text-government-blue border-government-blue',
+      ZONE: 'text-yellow-600 border-yellow-600',
+      ATTACK: 'text-red-600 border-red-600'
     };
-    
-    return isAI ? govColors[type as keyof typeof govColors] || 'text-government-blue border-government-blue' 
-                : truthColors[type as keyof typeof truthColors] || 'text-truth-red border-truth-red';
+
+    return isAI ? govColors[normalized] : truthColors[normalized];
   };
 
   const getRarityBg = (rarity: string) => {
@@ -70,11 +69,13 @@ const PlayedCardsDock: React.FC<PlayedCardsDockProps> = ({ playedCards }) => {
                   </span>
                 </div>
                 <div className="flex flex-wrap gap-2">
-                  {humanCards.map((playedCard, index) => (
-                    <div
-                      key={`human-${playedCard.card.id}-${index}`}
-                      className="group relative"
-                    >
+                  {humanCards.map((playedCard, index) => {
+                    const displayType = normalizeCardType(playedCard.card.type);
+                    return (
+                      <div
+                        key={`human-${playedCard.card.id}-${index}`}
+                        className="group relative"
+                      >
                       {/* Full card with newspaper styling - doubled size */}
                       <div className={`w-24 h-32 bg-gradient-to-b ${getRarityBg(playedCard.card.rarity)} border rounded shadow-sm animate-scale-in overflow-hidden`}>
                         {/* Card header with newspaper styling */}
@@ -113,7 +114,7 @@ const PlayedCardsDock: React.FC<PlayedCardsDockProps> = ({ playedCards }) => {
                         {/* Card type and cost */}
                         <div className="absolute top-5 left-0.5">
                           <Badge variant="outline" className={`text-[5px] px-0.5 py-0 ${getTypeColor(playedCard.card.type, false)}`}>
-                            {playedCard.card.type}
+                            {displayType}
                           </Badge>
                         </div>
                         <div className="absolute top-5 right-0.5 bg-primary text-primary-foreground text-[6px] font-bold px-1 py-0.5 rounded">
@@ -128,7 +129,7 @@ const PlayedCardsDock: React.FC<PlayedCardsDockProps> = ({ playedCards }) => {
                             {playedCard.card.name}
                           </div>
                           <div className="text-xs text-muted-foreground mb-2">
-                            {playedCard.card.type} • Cost: {playedCard.card.cost} IP
+                            {displayType} • Cost: {playedCard.card.cost} IP
                           </div>
                           <div className="text-xs text-foreground mb-2">
                             {playedCard.card.text}
@@ -139,7 +140,8 @@ const PlayedCardsDock: React.FC<PlayedCardsDockProps> = ({ playedCards }) => {
                         </div>
                       </div>
                     </div>
-                  ))}
+                  );
+                  })}
                 </div>
               </div>
             )}
@@ -158,11 +160,13 @@ const PlayedCardsDock: React.FC<PlayedCardsDockProps> = ({ playedCards }) => {
                   </span>
                 </div>
                 <div className="flex flex-wrap gap-2">
-                  {aiCards.map((playedCard, index) => (
-                    <div
-                      key={`ai-${playedCard.card.id}-${index}`}
-                      className="group relative"
-                    >
+                  {aiCards.map((playedCard, index) => {
+                    const displayType = normalizeCardType(playedCard.card.type);
+                    return (
+                      <div
+                        key={`ai-${playedCard.card.id}-${index}`}
+                        className="group relative"
+                      >
                       {/* Full card with newspaper styling - doubled size */}
                       <div className={`w-24 h-32 bg-gradient-to-b ${getRarityBg(playedCard.card.rarity)} border rounded shadow-sm animate-scale-in overflow-hidden`}>
                         {/* Card header with newspaper styling */}
@@ -201,7 +205,7 @@ const PlayedCardsDock: React.FC<PlayedCardsDockProps> = ({ playedCards }) => {
                         {/* Card type and cost */}
                         <div className="absolute top-5 left-0.5">
                           <Badge variant="outline" className={`text-[5px] px-0.5 py-0 ${getTypeColor(playedCard.card.type, true)}`}>
-                            {playedCard.card.type}
+                            {displayType}
                           </Badge>
                         </div>
                         <div className="absolute top-5 right-0.5 bg-primary text-primary-foreground text-[6px] font-bold px-1 py-0.5 rounded">
@@ -216,7 +220,7 @@ const PlayedCardsDock: React.FC<PlayedCardsDockProps> = ({ playedCards }) => {
                             {playedCard.card.name}
                           </div>
                           <div className="text-xs text-muted-foreground mb-2">
-                            {playedCard.card.type} • Cost: {playedCard.card.cost} IP
+                            {displayType} • Cost: {playedCard.card.cost} IP
                           </div>
                           <div className="text-xs text-foreground mb-2">
                             {playedCard.card.text}
@@ -227,7 +231,8 @@ const PlayedCardsDock: React.FC<PlayedCardsDockProps> = ({ playedCards }) => {
                         </div>
                       </div>
                     </div>
-                  ))}
+                  );
+                  })}
                 </div>
               </div>
             )}

--- a/src/content/mvpRules.ts
+++ b/src/content/mvpRules.ts
@@ -1,0 +1,81 @@
+import type { MVPCardType, Rarity } from '@/rules/mvp';
+import { MVP_COST_TABLE, MVP_CARD_TYPES } from '@/rules/mvp';
+
+export interface MvpRulesSection {
+  title: string;
+  description?: string;
+  bullets?: string[];
+}
+
+export interface MvpCostTableRow {
+  rarity: Rarity;
+  attack: { effect: string; cost: string };
+  media: { effect: string; cost: string };
+  zone: { effect: string; cost: string };
+}
+
+export const MVP_RARITIES: Rarity[] = ['common', 'uncommon', 'rare', 'legendary'];
+
+const effectSummary: Record<MVPCardType, string> = {
+  ATTACK: 'Take IP directly from the opponent. Optionally force discards at higher rarities.',
+  MEDIA: 'Shift national Truth toward your faction’s objective.',
+  ZONE: 'Build Pressure in a targeted state to claim control.',
+};
+
+export const MVP_RULES_TITLE = 'How to Play ShadowGov (MVP Rules)';
+
+export const MVP_RULES_SECTIONS: MvpRulesSection[] = [
+  {
+    title: 'Objective',
+    bullets: [
+      'Control 10 states to secure the map.',
+      'Truth faction wins at ≥ 90% Truth; Government faction wins at ≤ 10% Truth.',
+      'Reach 200 Influence Points (IP) to overrun your rival’s resources.',
+    ],
+  },
+  {
+    title: 'Setup',
+    bullets: [
+      'Each player draws 5 cards after shuffling their deck.',
+      'Set national Truth to 50% and both Influence Point tracks to 0.',
+      'Every state begins with 0 Pressure for both factions.',
+    ],
+  },
+  {
+    title: 'Turn Structure',
+    bullets: [
+      'Start: Gain 5 IP plus +1 IP for every state you control, then draw back up to 5 cards.',
+      'Main: Play up to three cards, paying their IP costs and choosing targets when required.',
+      'Capture Check: Any state where your Pressure meets or beats Defense flips to your control.',
+      'End: Optionally discard 1 card for free; additional discards cost 1 IP each.',
+    ],
+  },
+  {
+    title: 'Effect Whitelist (MVP)',
+    bullets: [
+      'ATTACK: ipDelta.opponent (required) and optional discardOpponent (max 2).',
+      'MEDIA: truthDelta (positive or negative shifts).',
+      'ZONE: pressureDelta (requires a target state).',
+    ],
+  },
+  {
+    title: 'Card Roles',
+    bullets: MVP_CARD_TYPES.map((type) => `${type}: ${effectSummary[type]}`),
+  },
+];
+
+export const MVP_COST_TABLE_ROWS: MvpCostTableRow[] = MVP_RARITIES.map((rarity) => ({
+  rarity,
+  attack: {
+    effect: `Take ${rarity === 'common' ? '1' : rarity === 'uncommon' ? '2' : rarity === 'rare' ? '3' : '4'} IP`,
+    cost: `${MVP_COST_TABLE.ATTACK[rarity]} IP`,
+  },
+  media: {
+    effect: `${rarity === 'legendary' ? '±4%' : rarity === 'rare' ? '±3%' : rarity === 'uncommon' ? '±2%' : '±1%'} Truth`,
+    cost: `${MVP_COST_TABLE.MEDIA[rarity]} IP`,
+  },
+  zone: {
+    effect: `+${rarity === 'legendary' ? '4' : rarity === 'rare' ? '3' : rarity === 'uncommon' ? '2' : '1'} Pressure`,
+    cost: `${MVP_COST_TABLE.ZONE[rarity]} IP`,
+  },
+}));


### PR DESCRIPTION
## Summary
- Replace the how-to-play overlays with inline MVP rule summaries and the shared cost benchmark table.
- Normalize card badges, filters, and tooltips to the ATTACK/MEDIA/ZONE set across hand, collection, and play views.
- Swap the legacy balancing dashboard for an MVP-focused briefing that highlights the current effect whitelist and costs.

## Testing
- npm run lint *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68cac370ed50832088f5da0f03228572