### PR TITLE
Simplify MVP balancing analytics and tooling

### DIFF
--- a/src/components/game/DistributionSettings.tsx
+++ b/src/components/game/DistributionSettings.tsx
@@ -1,16 +1,13 @@
-import React, { useState } from 'react';
+import React from 'react';
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Slider } from '@/components/ui/slider';
 import { Badge } from '@/components/ui/badge';
-import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { Switch } from '@/components/ui/switch';
 import { Label } from '@/components/ui/label';
 import { Progress } from '@/components/ui/progress';
 import { useDistributionSettings } from '@/hooks/useDistributionSettings';
-import { extensionManager } from '@/data/extensionSystem';
-import type { DistributionMode } from '@/data/weightedCardDistribution';
 
 interface DistributionSettingsProps {
   isOpen: boolean;
@@ -21,241 +18,150 @@ export const DistributionSettings = ({ isOpen, onClose }: DistributionSettingsPr
   const {
     settings,
     isLoading,
-    setMode,
-    setSetWeight,
     setRarityTarget,
     toggleTypeBalancing,
     setDuplicateLimit,
+    setEarlySeedCount,
     resetToDefaults,
-    getSimulation
+    getSimulation,
   } = useDistributionSettings();
 
-  const [simulationData, setSimulationData] = useState<any>(null);
+  const [simulationData, setSimulationData] = React.useState<any>(null);
 
-  // Get available sets
-  const availableSets = React.useMemo(() => {
-    const sets = [{ id: 'core', name: 'Core Set', enabled: true }];
-    const enabledExtensions = extensionManager.getEnabledExtensions();
-    
-    enabledExtensions.forEach(ext => {
-      sets.push({
-        id: ext.id,
-        name: ext.name,
-        enabled: true
-      });
-    });
-    
-    return sets;
-  }, []);
-
-  // Run simulation
   const runSimulation = () => {
-    const results = getSimulation(1000);
+    const results = getSimulation(500);
     setSimulationData(results);
-  };
-
-  // Get mode display name
-  const getModeDisplayName = (mode: DistributionMode) => {
-    switch (mode) {
-      case 'core-only': return 'Core Only';
-      case 'expansion-only': return 'Expansion Only';
-      case 'balanced': return 'Balanced Mix';
-      case 'custom': return 'Custom Mix';
-      default: return mode;
-    }
   };
 
   if (isLoading) return null;
 
   return (
     <Dialog open={isOpen} onOpenChange={onClose}>
-      <DialogContent className="max-w-4xl max-h-[80vh] overflow-y-auto">
+      <DialogContent className="max-w-3xl max-h-[80vh] overflow-y-auto">
         <DialogHeader>
-          <DialogTitle>Card Distribution Settings</DialogTitle>
+          <DialogTitle>MVP Card Distribution</DialogTitle>
         </DialogHeader>
 
-        <Tabs defaultValue="mode" className="w-full">
-          <TabsList className="grid w-full grid-cols-4">
-            <TabsTrigger value="mode">Mode</TabsTrigger>
-            <TabsTrigger value="weights">Weights</TabsTrigger>
-            <TabsTrigger value="balance">Balance</TabsTrigger>
-            <TabsTrigger value="preview">Preview</TabsTrigger>
-          </TabsList>
+        <div className="space-y-6 text-sm">
+          <Card>
+            <CardHeader>
+              <CardTitle>Summary</CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-2">
+              <p className="text-muted-foreground">
+                Extension sets are disabled for this milestone. Adjust the sliders below to fine-tune the core deck mix.
+              </p>
+              <div className="flex flex-wrap gap-2">
+                <Badge variant="outline">Duplicate Limit: {settings.duplicateLimit}</Badge>
+                <Badge variant="outline">Early Seeds: {settings.earlySeedCount}</Badge>
+                <Badge variant="outline">Type Balancing: {settings.typeBalancing.enabled ? 'Enabled' : 'Disabled'}</Badge>
+              </div>
+            </CardContent>
+          </Card>
 
-          <TabsContent value="mode" className="space-y-4">
-            <Card>
-              <CardHeader>
-                <CardTitle>Distribution Mode</CardTitle>
-              </CardHeader>
-              <CardContent className="space-y-4">
-                {(['core-only', 'expansion-only', 'balanced', 'custom'] as DistributionMode[]).map(mode => (
-                  <div key={mode} className="flex items-center space-x-2">
-                    <input
-                      type="radio"
-                      id={mode}
-                      checked={settings.mode === mode}
-                      onChange={() => setMode(mode)}
-                      className="w-4 h-4"
-                    />
-                    <label htmlFor={mode} className="flex-1 cursor-pointer">
-                      <div className="font-medium">{getModeDisplayName(mode)}</div>
-                      <div className="text-sm text-muted-foreground">
-                        {mode === 'core-only' && 'Only use core cards'}
-                        {mode === 'expansion-only' && 'Only use expansion cards'}
-                        {mode === 'balanced' && 'Core 2:1 ratio with expansions'}
-                        {mode === 'custom' && 'Custom weights for each set'}
-                      </div>
-                    </label>
-                  </div>
-                ))}
-              </CardContent>
-            </Card>
-          </TabsContent>
-
-          <TabsContent value="weights" className="space-y-4">
-            <Card>
-              <CardHeader>
-                <CardTitle>Set Weights</CardTitle>
-              </CardHeader>
-              <CardContent className="space-y-4">
-                {availableSets.map(set => (
-                  <div key={set.id} className="space-y-2">
-                    <div className="flex items-center justify-between">
-                      <Label>{set.name}</Label>
-                      <Badge variant="outline">
-                        {(settings.setWeights[set.id] || 0).toFixed(1)}
-                      </Badge>
-                    </div>
-                    <Slider
-                      value={[settings.setWeights[set.id] || 0]}
-                      onValueChange={([value]) => setSetWeight(set.id, value)}
-                      max={3}
-                      min={0}
-                      step={0.1}
-                      disabled={settings.mode !== 'custom'}
-                      className="w-full"
-                    />
-                  </div>
-                ))}
-                <div className="text-sm text-muted-foreground">
-                  {settings.mode !== 'custom' && 'Switch to Custom Mode to adjust weights manually'}
+          <Card>
+            <CardHeader>
+              <CardTitle>Type Balancing</CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              <div className="flex items-center justify-between">
+                <div>
+                  <Label>Prevent any type from exceeding {Math.round(settings.typeBalancing.maxTypeRatio * 100)}%</Label>
+                  <p className="text-xs text-muted-foreground">Ensures ATTACK/MEDIA/ZONE stay close to the MVP ratio.</p>
                 </div>
-              </CardContent>
-            </Card>
-          </TabsContent>
+                <Switch checked={settings.typeBalancing.enabled} onCheckedChange={toggleTypeBalancing} />
+              </div>
+              <div className="space-y-2">
+                <Label>Duplicate Limit: {settings.duplicateLimit}</Label>
+                <Slider
+                  value={[settings.duplicateLimit]}
+                  onValueChange={([value]) => setDuplicateLimit(value)}
+                  max={5}
+                  min={1}
+                  step={1}
+                />
+              </div>
+              <div className="space-y-2">
+                <Label>Early Seed Count: {settings.earlySeedCount}</Label>
+                <Slider
+                  value={[settings.earlySeedCount]}
+                  onValueChange={([value]) => setEarlySeedCount(value)}
+                  max={10}
+                  min={0}
+                  step={1}
+                />
+              </div>
+            </CardContent>
+          </Card>
 
-          <TabsContent value="balance" className="space-y-4">
-            <Card>
-              <CardHeader>
-                <CardTitle>Balance Safeguards</CardTitle>
-              </CardHeader>
-              <CardContent className="space-y-6">
-                <div className="flex items-center justify-between">
-                  <div>
-                    <Label>Type Balancing</Label>
-                    <div className="text-sm text-muted-foreground">
-                      Prevent any single card type from dominating
-                    </div>
+          <Card>
+            <CardHeader>
+              <CardTitle>Rarity Targets</CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              {Object.entries(settings.rarityTargets).map(([rarity, target]) => (
+                <div key={rarity} className="space-y-2">
+                  <div className="flex items-center justify-between">
+                    <Label className="uppercase">{rarity}</Label>
+                    <Badge variant="outline">{Math.round(target * 100)}%</Badge>
                   </div>
-                  <Switch
-                    checked={settings.typeBalancing.enabled}
-                    onCheckedChange={toggleTypeBalancing}
-                  />
-                </div>
-
-                <div className="space-y-2">
-                  <Label>Duplicate Limit: {settings.duplicateLimit}</Label>
                   <Slider
-                    value={[settings.duplicateLimit]}
-                    onValueChange={([value]) => setDuplicateLimit(value)}
-                    max={5}
-                    min={1}
-                    step={1}
-                    className="w-full"
+                    value={[target]}
+                    onValueChange={([value]) => setRarityTarget(rarity as keyof typeof settings.rarityTargets, value)}
+                    max={1}
+                    min={0}
+                    step={0.01}
                   />
                 </div>
+              ))}
+            </CardContent>
+          </Card>
 
-                <div className="space-y-4">
-                  <h4 className="font-medium">Rarity Distribution</h4>
-                  {Object.entries(settings.rarityTargets).map(([rarity, target]) => (
-                    <div key={rarity} className="space-y-2">
-                      <div className="flex items-center justify-between">
-                        <Label className="capitalize">{rarity}</Label>
-                        <Badge variant="outline">{(target * 100).toFixed(0)}%</Badge>
-                      </div>
-                      <Slider
-                        value={[target]}
-                        onValueChange={([value]) => setRarityTarget(rarity as any, value)}
-                        max={1}
-                        min={0}
-                        step={0.01}
-                        className="w-full"
-                      />
+          <Card>
+            <CardHeader>
+              <CardTitle>Simulation</CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-3">
+              <Button onClick={runSimulation} variant="outline">Run Sample Deck</Button>
+              {simulationData ? (
+                <div className="grid gap-2 md:grid-cols-3 text-xs text-muted-foreground">
+                  {simulationData.samples?.map((sample: any, index: number) => (
+                    <div key={index} className="space-y-1 border border-border rounded p-2">
+                      <div className="font-semibold text-foreground">Sample {index + 1}</div>
+                      <div>Attack: {sample.typeCounts?.ATTACK ?? 0}</div>
+                      <div>Media: {sample.typeCounts?.MEDIA ?? 0}</div>
+                      <div>Zone: {sample.typeCounts?.ZONE ?? 0}</div>
                     </div>
                   ))}
                 </div>
-              </CardContent>
-            </Card>
-          </TabsContent>
-
-          <TabsContent value="preview" className="space-y-4">
-            <Card>
-              <CardHeader>
-                <CardTitle>Distribution Preview</CardTitle>
-              </CardHeader>
-              <CardContent className="space-y-4">
-                <Button onClick={runSimulation} className="w-full">
-                  Simulate 1000 Decks
-                </Button>
-
-                {simulationData && (
-                  <div className="space-y-4">
-                    <div>
-                      <h4 className="font-medium mb-2">Set Distribution</h4>
-                      {Array.from(simulationData.setDistribution.entries()).map(([setId, count]) => {
-                        const percentage = ((count / 40000) * 100).toFixed(1);
-                        const setName = availableSets.find(s => s.id === setId)?.name || setId;
-                        return (
-                          <div key={setId} className="flex items-center justify-between">
-                            <span>{setName}</span>
-                            <div className="flex items-center space-x-2">
-                              <span className="text-sm">{percentage}%</span>
-                              <Progress value={parseFloat(percentage)} className="w-20" />
-                            </div>
-                          </div>
-                        );
-                      })}
+              ) : (
+                <p className="text-muted-foreground text-xs">Run the simulation to preview type distribution.</p>
+              )}
+              {simulationData?.rarityAverages && (
+                <div className="space-y-2">
+                  <div className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">Average Rarity Mix</div>
+                  {Object.entries(simulationData.rarityAverages).map(([rarity, value]: any) => (
+                    <div key={rarity}>
+                      <div className="flex items-center justify-between text-xs">
+                        <span className="uppercase">{rarity}</span>
+                        <span>{(value * 100).toFixed(1)}%</span>
+                      </div>
+                      <Progress value={value * 100} className="h-2" />
                     </div>
+                  ))}
+                </div>
+              )}
+            </CardContent>
+          </Card>
 
-                    <div>
-                      <h4 className="font-medium mb-2">Rarity Distribution</h4>
-                      {Array.from(simulationData.rarityDistribution.entries()).map(([rarity, count]) => {
-                        const percentage = ((count / 40000) * 100).toFixed(1);
-                        return (
-                          <div key={rarity} className="flex items-center justify-between">
-                            <span className="capitalize">{rarity}</span>
-                            <div className="flex items-center space-x-2">
-                              <span className="text-sm">{percentage}%</span>
-                              <Progress value={parseFloat(percentage)} className="w-20" />
-                            </div>
-                          </div>
-                        );
-                      })}
-                    </div>
-                  </div>
-                )}
-              </CardContent>
-            </Card>
-          </TabsContent>
-        </Tabs>
-
-        <div className="flex justify-between pt-4 border-t">
-          <Button variant="outline" onClick={resetToDefaults}>
-            Reset to Defaults
-          </Button>
-          <Button onClick={onClose}>
-            Done
-          </Button>
+          <div className="flex justify-between">
+            <Button variant="outline" onClick={resetToDefaults}>
+              Reset to Defaults
+            </Button>
+            <Button variant="outline" onClick={onClose}>
+              Close
+            </Button>
+          </div>
         </div>
       </DialogContent>
     </Dialog>

--- a/src/components/game/ManageExpansions.tsx
+++ b/src/components/game/ManageExpansions.tsx
@@ -1,162 +1,44 @@
+import { useMemo } from 'react';
 import { Card } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
-import { Input } from '@/components/ui/input';
-import { useState, useEffect } from 'react';
-import { extensionManager, type Extension } from '@/data/extensionSystem';
-import { DistributionSettingsButton } from './DistributionSettingsButton';
+import { CARD_DATABASE } from '@/data/cardDatabase';
+import { normalizeFaction } from '@/data/mvpAnalysisUtils';
 
 interface ManageExpansionsProps {
   onClose: () => void;
 }
 
-interface ExtensionDisplay extends Extension {
-  enabled: boolean;
-  source: 'cdn' | 'folder' | 'file';
-}
-
 const ManageExpansions = ({ onClose }: ManageExpansionsProps) => {
-  const [extensions, setExtensions] = useState<ExtensionDisplay[]>([]);
-  const [loading, setLoading] = useState(true);
-  const [searchFilter, setSearchFilter] = useState('');
-  const [error, setError] = useState<string | null>(null);
+  const stats = useMemo(() => {
+    const totals = {
+      types: new Map<string, number>(),
+      factions: { truth: 0, government: 0, neutral: 0 },
+      rarities: new Map<string, number>(),
+    };
 
-  useEffect(() => {
-    loadExtensions();
+    CARD_DATABASE.forEach(card => {
+      totals.types.set(card.type, (totals.types.get(card.type) ?? 0) + 1);
+      const faction = normalizeFaction(card.faction);
+      totals.factions[faction] += 1;
+      if (card.rarity) {
+        totals.rarities.set(card.rarity, (totals.rarities.get(card.rarity) ?? 0) + 1);
+      }
+    });
+
+    return {
+      totalCards: CARD_DATABASE.length,
+      types: Array.from(totals.types.entries()),
+      factions: totals.factions,
+      rarities: Array.from(totals.rarities.entries()),
+    };
   }, []);
-
-  const loadExtensions = async () => {
-    setLoading(true);
-    setError(null);
-    
-    try {
-      const cdnExtensions = await extensionManager.scanCDNExtensions();
-      const enabledList = extensionManager.getEnabledExtensions();
-      
-      const displayExtensions: ExtensionDisplay[] = cdnExtensions.map(ext => ({
-        ...ext,
-        enabled: enabledList.some(e => e.id === ext.id),
-        source: 'cdn' as const
-      }));
-
-      setExtensions(displayExtensions);
-      
-      if (displayExtensions.length === 0) {
-        setError('No extensions found. Try loading from folder or files below.');
-      }
-    } catch (err) {
-      console.warn('Extension loading failed:', err);
-      setError('Failed to load extensions from server. Try manual loading.');
-      setExtensions([]);
-    } finally {
-      setLoading(false);
-    }
-  };
-
-  const loadFromFolder = async () => {
-    try {
-      const folderExtensions = await extensionManager.loadFromFolderPicker();
-      const enabledList = extensionManager.getEnabledExtensions();
-      
-      const newExtensions: ExtensionDisplay[] = folderExtensions.map(ext => ({
-        ...ext,
-        enabled: enabledList.some(e => e.id === ext.id),
-        source: 'folder' as const
-      }));
-
-      // Merge with existing, avoiding duplicates
-      setExtensions(prev => {
-        const merged = [...prev];
-        newExtensions.forEach(newExt => {
-          const existingIndex = merged.findIndex(e => e.id === newExt.id);
-          if (existingIndex >= 0) {
-            merged[existingIndex] = newExt;
-          } else {
-            merged.push(newExt);
-          }
-        });
-        return merged;
-      });
-
-      if (folderExtensions.length === 0) {
-        setError('No valid extension files found in selected folder.');
-      } else {
-        setError(null);
-      }
-    } catch (err) {
-      setError('Failed to load extensions from folder.');
-    }
-  };
-
-  const loadFromFiles = async () => {
-    try {
-      const fileExtensions = await extensionManager.loadFromFilePicker();
-      const enabledList = extensionManager.getEnabledExtensions();
-      
-      const newExtensions: ExtensionDisplay[] = fileExtensions.map(ext => ({
-        ...ext,
-        enabled: enabledList.some(e => e.id === ext.id),
-        source: 'file' as const
-      }));
-
-      // Merge with existing, avoiding duplicates
-      setExtensions(prev => {
-        const merged = [...prev];
-        newExtensions.forEach(newExt => {
-          const existingIndex = merged.findIndex(e => e.id === newExt.id);
-          if (existingIndex >= 0) {
-            merged[existingIndex] = newExt;
-          } else {
-            merged.push(newExt);
-          }
-        });
-        return merged;
-      });
-
-      if (fileExtensions.length === 0) {
-        setError('No valid extension files selected.');
-      } else {
-        setError(null);
-      }
-    } catch (err) {
-      setError('Failed to load extensions from files.');
-    }
-  };
-
-  const toggleExtension = (extension: ExtensionDisplay) => {
-    if (extension.enabled) {
-      extensionManager.disableExtension(extension.id);
-    } else {
-      extensionManager.enableExtension(extension, extension.source);
-    }
-    
-    // Update display
-    setExtensions(prev => prev.map(ext => 
-      ext.id === extension.id 
-        ? { ...ext, enabled: !ext.enabled }
-        : ext
-    ));
-  };
-
-  const filteredExtensions = extensions.filter(ext =>
-    ext.name.toLowerCase().includes(searchFilter.toLowerCase()) ||
-    ext.author.toLowerCase().includes(searchFilter.toLowerCase())
-  );
-
-  const getStatusColor = (enabled: boolean) => {
-    return enabled ? 'bg-green-600' : 'bg-government-blue';
-  };
-
-  const getStatusText = (enabled: boolean) => {
-    return enabled ? 'ENABLED' : 'DISABLED';
-  };
 
   return (
     <div className="min-h-screen bg-newspaper-bg flex items-center justify-center p-8 relative overflow-hidden">
-      {/* Redacted background pattern */}
       <div className="absolute inset-0 opacity-5">
         {Array.from({ length: 30 }).map((_, i) => (
-          <div 
+          <div
             key={i}
             className="absolute bg-newspaper-text h-6"
             style={{
@@ -169,8 +51,7 @@ const ManageExpansions = ({ onClose }: ManageExpansionsProps) => {
         ))}
       </div>
 
-      <Card className="max-w-6xl w-full p-8 bg-newspaper-bg border-4 border-newspaper-text animate-redacted-reveal relative" style={{ fontFamily: 'serif' }}>
-        {/* Classified stamps */}
+      <Card className="max-w-4xl w-full p-8 bg-newspaper-bg border-4 border-newspaper-text animate-redacted-reveal relative" style={{ fontFamily: 'serif' }}>
         <div className="absolute top-4 right-4 text-red-600 font-mono text-xs transform rotate-12 border-2 border-red-600 p-2">
           TOP SECRET
         </div>
@@ -178,167 +59,76 @@ const ManageExpansions = ({ onClose }: ManageExpansionsProps) => {
           EYES ONLY
         </div>
 
-        {/* Back button */}
-        <Button 
+        <Button
           onClick={onClose}
-          variant="outline" 
+          variant="outline"
           className="absolute top-4 left-4 border-newspaper-text text-newspaper-text hover:bg-newspaper-text/10"
         >
           ← BACK TO BASE
         </Button>
 
         <div className="text-center mb-8 mt-8">
-          <h1 className="text-4xl font-bold text-newspaper-text mb-4">
-            EXTENSION ARCHIVES
+          <h1 className="text-4xl font-bold text-newspaper-text mb-2">
+            CORE SET OVERVIEW
           </h1>
-          <div className="text-sm text-newspaper-text/80 mb-4">
-            Classified expansion packages and cryptid modules
-          </div>
+          <p className="text-sm text-newspaper-text/80">
+            Extension loading is paused for the MVP sprint. Review core inventory below.
+          </p>
         </div>
 
-        {/* Search and Controls */}
-        <div className="mb-6 space-y-4">
-          <div className="flex gap-4 items-center">
-            <Input
-              placeholder="Search extensions..."
-              value={searchFilter}
-              onChange={(e) => setSearchFilter(e.target.value)}
-              className="flex-1 border-newspaper-text text-newspaper-text"
-            />
-            <Button
-              onClick={loadExtensions}
-              variant="outline"
-              className="border-newspaper-text text-newspaper-text hover:bg-newspaper-text/10"
-              disabled={loading}
-            >
-              {loading ? 'SCANNING...' : 'REFRESH'}
-            </Button>
-          </div>
-          
-          <div className="flex gap-4">
-            <Button
-              onClick={loadFromFolder}
-              variant="outline"
-              className="border-newspaper-text text-newspaper-text hover:bg-newspaper-text/10"
-            >
-              Load From Folder...
-            </Button>
-            <Button
-              onClick={loadFromFiles}
-              variant="outline"
-              className="border-newspaper-text text-newspaper-text hover:bg-newspaper-text/10"
-            >
-              Add JSON Files...
-            </Button>
-            <DistributionSettingsButton />
-          </div>
-
-          {error && (
-            <div className="text-truth-red text-sm p-2 border border-truth-red/30 bg-truth-red/5">
-              {error}
-            </div>
-          )}
-        </div>
-
-        <div className="grid gap-6">
-          {loading ? (
-            <div className="text-center text-newspaper-text/60 py-8">
-              <div className="text-lg mb-2">SCANNING EXTENSIONS...</div>
-              <div className="text-sm">Checking /extensions/ directory</div>
-            </div>
-          ) : filteredExtensions.length === 0 ? (
-            <div className="text-center text-newspaper-text/60 py-8">
-              <div className="text-lg mb-2">NO EXTENSIONS FOUND</div>
-              <div className="text-sm mb-4">
-                {searchFilter 
-                  ? 'No extensions match your search criteria.' 
-                  : 'Use the buttons above to load extension files.'
-                }
+        <div className="grid gap-6 md:grid-cols-2">
+          <Card className="p-6 border-2 border-newspaper-text bg-newspaper-bg">
+            <h2 className="font-bold text-xl text-newspaper-text mb-4">Faction Breakdown</h2>
+            <div className="space-y-3 text-sm text-newspaper-text">
+              <div className="flex items-center justify-between">
+                <span>Truth Seekers</span>
+                <Badge variant="outline">{stats.factions.truth}</Badge>
+              </div>
+              <div className="flex items-center justify-between">
+                <span>Government</span>
+                <Badge variant="outline">{stats.factions.government}</Badge>
+              </div>
+              <div className="flex items-center justify-between">
+                <span>Neutral</span>
+                <Badge variant="outline">{stats.factions.neutral}</Badge>
               </div>
             </div>
-          ) : (
-            filteredExtensions.map((extension) => (
-              <Card key={extension.id} className="p-6 border-2 border-newspaper-text bg-newspaper-bg hover:border-newspaper-text/80 transition-all">
-                <div className="flex flex-col md:flex-row justify-between items-start gap-4">
-                  <div className="flex-1">
-                    <div className="flex items-center gap-3 mb-2">
-                      <h3 className="font-bold text-xl text-newspaper-text">
-                        {extension.name}
-                      </h3>
-                      <Badge className={`${getStatusColor(extension.enabled)} text-white font-mono text-xs`}>
-                        {getStatusText(extension.enabled)}
-                      </Badge>
-                      <Badge variant="outline" className="border-newspaper-text text-newspaper-text font-mono">
-                        v{extension.version}
-                      </Badge>
-                      {extension.enabled && (
-                        <Badge className="bg-green-600 text-white font-mono text-xs">
-                          🦎 ACTIVE
-                        </Badge>
-                      )}
-                    </div>
-                    
-                    <p className="text-sm text-newspaper-text/80 mb-3">
-                      {extension.description}
-                    </p>
-                    
-                    <div className="flex flex-wrap gap-2 mb-3">
-                      <Badge variant="outline" className="text-xs border-newspaper-text/40 text-newspaper-text/70">
-                        {extension.count} Cards
-                      </Badge>
-                      <Badge variant="outline" className="text-xs border-newspaper-text/40 text-newspaper-text/70">
-                        {extension.factions.join(' + ')}
-                      </Badge>
-                      <Badge variant="outline" className="text-xs border-newspaper-text/40 text-newspaper-text/70">
-                        {extension.source.toUpperCase()}
-                      </Badge>
-                    </div>
-                    
-                    <div className="text-xs font-mono text-red-600 border border-red-600/30 p-2 bg-red-600/5 inline-block">
-                      CLASSIFIED - AUTHOR: {extension.author}
-                    </div>
-                  </div>
-                  
-                  <div className="flex flex-col gap-2 min-w-[120px]">
-                    <Button 
-                      onClick={() => toggleExtension(extension)}
-                      className={`w-full ${
-                        extension.enabled 
-                          ? 'bg-truth-red hover:bg-truth-red/80' 
-                          : 'bg-government-blue hover:bg-government-blue/80'
-                      } text-white`}
-                    >
-                      {extension.enabled ? 'DISABLE' : 'ENABLE'}
-                    </Button>
-                    <div className="text-xs text-center text-newspaper-text/60 font-mono">
-                      ID: {extension.id}
-                    </div>
-                  </div>
+          </Card>
+
+          <Card className="p-6 border-2 border-newspaper-text bg-newspaper-bg">
+            <h2 className="font-bold text-xl text-newspaper-text mb-4">Type Inventory</h2>
+            <div className="space-y-3 text-sm text-newspaper-text">
+              {stats.types.map(([type, count]) => (
+                <div key={type} className="flex items-center justify-between">
+                  <span className="uppercase">{type}</span>
+                  <Badge variant="outline">{count}</Badge>
                 </div>
-              </Card>
-            ))
-          )}
+              ))}
+            </div>
+          </Card>
         </div>
 
-        {/* Stats Footer */}
-        <div className="mt-8 p-4 border-t-2 border-newspaper-text/30">
-          <div className="flex flex-wrap justify-between items-center text-sm text-newspaper-text/60 font-mono">
-            <div>LOADED: {extensions.length}</div>
-            <div>ENABLED: {extensions.filter(e => e.enabled).length}</div>
-            <div>TOTAL CARDS: {extensions.filter(e => e.enabled).reduce((sum, ext) => sum + ext.count, 0)}</div>
-            {searchFilter && (
-              <div>FILTERED: {filteredExtensions.length}/{extensions.length}</div>
-            )}
+        <Card className="mt-6 p-6 border-2 border-newspaper-text bg-newspaper-bg">
+          <h2 className="font-bold text-xl text-newspaper-text mb-4">Rarity Spread</h2>
+          <div className="grid gap-4 md:grid-cols-4 text-sm text-newspaper-text">
+            {stats.rarities.length === 0 && <div>No rarities assigned yet.</div>}
+            {stats.rarities.map(([rarity, count]) => (
+              <div key={rarity} className="flex flex-col items-center gap-1">
+                <span className="uppercase font-semibold">{rarity}</span>
+                <Badge variant="outline">{count}</Badge>
+              </div>
+            ))}
           </div>
-        </div>
+        </Card>
 
-        {/* Footer */}
-        <div className="mt-6 text-center text-xs text-newspaper-text/60">
-          <div className="mb-2">WARNING: Extension content may cause reality distortion</div>
-          <div>Extensions are loaded from JSON files and may contain satirical content</div>
-          <div className="mt-2 text-red-600 font-bold">
-            [REDACTED] - Clearance Level: EXTENSION MANAGER
-          </div>
+        <div className="mt-6 text-sm text-newspaper-text/80 space-y-2">
+          <p>Total MVP-ready cards: {stats.totalCards}</p>
+          <p>
+            Want to prototype new content? Tag it as core and run balancing from the dashboard.
+          </p>
+          <p>
+            Extension toggles will return after the MVP launch window when additional mechanics are revalidated.
+          </p>
         </div>
       </Card>
     </div>

--- a/src/data/enhancedCardBalancing.ts
+++ b/src/data/enhancedCardBalancing.ts
@@ -1,68 +1,40 @@
-// Enhanced Card Balancing System for Shadow Government v2.1E
-// Updated for new type system with GameCard and CardEffects
-
 import type { GameCard } from '@/rules/mvp';
-import type { CardEffects } from '@/types/cardEffects';
 import { CARD_DATABASE } from './cardDatabase';
-import { extensionManager } from './extensionSystem';
+import {
+  classifyMvpCost,
+  computeMvpEffectScore,
+  getExpectedMvpCost,
+  getMvpEffectSummary,
+  normalizeFaction,
+  summarizeFactionCounts,
+  type MvpCostStatus,
+  type MvpEffectSummary,
+} from './mvpAnalysisUtils';
 
-// Enhanced interfaces for the new system
 export interface EnhancedCardAnalysis {
   cardId: string;
   name: string;
-  type: string;
-  faction: string;
-  rarity: string;
+  type: GameCard['type'];
+  faction: 'truth' | 'government' | 'neutral';
+  rarity?: GameCard['rarity'];
   cost: number;
-  
-  // Analysis results
-  totalUtility: number;
-  utilityBreakdown: {
-    truth: number;
-    ip: number;
-    pressure: number;
-    draw: number;
-    flags: number;
-    developments: number;
-  };
-  
-  classification: 'On Curve' | 'Undercosted' | 'Overcosted';
-  severity: 'Low' | 'Medium' | 'High' | 'Severe';
-  
-  factionAlignment: {
-    alignment: 'Aligned' | 'Mixed' | 'Misaligned';
-    reason: string;
-  };
-  
-  recommendation: {
-    cost: number | null;
-    rarity: string | null;
-    reasoning: string;
-  };
+  expectedCost: number | null;
+  costStatus: MvpCostStatus;
+  costDelta: number | null;
+  effects: MvpEffectSummary;
+  mvpScore: number;
 }
 
 export interface EnhancedBalanceReport {
   totalCards: number;
   onCurve: number;
-  undercosted: number;  
+  undercosted: number;
   overcosted: number;
-  
-  // Faction distribution
-  truthCards: number;
-  governmentCards: number;
-  neutralCards: number;
-  misalignedCards: number;
-  
-  // Statistics
+  costTableConformity: number;
+  factionCounts: { truth: number; government: number; neutral: number };
   averageCost: number;
-  averageUtility: number;
-  averageCostByType: Record<string, number>;
-  averageCostByRarity: Record<string, number>;
-  
-  // Card analyses
+  averageScore: number;
   cardAnalysis: EnhancedCardAnalysis[];
-  
-  // Global recommendations
   globalRecommendations: string[];
 }
 
@@ -71,569 +43,162 @@ export interface SimulationReport {
   truthWinRate: number;
   governmentWinRate: number;
   drawRate: number;
-  
-  // Performance metrics
-  averageGameLength: number;
-  overusedCards: Array<{ name: string; usageRate: number; }>;
-  underusedCards: Array<{ name: string; usageRate: number; }>;
-  
-  // Card performance data
-  cardPerformance: Array<{
-    cardId: string;
-    name: string;
-    winRate: number;
-    usageRate: number;
-    totalUtility: number;
+  winConditionBreakdown: Array<{
+    condition: 'truth' | 'ip' | 'pressure';
+    weight: number;
   }>;
 }
-
-export interface PatchEntry {
-  cardId: string;
-  cardName: string;
-  currentCost: number;
-  recommendedCost: number;
-  reasoning: string;
-  severity: string;
-}
-
-// IP-equivalent utility weights for different effects
-const IP_EQUIVALENT_WEIGHTS = {
-  // Core effects
-  truthBase: 0.8,           // Truth effects worth 0.8 IP per point
-  truthDiminishing: 0.4,    // Diminishing returns after cap
-  ipBase: 1.0,              // IP effects at face value
-  pressureBase: 1.2,        // Pressure slightly more valuable
-  drawBase: 4.0,            // Card draw worth 4 IP per card
-  drawDiminishing: 2.0,     // Diminishing returns after 2 cards
-  
-  // Special effects
-  forceDiscard: 3.0,        // Forcing opponent discard
-  zoneDefenseBase: 2.0,     // Zone defense per point
-  skipAction: 8.0,          // Skip opponent action
-  blockAttack: 6.0,         // Block an attack
-  immune: 5.0,              // Immunity effects
-  zoneCostReduction: 3.0,   // Zone cost reduction
-  
-  // Multipliers
-  developmentMultiplier: 0.7, // Permanent effects get discount
-};
-
-// Rarity-based cost budgets (IP-equivalent utility expected)
-const RARITY_BUDGETS = {
-  common: { min: 4, max: 8, baseline: 6 },
-  uncommon: { min: 6, max: 12, baseline: 9 },
-  rare: { min: 10, max: 18, baseline: 14 },
-  legendary: { min: 20, max: 30, baseline: 25 }
-};
-
-// Balancing constraints
-const BALANCING_CONSTRAINTS = {
-  costChangeLimit: 3,       // Max ±3 IP cost change
-  truthEffectCap: 15,       // Truth effects over 15% get diminishing returns
-  onCurveThreshold: 0.15,   // ±15% considered "on curve"
-  severeThreshold: 0.35,    // ±35% considered "severe"
-  
-  // Threshold scaling for Truth effects
-  truthThresholdRange: 15,    // ±15 p.p. from relevant thresholds
-  truthMaxScale: 2.0         // Max 2x multiplier near thresholds
-};
 
 export class EnhancedCardBalancer {
   private cards: GameCard[];
 
-  constructor(includeExtensions: boolean = true) {
-    if (includeExtensions) {
-      const extensionCards = extensionManager.getAllExtensionCards();
-      this.cards = [...CARD_DATABASE, ...extensionCards];
-    } else {
-      this.cards = CARD_DATABASE;
-    }
-    
-    // Normalize encoding issues in text fields
-    this.cards = this.cards.map(card => ({
-      ...card,
-      name: this.normalizeText(card.name),
-      text: this.normalizeText(card.text),
-      flavorTruth: this.normalizeText(card.flavorTruth),
-      flavorGov: this.normalizeText(card.flavorGov)
-    }));
+  constructor(includeExtensions: boolean = false) {
+    // MVP build ignores extension cards entirely. The flag remains for compatibility with callers.
+    this.cards = CARD_DATABASE;
   }
 
-  private normalizeText(text: string | undefined): string {
-    if (!text) return '';
-    return text
-      .replace(/Ã©/g, 'é')
-      .replace(/Ã¡/g, 'á')
-      .replace(/Ã­/g, 'í')
-      .replace(/Ã³/g, 'ó')
-      .replace(/Ãº/g, 'ú')
-      .replace(/Ã±/g, 'ñ')
-      .replace(/Ã /g, 'à');
-  }
+  private analyzeCard(card: GameCard): EnhancedCardAnalysis {
+    const effects = getMvpEffectSummary(card);
+    const expectedCost = getExpectedMvpCost(card);
+    const { status: costStatus, delta: costDelta } = classifyMvpCost(card, expectedCost);
+    const mvpScore = computeMvpEffectScore(effects);
 
-  private determineFaction(card: GameCard): 'Truth' | 'Government' | 'Neutral' {
-    // Use the actual faction field from v2.1E system
-    if (card.faction === 'truth' || card.faction === 'Truth') return 'Truth';
-    if (card.faction === 'government' || card.faction === 'Government') return 'Government';
-    return 'Neutral';
-  }
-
-  private analyzeCardEffects(card: GameCard): { totalUtility: number; breakdown: any } {
-    const breakdown = {
-      truth: 0,
-      ip: 0,
-      pressure: 0,
-      draw: 0,
-      flags: 0,
-      developments: 0
+    return {
+      cardId: card.id,
+      name: card.name,
+      type: card.type,
+      faction: normalizeFaction(card.faction),
+      rarity: card.rarity,
+      cost: card.cost,
+      expectedCost,
+      costStatus,
+      costDelta,
+      effects,
+      mvpScore,
     };
-
-    const effects = card.effects;
-    if (!effects) {
-      return { totalUtility: 0, breakdown };
-    }
-
-    // Truth effects - use v2.1E structured data
-    if (effects.truthDelta) {
-      const truthValue = Math.abs(effects.truthDelta);
-      const baseValue = Math.min(truthValue, BALANCING_CONSTRAINTS.truthEffectCap) * IP_EQUIVALENT_WEIGHTS.truthBase;
-      const overageValue = Math.max(0, truthValue - BALANCING_CONSTRAINTS.truthEffectCap) * IP_EQUIVALENT_WEIGHTS.truthDiminishing;
-      breakdown.truth = baseValue + overageValue;
-    }
-
-    // IP effects
-    if (effects.ipDelta) {
-      if (effects.ipDelta.self) {
-        breakdown.ip += effects.ipDelta.self * IP_EQUIVALENT_WEIGHTS.ipBase;
-      }
-      if (effects.ipDelta.opponent) {
-        // Negative IP for opponent is positive for us
-        breakdown.ip += Math.abs(effects.ipDelta.opponent) * IP_EQUIVALENT_WEIGHTS.ipBase;
-      }
-    }
-
-    // Pressure effects  
-    if (effects.pressureDelta) {
-      breakdown.pressure += Math.abs(effects.pressureDelta) * IP_EQUIVALENT_WEIGHTS.pressureBase;
-    }
-
-    // Draw effects
-    if (effects.draw) {
-      const drawValue = effects.draw;
-      if (drawValue <= 2) {
-        breakdown.draw += drawValue * IP_EQUIVALENT_WEIGHTS.drawBase;
-      } else {
-        breakdown.draw += 2 * IP_EQUIVALENT_WEIGHTS.drawBase + 
-                        (drawValue - 2) * IP_EQUIVALENT_WEIGHTS.drawDiminishing;
-      }
-    }
-
-    // Discard effects
-    if (effects.discardOpponent) {
-      breakdown.flags += effects.discardOpponent * IP_EQUIVALENT_WEIGHTS.forceDiscard;
-    }
-
-    // Zone defense effects
-    if (effects.zoneDefense) {
-      breakdown.flags += effects.zoneDefense * IP_EQUIVALENT_WEIGHTS.zoneDefenseBase;
-    }
-
-    // Conditional effects - simplified evaluation
-    if (effects.conditional) {
-      const conditionalEffects = Array.isArray(effects.conditional) ? effects.conditional : [effects.conditional];
-      for (const condition of conditionalEffects) {
-        if (condition.then) {
-          const subAnalysis = this.analyzeCardEffects({ ...card, effects: condition.then });
-          // Conditional effects get 60% value due to uncertainty
-          Object.keys(breakdown).forEach(key => {
-            breakdown[key] += subAnalysis.breakdown[key] * 0.6;
-          });
-        }
-      }
-    }
-
-    const totalUtility = Object.values(breakdown).reduce((sum, val) => sum + val, 0);
-    
-    return { totalUtility, breakdown };
-  }
-
-  private analyzeFactionAlignment(card: GameCard): { alignment: string; reason: string } {
-    const faction = this.determineFaction(card);
-    const { totalUtility } = this.analyzeCardEffects(card);
-    const effects = card.effects;
-
-    if (!effects) {
-      return { alignment: 'Aligned', reason: 'No effects to analyze' };
-    }
-
-    // Check for severe misalignment using structured effects
-    if (faction === 'Truth' && effects.truthDelta && effects.truthDelta < 0) {
-      if (totalUtility <= 0) {
-        return { 
-          alignment: 'Misaligned' as const, 
-          reason: 'Truth card with negative Truth effect and insufficient compensation' 
-        };
-      } else if (totalUtility < 5) {
-        return { 
-          alignment: 'Mixed' as const, 
-          reason: 'Truth card with negative Truth effect but some compensating utility' 
-        };
-      }
-    }
-
-    if (faction === 'Government' && effects.truthDelta && effects.truthDelta > 0) {
-      if (totalUtility <= 0) {
-        return { 
-          alignment: 'Misaligned' as const, 
-          reason: 'Government card with positive Truth effect and insufficient compensation' 
-        };
-      } else if (totalUtility < 5) {
-        return { 
-          alignment: 'Mixed' as const, 
-          reason: 'Government card with positive Truth effect but some compensating utility' 
-        };
-      }
-    }
-
-    return { alignment: 'Aligned' as const, reason: 'Effects align with faction goals' };
-  }
-
-  private calculateOptimalCost(card: GameCard, totalUtility: number): number {
-    const budget = RARITY_BUDGETS[card.rarity as keyof typeof RARITY_BUDGETS];
-    if (!budget) return card.cost;
-
-    // Convert utility to cost (IP)
-    const optimalCost = Math.round(totalUtility);
-    
-    // Constrain to rarity bounds
-    return Math.max(budget.min, Math.min(budget.max, optimalCost));
-  }
-
-  private generateRecommendation(card: GameCard, analysis: any): { cost: number | null; rarity: string | null; reasoning: string } {
-    const { totalUtility } = this.analyzeCardEffects(card);
-    const currentBudget = RARITY_BUDGETS[card.rarity as keyof typeof RARITY_BUDGETS];
-    
-    if (!currentBudget) {
-      return { cost: null, rarity: null, reasoning: 'Unknown rarity' };
-    }
-
-    const utilityDifference = totalUtility - currentBudget.baseline;
-    const percentageDiff = Math.abs(utilityDifference) / currentBudget.baseline;
-
-    if (percentageDiff <= BALANCING_CONSTRAINTS.onCurveThreshold) {
-      return { cost: null, rarity: null, reasoning: 'Card is balanced within acceptable range' };
-    }
-
-    const optimalCost = this.calculateOptimalCost(card, totalUtility);
-    const costChange = optimalCost - card.cost;
-
-    if (Math.abs(costChange) > BALANCING_CONSTRAINTS.costChangeLimit) {
-      const cappedChange = Math.sign(costChange) * BALANCING_CONSTRAINTS.costChangeLimit;
-      const newCost = card.cost + cappedChange;
-      return { 
-        cost: newCost, 
-        rarity: null, 
-        reasoning: `Major rebalancing needed: utility suggests ${optimalCost} IP, but limited to ±${BALANCING_CONSTRAINTS.costChangeLimit} change` 
-      };
-    }
-
-    return { 
-      cost: optimalCost, 
-      rarity: null, 
-      reasoning: `Utility analysis suggests ${costChange > 0 ? 'increase' : 'decrease'} of ${Math.abs(costChange)} IP` 
-    };
-  }
-
-  private classifyCard(card: GameCard, totalUtility: number): 'On Curve' | 'Undercosted' | 'Overcosted' {
-    const budget = RARITY_BUDGETS[card.rarity as keyof typeof RARITY_BUDGETS];
-    if (!budget) return 'On Curve';
-
-    const utilityDifference = totalUtility - budget.baseline;
-    const percentageDiff = utilityDifference / budget.baseline;
-
-    if (Math.abs(percentageDiff) <= BALANCING_CONSTRAINTS.onCurveThreshold) {
-      return 'On Curve';
-    }
-
-    if (percentageDiff > 0) {
-      return 'Undercosted';
-    }
-
-    return 'Overcosted';
   }
 
   public generateEnhancedReport(): EnhancedBalanceReport {
-    const cardAnalyses: EnhancedCardAnalysis[] = [];
-    
-    for (const card of this.cards) {
-      const { totalUtility, breakdown } = this.analyzeCardEffects(card);
-      const faction = this.determineFaction(card);
-      const alignment = this.analyzeFactionAlignment(card);
-      const classification = this.classifyCard(card, totalUtility);
-      const recommendation = this.generateRecommendation(card, { totalUtility, classification });
-      
-      // Determine severity
-      let severity: 'Low' | 'Medium' | 'High' | 'Severe' = 'Low';
-      if (alignment.alignment === 'Misaligned') {
-        severity = 'Severe';
-      } else {
-        const budget = RARITY_BUDGETS[card.rarity as keyof typeof RARITY_BUDGETS];
-        if (budget) {
-          const percentageDiff = Math.abs(totalUtility - budget.baseline) / budget.baseline;
-          if (percentageDiff > BALANCING_CONSTRAINTS.severeThreshold) {
-            severity = 'Severe';
-          } else if (percentageDiff > 0.25) {
-            severity = 'High';
-          } else if (percentageDiff > BALANCING_CONSTRAINTS.onCurveThreshold) {
-            severity = 'Medium';
-          }
-        }
-      }
+    const cardAnalysis = this.cards.map(card => this.analyzeCard(card));
+    const totalCards = cardAnalysis.length;
 
-      cardAnalyses.push({
-        cardId: card.id,
-        name: card.name,
-        type: card.type,
-        faction: faction,
-        rarity: card.rarity || 'common',
-        cost: card.cost,
-        totalUtility,
-        utilityBreakdown: breakdown,
-        classification,
-        severity,
-        factionAlignment: {
-          alignment: alignment.alignment as 'Aligned' | 'Mixed' | 'Misaligned',
-          reason: alignment.reason
-        },
-        recommendation
-      });
+    const onCurve = cardAnalysis.filter(card => card.costStatus === 'On Curve').length;
+    const undercosted = cardAnalysis.filter(card => card.costStatus === 'Undercosted').length;
+    const overcosted = cardAnalysis.filter(card => card.costStatus === 'Overcosted').length;
+
+    const costTableConformity = totalCards > 0 ? (onCurve / totalCards) * 100 : 0;
+    const factionCounts = summarizeFactionCounts(this.cards);
+    const averageCost =
+      totalCards > 0
+        ? cardAnalysis.reduce((sum, card) => sum + card.cost, 0) / totalCards
+        : 0;
+    const averageScore =
+      totalCards > 0
+        ? cardAnalysis.reduce((sum, card) => sum + card.mvpScore, 0) / totalCards
+        : 0;
+
+    const globalRecommendations: string[] = [];
+    globalRecommendations.push(
+      `${onCurve} of ${totalCards} cards (${costTableConformity.toFixed(0)}%) match MVP cost tables.`
+    );
+
+    if (undercosted > totalCards * 0.15) {
+      globalRecommendations.push('Large group of undercosted cards detected — raise costs or trim effects.');
     }
 
-    // Calculate report statistics
-    const onCurve = cardAnalyses.filter(c => c.classification === 'On Curve').length;
-    const undercosted = cardAnalyses.filter(c => c.classification === 'Undercosted').length;
-    const overcosted = cardAnalyses.filter(c => c.classification === 'Overcosted').length;
-    
-    const truthCards = cardAnalyses.filter(c => c.faction === 'Truth').length;
-    const governmentCards = cardAnalyses.filter(c => c.faction === 'Government').length;
-    const neutralCards = cardAnalyses.filter(c => c.faction === 'Neutral').length;
-    const misalignedCards = cardAnalyses.filter(c => c.factionAlignment.alignment === 'Misaligned').length;
-
-    const averageCost = cardAnalyses.reduce((sum, c) => sum + c.cost, 0) / cardAnalyses.length;
-    const averageUtility = cardAnalyses.reduce((sum, c) => sum + c.totalUtility, 0) / cardAnalyses.length;
-
-    // Group by type and rarity for averages
-    const costByType: Record<string, number> = {};
-    const costByRarity: Record<string, number> = {};
-    const typeGroups: Record<string, number[]> = {};
-    const rarityGroups: Record<string, number[]> = {};
-
-    cardAnalyses.forEach(card => {
-      if (!typeGroups[card.type]) typeGroups[card.type] = [];
-      if (!rarityGroups[card.rarity]) rarityGroups[card.rarity] = [];
-      
-      typeGroups[card.type].push(card.cost);
-      rarityGroups[card.rarity].push(card.cost);
-    });
-
-    Object.keys(typeGroups).forEach(type => {
-      costByType[type] = typeGroups[type].reduce((sum, cost) => sum + cost, 0) / typeGroups[type].length;
-    });
-
-    Object.keys(rarityGroups).forEach(rarity => {
-      costByRarity[rarity] = rarityGroups[rarity].reduce((sum, cost) => sum + cost, 0) / rarityGroups[rarity].length;
-    });
-
-    // Generate global recommendations
-    const globalRecommendations = [];
-    
-    if (undercosted > overcosted * 1.5) {
-      globalRecommendations.push('Many cards are undercosted - consider global cost increases');
+    if (overcosted > totalCards * 0.15) {
+      globalRecommendations.push('Many cards read overpriced. Consider easing costs or boosting effects.');
     }
-    if (overcosted > undercosted * 1.5) {
-      globalRecommendations.push('Many cards are overcosted - consider global cost reductions');
+
+    const factionSpread = Math.abs(factionCounts.truth - factionCounts.government);
+    if (factionSpread > 3) {
+      const strongerFaction = factionCounts.truth > factionCounts.government ? 'Truth Seekers' : 'Government';
+      globalRecommendations.push(
+        `${strongerFaction} have noticeably more cards. Add rivals or rebalance supply.`
+      );
     }
-    if (misalignedCards > cardAnalyses.length * 0.1) {
-      globalRecommendations.push('High faction misalignment detected - review card design');
+
+    if (averageScore > 15) {
+      globalRecommendations.push('Average MVP impact is high. Revisit top-end effects before playtest.');
     }
 
     return {
-      totalCards: cardAnalyses.length,
+      totalCards,
       onCurve,
       undercosted,
       overcosted,
-      truthCards,
-      governmentCards,
-      neutralCards,
-      misalignedCards,
+      costTableConformity,
+      factionCounts,
       averageCost,
-      averageUtility,
-      averageCostByType: costByType,
-      averageCostByRarity: costByRarity,
-      cardAnalysis: cardAnalyses,
-      globalRecommendations
+      averageScore,
+      cardAnalysis,
+      globalRecommendations,
     };
   }
 
   public runEnhancedSimulation(iterations: number = 1000): SimulationReport {
-    const cardUsage: Record<string, { played: number; wonWithCard: number; }> = {};
-    
-    // Initialize usage tracking
-    this.cards.forEach(card => {
-      cardUsage[card.id] = { played: 0, wonWithCard: 0 };
-    });
+    const cardAnalysis = this.cards.map(card => this.analyzeCard(card));
 
-    let truthWins = 0;
-    let governmentWins = 0;
-    let draws = 0;
-    let totalGameLength = 0;
+    const truthStrength = cardAnalysis
+      .filter(card => card.faction === 'truth')
+      .reduce((sum, card) => sum + card.mvpScore, 0);
+    const governmentStrength = cardAnalysis
+      .filter(card => card.faction === 'government')
+      .reduce((sum, card) => sum + card.mvpScore, 0);
+    const totalStrength = truthStrength + governmentStrength;
 
-    for (let i = 0; i < iterations; i++) {
-      // Simulate a game
-      let truthLevel = 50; // Start at neutral
-      let gameLength = 0;
-      const maxTurns = 20;
-      const cardsPlayedThisGame: string[] = [];
+    const truthWinRate = totalStrength > 0 ? (truthStrength / totalStrength) * 100 : 50;
+    const governmentWinRate = totalStrength > 0 ? (governmentStrength / totalStrength) * 100 : 50;
+    const drawRate = Math.max(0, 100 - truthWinRate - governmentWinRate);
 
-      for (let turn = 0; turn < maxTurns; turn++) {
-        gameLength++;
-        
-        // Simulate 2-3 card plays per turn
-        const cardsThisTurn = 2 + Math.floor(Math.random() * 2);
-        
-        for (let play = 0; play < cardsThisTurn; play++) {
-          const randomCard = this.cards[Math.floor(Math.random() * this.cards.length)];
-          cardsPlayedThisGame.push(randomCard.id);
-          cardUsage[randomCard.id].played++;
-          
-          // Apply effects based on enhanced analysis
-          const { totalUtility, breakdown } = this.analyzeCardEffects(randomCard);
-          
-          // Apply truth effects
-          if (breakdown.truth !== 0) {
-            const truthChange = breakdown.truth / IP_EQUIVALENT_WEIGHTS.truthBase;
-            truthLevel = Math.max(0, Math.min(100, truthLevel + truthChange));
-          }
-          
-          // Check for game end conditions
-          if (truthLevel >= 85) {
-            truthWins++;
-            cardsPlayedThisGame.forEach(cardId => cardUsage[cardId].wonWithCard++);
-            break;
-          } else if (truthLevel <= 15) {
-            governmentWins++;
-            cardsPlayedThisGame.forEach(cardId => cardUsage[cardId].wonWithCard++);
-            break;
-          }
-        }
+    const truthWeight = cardAnalysis.reduce(
+      (sum, card) => sum + Math.max(0, card.effects.truthDelta),
+      0
+    );
+    const ipWeight = cardAnalysis.reduce(
+      (sum, card) => sum + Math.max(0, card.effects.ipDeltaOpponent),
+      0
+    );
+    const pressureWeight = cardAnalysis.reduce(
+      (sum, card) => sum + Math.max(0, card.effects.pressureDelta),
+      0
+    );
 
-        // Early exit if game ended
-        if (truthLevel >= 85 || truthLevel <= 15) break;
-      }
-
-      // If no winner after max turns, it's a draw
-      if (truthLevel < 85 && truthLevel > 15) {
-        draws++;
-      }
-
-      totalGameLength += gameLength;
-    }
-
-    // Analyze card performance
-    const cardPerformanceData = Object.entries(cardUsage).map(([cardId, stats]) => {
-      const card = this.cards.find(c => c.id === cardId);
-      const { totalUtility } = this.analyzeCardEffects(card!);
-      const winRate = stats.played > 0 ? stats.wonWithCard / stats.played : 0;
-      const usageRate = stats.played / iterations;
-      
-      return {
-        cardId,
-        name: card?.name || 'Unknown',
-        totalUtility,
-        winRate,
-        usageRate,
-      };
-    });
-
-    const overusedCards = cardPerformanceData
-      .filter(c => c.usageRate > 0.8) // High usage threshold
-      .sort((a, b) => b.usageRate - a.usageRate)
-      .slice(0, 10)
-      .map(c => ({ name: c.name, usageRate: c.usageRate }));
-
-    const underusedCards = cardPerformanceData
-      .filter(c => c.usageRate < 0.1) // Low usage threshold
-      .sort((a, b) => a.usageRate - b.usageRate)
-      .slice(0, 10)
-      .map(c => ({ name: c.name, usageRate: c.usageRate }));
+    const totalWeight = truthWeight + ipWeight + pressureWeight;
+    const toPercent = (value: number) => (totalWeight > 0 ? (value / totalWeight) * 100 : 0);
 
     return {
       iterations,
-      truthWinRate: (truthWins / iterations) * 100,
-      governmentWinRate: (governmentWins / iterations) * 100,
-      drawRate: (draws / iterations) * 100,
-      averageGameLength: totalGameLength / iterations,
-      overusedCards,
-      underusedCards,
-      cardPerformance: cardPerformanceData
+      truthWinRate,
+      governmentWinRate,
+      drawRate,
+      winConditionBreakdown: [
+        { condition: 'truth', weight: toPercent(truthWeight) },
+        { condition: 'ip', weight: toPercent(ipWeight) },
+        { condition: 'pressure', weight: toPercent(pressureWeight) },
+      ],
     };
   }
 
-  public generatePatchExport(format: 'json' | 'csv' | 'txt' = 'json'): string {
-    const report = this.generateEnhancedReport();
-    const patches = report.cardAnalysis
-      .filter(card => card.recommendation.cost !== null)
-      .map(card => ({
-        cardId: card.cardId,
-        cardName: card.name,
-        currentCost: card.cost,
-        recommendedCost: card.recommendation.cost!,
-        reasoning: card.recommendation.reasoning,
-        severity: card.severity
-      }));
-
-    switch (format) {
-      case 'csv':
-        const csvHeader = 'cardId,cardName,currentCost,recommendedCost,reasoning,severity';
-        const csvRows = patches.map(p => 
-          `${p.cardId},"${p.cardName}",${p.currentCost},${p.recommendedCost},"${p.reasoning}",${p.severity}`
-        );
-        return [csvHeader, ...csvRows].join('\n');
-
-      case 'txt':
-        return patches.map(p => 
-          `${p.cardName} (${p.cardId}): ${p.currentCost} → ${p.recommendedCost} IP\n` +
-          `  Reason: ${p.reasoning}\n` +
-          `  Severity: ${p.severity}\n`
-        ).join('\n');
-
-      default:
-        return JSON.stringify(patches, null, 2);
-    }
-  }
-
-  public exportFullAnalysis(): any {
-    const report = this.generateEnhancedReport();
-    const simulation = this.runEnhancedSimulation();
-    const patches = this.generatePatchExport('json');
-
+  public exportSummary() {
     return {
-      timestamp: new Date().toISOString(),
-      version: '2.1E',
-      report,
-      simulation,
-      patches: JSON.parse(patches)
+      generatedAt: new Date().toISOString(),
+      version: 'MVP',
+      report: this.generateEnhancedReport(),
+      simulation: this.runEnhancedSimulation(),
     };
   }
 }
 
-// Public utility functions
-export function analyzeCardBalanceEnhanced(includeExtensions: boolean = true): EnhancedBalanceReport {
+export function analyzeCardBalanceEnhanced(includeExtensions: boolean = false): EnhancedBalanceReport {
   const balancer = new EnhancedCardBalancer(includeExtensions);
   return balancer.generateEnhancedReport();
 }
 
-export function runBalanceSimulationEnhanced(iterations: number = 1000, includeExtensions: boolean = true): SimulationReport {
+export function runBalanceSimulationEnhanced(
+  iterations: number = 1000,
+  includeExtensions: boolean = false
+): SimulationReport {
   const balancer = new EnhancedCardBalancer(includeExtensions);
   return balancer.runEnhancedSimulation(iterations);
 }

--- a/src/data/factionBalanceAnalyzer.ts
+++ b/src/data/factionBalanceAnalyzer.ts
@@ -1,29 +1,15 @@
-// Faction Balance Analyzer for Shadow Government
-// Comprehensive card analysis system with faction alignment and balance evaluation
-
 import { CARD_DATABASE } from './cardDatabase';
-import { extensionManager } from './extensionSystem';
-
-// Use centralized v2.1E types
-import type { GameCard, Faction, CardType } from '@/rules/mvp';
-
-// Core interfaces for analysis system
-export interface FactionAlignmentMatrix {
-  truthSeekerEffects: {
-    truthPositive: number;    // Truth + = ✅
-    truthNegative: number;    // Truth - = ❌ (flagged)
-    ipSelf: number;          // IP(player)+ = ✅
-    ipOpponent: number;      // IP(ai)- = ✅
-    pressureSelf: number;    // Own pressure = situational positive
-  };
-  governmentEffects: {
-    truthNegative: number;   // Truth - = ✅
-    truthPositive: number;   // Truth + = ❌ (flagged)
-    ipSelf: number;         // IP(ai)+ = ✅
-    ipOpponent: number;     // IP(player)- = ✅
-    pressureSelf: number;   // Own pressure = situational positive
-  };
-}
+import type { GameCard } from '@/rules/mvp';
+import {
+  classifyMvpCost,
+  computeMvpEffectScore,
+  getExpectedMvpCost,
+  getMvpEffectSummary,
+  normalizeFaction,
+  summarizeFactionCounts,
+  type MvpCostStatus,
+  type MvpEffectSummary,
+} from './mvpAnalysisUtils';
 
 export interface NetUtilityScore {
   total: number;
@@ -31,344 +17,159 @@ export interface NetUtilityScore {
     truth: number;
     ip: number;
     pressure: number;
-    defensive: number;
-    utility: number;
   };
-  explanation: string[];
 }
 
 export interface CardAnalysisResult {
   cardId: string;
   name: string;
-  type: string;
-  rarity: string;
+  type: GameCard['type'];
+  rarity?: GameCard['rarity'];
   faction: 'truth' | 'government' | 'neutral';
-  
-  // Faction alignment
   alignment: 'Aligned' | 'Mixed' | 'Misaligned';
   alignmentReason: string;
-  
-  // Net utility
+  effects: MvpEffectSummary;
   netUtilityScore: NetUtilityScore;
-  
-  // Cost analysis
   cost: number;
-  expectedCostRange: { min: number; max: number };
-  costStatus: 'Undercosted' | 'On Curve' | 'Overcosted';
-  
-  // Issue classification
-  severity: 'Low' | 'Medium' | 'High' | 'Severe';
-  issues: string[];
+  expectedCost: number | null;
+  costStatus: MvpCostStatus;
+  costDelta: number | null;
+  severity: 'Low' | 'Medium' | 'High';
+  notes: string[];
   recommendations: string[];
 }
 
 export interface BalanceReport {
   timestamp: string;
   totalCards: number;
-  
-  // Per faction stats
-  truthSeekerStats: {
-    total: number;
-    aligned: number;
-    mixed: number;
-    misaligned: number;
-    averageNUS: number;
-  };
-  
-  governmentStats: {
-    total: number;
-    aligned: number;
-    mixed: number;
-    misaligned: number;
-    averageNUS: number;
-  };
-  
-  // Cost distribution
-  costByType: Record<string, number>;
-  costByRarity: Record<string, number>;
-  
-  // Problem summary
-  severeIssues: number;
-  highIssues: number;
-  mediumIssues: number;
-  lowIssues: number;
-  
-  // Detailed analysis
+  factionCounts: { truth: number; government: number; neutral: number };
+  alignmentSummary: { aligned: number; mixed: number; misaligned: number };
+  costSummary: { onCurve: number; undercosted: number; overcosted: number };
+  averageUtility: number;
   cardAnalysis: CardAnalysisResult[];
-  
-  // Global recommendations
   globalRecommendations: string[];
 }
 
 export interface SimulationResult {
   truthWinRate: number;
   governmentWinRate: number;
-  averageTruthPath: number[];
-  averageIPSwing: number;
-  averageCardsPerTurn: number;
-  topOverpoweredCards: string[];
-  topUnderpoweredCards: string[];
+  drawRate: number;
+  winDrivers: Array<{
+    condition: 'truth' | 'ip' | 'pressure';
+    weight: number;
+  }>;
 }
-
-// Cost curves per rarity (IP cost expectations)
-const COST_CURVES = {
-  common: { min: 1, max: 4, baseline: 2.5 },
-  uncommon: { min: 3, max: 6, baseline: 4.5 },
-  rare: { min: 5, max: 9, baseline: 7 },
-  legendary: { min: 8, max: 15, baseline: 11 }
-};
-
-// Effect value weights for NUS calculation
-const EFFECT_WEIGHTS = {
-  truth: 1.0,           // Truth ±10 = 10 points
-  ip: 0.8,              // IP ±10 = 8 points
-  pressure: 1.2,        // Pressure +1 = 1.2 points (territorial control)
-  defensive: 1.5,       // Defensive effects = 1.5x multiplier
-  utility: 0.6,         // Card draw, discount = 0.6x
-  instant: 1.0,         // No modifier for instant effects
-  permanent: 1.8        // Permanent effects get 1.8x multiplier
-};
 
 export class FactionBalanceAnalyzer {
   private cards: GameCard[];
 
-  constructor(includeExtensions: boolean = true) {
-    if (includeExtensions) {
-      const extensionCards = extensionManager.getAllExtensionCards();
-      this.cards = [...CARD_DATABASE, ...extensionCards];
-    } else {
-      this.cards = CARD_DATABASE;
-    }
+  constructor(cards: GameCard[] = CARD_DATABASE) {
+    this.cards = cards;
   }
 
-  // Extract numerical effect value from card text
-  private extractEffectValue(cardText: string | undefined, cardType: string): number {
-    const text = cardText ?? '';
-    let totalValue = 0;
-
-    // Truth effects
-    const truthMatch = text.match(/Truth\s*([+-]?\d+)/gi);
-    if (truthMatch) {
-      truthMatch.forEach(match => {
-        const value = parseInt(match.replace('Truth', '').trim());
-        totalValue += Math.abs(value) * EFFECT_WEIGHTS.truth;
-      });
-    }
-    
-    // IP effects
-    const ipMatch = text.match(/IP\s*([+-]?\d+)/gi);
-    if (ipMatch) {
-      ipMatch.forEach(match => {
-        const value = parseInt(match.replace('IP', '').trim());
-        totalValue += Math.abs(value) * EFFECT_WEIGHTS.ip;
-      });
-    }
-    
-    // Pressure effects
-    const pressureMatch = text.match(/([+-]?\d+)\s*Pressure/gi);
-    if (pressureMatch) {
-      pressureMatch.forEach(match => {
-        const value = parseInt(match.replace('Pressure', '').trim());
-        totalValue += Math.abs(value) * EFFECT_WEIGHTS.pressure;
-      });
-    }
-    
-    // Defensive keywords
-    const lowered = text.toLowerCase();
-    if (lowered.includes('block') || lowered.includes('immune') || lowered.includes('reduce')) {
-      totalValue += 3 * EFFECT_WEIGHTS.defensive;
-    }
-    
-    // Utility effects
-    if (lowered.includes('draw')) {
-      totalValue += 2 * EFFECT_WEIGHTS.utility;
-    }
-    
-    // Base values for card types if no specific effects found
-    if (totalValue === 0) {
-      switch (cardType) {
-        case 'MEDIA': return 8;      // Moderate effect
-        case 'ZONE': return 6;       // Territorial value
-        case 'ATTACK': return 12;    // High impact
-        case 'DEFENSIVE': return 10; // Protective value
-        default: return 5;
-      }
-    }
-    
-    return totalValue;
-  }
-
-  // Determine faction based on card effects
-  private determineFaction(card: GameCard): 'truth' | 'government' | 'neutral' {
-    const text = (card.text ?? '').toLowerCase();
-    
-    // Check for truth-positive effects
-    const truthPositive = /truth\s*\+/.test(text);
-    const truthNegative = /truth\s*-/.test(text);
-    
-    if (truthPositive && !truthNegative) return 'truth';
-    if (truthNegative && !truthPositive) return 'government';
-    
-    // Check flavor text for additional context
-    const govFlavor = (card.flavorGov || '').toLowerCase();
-    const truthFlavor = (card.flavorTruth || '').toLowerCase();
-    
-    if (govFlavor.includes('suppress') || govFlavor.includes('control')) return 'government';
-    if (truthFlavor.includes('reveal') || truthFlavor.includes('expose')) return 'truth';
-    
-    return 'neutral';
-  }
-
-  // Calculate Net Utility Score for a faction
-  private calculateNUS(card: GameCard, forFaction: 'truth' | 'government'): NetUtilityScore {
+  private buildNetUtility(effects: MvpEffectSummary): NetUtilityScore {
     const breakdown = {
-      truth: 0,
-      ip: 0,
-      pressure: 0,
-      defensive: 0,
-      utility: 0
+      truth: effects.truthDelta,
+      ip: effects.ipDeltaOpponent,
+      pressure: effects.pressureDelta * 5,
     };
-    
-    const explanations: string[] = [];
-    
-    // Parse truth effects
-    const text = (card.text ?? '').toLowerCase();
 
-    const truthMatch = text.match(/truth\s*([+-]?\d+)/);
-    if (truthMatch) {
-      const value = parseInt(truthMatch[1]);
-      const sign = forFaction === 'truth' ? 1 : -1;
-      breakdown.truth = value * sign * EFFECT_WEIGHTS.truth;
-      explanations.push(`Truth ${value} → ${breakdown.truth.toFixed(1)} points for ${forFaction}`);
-    }
-    
-    // Parse IP effects (need to determine target)
-    const ipMatch = text.match(/ip\s*([+-]?\d+)/);
-    if (ipMatch) {
-      const value = parseInt(ipMatch[1]);
-      // Assume positive IP goes to player, negative damages opponent
-      const sign = value > 0 ? 1 : -1;
-      breakdown.ip = Math.abs(value) * sign * EFFECT_WEIGHTS.ip;
-      explanations.push(`IP ${value} → ${breakdown.ip.toFixed(1)} points`);
-    }
-    
-    // Pressure effects (always positive for card owner)
-    const pressureMatch = text.match(/([+-]?\d+)\s*pressure/);
-    if (pressureMatch) {
-      const value = Math.abs(parseInt(pressureMatch[1]));
-      breakdown.pressure = value * EFFECT_WEIGHTS.pressure;
-      explanations.push(`+${value} Pressure → ${breakdown.pressure.toFixed(1)} points`);
-    }
-    
-    // Defensive effects
-    if (card.type === 'DEFENSIVE' || text.includes('block')) {
-      breakdown.defensive = 4 * EFFECT_WEIGHTS.defensive;
-      explanations.push(`Defensive effect → ${breakdown.defensive.toFixed(1)} points`);
-    }
-    
-    // Utility effects
-    if (text.includes('draw')) {
-      breakdown.utility = 3 * EFFECT_WEIGHTS.utility;
-      explanations.push(`Card utility → ${breakdown.utility.toFixed(1)} points`);
-    }
-    
-    const total = Object.values(breakdown).reduce((sum, val) => sum + val, 0);
-    
     return {
-      total,
       breakdown,
-      explanation: explanations
+      total: breakdown.truth + breakdown.ip + breakdown.pressure,
     };
   }
 
-  // Analyze faction alignment
-  private analyzeFactionAlignment(card: GameCard): { alignment: CardAnalysisResult['alignment']; reason: string } {
-    const cardFaction = this.determineFaction(card);
-    const truthNUS = this.calculateNUS(card, 'truth');
-    const govNUS = this.calculateNUS(card, 'government');
-    
-    // Severe misalignment: card helps opposing faction more than its own
-    if (cardFaction === 'truth' && govNUS.total > truthNUS.total + 3) {
-      return { alignment: 'Misaligned', reason: 'Truth card helps Government more than Truth Seekers' };
+  private evaluateAlignment(
+    faction: 'truth' | 'government' | 'neutral',
+    effects: MvpEffectSummary
+  ): { alignment: CardAnalysisResult['alignment']; reason: string } {
+    if (faction === 'neutral') {
+      return { alignment: 'Aligned', reason: 'Neutral cards are baseline legal in MVP.' };
     }
-    
-    if (cardFaction === 'government' && truthNUS.total > govNUS.total + 3) {
-      return { alignment: 'Misaligned', reason: 'Government card helps Truth Seekers more than Government' };
+
+    if (faction === 'truth') {
+      if (effects.truthDelta < 0) {
+        return {
+          alignment: 'Misaligned',
+          reason: 'Truth cards should not suppress public truth.',
+        };
+      }
+
+      if (effects.truthDelta === 0 && effects.ipDeltaOpponent <= 0 && effects.pressureDelta <= 0) {
+        return {
+          alignment: 'Mixed',
+          reason: 'Limited truth gain or disruption — verify intent.',
+        };
+      }
+
+      return {
+        alignment: 'Aligned',
+        reason: 'Promotes truth growth or damages the opposition.',
+      };
     }
-    
-    // Mixed: has both positive and negative effects for faction
-    if (cardFaction !== 'neutral') {
-      const targetNUS = cardFaction === 'truth' ? truthNUS : govNUS;
-      if (targetNUS.total > 0 && targetNUS.total < 5) {
-        return { alignment: 'Mixed', reason: 'Has both positive and negative effects for faction' };
+
+    // Government faction expectations
+    if (effects.truthDelta > 0) {
+      return {
+        alignment: 'Misaligned',
+        reason: 'Government suppression tools should not raise truth.',
+      };
+    }
+
+    if (effects.truthDelta === 0 && effects.ipDeltaOpponent <= 0 && effects.pressureDelta <= 0) {
+      return {
+        alignment: 'Mixed',
+        reason: 'Minimal suppression or board impact — double-check purpose.',
+      };
+    }
+
+    return {
+      alignment: 'Aligned',
+      reason: 'Applies pressure or lowers truth as expected.',
+    };
+  }
+
+  private analyzeCard(card: GameCard): CardAnalysisResult {
+    const faction = normalizeFaction(card.faction);
+    const effects = getMvpEffectSummary(card);
+    const expectedCost = getExpectedMvpCost(card);
+    const { status: costStatus, delta: costDelta } = classifyMvpCost(card, expectedCost);
+    const netUtilityScore = this.buildNetUtility(effects);
+    const alignment = this.evaluateAlignment(faction, effects);
+
+    const notes: string[] = [];
+    const recommendations: string[] = [];
+    let severity: CardAnalysisResult['severity'] = 'Low';
+
+    if (alignment.alignment === 'Misaligned') {
+      severity = 'High';
+      notes.push('Faction alignment conflicts with MVP expectations.');
+      recommendations.push('Flip effect polarity or move card to opposing faction.');
+    }
+
+    if (costStatus !== 'On Curve') {
+      severity = severity === 'High' ? 'High' : 'Medium';
+      notes.push('Cost deviates from MVP table.');
+      if (costDelta !== null) {
+        const direction = costDelta < 0 ? 'Increase' : 'Reduce';
+        recommendations.push(`${direction} cost by ${Math.abs(costDelta).toFixed(1)} IP or adjust effect size.`);
       }
     }
-    
-    // Aligned: clearly benefits its faction
-    return { alignment: 'Aligned', reason: 'Effects clearly benefit intended faction' };
-  }
 
-  // Analyze single card
-  private analyzeCard(card: GameCard): CardAnalysisResult {
-    const faction = this.determineFaction(card);
-    const alignment = this.analyzeFactionAlignment(card);
-    // Convert neutral faction to truth for NUS calculation (default assumption)
-    const nusTarget: 'truth' | 'government' = faction === 'neutral' ? 'truth' : faction;
-    const nus = this.calculateNUS(card, nusTarget);
-    
-    // Cost analysis
-    const expectedRange = COST_CURVES[card.rarity as keyof typeof COST_CURVES];
-    const effectValue = this.extractEffectValue(card.text ?? '', card.type);
-    const expectedCost = Math.max(expectedRange.min, Math.min(expectedRange.max, 
-      expectedRange.baseline + (effectValue - 8) * 0.3));
-    
-    let costStatus: CardAnalysisResult['costStatus'] = 'On Curve';
-    if (card.cost < expectedCost - 1.5) costStatus = 'Undercosted';
-    if (card.cost > expectedCost + 1.5) costStatus = 'Overcosted';
-    
-    // Determine severity and issues
-    const issues: string[] = [];
-    let severity: CardAnalysisResult['severity'] = 'Low';
-    
-    if (alignment.alignment === 'Misaligned') {
-      issues.push('Faction misalignment detected');
-      severity = 'Severe';
+    if (Math.abs(netUtilityScore.total) >= 15) {
+      if (severity === 'Low') severity = 'Medium';
+      notes.push('High swing effect — confirm during testing.');
     }
-    
-    if (nus.total < 0 && faction !== 'neutral') {
-      issues.push('Negative net utility for intended faction');
-      severity = severity === 'Severe' ? 'Severe' : 'High';
+
+    if (notes.length === 0) {
+      notes.push('Within MVP expectations.');
     }
-    
-    if (costStatus === 'Undercosted' && effectValue > 12) {
-      issues.push('Undercosted high-impact card');
-      severity = severity === 'Severe' ? 'Severe' : 'High';
+
+    if (recommendations.length === 0) {
+      recommendations.push('Track during playtest to confirm it feels fair.');
     }
-    
-    if (costStatus === 'Overcosted' && effectValue < 6) {
-      issues.push('Overcosted low-impact card');
-      severity = severity === 'Severe' || severity === 'High' ? severity : 'Medium';
-    }
-    
-    // Generate recommendations
-    const recommendations: string[] = [];
-    
-    if (alignment.alignment === 'Misaligned') {
-      recommendations.push('Review card effect polarity - consider flipping Truth +/- signs');
-    }
-    
-    if (costStatus === 'Undercosted') {
-      recommendations.push(`Increase cost to ${Math.ceil(expectedCost)} IP or reduce effect strength`);
-    }
-    
-    if (costStatus === 'Overcosted') {
-      recommendations.push(`Reduce cost to ${Math.floor(expectedCost)} IP or increase effect strength`);
-    }
-    
-    if (nus.total < 0) {
-      recommendations.push('Add positive effects for intended faction or reduce negative impact');
-    }
-    
+
     return {
       cardId: card.id,
       name: card.name,
@@ -377,229 +178,131 @@ export class FactionBalanceAnalyzer {
       faction,
       alignment: alignment.alignment,
       alignmentReason: alignment.reason,
-      netUtilityScore: nus,
+      effects,
+      netUtilityScore,
       cost: card.cost,
-      expectedCostRange: { min: expectedRange.min, max: expectedRange.max },
+      expectedCost,
       costStatus,
+      costDelta,
       severity,
-      issues,
-      recommendations
+      notes,
+      recommendations,
     };
   }
 
-  // Generate full balance report
   generateBalanceReport(): BalanceReport {
     const cardAnalysis = this.cards.map(card => this.analyzeCard(card));
-    
-    const truthCards = cardAnalysis.filter(c => c.faction === 'truth');
-    const govCards = cardAnalysis.filter(c => c.faction === 'government');
-    
-    // Calculate faction stats
-    const truthSeekerStats = {
-      total: truthCards.length,
-      aligned: truthCards.filter(c => c.alignment === 'Aligned').length,
-      mixed: truthCards.filter(c => c.alignment === 'Mixed').length,
-      misaligned: truthCards.filter(c => c.alignment === 'Misaligned').length,
-      averageNUS: truthCards.reduce((sum, c) => sum + c.netUtilityScore.total, 0) / truthCards.length || 0
+    const totalCards = cardAnalysis.length;
+    const factionCounts = summarizeFactionCounts(this.cards);
+
+    const alignmentSummary = {
+      aligned: cardAnalysis.filter(card => card.alignment === 'Aligned').length,
+      mixed: cardAnalysis.filter(card => card.alignment === 'Mixed').length,
+      misaligned: cardAnalysis.filter(card => card.alignment === 'Misaligned').length,
     };
-    
-    const governmentStats = {
-      total: govCards.length,
-      aligned: govCards.filter(c => c.alignment === 'Aligned').length,
-      mixed: govCards.filter(c => c.alignment === 'Mixed').length,
-      misaligned: govCards.filter(c => c.alignment === 'Misaligned').length,
-      averageNUS: govCards.reduce((sum, c) => sum + c.netUtilityScore.total, 0) / govCards.length || 0
+
+    const costSummary = {
+      onCurve: cardAnalysis.filter(card => card.costStatus === 'On Curve').length,
+      undercosted: cardAnalysis.filter(card => card.costStatus === 'Undercosted').length,
+      overcosted: cardAnalysis.filter(card => card.costStatus === 'Overcosted').length,
     };
-    
-    // Cost distributions
-    const costByType: Record<string, number> = {};
-    const costByRarity: Record<string, number> = {};
-    
-    ['MEDIA', 'ZONE', 'ATTACK', 'DEFENSIVE'].forEach(type => {
-      const typeCards = cardAnalysis.filter(c => c.type === type);
-      costByType[type] = typeCards.reduce((sum, c) => sum + c.cost, 0) / typeCards.length || 0;
-    });
-    
-    ['common', 'uncommon', 'rare', 'legendary'].forEach(rarity => {
-      const rarityCards = cardAnalysis.filter(c => c.rarity === rarity);
-      costByRarity[rarity] = rarityCards.reduce((sum, c) => sum + c.cost, 0) / rarityCards.length || 0;
-    });
-    
-    // Issue counts
-    const severeIssues = cardAnalysis.filter(c => c.severity === 'Severe').length;
-    const highIssues = cardAnalysis.filter(c => c.severity === 'High').length;
-    const mediumIssues = cardAnalysis.filter(c => c.severity === 'Medium').length;
-    const lowIssues = cardAnalysis.filter(c => c.severity === 'Low').length;
-    
-    // Global recommendations
+
+    const averageUtility =
+      totalCards > 0
+        ? cardAnalysis.reduce((sum, card) => sum + Math.abs(card.netUtilityScore.total), 0) / totalCards
+        : 0;
+
     const globalRecommendations: string[] = [];
-    
-    if (severeIssues > 0) {
-      globalRecommendations.push(`${severeIssues} severe faction alignment issues require immediate attention`);
+    if (alignmentSummary.misaligned > 0) {
+      globalRecommendations.push(
+        `${alignmentSummary.misaligned} cards violate faction expectations — reassign or retune effects.`
+      );
     }
-    
-    if (Math.abs(truthSeekerStats.averageNUS - governmentStats.averageNUS) > 3) {
-      const stronger = truthSeekerStats.averageNUS > governmentStats.averageNUS ? 'Truth Seekers' : 'Government';
-      globalRecommendations.push(`${stronger} cards are significantly stronger on average - consider faction rebalancing`);
+
+    if (costSummary.undercosted > totalCards * 0.15) {
+      globalRecommendations.push('Undercosted cards exceed tolerance. Review IP deltas for offenders.');
     }
-    
-    const undercosted = cardAnalysis.filter(c => c.costStatus === 'Undercosted').length;
-    const overcosted = cardAnalysis.filter(c => c.costStatus === 'Overcosted').length;
-    
-    if (undercosted > this.cards.length * 0.2) {
-      globalRecommendations.push(`${undercosted} cards are undercosted - consider global cost increase`);
+
+    if (costSummary.overcosted > totalCards * 0.15) {
+      globalRecommendations.push('Several cards appear overcosted. Consider easing their costs.');
     }
-    
-    if (overcosted > this.cards.length * 0.2) {
-      globalRecommendations.push(`${overcosted} cards are overcosted - consider global cost reduction`);
+
+    if (averageUtility > 12) {
+      globalRecommendations.push('Average swing per card is high. Trim extremes before external demos.');
     }
-    
+
+    if (globalRecommendations.length === 0) {
+      globalRecommendations.push('Faction spread and costs look healthy for MVP.');
+    }
+
     return {
       timestamp: new Date().toISOString(),
-      totalCards: this.cards.length,
-      truthSeekerStats,
-      governmentStats,
-      costByType,
-      costByRarity,
-      severeIssues,
-      highIssues,
-      mediumIssues,
-      lowIssues,
+      totalCards,
+      factionCounts,
+      alignmentSummary,
+      costSummary,
+      averageUtility,
       cardAnalysis,
-      globalRecommendations
+      globalRecommendations,
     };
   }
 
-  // Simple balance simulation
-  runBalanceSimulation(iterations: number = 1000): SimulationResult {
-    let truthWins = 0;
-    let governmentWins = 0;
-    const truthPaths: number[][] = [];
-    let totalIPSwing = 0;
-    let totalCardsPerTurn = 0;
-    
-    for (let i = 0; i < iterations; i++) {
-      // Simplified simulation - random card plays for 15 turns
-      let truthLevel = 50;
-      let playerIP = 50;
-      let aiIP = 50;
-      let cardsThisSim = 0;
-      const truthPath = [50];
-      
-      for (let turn = 0; turn < 15; turn++) {
-        // Simulate 2-3 random card plays per turn
-        const cardsThisTurn = 2 + Math.floor(Math.random() * 2);
-        cardsThisSim += cardsThisTurn;
-        
-        for (let play = 0; play < cardsThisTurn; play++) {
-          const randomCard = this.cards[Math.floor(Math.random() * this.cards.length)];
-          
-          // Apply simplified effects
-          const truthMatch = randomCard.text.match(/Truth\s*([+-]?\d+)/);
-          if (truthMatch) {
-            const truthChange = parseInt(truthMatch[1]);
-            truthLevel = Math.max(0, Math.min(100, truthLevel + truthChange));
-          }
-          
-          const ipMatch = randomCard.text.match(/IP\s*([+-]?\d+)/);
-          if (ipMatch) {
-            const ipChange = parseInt(ipMatch[1]);
-            if (Math.random() > 0.5) { // Random targeting
-              playerIP = Math.max(0, playerIP + ipChange);
-            } else {
-              aiIP = Math.max(0, aiIP + ipChange);
-            }
-          }
-        }
-        
-        truthPath.push(truthLevel);
-        
-        // Check win conditions
-        if (truthLevel >= 90) {
-          truthWins++;
-          break;
-        }
-        if (truthLevel <= 10) {
-          governmentWins++;
-          break;
-        }
-        if (playerIP >= 200) {
-          truthWins++;
-          break;
-        }
-        if (aiIP >= 200) {
-          governmentWins++;
-          break;
-        }
-      }
-      
-      truthPaths.push(truthPath);
-      totalIPSwing += Math.abs(playerIP - aiIP);
-      totalCardsPerTurn += cardsThisSim / 15;
-    }
-    
-    // Calculate averages
-    const avgTruthPath: number[] = [];
-    const maxLength = Math.max(...truthPaths.map(p => p.length));
-    
-    for (let i = 0; i < maxLength; i++) {
-      const validPaths = truthPaths.filter(p => p[i] !== undefined);
-      avgTruthPath[i] = validPaths.reduce((sum, p) => sum + p[i], 0) / validPaths.length;
-    }
-    
-    // Find problematic cards based on analysis
-    const analysis = this.generateBalanceReport();
-    const topOverpowered = analysis.cardAnalysis
-      .filter(c => c.severity === 'Severe' || c.severity === 'High')
-      .filter(c => c.costStatus === 'Undercosted')
-      .sort((a, b) => b.netUtilityScore.total - a.netUtilityScore.total)
-      .slice(0, 5)
-      .map(c => c.name);
-      
-    const topUnderpowered = analysis.cardAnalysis
-      .filter(c => c.costStatus === 'Overcosted')
-      .sort((a, b) => a.netUtilityScore.total - b.netUtilityScore.total)
-      .slice(0, 5)
-      .map(c => c.name);
-    
+  runBalanceSimulation(): SimulationResult {
+    const analysis = this.cards.map(card => this.analyzeCard(card));
+
+    const truthStrength = analysis
+      .filter(card => card.faction === 'truth')
+      .reduce((sum, card) => sum + computeMvpEffectScore(card.effects), 0);
+    const governmentStrength = analysis
+      .filter(card => card.faction === 'government')
+      .reduce((sum, card) => sum + computeMvpEffectScore(card.effects), 0);
+    const totalStrength = truthStrength + governmentStrength;
+
+    const truthWinRate = totalStrength > 0 ? (truthStrength / totalStrength) * 100 : 50;
+    const governmentWinRate = totalStrength > 0 ? (governmentStrength / totalStrength) * 100 : 50;
+    const drawRate = Math.max(0, 100 - truthWinRate - governmentWinRate);
+
+    const truthWeight = analysis.reduce((sum, card) => sum + Math.max(0, card.effects.truthDelta), 0);
+    const ipWeight = analysis.reduce((sum, card) => sum + Math.max(0, card.effects.ipDeltaOpponent), 0);
+    const pressureWeight = analysis.reduce((sum, card) => sum + Math.max(0, card.effects.pressureDelta), 0);
+    const totalWeight = truthWeight + ipWeight + pressureWeight;
+
+    const weightPercent = (value: number) => (totalWeight > 0 ? (value / totalWeight) * 100 : 0);
+
     return {
-      truthWinRate: (truthWins / iterations) * 100,
-      governmentWinRate: (governmentWins / iterations) * 100,
-      averageTruthPath: avgTruthPath,
-      averageIPSwing: totalIPSwing / iterations,
-      averageCardsPerTurn: totalCardsPerTurn / iterations,
-      topOverpoweredCards: topOverpowered,
-      topUnderpoweredCards: topUnderpowered
+      truthWinRate,
+      governmentWinRate,
+      drawRate,
+      winDrivers: [
+        { condition: 'truth', weight: weightPercent(truthWeight) },
+        { condition: 'ip', weight: weightPercent(ipWeight) },
+        { condition: 'pressure', weight: weightPercent(pressureWeight) },
+      ],
     };
   }
 
-  // Export data for external analysis
   exportBalanceData(): { report: BalanceReport; simulation: SimulationResult } {
     return {
       report: this.generateBalanceReport(),
-      simulation: this.runBalanceSimulation()
+      simulation: this.runBalanceSimulation(),
     };
   }
 }
 
-// Lint function for development
 export function lintCardBalance(cards: GameCard[]): { errors: string[]; warnings: string[] } {
-  const analyzer = new FactionBalanceAnalyzer(false); // Don't include extensions for lint
-  analyzer['cards'] = cards; // Override cards for linting
-  
+  const analyzer = new FactionBalanceAnalyzer(cards);
   const report = analyzer.generateBalanceReport();
   const errors: string[] = [];
   const warnings: string[] = [];
-  
-  // Severe issues become errors
+
   report.cardAnalysis.forEach(card => {
-    if (card.severity === 'Severe') {
+    if (card.alignment === 'Misaligned') {
       errors.push(`${card.name}: ${card.alignmentReason}`);
     } else if (card.severity === 'High') {
-      warnings.push(`${card.name}: ${card.issues.join(', ')}`);
+      warnings.push(`${card.name}: ${card.notes.join(' ')}`);
     }
   });
-  
+
   return { errors, warnings };
 }
 

--- a/src/data/mvpAnalysisUtils.ts
+++ b/src/data/mvpAnalysisUtils.ts
@@ -1,0 +1,97 @@
+import type { GameCard, MVPCardType } from '@/rules/mvp';
+import { MVP_CARD_TYPES, expectedCost } from '@/rules/mvp';
+
+export interface MvpEffectSummary {
+  truthDelta: number;
+  ipDeltaOpponent: number;
+  pressureDelta: number;
+}
+
+export type MvpCostStatus = 'On Curve' | 'Undercosted' | 'Overcosted';
+
+export function getMvpEffectSummary(card: GameCard): MvpEffectSummary {
+  const effects = card.effects ?? {};
+  const truthDelta = effects.truthDelta ?? 0;
+  const ipDeltaOpponent = effects.ipDelta?.opponent ?? 0;
+  const pressureDelta = effects.pressureDelta ?? 0;
+
+  return {
+    truthDelta,
+    ipDeltaOpponent,
+    pressureDelta,
+  };
+}
+
+export function getExpectedMvpCost(card: GameCard): number | null {
+  const rarity = card.rarity;
+  const type = card.type;
+
+  if (!rarity || !MVP_CARD_TYPES.includes(type as MVPCardType)) {
+    return null;
+  }
+
+  try {
+    return expectedCost(type, rarity);
+  } catch (error) {
+    return null;
+  }
+}
+
+export function classifyMvpCost(
+  card: GameCard,
+  expected: number | null,
+  tolerance: number = 1
+): { status: MvpCostStatus; delta: number | null } {
+  if (expected === null) {
+    return { status: 'On Curve', delta: null };
+  }
+
+  const delta = card.cost - expected;
+  if (Math.abs(delta) <= tolerance) {
+    return { status: 'On Curve', delta };
+  }
+
+  if (delta < 0) {
+    return { status: 'Undercosted', delta };
+  }
+
+  return { status: 'Overcosted', delta };
+}
+
+export function computeMvpEffectScore(summary: MvpEffectSummary): number {
+  const truthWeight = Math.abs(summary.truthDelta);
+  const ipWeight = Math.abs(summary.ipDeltaOpponent);
+  const pressureWeight = Math.abs(summary.pressureDelta) * 5;
+
+  return truthWeight + ipWeight + pressureWeight;
+}
+
+export function normalizeFaction(
+  faction: GameCard['faction']
+): 'truth' | 'government' | 'neutral' {
+  if (!faction) return 'neutral';
+  const normalized = faction.toString().toLowerCase();
+
+  if (normalized === 'truth') return 'truth';
+  if (normalized === 'government') return 'government';
+  return 'neutral';
+}
+
+export function summarizeFactionCounts(cards: GameCard[]): {
+  truth: number;
+  government: number;
+  neutral: number;
+} {
+  return cards.reduce(
+    (acc, card) => {
+      const faction = normalizeFaction(card.faction);
+      acc[faction]++;
+      return acc;
+    },
+    { truth: 0, government: 0, neutral: 0 } as {
+      truth: number;
+      government: number;
+      neutral: number;
+    }
+  );
+}

--- a/src/data/weightedCardDistribution.ts
+++ b/src/data/weightedCardDistribution.ts
@@ -119,7 +119,7 @@ export interface DistributionSettings {
 
 // Default settings
 export const DEFAULT_DISTRIBUTION_SETTINGS: DistributionSettings = {
-  mode: 'balanced',
+  mode: 'core-only',
   setWeights: {
     core: 2.0
   },

--- a/src/hooks/useDistributionSettings.ts
+++ b/src/hooks/useDistributionSettings.ts
@@ -1,44 +1,36 @@
 import { useState, useEffect } from 'react';
-import { 
-  DistributionSettings, 
-  DistributionMode, 
+import {
+  DistributionSettings,
+  DistributionMode,
   DEFAULT_DISTRIBUTION_SETTINGS,
-  weightedDistribution
+  weightedDistribution,
 } from '@/data/weightedCardDistribution';
-import { extensionManager } from '@/data/extensionSystem';
 
 const STORAGE_KEY = 'shadowgov-distribution-settings';
 
+const sanitizeSettings = (incoming: DistributionSettings): DistributionSettings => {
+  const coreWeight = incoming.setWeights?.core ?? DEFAULT_DISTRIBUTION_SETTINGS.setWeights.core;
+  return {
+    ...DEFAULT_DISTRIBUTION_SETTINGS,
+    ...incoming,
+    mode: 'core-only',
+    setWeights: { core: coreWeight },
+  };
+};
+
 export const useDistributionSettings = () => {
-  const [settings, setSettings] = useState<DistributionSettings>(DEFAULT_DISTRIBUTION_SETTINGS);
+  const [settings, setSettings] = useState<DistributionSettings>(sanitizeSettings(DEFAULT_DISTRIBUTION_SETTINGS));
   const [isLoading, setIsLoading] = useState(true);
 
-  // Load settings from localStorage on mount
   useEffect(() => {
     const loadSettings = () => {
       try {
         const saved = localStorage.getItem(STORAGE_KEY);
         if (saved) {
-          const savedSettings = JSON.parse(saved);
-          
-          // Ensure enabled extensions have weights
-          const enabledExtensions = extensionManager.getEnabledExtensions();
-          const updatedWeights = { ...savedSettings.setWeights };
-          
-          enabledExtensions.forEach(ext => {
-            if (!(ext.id in updatedWeights)) {
-              updatedWeights[ext.id] = 1.0; // Default weight for new extensions
-            }
-          });
-
-          const mergedSettings = {
-            ...DEFAULT_DISTRIBUTION_SETTINGS,
-            ...savedSettings,
-            setWeights: updatedWeights
-          };
-          
-          setSettings(mergedSettings);
-          weightedDistribution.updateSettings(mergedSettings);
+          const savedSettings = JSON.parse(saved) as DistributionSettings;
+          const merged = sanitizeSettings(savedSettings);
+          setSettings(merged);
+          weightedDistribution.updateSettings(merged);
         }
       } catch (error) {
         console.error('Failed to load distribution settings:', error);
@@ -50,76 +42,70 @@ export const useDistributionSettings = () => {
     loadSettings();
   }, []);
 
-  // Save settings to localStorage whenever they change
   useEffect(() => {
     if (!isLoading) {
       try {
-        localStorage.setItem(STORAGE_KEY, JSON.stringify(settings));
-        weightedDistribution.updateSettings(settings);
+        const sanitized = sanitizeSettings(settings);
+        localStorage.setItem(STORAGE_KEY, JSON.stringify(sanitized));
+        weightedDistribution.updateSettings(sanitized);
       } catch (error) {
         console.error('Failed to save distribution settings:', error);
       }
     }
   }, [settings, isLoading]);
 
-  // Update mode
-  const setMode = (mode: DistributionMode) => {
-    setSettings(prev => ({ ...prev, mode }));
+  const setMode = (_mode: DistributionMode) => {
+    setSettings(prev => ({ ...prev, mode: 'core-only' }));
   };
 
-  // Update set weight
   const setSetWeight = (setId: string, weight: number) => {
+    if (setId !== 'core') return;
     const clampedWeight = Math.max(0, Math.min(3, weight));
     setSettings(prev => ({
       ...prev,
-      setWeights: {
-        ...prev.setWeights,
-        [setId]: clampedWeight
-      }
+      setWeights: { core: clampedWeight },
     }));
   };
 
-  // Update rarity targets
-  const setRarityTarget = (rarity: keyof DistributionSettings['rarityTargets'], value: number) => {
+  const setRarityTarget = (
+    rarity: keyof DistributionSettings['rarityTargets'],
+    value: number,
+  ) => {
     const clampedValue = Math.max(0, Math.min(1, value));
     setSettings(prev => ({
       ...prev,
       rarityTargets: {
         ...prev.rarityTargets,
-        [rarity]: clampedValue
-      }
+        [rarity]: clampedValue,
+      },
     }));
   };
 
-  // Toggle type balancing
   const toggleTypeBalancing = () => {
     setSettings(prev => ({
       ...prev,
       typeBalancing: {
         ...prev.typeBalancing,
-        enabled: !prev.typeBalancing.enabled
-      }
+        enabled: !prev.typeBalancing.enabled,
+      },
     }));
   };
 
-  // Set duplicate limit
   const setDuplicateLimit = (limit: number) => {
     const clampedLimit = Math.max(1, Math.min(5, limit));
     setSettings(prev => ({ ...prev, duplicateLimit: clampedLimit }));
   };
 
-  // Set early seed count
   const setEarlySeedCount = (count: number) => {
     const clampedCount = Math.max(0, Math.min(10, count));
     setSettings(prev => ({ ...prev, earlySeedCount: clampedCount }));
   };
 
-  // Reset to defaults
   const resetToDefaults = () => {
-    setSettings(DEFAULT_DISTRIBUTION_SETTINGS);
+    const defaults = sanitizeSettings(DEFAULT_DISTRIBUTION_SETTINGS);
+    setSettings(defaults);
   };
 
-  // Get simulation results
   const getSimulation = (trials: number = 1000) => {
     return weightedDistribution.simulateDeckComposition(trials);
   };
@@ -134,6 +120,6 @@ export const useDistributionSettings = () => {
     setDuplicateLimit,
     setEarlySeedCount,
     resetToDefaults,
-    getSimulation
+    getSimulation,
   };
 };

--- a/src/pages/CardTest.tsx
+++ b/src/pages/CardTest.tsx
@@ -116,12 +116,11 @@ const CardTest: React.FC = () => {
             <div className="text-sm space-y-2">
               <div className="font-medium">✅ Completed Features:</div>
               <ul className="list-disc list-inside space-y-1 ml-4 text-muted-foreground">
-                <li>Type-safe CardEffects schema with conditionals and duration support</li>
-                <li>MVP-aligned resolver that applies effects deterministically</li>
-                <li>Text generation from effects data (no more hardcoded descriptions)</li>
-                <li>Validation system to check text↔effects consistency</li>
-                <li>Migration utilities for legacy card format compatibility</li>
-                <li>Development tools and testing components</li>
+                <li>MVP CardEffects schema centred on truth, opponent IP, and pressure deltas</li>
+                <li>Deterministic resolver wired to the MVP engine pipeline</li>
+                <li>Rules text generation sourced from card effect data</li>
+                <li>Validation system to keep text and gameplay in sync</li>
+                <li>Lightweight developer tools for spot-checking new core cards</li>
                 <li>Unified gameplay logic replacing hardcoded switch statements</li>
               </ul>
               

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -38,7 +38,6 @@ import { VisualEffectsCoordinator } from '@/utils/visualEffects';
 import ExtraEditionNewspaper from '@/components/game/ExtraEditionNewspaper';
 import InGameOptions from '@/components/game/InGameOptions';
 import EnhancedNewspaper from '@/components/game/EnhancedNewspaper';
-import EnhancedExpansionManager from '@/components/game/EnhancedExpansionManager';
 import MinimizedHand from '@/components/game/MinimizedHand';
 import { VictoryConditions } from '@/components/game/VictoryConditions';
 import toast, { Toaster } from 'react-hot-toast';


### PR DESCRIPTION
## Summary
- replace the enhanced and faction balancing analyzers with MVP-only logic focused on truth, opponent IP, and pressure deltas
- add a shared MVP analysis utility and update card balancing plus dashboard components to surface core metrics and win-condition signals
- simplify developer overlays such as Manage Expansions, distribution settings, and card test copy to remove references to extensions and deprecated systems

## Testing
- npm run lint *(fails: missing dependencies because npm registry access returned HTTP 403)*
- npm install *(fails: npm registry returned HTTP 403 for ts-node)*
- bun install *(fails: npm registry returned HTTP 403 for several packages)*

------
https://chatgpt.com/codex/tasks/task_e_68cacd9942b08320b52d9b5f0ddf7b01