### PR TITLE
Add MVP expansion loader and UI controls

### DIFF
--- a/src/components/game/ManageExpansions.tsx
+++ b/src/components/game/ManageExpansions.tsx
@@ -1,38 +1,128 @@
-import { useMemo } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { Card } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
-import { CARD_DATABASE } from '@/data/cardDatabase';
+import type { GameCard } from '@/rules/mvp';
+import { getCoreCards } from '@/data/cardDatabase';
 import { normalizeFaction } from '@/data/mvpAnalysisUtils';
+import { EXPANSION_MANIFEST } from '@/data/expansions';
+import {
+  getEnabledExpansionIdsSnapshot,
+  getExpansionCardsSnapshot,
+  subscribeToExpansionChanges,
+} from '@/data/expansions/state';
 
 interface ManageExpansionsProps {
   onClose: () => void;
 }
 
+interface StatBlock {
+  totalCards: number;
+  types: Array<[string, number]>;
+  factions: { truth: number; government: number; neutral: number };
+  rarities: Array<[string, number]>;
+}
+
+const computeStats = (cards: GameCard[]): StatBlock => {
+  const typeCounts = new Map<string, number>();
+  const rarityCounts = new Map<string, number>();
+  const factions = { truth: 0, government: 0, neutral: 0 };
+
+  cards.forEach(card => {
+    typeCounts.set(card.type, (typeCounts.get(card.type) ?? 0) + 1);
+    const faction = normalizeFaction(card.faction);
+    factions[faction] += 1;
+    if (card.rarity) {
+      rarityCounts.set(card.rarity, (rarityCounts.get(card.rarity) ?? 0) + 1);
+    }
+  });
+
+  return {
+    totalCards: cards.length,
+    types: Array.from(typeCounts.entries()),
+    factions,
+    rarities: Array.from(rarityCounts.entries()),
+  };
+};
+
+const groupCardsByExpansion = (cards: GameCard[]): Map<string, number> => {
+  const counts = new Map<string, number>();
+  cards.forEach(card => {
+    if (!card.extId) return;
+    counts.set(card.extId, (counts.get(card.extId) ?? 0) + 1);
+  });
+  return counts;
+};
+
 const ManageExpansions = ({ onClose }: ManageExpansionsProps) => {
-  const stats = useMemo(() => {
-    const totals = {
-      types: new Map<string, number>(),
-      factions: { truth: 0, government: 0, neutral: 0 },
-      rarities: new Map<string, number>(),
-    };
+  const [coreCards] = useState<GameCard[]>(() => getCoreCards());
+  const [expansionState, setExpansionState] = useState(() => ({
+    ids: getEnabledExpansionIdsSnapshot(),
+    cards: getExpansionCardsSnapshot(),
+  }));
 
-    CARD_DATABASE.forEach(card => {
-      totals.types.set(card.type, (totals.types.get(card.type) ?? 0) + 1);
-      const faction = normalizeFaction(card.faction);
-      totals.factions[faction] += 1;
-      if (card.rarity) {
-        totals.rarities.set(card.rarity, (totals.rarities.get(card.rarity) ?? 0) + 1);
-      }
+  useEffect(() => {
+    const unsubscribe = subscribeToExpansionChanges(payload => {
+      setExpansionState(payload);
     });
-
-    return {
-      totalCards: CARD_DATABASE.length,
-      types: Array.from(totals.types.entries()),
-      factions: totals.factions,
-      rarities: Array.from(totals.rarities.entries()),
-    };
+    return () => unsubscribe();
   }, []);
+
+  const coreStats = useMemo(() => computeStats(coreCards), [coreCards]);
+  const expansionStats = useMemo(
+    () => computeStats(expansionState.cards),
+    [expansionState.cards],
+  );
+  const combinedStats = useMemo(
+    () => computeStats([...coreCards, ...expansionState.cards]),
+    [coreCards, expansionState.cards],
+  );
+
+  const cardsByExpansion = useMemo(
+    () => groupCardsByExpansion(expansionState.cards),
+    [expansionState.cards],
+  );
+
+  const expansionDetails = useMemo(
+    () =>
+      EXPANSION_MANIFEST.map(pack => ({
+        id: pack.id,
+        title: pack.title,
+        enabled: expansionState.ids.includes(pack.id),
+        count: cardsByExpansion.get(pack.id) ?? 0,
+      })),
+    [cardsByExpansion, expansionState.ids],
+  );
+
+  const typeKeys = useMemo(() => {
+    const keys = new Set<string>();
+    coreStats.types.forEach(([type]) => keys.add(type));
+    expansionStats.types.forEach(([type]) => keys.add(type));
+    return Array.from(keys).sort();
+  }, [coreStats.types, expansionStats.types]);
+
+  const rarityKeys = useMemo(() => {
+    const keys = new Set<string>();
+    coreStats.rarities.forEach(([rarity]) => keys.add(rarity));
+    expansionStats.rarities.forEach(([rarity]) => keys.add(rarity));
+    return Array.from(keys).sort();
+  }, [coreStats.rarities, expansionStats.rarities]);
+
+  const coreTypeMap = useMemo(() => new Map(coreStats.types), [coreStats.types]);
+  const expansionTypeMap = useMemo(
+    () => new Map(expansionStats.types),
+    [expansionStats.types],
+  );
+  const coreRarityMap = useMemo(() => new Map(coreStats.rarities), [coreStats.rarities]);
+  const expansionRarityMap = useMemo(
+    () => new Map(expansionStats.rarities),
+    [expansionStats.rarities],
+  );
+
+  const activeExpansionNames = expansionDetails
+    .filter(detail => detail.enabled && detail.count > 0)
+    .map(detail => detail.title)
+    .join(', ');
 
   return (
     <div className="min-h-screen bg-newspaper-bg flex items-center justify-center p-8 relative overflow-hidden">
@@ -69,28 +159,100 @@ const ManageExpansions = ({ onClose }: ManageExpansionsProps) => {
 
         <div className="text-center mb-8 mt-8">
           <h1 className="text-4xl font-bold text-newspaper-text mb-2">
-            CORE SET OVERVIEW
+            EXPANSION CONTROL ROOM
           </h1>
           <p className="text-sm text-newspaper-text/80">
-            Extension loading is paused for the MVP sprint. Review core inventory below.
+            Review the core inventory and MVP-approved expansion packs.
+          </p>
+          <p className="text-xs text-newspaper-text/60 mt-2">
+            Toggle packs via Options → Expansion Content. Only ATTACK, MEDIA and ZONE cards that pass the MVP whitelist are enabled.
           </p>
         </div>
 
-        <div className="grid gap-6 md:grid-cols-2">
+        <div className="grid gap-4 md:grid-cols-3">
+          <Card className="p-4 border-2 border-newspaper-text bg-newspaper-bg">
+            <div className="text-xs uppercase text-newspaper-text/70">Core Set</div>
+            <div className="text-2xl font-bold text-newspaper-text">{coreStats.totalCards}</div>
+            <div className="text-xs text-newspaper-text/60">Recovered MVP-ready cards</div>
+          </Card>
+          <Card className="p-4 border-2 border-newspaper-text bg-newspaper-bg">
+            <div className="text-xs uppercase text-newspaper-text/70">Expansions</div>
+            <div className="text-2xl font-bold text-newspaper-text">{expansionStats.totalCards}</div>
+            <div className="text-xs text-newspaper-text/60">
+              {activeExpansionNames ? `Active packs: ${activeExpansionNames}` : 'No expansion packs enabled'}
+            </div>
+          </Card>
+          <Card className="p-4 border-2 border-newspaper-text bg-newspaper-bg">
+            <div className="text-xs uppercase text-newspaper-text/70">Total Pool</div>
+            <div className="text-2xl font-bold text-newspaper-text">{combinedStats.totalCards}</div>
+            <div className="text-xs text-newspaper-text/60">Core + expansions feeding deck builders</div>
+          </Card>
+        </div>
+
+        <Card className="mt-6 p-6 border-2 border-newspaper-text bg-newspaper-bg">
+          <h2 className="font-bold text-xl text-newspaper-text mb-4">Expansion Packs</h2>
+          <div className="space-y-3 text-sm text-newspaper-text">
+            {expansionDetails.map(detail => (
+              <div key={detail.id} className="flex flex-col gap-1 border border-dashed border-newspaper-text/30 p-3 rounded">
+                <div className="flex items-center justify-between">
+                  <span className="font-semibold">{detail.title}</span>
+                  <div className="flex items-center gap-2">
+                    <Badge variant="outline">{detail.count} cards</Badge>
+                    <Badge
+                      variant={detail.enabled ? 'default' : 'outline'}
+                      className={detail.enabled ? 'bg-green-700 hover:bg-green-600 border-green-700' : ''}
+                    >
+                      {detail.enabled ? 'Enabled' : 'Disabled'}
+                    </Badge>
+                  </div>
+                </div>
+                <div className="text-xs text-newspaper-text/70">
+                  {detail.enabled
+                    ? 'Included in MVP deck construction.'
+                    : 'Toggle on from Options to add these cards.'}
+                </div>
+              </div>
+            ))}
+          </div>
+        </Card>
+
+        <div className="grid gap-6 md:grid-cols-2 mt-6">
           <Card className="p-6 border-2 border-newspaper-text bg-newspaper-bg">
             <h2 className="font-bold text-xl text-newspaper-text mb-4">Faction Breakdown</h2>
-            <div className="space-y-3 text-sm text-newspaper-text">
-              <div className="flex items-center justify-between">
-                <span>Truth Seekers</span>
-                <Badge variant="outline">{stats.factions.truth}</Badge>
+            <div className="grid gap-4 md:grid-cols-2 text-sm text-newspaper-text">
+              <div>
+                <div className="text-xs uppercase text-newspaper-text/60 mb-2">Core</div>
+                <div className="space-y-2">
+                  <div className="flex items-center justify-between">
+                    <span>Truth Seekers</span>
+                    <Badge variant="outline">{coreStats.factions.truth}</Badge>
+                  </div>
+                  <div className="flex items-center justify-between">
+                    <span>Government</span>
+                    <Badge variant="outline">{coreStats.factions.government}</Badge>
+                  </div>
+                  <div className="flex items-center justify-between">
+                    <span>Neutral</span>
+                    <Badge variant="outline">{coreStats.factions.neutral}</Badge>
+                  </div>
+                </div>
               </div>
-              <div className="flex items-center justify-between">
-                <span>Government</span>
-                <Badge variant="outline">{stats.factions.government}</Badge>
-              </div>
-              <div className="flex items-center justify-between">
-                <span>Neutral</span>
-                <Badge variant="outline">{stats.factions.neutral}</Badge>
+              <div>
+                <div className="text-xs uppercase text-newspaper-text/60 mb-2">Expansions</div>
+                <div className="space-y-2">
+                  <div className="flex items-center justify-between">
+                    <span>Truth Seekers</span>
+                    <Badge variant="outline">{expansionStats.factions.truth}</Badge>
+                  </div>
+                  <div className="flex items-center justify-between">
+                    <span>Government</span>
+                    <Badge variant="outline">{expansionStats.factions.government}</Badge>
+                  </div>
+                  <div className="flex items-center justify-between">
+                    <span>Neutral</span>
+                    <Badge variant="outline">{expansionStats.factions.neutral}</Badge>
+                  </div>
+                </div>
               </div>
             </div>
           </Card>
@@ -98,10 +260,13 @@ const ManageExpansions = ({ onClose }: ManageExpansionsProps) => {
           <Card className="p-6 border-2 border-newspaper-text bg-newspaper-bg">
             <h2 className="font-bold text-xl text-newspaper-text mb-4">Type Inventory</h2>
             <div className="space-y-3 text-sm text-newspaper-text">
-              {stats.types.map(([type, count]) => (
+              {typeKeys.map(type => (
                 <div key={type} className="flex items-center justify-between">
                   <span className="uppercase">{type}</span>
-                  <Badge variant="outline">{count}</Badge>
+                  <div className="flex items-center gap-2">
+                    <Badge variant="outline">Core {coreTypeMap.get(type) ?? 0}</Badge>
+                    <Badge variant="outline">Exp {expansionTypeMap.get(type) ?? 0}</Badge>
+                  </div>
                 </div>
               ))}
             </div>
@@ -110,24 +275,27 @@ const ManageExpansions = ({ onClose }: ManageExpansionsProps) => {
 
         <Card className="mt-6 p-6 border-2 border-newspaper-text bg-newspaper-bg">
           <h2 className="font-bold text-xl text-newspaper-text mb-4">Rarity Spread</h2>
-          <div className="grid gap-4 md:grid-cols-4 text-sm text-newspaper-text">
-            {stats.rarities.length === 0 && <div>No rarities assigned yet.</div>}
-            {stats.rarities.map(([rarity, count]) => (
-              <div key={rarity} className="flex flex-col items-center gap-1">
+          <div className="space-y-3 text-sm text-newspaper-text">
+            {rarityKeys.length === 0 && <div>No rarities assigned yet.</div>}
+            {rarityKeys.map(rarity => (
+              <div key={rarity} className="flex items-center justify-between">
                 <span className="uppercase font-semibold">{rarity}</span>
-                <Badge variant="outline">{count}</Badge>
+                <div className="flex items-center gap-2">
+                  <Badge variant="outline">Core {coreRarityMap.get(rarity) ?? 0}</Badge>
+                  <Badge variant="outline">Exp {expansionRarityMap.get(rarity) ?? 0}</Badge>
+                </div>
               </div>
             ))}
           </div>
         </Card>
 
         <div className="mt-6 text-sm text-newspaper-text/80 space-y-2">
-          <p>Total MVP-ready cards: {stats.totalCards}</p>
+          <p>Total MVP-ready cards: {combinedStats.totalCards}</p>
           <p>
-            Want to prototype new content? Tag it as core and run balancing from the dashboard.
+            Expansion selections persist locally. Deck builders draw from the combined pool once packs are enabled.
           </p>
           <p>
-            Extension toggles will return after the MVP launch window when additional mechanics are revalidated.
+            Keep new content within the MVP whitelist—ATTACK, MEDIA, and ZONE templates with baseline costs—to stay compatible with automated validation.
           </p>
         </div>
       </Card>

--- a/src/data/expansions/cryptids_MVP.ts
+++ b/src/data/expansions/cryptids_MVP.ts
@@ -1,0 +1,4519 @@
+import type { GameCard } from '@/rules/mvp';
+
+const cards: GameCard[] = [
+  {
+    "id": "CRY-TS-001",
+    "name": "Cryptid Field Research",
+    "type": "ZONE",
+    "faction": "truth",
+    "rarity": "uncommon",
+    "cost": 5,
+    "effects": {
+      "pressureDelta": 2
+    },
+    "extId": "cryptids",
+    "flavor": "\"CLASSIFIED INTELLIGENCE: Cryptid looked straight into the lens.\"",
+    "target": {
+      "scope": "state",
+      "count": 1
+    }
+  },
+  {
+    "id": "CRY-TS-002",
+    "name": "Ultra Disclosure Protocol",
+    "type": "MEDIA",
+    "faction": "truth",
+    "rarity": "legendary",
+    "cost": 6,
+    "effects": {
+      "truthDelta": 4
+    },
+    "extId": "cryptids",
+    "flavor": "\"CLASSIFIED INTELLIGENCE: Tabloid headline writes itself.\""
+  },
+  {
+    "id": "CRY-TS-003",
+    "name": "Bigfoot Expedition",
+    "type": "ZONE",
+    "faction": "truth",
+    "rarity": "uncommon",
+    "cost": 5,
+    "effects": {
+      "pressureDelta": 2
+    },
+    "extId": "cryptids",
+    "flavor": "\"CLASSIFIED INTELLIGENCE: Experts disagree; the crowd screams yes.\"",
+    "target": {
+      "scope": "state",
+      "count": 1
+    }
+  },
+  {
+    "id": "CRY-TS-004",
+    "name": "Alien Abduction Support Group",
+    "type": "ATTACK",
+    "faction": "truth",
+    "rarity": "uncommon",
+    "cost": 3,
+    "effects": {
+      "ipDelta": {
+        "opponent": 2
+      }
+    },
+    "extId": "cryptids",
+    "flavor": "\"CLASSIFIED INTELLIGENCE: Alien looked straight into the lens.\""
+  },
+  {
+    "id": "CRY-TS-005",
+    "name": "UFO Hotline Network",
+    "type": "MEDIA",
+    "faction": "truth",
+    "rarity": "uncommon",
+    "cost": 4,
+    "effects": {
+      "truthDelta": 2
+    },
+    "extId": "cryptids",
+    "flavor": "\"CLASSIFIED INTELLIGENCE: UFO looked straight into the lens.\""
+  },
+  {
+    "id": "CRY-TS-006",
+    "name": "Mothman Prophecies",
+    "type": "ATTACK",
+    "faction": "truth",
+    "rarity": "rare",
+    "cost": 4,
+    "effects": {
+      "ipDelta": {
+        "opponent": 3
+      },
+      "discardOpponent": 1
+    },
+    "extId": "cryptids",
+    "flavor": "\"CLASSIFIED INTELLIGENCE: Pixels enhanced: chills confirmed.\""
+  },
+  {
+    "id": "CRY-TS-007",
+    "name": "Chupacabra Sighting Report",
+    "type": "ATTACK",
+    "faction": "truth",
+    "rarity": "uncommon",
+    "cost": 3,
+    "effects": {
+      "ipDelta": {
+        "opponent": 2
+      }
+    },
+    "extId": "cryptids",
+    "flavor": "\"CLASSIFIED INTELLIGENCE: Chupacabra looked straight into the lens.\""
+  },
+  {
+    "id": "CRY-TS-008",
+    "name": "Lake Monster Sonar Evidence",
+    "type": "ATTACK",
+    "faction": "truth",
+    "rarity": "uncommon",
+    "cost": 3,
+    "effects": {
+      "ipDelta": {
+        "opponent": 2
+      }
+    },
+    "extId": "cryptids",
+    "flavor": "\"CLASSIFIED INTELLIGENCE: Experts disagree; the crowd screams yes.\""
+  },
+  {
+    "id": "CRY-TS-009",
+    "name": "Ancient Astronaut Theory",
+    "type": "MEDIA",
+    "faction": "truth",
+    "rarity": "rare",
+    "cost": 5,
+    "effects": {
+      "truthDelta": 3
+    },
+    "extId": "cryptids",
+    "flavor": "\"CLASSIFIED INTELLIGENCE: We brought snacks and a camcorder.\""
+  },
+  {
+    "id": "CRY-TS-010",
+    "name": "Roswell Survivor Testimony",
+    "type": "MEDIA",
+    "faction": "truth",
+    "rarity": "rare",
+    "cost": 5,
+    "effects": {
+      "truthDelta": 3
+    },
+    "extId": "cryptids",
+    "flavor": "\"CLASSIFIED INTELLIGENCE: Roswell looked straight into the lens.\""
+  },
+  {
+    "id": "CRY-TS-011",
+    "name": "Area 51 Infiltration",
+    "type": "ATTACK",
+    "faction": "truth",
+    "rarity": "legendary",
+    "cost": 5,
+    "effects": {
+      "ipDelta": {
+        "opponent": 4
+      },
+      "discardOpponent": 2
+    },
+    "extId": "cryptids",
+    "flavor": "\"CLASSIFIED INTELLIGENCE: Experts disagree; the crowd screams yes.\""
+  },
+  {
+    "id": "CRY-TS-012",
+    "name": "Jersey Devil Hunt",
+    "type": "ATTACK",
+    "faction": "truth",
+    "rarity": "common",
+    "cost": 2,
+    "effects": {
+      "ipDelta": {
+        "opponent": 1
+      }
+    },
+    "extId": "cryptids",
+    "flavor": "\"CLASSIFIED INTELLIGENCE: Pixels enhanced: chills confirmed.\""
+  },
+  {
+    "id": "CRY-TS-013",
+    "name": "Skunk Ape Footage",
+    "type": "MEDIA",
+    "faction": "truth",
+    "rarity": "uncommon",
+    "cost": 4,
+    "effects": {
+      "truthDelta": 2
+    },
+    "extId": "cryptids",
+    "flavor": "\"CLASSIFIED INTELLIGENCE: Pixels enhanced: chills confirmed.\""
+  },
+  {
+    "id": "CRY-TS-014",
+    "name": "Beast of Bray Road Tracking",
+    "type": "ATTACK",
+    "faction": "truth",
+    "rarity": "uncommon",
+    "cost": 3,
+    "effects": {
+      "ipDelta": {
+        "opponent": 2
+      }
+    },
+    "extId": "cryptids",
+    "flavor": "\"CLASSIFIED INTELLIGENCE: Tabloid headline writes itself.\""
+  },
+  {
+    "id": "CRY-TS-015",
+    "name": "Phantom Kangaroo Tracking Network",
+    "type": "ZONE",
+    "faction": "truth",
+    "rarity": "uncommon",
+    "cost": 5,
+    "effects": {
+      "pressureDelta": 2
+    },
+    "extId": "cryptids",
+    "flavor": "\"CLASSIFIED INTELLIGENCE: Experts disagree; the crowd screams yes.\"",
+    "target": {
+      "scope": "state",
+      "count": 1
+    }
+  },
+  {
+    "id": "CRY-TS-016",
+    "name": "Fouke Monster Evidence",
+    "type": "ATTACK",
+    "faction": "truth",
+    "rarity": "uncommon",
+    "cost": 3,
+    "effects": {
+      "ipDelta": {
+        "opponent": 2
+      }
+    },
+    "extId": "cryptids",
+    "flavor": "\"CLASSIFIED INTELLIGENCE: Tabloid headline writes itself.\""
+  },
+  {
+    "id": "CRY-TS-017",
+    "name": "Thunderbird Sightings Database",
+    "type": "ATTACK",
+    "faction": "truth",
+    "rarity": "rare",
+    "cost": 4,
+    "effects": {
+      "ipDelta": {
+        "opponent": 3
+      },
+      "discardOpponent": 1
+    },
+    "extId": "cryptids",
+    "flavor": "\"CLASSIFIED INTELLIGENCE: Experts disagree; the crowd screams yes.\""
+  },
+  {
+    "id": "CRY-TS-018",
+    "name": "Shadow People Documentation",
+    "type": "ATTACK",
+    "faction": "truth",
+    "rarity": "uncommon",
+    "cost": 3,
+    "effects": {
+      "ipDelta": {
+        "opponent": 2
+      }
+    },
+    "extId": "cryptids",
+    "flavor": "\"CLASSIFIED INTELLIGENCE: Tabloid headline writes itself.\""
+  },
+  {
+    "id": "CRY-TS-019",
+    "name": "Hopkinsville Goblins Testimony",
+    "type": "MEDIA",
+    "faction": "truth",
+    "rarity": "uncommon",
+    "cost": 4,
+    "effects": {
+      "truthDelta": 2
+    },
+    "extId": "cryptids",
+    "flavor": "\"CLASSIFIED INTELLIGENCE: Hopkinsville looked straight into the lens.\""
+  },
+  {
+    "id": "CRY-TS-020",
+    "name": "Lizard People Exposé",
+    "type": "ATTACK",
+    "faction": "truth",
+    "rarity": "legendary",
+    "cost": 5,
+    "effects": {
+      "ipDelta": {
+        "opponent": 4
+      },
+      "discardOpponent": 2
+    },
+    "extId": "cryptids",
+    "flavor": "\"CLASSIFIED INTELLIGENCE: Lizard looked straight into the lens.\""
+  },
+  {
+    "id": "CRY-TS-021",
+    "name": "Hollow Earth Expedition",
+    "type": "ZONE",
+    "faction": "truth",
+    "rarity": "rare",
+    "cost": 6,
+    "effects": {
+      "pressureDelta": 3
+    },
+    "extId": "cryptids",
+    "flavor": "\"CLASSIFIED INTELLIGENCE: Tabloid headline writes itself.\"",
+    "target": {
+      "scope": "state",
+      "count": 1
+    }
+  },
+  {
+    "id": "CRY-TS-022",
+    "name": "Time Traveler Interview",
+    "type": "MEDIA",
+    "faction": "truth",
+    "rarity": "legendary",
+    "cost": 6,
+    "effects": {
+      "truthDelta": 4
+    },
+    "extId": "cryptids",
+    "flavor": "\"CLASSIFIED INTELLIGENCE: Tabloid headline writes itself.\""
+  },
+  {
+    "id": "CRY-TS-023",
+    "name": "UFO Crash Retrieval Team",
+    "type": "MEDIA",
+    "faction": "truth",
+    "rarity": "uncommon",
+    "cost": 4,
+    "effects": {
+      "truthDelta": 2
+    },
+    "extId": "cryptids",
+    "flavor": "\"CLASSIFIED INTELLIGENCE: Pixels enhanced: chills confirmed.\""
+  },
+  {
+    "id": "CRY-TS-024",
+    "name": "Interdimensional Portal Research",
+    "type": "MEDIA",
+    "faction": "truth",
+    "rarity": "uncommon",
+    "cost": 4,
+    "effects": {
+      "truthDelta": 2
+    },
+    "extId": "cryptids",
+    "flavor": "\"CLASSIFIED INTELLIGENCE: Interdimensional looked straight into the lens.\""
+  },
+  {
+    "id": "CRY-TS-025",
+    "name": "Phantom Black Dog Network",
+    "type": "ZONE",
+    "faction": "truth",
+    "rarity": "uncommon",
+    "cost": 5,
+    "effects": {
+      "pressureDelta": 2
+    },
+    "extId": "cryptids",
+    "flavor": "\"CLASSIFIED INTELLIGENCE: Phantom looked straight into the lens.\"",
+    "target": {
+      "scope": "state",
+      "count": 1
+    }
+  },
+  {
+    "id": "CRY-TS-026",
+    "name": "Yeti Hair Analysis",
+    "type": "MEDIA",
+    "faction": "truth",
+    "rarity": "uncommon",
+    "cost": 4,
+    "effects": {
+      "truthDelta": 2
+    },
+    "extId": "cryptids",
+    "flavor": "\"CLASSIFIED INTELLIGENCE: Tabloid headline writes itself.\""
+  },
+  {
+    "id": "CRY-TS-027",
+    "name": "Skinwalker Ranch Investigation",
+    "type": "ATTACK",
+    "faction": "truth",
+    "rarity": "rare",
+    "cost": 4,
+    "effects": {
+      "ipDelta": {
+        "opponent": 3
+      },
+      "discardOpponent": 1
+    },
+    "extId": "cryptids",
+    "flavor": "\"CLASSIFIED INTELLIGENCE: Tabloid headline writes itself.\""
+  },
+  {
+    "id": "CRY-TS-028",
+    "name": "Dover Demon Witness Testimony",
+    "type": "MEDIA",
+    "faction": "truth",
+    "rarity": "uncommon",
+    "cost": 4,
+    "effects": {
+      "truthDelta": 2
+    },
+    "extId": "cryptids",
+    "flavor": "\"CLASSIFIED INTELLIGENCE: Experts disagree; the crowd screams yes.\""
+  },
+  {
+    "id": "CRY-TS-029",
+    "name": "Real Alien Autopsy Leak",
+    "type": "MEDIA",
+    "faction": "truth",
+    "rarity": "rare",
+    "cost": 5,
+    "effects": {
+      "truthDelta": 3
+    },
+    "extId": "cryptids",
+    "flavor": "\"CLASSIFIED INTELLIGENCE: Real looked straight into the lens.\""
+  },
+  {
+    "id": "CRY-TS-030",
+    "name": "Cattle Mutilation Pattern Analysis",
+    "type": "ZONE",
+    "faction": "truth",
+    "rarity": "uncommon",
+    "cost": 5,
+    "effects": {
+      "pressureDelta": 2
+    },
+    "extId": "cryptids",
+    "flavor": "\"CLASSIFIED INTELLIGENCE: Tabloid headline writes itself.\"",
+    "target": {
+      "scope": "state",
+      "count": 1
+    }
+  },
+  {
+    "id": "CRY-TS-031",
+    "name": "Crop Circle Decoder Ring",
+    "type": "MEDIA",
+    "faction": "truth",
+    "rarity": "uncommon",
+    "cost": 4,
+    "effects": {
+      "truthDelta": 2
+    },
+    "extId": "cryptids",
+    "flavor": "\"CLASSIFIED INTELLIGENCE: Experts disagree; the crowd screams yes.\""
+  },
+  {
+    "id": "CRY-TS-032",
+    "name": "1897 Phantom Airship Reports",
+    "type": "MEDIA",
+    "faction": "truth",
+    "rarity": "uncommon",
+    "cost": 4,
+    "effects": {
+      "truthDelta": 2
+    },
+    "extId": "cryptids",
+    "flavor": "\"CLASSIFIED INTELLIGENCE: Pixels enhanced: chills confirmed.\""
+  },
+  {
+    "id": "CRY-TS-033",
+    "name": "Beast of Bladenboro Hunt",
+    "type": "ATTACK",
+    "faction": "truth",
+    "rarity": "uncommon",
+    "cost": 3,
+    "effects": {
+      "ipDelta": {
+        "opponent": 2
+      }
+    },
+    "extId": "cryptids",
+    "flavor": "\"CLASSIFIED INTELLIGENCE: Pixels enhanced: chills confirmed.\""
+  },
+  {
+    "id": "CRY-TS-034",
+    "name": "Washington Sea Serpent Sonar",
+    "type": "ZONE",
+    "faction": "truth",
+    "rarity": "uncommon",
+    "cost": 5,
+    "effects": {
+      "pressureDelta": 2
+    },
+    "extId": "cryptids",
+    "flavor": "\"CLASSIFIED INTELLIGENCE: Experts disagree; the crowd screams yes.\"",
+    "target": {
+      "scope": "state",
+      "count": 1
+    }
+  },
+  {
+    "id": "CRY-TS-035",
+    "name": "Moon-Eyed People Archaeological Site",
+    "type": "ZONE",
+    "faction": "truth",
+    "rarity": "rare",
+    "cost": 6,
+    "effects": {
+      "pressureDelta": 3
+    },
+    "extId": "cryptids",
+    "flavor": "\"CLASSIFIED INTELLIGENCE: Tabloid headline writes itself.\"",
+    "target": {
+      "scope": "state",
+      "count": 1
+    }
+  },
+  {
+    "id": "CRY-TS-036",
+    "name": "Giant Pacific Octopus Encounter",
+    "type": "ZONE",
+    "faction": "truth",
+    "rarity": "rare",
+    "cost": 6,
+    "effects": {
+      "pressureDelta": 3
+    },
+    "extId": "cryptids",
+    "flavor": "\"CLASSIFIED INTELLIGENCE: Tabloid headline writes itself.\"",
+    "target": {
+      "scope": "state",
+      "count": 1
+    }
+  },
+  {
+    "id": "CRY-TS-037",
+    "name": "Remote Viewing Leak",
+    "type": "MEDIA",
+    "faction": "truth",
+    "rarity": "rare",
+    "cost": 5,
+    "effects": {
+      "truthDelta": 3
+    },
+    "extId": "cryptids",
+    "flavor": "\"CLASSIFIED INTELLIGENCE: We brought snacks and a camcorder.\""
+  },
+  {
+    "id": "CRY-TS-038",
+    "name": "Invisible Aircraft Photos",
+    "type": "MEDIA",
+    "faction": "truth",
+    "rarity": "legendary",
+    "cost": 6,
+    "effects": {
+      "truthDelta": 4
+    },
+    "extId": "cryptids",
+    "flavor": "\"CLASSIFIED INTELLIGENCE: We brought snacks and a camcorder.\""
+  },
+  {
+    "id": "CRY-TS-039",
+    "name": "Missing Time Survivor Network",
+    "type": "MEDIA",
+    "faction": "truth",
+    "rarity": "rare",
+    "cost": 5,
+    "effects": {
+      "truthDelta": 3
+    },
+    "extId": "cryptids",
+    "flavor": "\"CLASSIFIED INTELLIGENCE: Experts disagree; the crowd screams yes.\""
+  },
+  {
+    "id": "CRY-TS-040",
+    "name": "Grey Alien Eyewitness Testimony",
+    "type": "MEDIA",
+    "faction": "truth",
+    "rarity": "rare",
+    "cost": 5,
+    "effects": {
+      "truthDelta": 3
+    },
+    "extId": "cryptids",
+    "flavor": "\"CLASSIFIED INTELLIGENCE: Pixels enhanced: chills confirmed.\""
+  },
+  {
+    "id": "CRY-TS-041",
+    "name": "Reality Breach Detector",
+    "type": "MEDIA",
+    "faction": "truth",
+    "rarity": "legendary",
+    "cost": 6,
+    "effects": {
+      "truthDelta": 4
+    },
+    "extId": "cryptids",
+    "flavor": "\"CLASSIFIED INTELLIGENCE: We brought snacks and a camcorder.\""
+  },
+  {
+    "id": "CRY-TS-042",
+    "name": "Paranormal Investigation Society",
+    "type": "MEDIA",
+    "faction": "truth",
+    "rarity": "uncommon",
+    "cost": 4,
+    "effects": {
+      "truthDelta": 2
+    },
+    "extId": "cryptids",
+    "flavor": "\"CLASSIFIED INTELLIGENCE: Tabloid headline writes itself.\""
+  },
+  {
+    "id": "CRY-TS-043",
+    "name": "Alien Implant Removal Clinic",
+    "type": "ZONE",
+    "faction": "truth",
+    "rarity": "rare",
+    "cost": 6,
+    "effects": {
+      "pressureDelta": 3
+    },
+    "extId": "cryptids",
+    "flavor": "\"CLASSIFIED INTELLIGENCE: Experts disagree; the crowd screams yes.\"",
+    "target": {
+      "scope": "state",
+      "count": 1
+    }
+  },
+  {
+    "id": "CRY-TS-044",
+    "name": "Consciousness Expansion Workshop",
+    "type": "MEDIA",
+    "faction": "truth",
+    "rarity": "rare",
+    "cost": 5,
+    "effects": {
+      "truthDelta": 3
+    },
+    "extId": "cryptids",
+    "flavor": "\"CLASSIFIED INTELLIGENCE: Tabloid headline writes itself.\""
+  },
+  {
+    "id": "CRY-TS-045",
+    "name": "Multidimensional Gateway",
+    "type": "MEDIA",
+    "faction": "truth",
+    "rarity": "legendary",
+    "cost": 6,
+    "effects": {
+      "truthDelta": 4
+    },
+    "extId": "cryptids",
+    "flavor": "\"CLASSIFIED INTELLIGENCE: Tabloid headline writes itself.\""
+  },
+  {
+    "id": "CRY-TS-046",
+    "name": "Moon Landing Hoax Evidence",
+    "type": "MEDIA",
+    "faction": "truth",
+    "rarity": "uncommon",
+    "cost": 4,
+    "effects": {
+      "truthDelta": 2
+    },
+    "extId": "cryptids",
+    "flavor": "\"CLASSIFIED INTELLIGENCE: Experts disagree; the crowd screams yes.\""
+  },
+  {
+    "id": "CRY-TS-047",
+    "name": "Memory Recovery Session",
+    "type": "MEDIA",
+    "faction": "truth",
+    "rarity": "rare",
+    "cost": 5,
+    "effects": {
+      "truthDelta": 3
+    },
+    "extId": "cryptids",
+    "flavor": "\"CLASSIFIED INTELLIGENCE: Tabloid headline writes itself.\""
+  },
+  {
+    "id": "CRY-TS-048",
+    "name": "Shadow Government Infiltration",
+    "type": "ATTACK",
+    "faction": "truth",
+    "rarity": "legendary",
+    "cost": 5,
+    "effects": {
+      "ipDelta": {
+        "opponent": 4
+      },
+      "discardOpponent": 2
+    },
+    "extId": "cryptids",
+    "flavor": "\"CLASSIFIED INTELLIGENCE: Pixels enhanced: chills confirmed.\""
+  },
+  {
+    "id": "CRY-TS-049",
+    "name": "Operation Paperclip Files",
+    "type": "MEDIA",
+    "faction": "truth",
+    "rarity": "rare",
+    "cost": 5,
+    "effects": {
+      "truthDelta": 3
+    },
+    "extId": "cryptids",
+    "flavor": "\"CLASSIFIED INTELLIGENCE: Pixels enhanced: chills confirmed.\""
+  },
+  {
+    "id": "CRY-TS-050",
+    "name": "Holographic Universe Theory",
+    "type": "MEDIA",
+    "faction": "truth",
+    "rarity": "uncommon",
+    "cost": 4,
+    "effects": {
+      "truthDelta": 2
+    },
+    "extId": "cryptids",
+    "flavor": "\"CLASSIFIED INTELLIGENCE: Tabloid headline writes itself.\""
+  },
+  {
+    "id": "CRY-TS-051",
+    "name": "Cryptid DNA Evidence Database",
+    "type": "MEDIA",
+    "faction": "truth",
+    "rarity": "rare",
+    "cost": 5,
+    "effects": {
+      "truthDelta": 3
+    },
+    "extId": "cryptids",
+    "flavor": "\"CLASSIFIED INTELLIGENCE: Experts disagree; the crowd screams yes.\""
+  },
+  {
+    "id": "CRY-TS-052",
+    "name": "Phantom Satellite Tracking",
+    "type": "MEDIA",
+    "faction": "truth",
+    "rarity": "rare",
+    "cost": 5,
+    "effects": {
+      "truthDelta": 3
+    },
+    "extId": "cryptids",
+    "flavor": "\"CLASSIFIED INTELLIGENCE: We brought snacks and a camcorder.\""
+  },
+  {
+    "id": "CRY-TS-053",
+    "name": "Consciousness Upload Technology",
+    "type": "MEDIA",
+    "faction": "truth",
+    "rarity": "uncommon",
+    "cost": 4,
+    "effects": {
+      "truthDelta": 2
+    },
+    "extId": "cryptids",
+    "flavor": "\"CLASSIFIED INTELLIGENCE: We brought snacks and a camcorder.\""
+  },
+  {
+    "id": "CRY-TS-054",
+    "name": "Multidimensional Broadcast Network",
+    "type": "ZONE",
+    "faction": "truth",
+    "rarity": "legendary",
+    "cost": 7,
+    "effects": {
+      "pressureDelta": 4
+    },
+    "extId": "cryptids",
+    "flavor": "\"CLASSIFIED INTELLIGENCE: We brought snacks and a camcorder.\"",
+    "target": {
+      "scope": "state",
+      "count": 1
+    }
+  },
+  {
+    "id": "CRY-TS-055",
+    "name": "Crystal Wi-Fi Chakra Network",
+    "type": "MEDIA",
+    "faction": "truth",
+    "rarity": "uncommon",
+    "cost": 4,
+    "effects": {
+      "truthDelta": 2
+    },
+    "extId": "cryptids",
+    "flavor": "\"CLASSIFIED INTELLIGENCE: Tabloid headline writes itself.\""
+  },
+  {
+    "id": "CRY-TS-056",
+    "name": "Late Night AM Radio",
+    "type": "MEDIA",
+    "faction": "truth",
+    "rarity": "uncommon",
+    "cost": 4,
+    "effects": {
+      "truthDelta": 2
+    },
+    "extId": "cryptids",
+    "flavor": "\"CLASSIFIED INTELLIGENCE: Experts disagree; the crowd screams yes.\""
+  },
+  {
+    "id": "CRY-TS-057",
+    "name": "Viral Thread Storm",
+    "type": "MEDIA",
+    "faction": "truth",
+    "rarity": "rare",
+    "cost": 5,
+    "effects": {
+      "truthDelta": 3
+    },
+    "extId": "cryptids",
+    "flavor": "\"CLASSIFIED INTELLIGENCE: Pixels enhanced: chills confirmed.\""
+  },
+  {
+    "id": "CRY-TS-058",
+    "name": "Bigfoot Field Operations",
+    "type": "ZONE",
+    "faction": "truth",
+    "rarity": "rare",
+    "cost": 6,
+    "effects": {
+      "pressureDelta": 3
+    },
+    "extId": "cryptids",
+    "flavor": "\"CLASSIFIED INTELLIGENCE: Bigfoot looked straight into the lens.\"",
+    "target": {
+      "scope": "state",
+      "count": 1
+    }
+  },
+  {
+    "id": "CRY-TS-059",
+    "name": "Mothman Omen Network",
+    "type": "ATTACK",
+    "faction": "truth",
+    "rarity": "uncommon",
+    "cost": 3,
+    "effects": {
+      "ipDelta": {
+        "opponent": 2
+      }
+    },
+    "extId": "cryptids",
+    "flavor": "\"CLASSIFIED INTELLIGENCE: Experts disagree; the crowd screams yes.\""
+  },
+  {
+    "id": "CRY-TS-060",
+    "name": "Essential Oils Mind Shield",
+    "type": "MEDIA",
+    "faction": "truth",
+    "rarity": "uncommon",
+    "cost": 4,
+    "effects": {
+      "truthDelta": 2
+    },
+    "extId": "cryptids",
+    "flavor": "\"CLASSIFIED INTELLIGENCE: Pixels enhanced: chills confirmed.\""
+  },
+  {
+    "id": "CRY-TS-061",
+    "name": "Healing Crystal Array",
+    "type": "MEDIA",
+    "faction": "truth",
+    "rarity": "uncommon",
+    "cost": 4,
+    "effects": {
+      "truthDelta": 2
+    },
+    "extId": "cryptids",
+    "flavor": "\"CLASSIFIED INTELLIGENCE: Healing looked straight into the lens.\""
+  },
+  {
+    "id": "CRY-TS-062",
+    "name": "Really Long YouTube Videos",
+    "type": "MEDIA",
+    "faction": "truth",
+    "rarity": "uncommon",
+    "cost": 4,
+    "effects": {
+      "truthDelta": 2
+    },
+    "extId": "cryptids",
+    "flavor": "\"CLASSIFIED INTELLIGENCE: Pixels enhanced: chills confirmed.\""
+  },
+  {
+    "id": "CRY-TS-063",
+    "name": "Whistleblower Protection Network",
+    "type": "MEDIA",
+    "faction": "truth",
+    "rarity": "rare",
+    "cost": 5,
+    "effects": {
+      "truthDelta": 3
+    },
+    "extId": "cryptids",
+    "flavor": "\"CLASSIFIED INTELLIGENCE: Pixels enhanced: chills confirmed.\""
+  },
+  {
+    "id": "CRY-TS-064",
+    "name": "Anonymous Leak Platform",
+    "type": "MEDIA",
+    "faction": "truth",
+    "rarity": "rare",
+    "cost": 5,
+    "effects": {
+      "truthDelta": 3
+    },
+    "extId": "cryptids",
+    "flavor": "\"CLASSIFIED INTELLIGENCE: Tabloid headline writes itself.\""
+  },
+  {
+    "id": "CRY-TS-065",
+    "name": "Flat Earth Conference",
+    "type": "MEDIA",
+    "faction": "truth",
+    "rarity": "uncommon",
+    "cost": 4,
+    "effects": {
+      "truthDelta": 2
+    },
+    "extId": "cryptids",
+    "flavor": "\"CLASSIFIED INTELLIGENCE: Flat looked straight into the lens.\""
+  },
+  {
+    "id": "CRY-TS-066",
+    "name": "Chemtrail Detection Kit",
+    "type": "ZONE",
+    "faction": "truth",
+    "rarity": "uncommon",
+    "cost": 5,
+    "effects": {
+      "pressureDelta": 2
+    },
+    "extId": "cryptids",
+    "flavor": "\"CLASSIFIED INTELLIGENCE: We brought snacks and a camcorder.\"",
+    "target": {
+      "scope": "state",
+      "count": 1
+    }
+  },
+  {
+    "id": "CRY-TS-067",
+    "name": "Vaccine Truth Bomb Campaign",
+    "type": "ZONE",
+    "faction": "truth",
+    "rarity": "rare",
+    "cost": 6,
+    "effects": {
+      "pressureDelta": 3
+    },
+    "extId": "cryptids",
+    "flavor": "\"CLASSIFIED INTELLIGENCE: Tabloid headline writes itself.\"",
+    "target": {
+      "scope": "state",
+      "count": 1
+    }
+  },
+  {
+    "id": "CRY-TS-068",
+    "name": "Alabama Cryptid Mass Sighting",
+    "type": "ATTACK",
+    "faction": "truth",
+    "rarity": "common",
+    "cost": 2,
+    "effects": {
+      "ipDelta": {
+        "opponent": 1
+      }
+    },
+    "extId": "cryptids",
+    "flavor": "\"CLASSIFIED INTELLIGENCE: The locals swear alabama cryptid waved back.\""
+  },
+  {
+    "id": "CRY-TS-069",
+    "name": "Tizheruk Mass Sighting",
+    "type": "ZONE",
+    "faction": "truth",
+    "rarity": "common",
+    "cost": 4,
+    "effects": {
+      "pressureDelta": 1
+    },
+    "extId": "cryptids",
+    "flavor": "\"CLASSIFIED INTELLIGENCE: The locals swear tizheruk waved back.\"",
+    "target": {
+      "scope": "state",
+      "count": 1
+    }
+  },
+  {
+    "id": "CRY-TS-070",
+    "name": "Thunderbird Mass Sighting",
+    "type": "ATTACK",
+    "faction": "truth",
+    "rarity": "common",
+    "cost": 2,
+    "effects": {
+      "ipDelta": {
+        "opponent": 1
+      }
+    },
+    "extId": "cryptids",
+    "flavor": "\"CLASSIFIED INTELLIGENCE: The locals swear thunderbird waved back.\""
+  },
+  {
+    "id": "CRY-TS-071",
+    "name": "Fouke Monster Mass Sighting",
+    "type": "ATTACK",
+    "faction": "truth",
+    "rarity": "common",
+    "cost": 2,
+    "effects": {
+      "ipDelta": {
+        "opponent": 1
+      }
+    },
+    "extId": "cryptids",
+    "flavor": "\"CLASSIFIED INTELLIGENCE: The locals swear fouke monster waved back.\""
+  },
+  {
+    "id": "CRY-TS-072",
+    "name": "Bigfoot Mass Sighting",
+    "type": "ZONE",
+    "faction": "truth",
+    "rarity": "common",
+    "cost": 4,
+    "effects": {
+      "pressureDelta": 1
+    },
+    "extId": "cryptids",
+    "flavor": "\"CLASSIFIED INTELLIGENCE: The locals swear bigfoot waved back.\"",
+    "target": {
+      "scope": "state",
+      "count": 1
+    }
+  },
+  {
+    "id": "CRY-TS-073",
+    "name": "Colorado Cryptid Mass Sighting",
+    "type": "ATTACK",
+    "faction": "truth",
+    "rarity": "common",
+    "cost": 2,
+    "effects": {
+      "ipDelta": {
+        "opponent": 1
+      }
+    },
+    "extId": "cryptids",
+    "flavor": "\"CLASSIFIED INTELLIGENCE: The locals swear colorado cryptid waved back.\""
+  },
+  {
+    "id": "CRY-TS-074",
+    "name": "Connecticut Cryptid Mass Sighting",
+    "type": "ATTACK",
+    "faction": "truth",
+    "rarity": "common",
+    "cost": 2,
+    "effects": {
+      "ipDelta": {
+        "opponent": 1
+      }
+    },
+    "extId": "cryptids",
+    "flavor": "\"CLASSIFIED INTELLIGENCE: The locals swear connecticut cryptid waved back.\""
+  },
+  {
+    "id": "CRY-TS-075",
+    "name": "Delaware Cryptid Mass Sighting",
+    "type": "ZONE",
+    "faction": "truth",
+    "rarity": "common",
+    "cost": 4,
+    "effects": {
+      "pressureDelta": 1
+    },
+    "extId": "cryptids",
+    "flavor": "\"CLASSIFIED INTELLIGENCE: The locals swear delaware cryptid waved back.\"",
+    "target": {
+      "scope": "state",
+      "count": 1
+    }
+  },
+  {
+    "id": "CRY-TS-076",
+    "name": "Skunk Ape Mass Sighting",
+    "type": "ZONE",
+    "faction": "truth",
+    "rarity": "common",
+    "cost": 4,
+    "effects": {
+      "pressureDelta": 1
+    },
+    "extId": "cryptids",
+    "flavor": "\"CLASSIFIED INTELLIGENCE: The locals swear skunk ape waved back.\"",
+    "target": {
+      "scope": "state",
+      "count": 1
+    }
+  },
+  {
+    "id": "CRY-TS-077",
+    "name": "Georgia Cryptid Mass Sighting",
+    "type": "ZONE",
+    "faction": "truth",
+    "rarity": "common",
+    "cost": 4,
+    "effects": {
+      "pressureDelta": 1
+    },
+    "extId": "cryptids",
+    "flavor": "\"CLASSIFIED INTELLIGENCE: The locals swear georgia cryptid waved back.\"",
+    "target": {
+      "scope": "state",
+      "count": 1
+    }
+  },
+  {
+    "id": "CRY-TS-078",
+    "name": "Hawaii Cryptid Mass Sighting",
+    "type": "ZONE",
+    "faction": "truth",
+    "rarity": "common",
+    "cost": 4,
+    "effects": {
+      "pressureDelta": 1
+    },
+    "extId": "cryptids",
+    "flavor": "\"CLASSIFIED INTELLIGENCE: The locals swear hawaii cryptid waved back.\"",
+    "target": {
+      "scope": "state",
+      "count": 1
+    }
+  },
+  {
+    "id": "CRY-TS-079",
+    "name": "Idaho Cryptid Mass Sighting",
+    "type": "ZONE",
+    "faction": "truth",
+    "rarity": "common",
+    "cost": 4,
+    "effects": {
+      "pressureDelta": 1
+    },
+    "extId": "cryptids",
+    "flavor": "\"CLASSIFIED INTELLIGENCE: The locals swear idaho cryptid waved back.\"",
+    "target": {
+      "scope": "state",
+      "count": 1
+    }
+  },
+  {
+    "id": "CRY-TS-080",
+    "name": "Enfield Horror Mass Sighting",
+    "type": "ZONE",
+    "faction": "truth",
+    "rarity": "common",
+    "cost": 4,
+    "effects": {
+      "pressureDelta": 1
+    },
+    "extId": "cryptids",
+    "flavor": "\"CLASSIFIED INTELLIGENCE: The locals swear enfield horror waved back.\"",
+    "target": {
+      "scope": "state",
+      "count": 1
+    }
+  },
+  {
+    "id": "CRY-TS-081",
+    "name": "Indiana Cryptid Mass Sighting",
+    "type": "ZONE",
+    "faction": "truth",
+    "rarity": "common",
+    "cost": 4,
+    "effects": {
+      "pressureDelta": 1
+    },
+    "extId": "cryptids",
+    "flavor": "\"CLASSIFIED INTELLIGENCE: The locals swear indiana cryptid waved back.\"",
+    "target": {
+      "scope": "state",
+      "count": 1
+    }
+  },
+  {
+    "id": "CRY-TS-082",
+    "name": "Iowa Cryptid Mass Sighting",
+    "type": "ZONE",
+    "faction": "truth",
+    "rarity": "common",
+    "cost": 4,
+    "effects": {
+      "pressureDelta": 1
+    },
+    "extId": "cryptids",
+    "flavor": "\"CLASSIFIED INTELLIGENCE: The locals swear iowa cryptid waved back.\"",
+    "target": {
+      "scope": "state",
+      "count": 1
+    }
+  },
+  {
+    "id": "CRY-TS-083",
+    "name": "Kansas Cryptid Mass Sighting",
+    "type": "ZONE",
+    "faction": "truth",
+    "rarity": "common",
+    "cost": 4,
+    "effects": {
+      "pressureDelta": 1
+    },
+    "extId": "cryptids",
+    "flavor": "\"CLASSIFIED INTELLIGENCE: The locals swear kansas cryptid waved back.\"",
+    "target": {
+      "scope": "state",
+      "count": 1
+    }
+  },
+  {
+    "id": "CRY-TS-084",
+    "name": "Kelly–Hopkinsville Goblins Mass Sighting",
+    "type": "ZONE",
+    "faction": "truth",
+    "rarity": "common",
+    "cost": 4,
+    "effects": {
+      "pressureDelta": 1
+    },
+    "extId": "cryptids",
+    "flavor": "\"CLASSIFIED INTELLIGENCE: The locals swear kelly–hopkinsville goblins waved back.\"",
+    "target": {
+      "scope": "state",
+      "count": 1
+    }
+  },
+  {
+    "id": "CRY-TS-085",
+    "name": "Rougarou Mass Sighting",
+    "type": "ZONE",
+    "faction": "truth",
+    "rarity": "common",
+    "cost": 4,
+    "effects": {
+      "pressureDelta": 1
+    },
+    "extId": "cryptids",
+    "flavor": "\"CLASSIFIED INTELLIGENCE: The locals swear rougarou waved back.\"",
+    "target": {
+      "scope": "state",
+      "count": 1
+    }
+  },
+  {
+    "id": "CRY-TS-086",
+    "name": "Maine Cryptid Mass Sighting",
+    "type": "ZONE",
+    "faction": "truth",
+    "rarity": "common",
+    "cost": 4,
+    "effects": {
+      "pressureDelta": 1
+    },
+    "extId": "cryptids",
+    "flavor": "\"CLASSIFIED INTELLIGENCE: The locals swear maine cryptid waved back.\"",
+    "target": {
+      "scope": "state",
+      "count": 1
+    }
+  },
+  {
+    "id": "CRY-TS-087",
+    "name": "Snallygaster Mass Sighting",
+    "type": "ZONE",
+    "faction": "truth",
+    "rarity": "common",
+    "cost": 4,
+    "effects": {
+      "pressureDelta": 1
+    },
+    "extId": "cryptids",
+    "flavor": "\"CLASSIFIED INTELLIGENCE: The locals swear snallygaster waved back.\"",
+    "target": {
+      "scope": "state",
+      "count": 1
+    }
+  },
+  {
+    "id": "CRY-TS-088",
+    "name": "Dover Demon Mass Sighting",
+    "type": "ZONE",
+    "faction": "truth",
+    "rarity": "common",
+    "cost": 4,
+    "effects": {
+      "pressureDelta": 1
+    },
+    "extId": "cryptids",
+    "flavor": "\"CLASSIFIED INTELLIGENCE: The locals swear dover demon waved back.\"",
+    "target": {
+      "scope": "state",
+      "count": 1
+    }
+  },
+  {
+    "id": "CRY-TS-089",
+    "name": "Dogman Mass Sighting",
+    "type": "ZONE",
+    "faction": "truth",
+    "rarity": "common",
+    "cost": 4,
+    "effects": {
+      "pressureDelta": 1
+    },
+    "extId": "cryptids",
+    "flavor": "\"CLASSIFIED INTELLIGENCE: The locals swear dogman waved back.\"",
+    "target": {
+      "scope": "state",
+      "count": 1
+    }
+  },
+  {
+    "id": "CRY-TS-090",
+    "name": "Wendigo Mass Sighting",
+    "type": "ATTACK",
+    "faction": "truth",
+    "rarity": "common",
+    "cost": 2,
+    "effects": {
+      "ipDelta": {
+        "opponent": 1
+      }
+    },
+    "extId": "cryptids",
+    "flavor": "\"CLASSIFIED INTELLIGENCE: The locals swear wendigo waved back.\""
+  },
+  {
+    "id": "CRY-TS-091",
+    "name": "Mississippi Cryptid Mass Sighting",
+    "type": "ZONE",
+    "faction": "truth",
+    "rarity": "common",
+    "cost": 4,
+    "effects": {
+      "pressureDelta": 1
+    },
+    "extId": "cryptids",
+    "flavor": "\"CLASSIFIED INTELLIGENCE: The locals swear mississippi cryptid waved back.\"",
+    "target": {
+      "scope": "state",
+      "count": 1
+    }
+  },
+  {
+    "id": "CRY-TS-092",
+    "name": "Missouri Cryptid Mass Sighting",
+    "type": "ZONE",
+    "faction": "truth",
+    "rarity": "common",
+    "cost": 4,
+    "effects": {
+      "pressureDelta": 1
+    },
+    "extId": "cryptids",
+    "flavor": "\"CLASSIFIED INTELLIGENCE: The locals swear missouri cryptid waved back.\"",
+    "target": {
+      "scope": "state",
+      "count": 1
+    }
+  },
+  {
+    "id": "CRY-TS-093",
+    "name": "Shunka Warakin Mass Sighting",
+    "type": "ZONE",
+    "faction": "truth",
+    "rarity": "common",
+    "cost": 4,
+    "effects": {
+      "pressureDelta": 1
+    },
+    "extId": "cryptids",
+    "flavor": "\"CLASSIFIED INTELLIGENCE: The locals swear shunka warakin waved back.\"",
+    "target": {
+      "scope": "state",
+      "count": 1
+    }
+  },
+  {
+    "id": "CRY-TS-094",
+    "name": "Nebraska Cryptid Mass Sighting",
+    "type": "ZONE",
+    "faction": "truth",
+    "rarity": "common",
+    "cost": 4,
+    "effects": {
+      "pressureDelta": 1
+    },
+    "extId": "cryptids",
+    "flavor": "\"CLASSIFIED INTELLIGENCE: The locals swear nebraska cryptid waved back.\"",
+    "target": {
+      "scope": "state",
+      "count": 1
+    }
+  },
+  {
+    "id": "CRY-TS-095",
+    "name": "Tahoe Tessie Mass Sighting",
+    "type": "ZONE",
+    "faction": "truth",
+    "rarity": "common",
+    "cost": 4,
+    "effects": {
+      "pressureDelta": 1
+    },
+    "extId": "cryptids",
+    "flavor": "\"CLASSIFIED INTELLIGENCE: The locals swear tahoe tessie waved back.\"",
+    "target": {
+      "scope": "state",
+      "count": 1
+    }
+  },
+  {
+    "id": "CRY-TS-096",
+    "name": "Wood Devils Mass Sighting",
+    "type": "ZONE",
+    "faction": "truth",
+    "rarity": "common",
+    "cost": 4,
+    "effects": {
+      "pressureDelta": 1
+    },
+    "extId": "cryptids",
+    "flavor": "\"CLASSIFIED INTELLIGENCE: The locals swear wood devils waved back.\"",
+    "target": {
+      "scope": "state",
+      "count": 1
+    }
+  },
+  {
+    "id": "CRY-TS-097",
+    "name": "Jersey Devil Mass Sighting",
+    "type": "ATTACK",
+    "faction": "truth",
+    "rarity": "common",
+    "cost": 2,
+    "effects": {
+      "ipDelta": {
+        "opponent": 1
+      }
+    },
+    "extId": "cryptids",
+    "flavor": "\"CLASSIFIED INTELLIGENCE: The locals swear jersey devil waved back.\""
+  },
+  {
+    "id": "CRY-TS-098",
+    "name": "Skinwalkers Mass Sighting",
+    "type": "ATTACK",
+    "faction": "truth",
+    "rarity": "common",
+    "cost": 2,
+    "effects": {
+      "ipDelta": {
+        "opponent": 1
+      }
+    },
+    "extId": "cryptids",
+    "flavor": "\"CLASSIFIED INTELLIGENCE: The locals swear skinwalkers waved back.\""
+  },
+  {
+    "id": "CRY-TS-099",
+    "name": "Montauk Monster Mass Sighting",
+    "type": "ZONE",
+    "faction": "truth",
+    "rarity": "common",
+    "cost": 4,
+    "effects": {
+      "pressureDelta": 1
+    },
+    "extId": "cryptids",
+    "flavor": "\"CLASSIFIED INTELLIGENCE: The locals swear montauk monster waved back.\"",
+    "target": {
+      "scope": "state",
+      "count": 1
+    }
+  },
+  {
+    "id": "CRY-TS-100",
+    "name": "North Carolina Cryptid Mass Sighting",
+    "type": "ZONE",
+    "faction": "truth",
+    "rarity": "common",
+    "cost": 4,
+    "effects": {
+      "pressureDelta": 1
+    },
+    "extId": "cryptids",
+    "flavor": "\"CLASSIFIED INTELLIGENCE: The locals swear north carolina cryptid waved back.\"",
+    "target": {
+      "scope": "state",
+      "count": 1
+    }
+  },
+  {
+    "id": "CRY-TS-101",
+    "name": "North Dakota Cryptid Mass Sighting",
+    "type": "ZONE",
+    "faction": "truth",
+    "rarity": "common",
+    "cost": 4,
+    "effects": {
+      "pressureDelta": 1
+    },
+    "extId": "cryptids",
+    "flavor": "\"CLASSIFIED INTELLIGENCE: The locals swear north dakota cryptid waved back.\"",
+    "target": {
+      "scope": "state",
+      "count": 1
+    }
+  },
+  {
+    "id": "CRY-TS-102",
+    "name": "Loveland Frogman Mass Sighting",
+    "type": "ZONE",
+    "faction": "truth",
+    "rarity": "common",
+    "cost": 4,
+    "effects": {
+      "pressureDelta": 1
+    },
+    "extId": "cryptids",
+    "flavor": "\"CLASSIFIED INTELLIGENCE: The locals swear loveland frogman waved back.\"",
+    "target": {
+      "scope": "state",
+      "count": 1
+    }
+  },
+  {
+    "id": "CRY-TS-103",
+    "name": "Oklahoma Cryptid Mass Sighting",
+    "type": "ZONE",
+    "faction": "truth",
+    "rarity": "common",
+    "cost": 4,
+    "effects": {
+      "pressureDelta": 1
+    },
+    "extId": "cryptids",
+    "flavor": "\"CLASSIFIED INTELLIGENCE: The locals swear oklahoma cryptid waved back.\"",
+    "target": {
+      "scope": "state",
+      "count": 1
+    }
+  },
+  {
+    "id": "CRY-TS-104",
+    "name": "Bigfoot Mass Sighting",
+    "type": "ZONE",
+    "faction": "truth",
+    "rarity": "common",
+    "cost": 4,
+    "effects": {
+      "pressureDelta": 1
+    },
+    "extId": "cryptids",
+    "flavor": "\"CLASSIFIED INTELLIGENCE: The locals swear bigfoot waved back.\"",
+    "target": {
+      "scope": "state",
+      "count": 1
+    }
+  },
+  {
+    "id": "CRY-TS-105",
+    "name": "Pennsylvania Cryptid Mass Sighting",
+    "type": "ZONE",
+    "faction": "truth",
+    "rarity": "common",
+    "cost": 4,
+    "effects": {
+      "pressureDelta": 1
+    },
+    "extId": "cryptids",
+    "flavor": "\"CLASSIFIED INTELLIGENCE: The locals swear pennsylvania cryptid waved back.\"",
+    "target": {
+      "scope": "state",
+      "count": 1
+    }
+  },
+  {
+    "id": "CRY-TS-106",
+    "name": "Rhode Island Cryptid Mass Sighting",
+    "type": "ZONE",
+    "faction": "truth",
+    "rarity": "common",
+    "cost": 4,
+    "effects": {
+      "pressureDelta": 1
+    },
+    "extId": "cryptids",
+    "flavor": "\"CLASSIFIED INTELLIGENCE: The locals swear rhode island cryptid waved back.\"",
+    "target": {
+      "scope": "state",
+      "count": 1
+    }
+  },
+  {
+    "id": "CRY-TS-107",
+    "name": "South Carolina Cryptid Mass Sighting",
+    "type": "ZONE",
+    "faction": "truth",
+    "rarity": "common",
+    "cost": 4,
+    "effects": {
+      "pressureDelta": 1
+    },
+    "extId": "cryptids",
+    "flavor": "\"CLASSIFIED INTELLIGENCE: The locals swear south carolina cryptid waved back.\"",
+    "target": {
+      "scope": "state",
+      "count": 1
+    }
+  },
+  {
+    "id": "CRY-TS-108",
+    "name": "South Dakota Cryptid Mass Sighting",
+    "type": "ZONE",
+    "faction": "truth",
+    "rarity": "common",
+    "cost": 4,
+    "effects": {
+      "pressureDelta": 1
+    },
+    "extId": "cryptids",
+    "flavor": "\"CLASSIFIED INTELLIGENCE: The locals swear south dakota cryptid waved back.\"",
+    "target": {
+      "scope": "state",
+      "count": 1
+    }
+  },
+  {
+    "id": "CRY-TS-109",
+    "name": "Tennessee Cryptid Mass Sighting",
+    "type": "ZONE",
+    "faction": "truth",
+    "rarity": "common",
+    "cost": 4,
+    "effects": {
+      "pressureDelta": 1
+    },
+    "extId": "cryptids",
+    "flavor": "\"CLASSIFIED INTELLIGENCE: The locals swear tennessee cryptid waved back.\"",
+    "target": {
+      "scope": "state",
+      "count": 1
+    }
+  },
+  {
+    "id": "CRY-TS-110",
+    "name": "Chupacabra Mass Sighting",
+    "type": "ATTACK",
+    "faction": "truth",
+    "rarity": "common",
+    "cost": 2,
+    "effects": {
+      "ipDelta": {
+        "opponent": 1
+      }
+    },
+    "extId": "cryptids",
+    "flavor": "\"CLASSIFIED INTELLIGENCE: The locals swear chupacabra waved back.\""
+  },
+  {
+    "id": "CRY-TS-111",
+    "name": "Utah Cryptid Mass Sighting",
+    "type": "ZONE",
+    "faction": "truth",
+    "rarity": "common",
+    "cost": 4,
+    "effects": {
+      "pressureDelta": 1
+    },
+    "extId": "cryptids",
+    "flavor": "\"CLASSIFIED INTELLIGENCE: The locals swear utah cryptid waved back.\"",
+    "target": {
+      "scope": "state",
+      "count": 1
+    }
+  },
+  {
+    "id": "CRY-TS-112",
+    "name": "Champ Mass Sighting",
+    "type": "ZONE",
+    "faction": "truth",
+    "rarity": "common",
+    "cost": 4,
+    "effects": {
+      "pressureDelta": 1
+    },
+    "extId": "cryptids",
+    "flavor": "\"CLASSIFIED INTELLIGENCE: The locals swear champ waved back.\"",
+    "target": {
+      "scope": "state",
+      "count": 1
+    }
+  },
+  {
+    "id": "CRY-TS-113",
+    "name": "Virginia Cryptid Mass Sighting",
+    "type": "ZONE",
+    "faction": "truth",
+    "rarity": "common",
+    "cost": 4,
+    "effects": {
+      "pressureDelta": 1
+    },
+    "extId": "cryptids",
+    "flavor": "\"CLASSIFIED INTELLIGENCE: The locals swear virginia cryptid waved back.\"",
+    "target": {
+      "scope": "state",
+      "count": 1
+    }
+  },
+  {
+    "id": "CRY-TS-114",
+    "name": "Bigfoot Mass Sighting",
+    "type": "ZONE",
+    "faction": "truth",
+    "rarity": "common",
+    "cost": 4,
+    "effects": {
+      "pressureDelta": 1
+    },
+    "extId": "cryptids",
+    "flavor": "\"CLASSIFIED INTELLIGENCE: The locals swear bigfoot waved back.\"",
+    "target": {
+      "scope": "state",
+      "count": 1
+    }
+  },
+  {
+    "id": "CRY-TS-115",
+    "name": "Mothman Mass Sighting",
+    "type": "ATTACK",
+    "faction": "truth",
+    "rarity": "common",
+    "cost": 2,
+    "effects": {
+      "ipDelta": {
+        "opponent": 1
+      }
+    },
+    "extId": "cryptids",
+    "flavor": "\"CLASSIFIED INTELLIGENCE: The locals swear mothman waved back.\""
+  },
+  {
+    "id": "CRY-TS-116",
+    "name": "Beast of Bray Road Mass Sighting",
+    "type": "ATTACK",
+    "faction": "truth",
+    "rarity": "common",
+    "cost": 2,
+    "effects": {
+      "ipDelta": {
+        "opponent": 1
+      }
+    },
+    "extId": "cryptids",
+    "flavor": "\"CLASSIFIED INTELLIGENCE: The locals swear beast of bray road waved back.\""
+  },
+  {
+    "id": "CRY-TS-117",
+    "name": "Wyoming Cryptid Mass Sighting",
+    "type": "ZONE",
+    "faction": "truth",
+    "rarity": "common",
+    "cost": 4,
+    "effects": {
+      "pressureDelta": 1
+    },
+    "extId": "cryptids",
+    "flavor": "\"CLASSIFIED INTELLIGENCE: The locals swear wyoming cryptid waved back.\"",
+    "target": {
+      "scope": "state",
+      "count": 1
+    }
+  },
+  {
+    "id": "CRY-TS-118",
+    "name": "Chupacabra Panic Wave",
+    "type": "ATTACK",
+    "faction": "truth",
+    "rarity": "common",
+    "cost": 2,
+    "effects": {
+      "ipDelta": {
+        "opponent": 1
+      }
+    },
+    "extId": "cryptids",
+    "flavor": "\"CLASSIFIED INTELLIGENCE: Eyewitnesses report chills and grainy footage.\""
+  },
+  {
+    "id": "CRY-TS-119",
+    "name": "Tizheruk Panic Wave",
+    "type": "ATTACK",
+    "faction": "truth",
+    "rarity": "common",
+    "cost": 2,
+    "effects": {
+      "ipDelta": {
+        "opponent": 1
+      }
+    },
+    "extId": "cryptids",
+    "flavor": "\"CLASSIFIED INTELLIGENCE: Eyewitnesses report chills and grainy footage.\""
+  },
+  {
+    "id": "CRY-TS-120",
+    "name": "Wendigo Watch Patrols",
+    "type": "ATTACK",
+    "faction": "truth",
+    "rarity": "common",
+    "cost": 2,
+    "effects": {
+      "ipDelta": {
+        "opponent": 1
+      }
+    },
+    "extId": "cryptids",
+    "flavor": "\"CLASSIFIED INTELLIGENCE: Eyewitnesses report chills and grainy footage.\""
+  },
+  {
+    "id": "CRY-TS-121",
+    "name": "Loveland Frogman Watch Patrols",
+    "type": "MEDIA",
+    "faction": "truth",
+    "rarity": "common",
+    "cost": 3,
+    "effects": {
+      "truthDelta": 1
+    },
+    "extId": "cryptids",
+    "flavor": "\"CLASSIFIED INTELLIGENCE: Eyewitnesses report chills and grainy footage.\""
+  },
+  {
+    "id": "CRY-TS-122",
+    "name": "Bigfoot Panic Wave",
+    "type": "ATTACK",
+    "faction": "truth",
+    "rarity": "common",
+    "cost": 2,
+    "effects": {
+      "ipDelta": {
+        "opponent": 1
+      }
+    },
+    "extId": "cryptids",
+    "flavor": "\"CLASSIFIED INTELLIGENCE: Eyewitnesses report chills and grainy footage.\""
+  },
+  {
+    "id": "CRY-TS-123",
+    "name": "Dogman Panic Wave",
+    "type": "ATTACK",
+    "faction": "truth",
+    "rarity": "common",
+    "cost": 2,
+    "effects": {
+      "ipDelta": {
+        "opponent": 1
+      }
+    },
+    "extId": "cryptids",
+    "flavor": "\"CLASSIFIED INTELLIGENCE: Eyewitnesses report chills and grainy footage.\""
+  },
+  {
+    "id": "CRY-TS-124",
+    "name": "Rougarou Watch Patrols",
+    "type": "MEDIA",
+    "faction": "truth",
+    "rarity": "common",
+    "cost": 3,
+    "effects": {
+      "truthDelta": 1
+    },
+    "extId": "cryptids",
+    "flavor": "\"CLASSIFIED INTELLIGENCE: Eyewitnesses report chills and grainy footage.\""
+  },
+  {
+    "id": "CRY-TS-125",
+    "name": "Tahoe Tessie Panic Wave",
+    "type": "ATTACK",
+    "faction": "truth",
+    "rarity": "common",
+    "cost": 2,
+    "effects": {
+      "ipDelta": {
+        "opponent": 1
+      }
+    },
+    "extId": "cryptids",
+    "flavor": "\"CLASSIFIED INTELLIGENCE: Eyewitnesses report chills and grainy footage.\""
+  },
+  {
+    "id": "CRY-TS-126",
+    "name": "Beast of Bray Road Watch Patrols",
+    "type": "ATTACK",
+    "faction": "truth",
+    "rarity": "common",
+    "cost": 2,
+    "effects": {
+      "ipDelta": {
+        "opponent": 1
+      }
+    },
+    "extId": "cryptids",
+    "flavor": "\"CLASSIFIED INTELLIGENCE: Eyewitnesses report chills and grainy footage.\""
+  },
+  {
+    "id": "CRY-TS-127",
+    "name": "Wendigo Watch Patrols",
+    "type": "ATTACK",
+    "faction": "truth",
+    "rarity": "common",
+    "cost": 2,
+    "effects": {
+      "ipDelta": {
+        "opponent": 1
+      }
+    },
+    "extId": "cryptids",
+    "flavor": "\"CLASSIFIED INTELLIGENCE: Eyewitnesses report chills and grainy footage.\""
+  },
+  {
+    "id": "CRY-TS-128",
+    "name": "Dover Demon Panic Wave",
+    "type": "ATTACK",
+    "faction": "truth",
+    "rarity": "common",
+    "cost": 2,
+    "effects": {
+      "ipDelta": {
+        "opponent": 1
+      }
+    },
+    "extId": "cryptids",
+    "flavor": "\"CLASSIFIED INTELLIGENCE: Eyewitnesses report chills and grainy footage.\""
+  },
+  {
+    "id": "CRY-TS-129",
+    "name": "Tizheruk Watch Patrols",
+    "type": "MEDIA",
+    "faction": "truth",
+    "rarity": "common",
+    "cost": 3,
+    "effects": {
+      "truthDelta": 1
+    },
+    "extId": "cryptids",
+    "flavor": "\"CLASSIFIED INTELLIGENCE: Eyewitnesses report chills and grainy footage.\""
+  },
+  {
+    "id": "CRY-TS-130",
+    "name": "Fouke Monster Watch Patrols",
+    "type": "MEDIA",
+    "faction": "truth",
+    "rarity": "common",
+    "cost": 3,
+    "effects": {
+      "truthDelta": 1
+    },
+    "extId": "cryptids",
+    "flavor": "\"CLASSIFIED INTELLIGENCE: Eyewitnesses report chills and grainy footage.\""
+  },
+  {
+    "id": "CRY-TS-131",
+    "name": "Jersey Devil Panic Wave",
+    "type": "ATTACK",
+    "faction": "truth",
+    "rarity": "common",
+    "cost": 2,
+    "effects": {
+      "ipDelta": {
+        "opponent": 1
+      }
+    },
+    "extId": "cryptids",
+    "flavor": "\"CLASSIFIED INTELLIGENCE: Eyewitnesses report chills and grainy footage.\""
+  },
+  {
+    "id": "CRY-TS-132",
+    "name": "Tizheruk Panic Wave",
+    "type": "ATTACK",
+    "faction": "truth",
+    "rarity": "common",
+    "cost": 2,
+    "effects": {
+      "ipDelta": {
+        "opponent": 1
+      }
+    },
+    "extId": "cryptids",
+    "flavor": "\"CLASSIFIED INTELLIGENCE: Eyewitnesses report chills and grainy footage.\""
+  },
+  {
+    "id": "CRY-TS-133",
+    "name": "Tahoe Tessie Panic Wave",
+    "type": "ATTACK",
+    "faction": "truth",
+    "rarity": "common",
+    "cost": 2,
+    "effects": {
+      "ipDelta": {
+        "opponent": 1
+      }
+    },
+    "extId": "cryptids",
+    "flavor": "\"CLASSIFIED INTELLIGENCE: Eyewitnesses report chills and grainy footage.\""
+  },
+  {
+    "id": "CRY-TS-134",
+    "name": "Fouke Monster Panic Wave",
+    "type": "ATTACK",
+    "faction": "truth",
+    "rarity": "common",
+    "cost": 2,
+    "effects": {
+      "ipDelta": {
+        "opponent": 1
+      }
+    },
+    "extId": "cryptids",
+    "flavor": "\"CLASSIFIED INTELLIGENCE: Eyewitnesses report chills and grainy footage.\""
+  },
+  {
+    "id": "CRY-TS-135",
+    "name": "Snallygaster Watch Patrols",
+    "type": "MEDIA",
+    "faction": "truth",
+    "rarity": "common",
+    "cost": 3,
+    "effects": {
+      "truthDelta": 1
+    },
+    "extId": "cryptids",
+    "flavor": "\"CLASSIFIED INTELLIGENCE: Eyewitnesses report chills and grainy footage.\""
+  },
+  {
+    "id": "CRY-TS-136",
+    "name": "Chupacabra Panic Wave",
+    "type": "ATTACK",
+    "faction": "truth",
+    "rarity": "common",
+    "cost": 2,
+    "effects": {
+      "ipDelta": {
+        "opponent": 1
+      }
+    },
+    "extId": "cryptids",
+    "flavor": "\"CLASSIFIED INTELLIGENCE: Eyewitnesses report chills and grainy footage.\""
+  },
+  {
+    "id": "CRY-TS-137",
+    "name": "Shunka Warakin Panic Wave",
+    "type": "ATTACK",
+    "faction": "truth",
+    "rarity": "common",
+    "cost": 2,
+    "effects": {
+      "ipDelta": {
+        "opponent": 1
+      }
+    },
+    "extId": "cryptids",
+    "flavor": "\"CLASSIFIED INTELLIGENCE: Eyewitnesses report chills and grainy footage.\""
+  },
+  {
+    "id": "CRY-TS-138",
+    "name": "Tizheruk Panic Wave",
+    "type": "ATTACK",
+    "faction": "truth",
+    "rarity": "common",
+    "cost": 2,
+    "effects": {
+      "ipDelta": {
+        "opponent": 1
+      }
+    },
+    "extId": "cryptids",
+    "flavor": "\"CLASSIFIED INTELLIGENCE: Eyewitnesses report chills and grainy footage.\""
+  },
+  {
+    "id": "CRY-TS-139",
+    "name": "Fouke Monster Panic Wave",
+    "type": "ATTACK",
+    "faction": "truth",
+    "rarity": "common",
+    "cost": 2,
+    "effects": {
+      "ipDelta": {
+        "opponent": 1
+      }
+    },
+    "extId": "cryptids",
+    "flavor": "\"CLASSIFIED INTELLIGENCE: Eyewitnesses report chills and grainy footage.\""
+  },
+  {
+    "id": "CRY-TS-140",
+    "name": "Dover Demon Panic Wave",
+    "type": "ATTACK",
+    "faction": "truth",
+    "rarity": "common",
+    "cost": 2,
+    "effects": {
+      "ipDelta": {
+        "opponent": 1
+      }
+    },
+    "extId": "cryptids",
+    "flavor": "\"CLASSIFIED INTELLIGENCE: Eyewitnesses report chills and grainy footage.\""
+  },
+  {
+    "id": "CRY-TS-141",
+    "name": "Shunka Warakin Panic Wave",
+    "type": "ATTACK",
+    "faction": "truth",
+    "rarity": "common",
+    "cost": 2,
+    "effects": {
+      "ipDelta": {
+        "opponent": 1
+      }
+    },
+    "extId": "cryptids",
+    "flavor": "\"CLASSIFIED INTELLIGENCE: Eyewitnesses report chills and grainy footage.\""
+  },
+  {
+    "id": "CRY-TS-142",
+    "name": "Champ Watch Patrols",
+    "type": "MEDIA",
+    "faction": "truth",
+    "rarity": "common",
+    "cost": 3,
+    "effects": {
+      "truthDelta": 1
+    },
+    "extId": "cryptids",
+    "flavor": "\"CLASSIFIED INTELLIGENCE: Eyewitnesses report chills and grainy footage.\""
+  },
+  {
+    "id": "CRY-TS-143",
+    "name": "Loveland Frogman Watch Patrols",
+    "type": "MEDIA",
+    "faction": "truth",
+    "rarity": "common",
+    "cost": 3,
+    "effects": {
+      "truthDelta": 1
+    },
+    "extId": "cryptids",
+    "flavor": "\"CLASSIFIED INTELLIGENCE: Eyewitnesses report chills and grainy footage.\""
+  },
+  {
+    "id": "CRY-TS-144",
+    "name": "Montauk Monster Panic Wave",
+    "type": "ATTACK",
+    "faction": "truth",
+    "rarity": "common",
+    "cost": 2,
+    "effects": {
+      "ipDelta": {
+        "opponent": 1
+      }
+    },
+    "extId": "cryptids",
+    "flavor": "\"CLASSIFIED INTELLIGENCE: Eyewitnesses report chills and grainy footage.\""
+  },
+  {
+    "id": "CRY-TS-145",
+    "name": "Dogman Panic Wave",
+    "type": "ATTACK",
+    "faction": "truth",
+    "rarity": "common",
+    "cost": 2,
+    "effects": {
+      "ipDelta": {
+        "opponent": 1
+      }
+    },
+    "extId": "cryptids",
+    "flavor": "\"CLASSIFIED INTELLIGENCE: Eyewitnesses report chills and grainy footage.\""
+  },
+  {
+    "id": "CRY-TS-146",
+    "name": "Tizheruk Panic Wave",
+    "type": "ATTACK",
+    "faction": "truth",
+    "rarity": "common",
+    "cost": 2,
+    "effects": {
+      "ipDelta": {
+        "opponent": 1
+      }
+    },
+    "extId": "cryptids",
+    "flavor": "\"CLASSIFIED INTELLIGENCE: Eyewitnesses report chills and grainy footage.\""
+  },
+  {
+    "id": "CRY-TS-147",
+    "name": "Dover Demon Panic Wave",
+    "type": "ATTACK",
+    "faction": "truth",
+    "rarity": "common",
+    "cost": 2,
+    "effects": {
+      "ipDelta": {
+        "opponent": 1
+      }
+    },
+    "extId": "cryptids",
+    "flavor": "\"CLASSIFIED INTELLIGENCE: Eyewitnesses report chills and grainy footage.\""
+  },
+  {
+    "id": "CRY-TS-148",
+    "name": "Snallygaster Watch Patrols",
+    "type": "MEDIA",
+    "faction": "truth",
+    "rarity": "common",
+    "cost": 3,
+    "effects": {
+      "truthDelta": 1
+    },
+    "extId": "cryptids",
+    "flavor": "\"CLASSIFIED INTELLIGENCE: Eyewitnesses report chills and grainy footage.\""
+  },
+  {
+    "id": "CRY-TS-149",
+    "name": "Rougarou Panic Wave",
+    "type": "ATTACK",
+    "faction": "truth",
+    "rarity": "common",
+    "cost": 2,
+    "effects": {
+      "ipDelta": {
+        "opponent": 1
+      }
+    },
+    "extId": "cryptids",
+    "flavor": "\"CLASSIFIED INTELLIGENCE: Eyewitnesses report chills and grainy footage.\""
+  },
+  {
+    "id": "CRY-TS-150",
+    "name": "Montauk Monster Panic Wave",
+    "type": "ATTACK",
+    "faction": "truth",
+    "rarity": "common",
+    "cost": 2,
+    "effects": {
+      "ipDelta": {
+        "opponent": 1
+      }
+    },
+    "extId": "cryptids",
+    "flavor": "\"CLASSIFIED INTELLIGENCE: Eyewitnesses report chills and grainy footage.\""
+  },
+  {
+    "id": "CRY-GV-001",
+    "name": "Men in Black Sweep",
+    "type": "ATTACK",
+    "faction": "government",
+    "rarity": "rare",
+    "cost": 4,
+    "effects": {
+      "ipDelta": {
+        "opponent": 3
+      },
+      "discardOpponent": 1
+    },
+    "extId": "cryptids",
+    "flavor": "\"CLASSIFIED INTELLIGENCE: Situation normal—memo drafted and archived.\""
+  },
+  {
+    "id": "CRY-GV-002",
+    "name": "Weather Machine Alpha",
+    "type": "ZONE",
+    "faction": "government",
+    "rarity": "uncommon",
+    "cost": 5,
+    "effects": {
+      "pressureDelta": 2
+    },
+    "extId": "cryptids",
+    "flavor": "\"CLASSIFIED INTELLIGENCE: Situation normal—memo drafted and archived.\"",
+    "target": {
+      "scope": "state",
+      "count": 1
+    }
+  },
+  {
+    "id": "CRY-GV-003",
+    "name": "Project Grand Mandela",
+    "type": "MEDIA",
+    "faction": "government",
+    "rarity": "rare",
+    "cost": 5,
+    "effects": {
+      "truthDelta": 3
+    },
+    "extId": "cryptids",
+    "flavor": "\"CLASSIFIED INTELLIGENCE: Awaiting lab results; likely weather and shadows.\""
+  },
+  {
+    "id": "CRY-GV-004",
+    "name": "Chemtrail Deployment",
+    "type": "ZONE",
+    "faction": "government",
+    "rarity": "uncommon",
+    "cost": 5,
+    "effects": {
+      "pressureDelta": 2
+    },
+    "extId": "cryptids",
+    "flavor": "\"CLASSIFIED INTELLIGENCE: Public guidance issued; no chemtrail detected.\"",
+    "target": {
+      "scope": "state",
+      "count": 1
+    }
+  },
+  {
+    "id": "CRY-GV-005",
+    "name": "Area 51 Security",
+    "type": "ZONE",
+    "faction": "government",
+    "rarity": "common",
+    "cost": 4,
+    "effects": {
+      "pressureDelta": 1
+    },
+    "extId": "cryptids",
+    "flavor": "\"CLASSIFIED INTELLIGENCE: Filed under routine wildlife misidentification.\"",
+    "target": {
+      "scope": "state",
+      "count": 1
+    }
+  },
+  {
+    "id": "CRY-GV-006",
+    "name": "Fake Alien Invasion",
+    "type": "ZONE",
+    "faction": "government",
+    "rarity": "legendary",
+    "cost": 7,
+    "effects": {
+      "pressureDelta": 4
+    },
+    "extId": "cryptids",
+    "flavor": "\"CLASSIFIED INTELLIGENCE: Field note logged; further action unnecessary.\"",
+    "target": {
+      "scope": "state",
+      "count": 1
+    }
+  },
+  {
+    "id": "CRY-GV-007",
+    "name": "Roswell Cover Story",
+    "type": "MEDIA",
+    "faction": "government",
+    "rarity": "uncommon",
+    "cost": 4,
+    "effects": {
+      "truthDelta": 2
+    },
+    "extId": "cryptids",
+    "flavor": "\"CLASSIFIED INTELLIGENCE: Public guidance issued; no roswell detected.\""
+  },
+  {
+    "id": "CRY-GV-008",
+    "name": "Disinformation Bureau",
+    "type": "MEDIA",
+    "faction": "government",
+    "rarity": "rare",
+    "cost": 5,
+    "effects": {
+      "truthDelta": 3
+    },
+    "extId": "cryptids",
+    "flavor": "\"CLASSIFIED INTELLIGENCE: Awaiting lab results; likely weather and shadows.\""
+  },
+  {
+    "id": "CRY-GV-009",
+    "name": "Bigfoot Suit Factory",
+    "type": "ZONE",
+    "faction": "government",
+    "rarity": "uncommon",
+    "cost": 5,
+    "effects": {
+      "pressureDelta": 2
+    },
+    "extId": "cryptids",
+    "flavor": "\"CLASSIFIED INTELLIGENCE: Field note logged; further action unnecessary.\"",
+    "target": {
+      "scope": "state",
+      "count": 1
+    }
+  },
+  {
+    "id": "CRY-GV-010",
+    "name": "Project Blue Beam",
+    "type": "ATTACK",
+    "faction": "government",
+    "rarity": "legendary",
+    "cost": 5,
+    "effects": {
+      "ipDelta": {
+        "opponent": 4
+      },
+      "discardOpponent": 2
+    },
+    "extId": "cryptids",
+    "flavor": "\"CLASSIFIED INTELLIGENCE: Filed under routine wildlife misidentification.\""
+  },
+  {
+    "id": "CRY-GV-011",
+    "name": "Mothman Relocation Program",
+    "type": "ATTACK",
+    "faction": "government",
+    "rarity": "rare",
+    "cost": 4,
+    "effects": {
+      "ipDelta": {
+        "opponent": 3
+      },
+      "discardOpponent": 1
+    },
+    "extId": "cryptids",
+    "flavor": "\"CLASSIFIED INTELLIGENCE: Awaiting lab results; likely weather and shadows.\""
+  },
+  {
+    "id": "CRY-GV-012",
+    "name": "Chupacabra Protocol",
+    "type": "ATTACK",
+    "faction": "government",
+    "rarity": "uncommon",
+    "cost": 3,
+    "effects": {
+      "ipDelta": {
+        "opponent": 2
+      }
+    },
+    "extId": "cryptids",
+    "flavor": "\"CLASSIFIED INTELLIGENCE: Filed under routine wildlife misidentification.\""
+  },
+  {
+    "id": "CRY-GV-013",
+    "name": "Cryptid Containment Unit",
+    "type": "MEDIA",
+    "faction": "government",
+    "rarity": "common",
+    "cost": 3,
+    "effects": {
+      "truthDelta": 1
+    },
+    "extId": "cryptids",
+    "flavor": "\"CLASSIFIED INTELLIGENCE: Awaiting lab results; likely weather and shadows.\""
+  },
+  {
+    "id": "CRY-GV-014",
+    "name": "Jersey Devil Task Force",
+    "type": "ATTACK",
+    "faction": "government",
+    "rarity": "common",
+    "cost": 2,
+    "effects": {
+      "ipDelta": {
+        "opponent": 1
+      }
+    },
+    "extId": "cryptids",
+    "flavor": "\"CLASSIFIED INTELLIGENCE: Public guidance issued; no jersey devil detected.\""
+  },
+  {
+    "id": "CRY-GV-015",
+    "name": "Lake Monster Drainage",
+    "type": "ATTACK",
+    "faction": "government",
+    "rarity": "uncommon",
+    "cost": 3,
+    "effects": {
+      "ipDelta": {
+        "opponent": 2
+      }
+    },
+    "extId": "cryptids",
+    "flavor": "\"CLASSIFIED INTELLIGENCE: Public guidance issued; no lake detected.\""
+  },
+  {
+    "id": "CRY-GV-016",
+    "name": "Men in Beige",
+    "type": "ATTACK",
+    "faction": "government",
+    "rarity": "common",
+    "cost": 2,
+    "effects": {
+      "ipDelta": {
+        "opponent": 1
+      }
+    },
+    "extId": "cryptids",
+    "flavor": "\"CLASSIFIED INTELLIGENCE: Filed under routine wildlife misidentification.\""
+  },
+  {
+    "id": "CRY-GV-017",
+    "name": "Swamp Gas Generator",
+    "type": "ZONE",
+    "faction": "government",
+    "rarity": "uncommon",
+    "cost": 5,
+    "effects": {
+      "pressureDelta": 2
+    },
+    "extId": "cryptids",
+    "flavor": "\"CLASSIFIED INTELLIGENCE: Situation normal—memo drafted and archived.\"",
+    "target": {
+      "scope": "state",
+      "count": 1
+    }
+  },
+  {
+    "id": "CRY-GV-018",
+    "name": "Deniability Protocols",
+    "type": "ZONE",
+    "faction": "government",
+    "rarity": "uncommon",
+    "cost": 5,
+    "effects": {
+      "pressureDelta": 2
+    },
+    "extId": "cryptids",
+    "flavor": "\"CLASSIFIED INTELLIGENCE: Field note logged; further action unnecessary.\"",
+    "target": {
+      "scope": "state",
+      "count": 1
+    }
+  },
+  {
+    "id": "CRY-GV-019",
+    "name": "Black Helicopters",
+    "type": "ATTACK",
+    "faction": "government",
+    "rarity": "rare",
+    "cost": 4,
+    "effects": {
+      "ipDelta": {
+        "opponent": 3
+      },
+      "discardOpponent": 1
+    },
+    "extId": "cryptids",
+    "flavor": "\"CLASSIFIED INTELLIGENCE: Public guidance issued; no black detected.\""
+  },
+  {
+    "id": "CRY-GV-020",
+    "name": "Cryptozoology Department",
+    "type": "ZONE",
+    "faction": "government",
+    "rarity": "uncommon",
+    "cost": 5,
+    "effects": {
+      "pressureDelta": 2
+    },
+    "extId": "cryptids",
+    "flavor": "\"CLASSIFIED INTELLIGENCE: Field note logged; further action unnecessary.\"",
+    "target": {
+      "scope": "state",
+      "count": 1
+    }
+  },
+  {
+    "id": "CRY-GV-021",
+    "name": "Flatwoods Incident",
+    "type": "ZONE",
+    "faction": "government",
+    "rarity": "uncommon",
+    "cost": 5,
+    "effects": {
+      "pressureDelta": 2
+    },
+    "extId": "cryptids",
+    "flavor": "\"CLASSIFIED INTELLIGENCE: Awaiting lab results; likely weather and shadows.\"",
+    "target": {
+      "scope": "state",
+      "count": 1
+    }
+  },
+  {
+    "id": "CRY-GV-022",
+    "name": "Skunk Ape Safari",
+    "type": "ZONE",
+    "faction": "government",
+    "rarity": "common",
+    "cost": 4,
+    "effects": {
+      "pressureDelta": 1
+    },
+    "extId": "cryptids",
+    "flavor": "\"CLASSIFIED INTELLIGENCE: Field note logged; further action unnecessary.\"",
+    "target": {
+      "scope": "state",
+      "count": 1
+    }
+  },
+  {
+    "id": "CRY-GV-023",
+    "name": "Thunderbird Tracking",
+    "type": "ATTACK",
+    "faction": "government",
+    "rarity": "uncommon",
+    "cost": 3,
+    "effects": {
+      "ipDelta": {
+        "opponent": 2
+      }
+    },
+    "extId": "cryptids",
+    "flavor": "\"CLASSIFIED INTELLIGENCE: Public guidance issued; no thunderbird detected.\""
+  },
+  {
+    "id": "CRY-GV-024",
+    "name": "Shadow People Census",
+    "type": "ATTACK",
+    "faction": "government",
+    "rarity": "uncommon",
+    "cost": 3,
+    "effects": {
+      "ipDelta": {
+        "opponent": 2
+      }
+    },
+    "extId": "cryptids",
+    "flavor": "\"CLASSIFIED INTELLIGENCE: Public guidance issued; no shadow detected.\""
+  },
+  {
+    "id": "CRY-GV-025",
+    "name": "Hopkinsville Goblins",
+    "type": "ZONE",
+    "faction": "government",
+    "rarity": "rare",
+    "cost": 6,
+    "effects": {
+      "pressureDelta": 3
+    },
+    "extId": "cryptids",
+    "flavor": "\"CLASSIFIED INTELLIGENCE: Situation normal—memo drafted and archived.\"",
+    "target": {
+      "scope": "state",
+      "count": 1
+    }
+  },
+  {
+    "id": "CRY-GV-026",
+    "name": "Lizard Person Council",
+    "type": "MEDIA",
+    "faction": "government",
+    "rarity": "legendary",
+    "cost": 6,
+    "effects": {
+      "truthDelta": 4
+    },
+    "extId": "cryptids",
+    "flavor": "\"CLASSIFIED INTELLIGENCE: Situation normal—memo drafted and archived.\""
+  },
+  {
+    "id": "CRY-GV-027",
+    "name": "Hollow Earth Drilling",
+    "type": "ZONE",
+    "faction": "government",
+    "rarity": "rare",
+    "cost": 6,
+    "effects": {
+      "pressureDelta": 3
+    },
+    "extId": "cryptids",
+    "flavor": "\"CLASSIFIED INTELLIGENCE: Situation normal—memo drafted and archived.\"",
+    "target": {
+      "scope": "state",
+      "count": 1
+    }
+  },
+  {
+    "id": "CRY-GV-028",
+    "name": "Time Travel Bureau",
+    "type": "MEDIA",
+    "faction": "government",
+    "rarity": "uncommon",
+    "cost": 4,
+    "effects": {
+      "truthDelta": 2
+    },
+    "extId": "cryptids",
+    "flavor": "\"CLASSIFIED INTELLIGENCE: Public guidance issued; no time detected.\""
+  },
+  {
+    "id": "CRY-GV-029",
+    "name": "Flying Saucer Hangar",
+    "type": "ZONE",
+    "faction": "government",
+    "rarity": "rare",
+    "cost": 6,
+    "effects": {
+      "pressureDelta": 3
+    },
+    "extId": "cryptids",
+    "flavor": "\"CLASSIFIED INTELLIGENCE: Filed under routine wildlife misidentification.\"",
+    "target": {
+      "scope": "state",
+      "count": 1
+    }
+  },
+  {
+    "id": "CRY-GV-030",
+    "name": "Interdimensional Gate",
+    "type": "ZONE",
+    "faction": "government",
+    "rarity": "rare",
+    "cost": 6,
+    "effects": {
+      "pressureDelta": 3
+    },
+    "extId": "cryptids",
+    "flavor": "\"CLASSIFIED INTELLIGENCE: Filed under routine wildlife misidentification.\"",
+    "target": {
+      "scope": "state",
+      "count": 1
+    }
+  },
+  {
+    "id": "CRY-GV-031",
+    "name": "Yeti Expedition Hoax",
+    "type": "ZONE",
+    "faction": "government",
+    "rarity": "uncommon",
+    "cost": 5,
+    "effects": {
+      "pressureDelta": 2
+    },
+    "extId": "cryptids",
+    "flavor": "\"CLASSIFIED INTELLIGENCE: Field note logged; further action unnecessary.\"",
+    "target": {
+      "scope": "state",
+      "count": 1
+    }
+  },
+  {
+    "id": "CRY-GV-032",
+    "name": "Skinwalker Ranch Buyout",
+    "type": "ATTACK",
+    "faction": "government",
+    "rarity": "uncommon",
+    "cost": 3,
+    "effects": {
+      "ipDelta": {
+        "opponent": 2
+      }
+    },
+    "extId": "cryptids",
+    "flavor": "\"CLASSIFIED INTELLIGENCE: Field note logged; further action unnecessary.\""
+  },
+  {
+    "id": "CRY-GV-033",
+    "name": "Dover Demon Debunking",
+    "type": "ZONE",
+    "faction": "government",
+    "rarity": "uncommon",
+    "cost": 5,
+    "effects": {
+      "pressureDelta": 2
+    },
+    "extId": "cryptids",
+    "flavor": "\"CLASSIFIED INTELLIGENCE: Filed under routine wildlife misidentification.\"",
+    "target": {
+      "scope": "state",
+      "count": 1
+    }
+  },
+  {
+    "id": "CRY-GV-034",
+    "name": "Alien Autopsy Studio",
+    "type": "ZONE",
+    "faction": "government",
+    "rarity": "rare",
+    "cost": 6,
+    "effects": {
+      "pressureDelta": 3
+    },
+    "extId": "cryptids",
+    "flavor": "\"CLASSIFIED INTELLIGENCE: Filed under routine wildlife misidentification.\"",
+    "target": {
+      "scope": "state",
+      "count": 1
+    }
+  },
+  {
+    "id": "CRY-GV-035",
+    "name": "Cattle Mutilation Labs",
+    "type": "ZONE",
+    "faction": "government",
+    "rarity": "uncommon",
+    "cost": 5,
+    "effects": {
+      "pressureDelta": 2
+    },
+    "extId": "cryptids",
+    "flavor": "\"CLASSIFIED INTELLIGENCE: Filed under routine wildlife misidentification.\"",
+    "target": {
+      "scope": "state",
+      "count": 1
+    }
+  },
+  {
+    "id": "CRY-GV-036",
+    "name": "Crop Circle Artists Guild",
+    "type": "ZONE",
+    "faction": "government",
+    "rarity": "uncommon",
+    "cost": 5,
+    "effects": {
+      "pressureDelta": 2
+    },
+    "extId": "cryptids",
+    "flavor": "\"CLASSIFIED INTELLIGENCE: Awaiting lab results; likely weather and shadows.\"",
+    "target": {
+      "scope": "state",
+      "count": 1
+    }
+  },
+  {
+    "id": "CRY-GV-037",
+    "name": "Phantom Airships",
+    "type": "ZONE",
+    "faction": "government",
+    "rarity": "common",
+    "cost": 4,
+    "effects": {
+      "pressureDelta": 1
+    },
+    "extId": "cryptids",
+    "flavor": "\"CLASSIFIED INTELLIGENCE: Field note logged; further action unnecessary.\"",
+    "target": {
+      "scope": "state",
+      "count": 1
+    }
+  },
+  {
+    "id": "CRY-GV-038",
+    "name": "Washington Sea Serpent",
+    "type": "ZONE",
+    "faction": "government",
+    "rarity": "uncommon",
+    "cost": 5,
+    "effects": {
+      "pressureDelta": 2
+    },
+    "extId": "cryptids",
+    "flavor": "\"CLASSIFIED INTELLIGENCE: Awaiting lab results; likely weather and shadows.\"",
+    "target": {
+      "scope": "state",
+      "count": 1
+    }
+  },
+  {
+    "id": "CRY-GV-039",
+    "name": "Moon-Eyed People Census",
+    "type": "ZONE",
+    "faction": "government",
+    "rarity": "uncommon",
+    "cost": 5,
+    "effects": {
+      "pressureDelta": 2
+    },
+    "extId": "cryptids",
+    "flavor": "\"CLASSIFIED INTELLIGENCE: Public guidance issued; no moon-eyed detected.\"",
+    "target": {
+      "scope": "state",
+      "count": 1
+    }
+  },
+  {
+    "id": "CRY-GV-040",
+    "name": "Giant Octopus Cover-up",
+    "type": "MEDIA",
+    "faction": "government",
+    "rarity": "rare",
+    "cost": 5,
+    "effects": {
+      "truthDelta": 3
+    },
+    "extId": "cryptids",
+    "flavor": "\"CLASSIFIED INTELLIGENCE: Public guidance issued; no giant detected.\""
+  },
+  {
+    "id": "CRY-GV-041",
+    "name": "Psychic Spying Program",
+    "type": "ZONE",
+    "faction": "government",
+    "rarity": "uncommon",
+    "cost": 5,
+    "effects": {
+      "pressureDelta": 2
+    },
+    "extId": "cryptids",
+    "flavor": "\"CLASSIFIED INTELLIGENCE: Field note logged; further action unnecessary.\"",
+    "target": {
+      "scope": "state",
+      "count": 1
+    }
+  },
+  {
+    "id": "CRY-GV-042",
+    "name": "Invisible Aircraft Project",
+    "type": "MEDIA",
+    "faction": "government",
+    "rarity": "legendary",
+    "cost": 6,
+    "effects": {
+      "truthDelta": 4
+    },
+    "extId": "cryptids",
+    "flavor": "\"CLASSIFIED INTELLIGENCE: Public guidance issued; no invisible detected.\""
+  },
+  {
+    "id": "CRY-GV-043",
+    "name": "Missing Time Protocol",
+    "type": "ATTACK",
+    "faction": "government",
+    "rarity": "uncommon",
+    "cost": 3,
+    "effects": {
+      "ipDelta": {
+        "opponent": 2
+      }
+    },
+    "extId": "cryptids",
+    "flavor": "\"CLASSIFIED INTELLIGENCE: Situation normal—memo drafted and archived.\""
+  },
+  {
+    "id": "CRY-GV-044",
+    "name": "Greys Employment Program",
+    "type": "ZONE",
+    "faction": "government",
+    "rarity": "uncommon",
+    "cost": 5,
+    "effects": {
+      "pressureDelta": 2
+    },
+    "extId": "cryptids",
+    "flavor": "\"CLASSIFIED INTELLIGENCE: Filed under routine wildlife misidentification.\"",
+    "target": {
+      "scope": "state",
+      "count": 1
+    }
+  },
+  {
+    "id": "CRY-GV-045",
+    "name": "Reality Anchor Array",
+    "type": "MEDIA",
+    "faction": "government",
+    "rarity": "rare",
+    "cost": 5,
+    "effects": {
+      "truthDelta": 3
+    },
+    "extId": "cryptids",
+    "flavor": "\"CLASSIFIED INTELLIGENCE: Situation normal—memo drafted and archived.\""
+  },
+  {
+    "id": "CRY-GV-046",
+    "name": "Dimension X Portal",
+    "type": "ZONE",
+    "faction": "government",
+    "rarity": "uncommon",
+    "cost": 5,
+    "effects": {
+      "pressureDelta": 2
+    },
+    "extId": "cryptids",
+    "flavor": "\"CLASSIFIED INTELLIGENCE: Situation normal—memo drafted and archived.\"",
+    "target": {
+      "scope": "state",
+      "count": 1
+    }
+  },
+  {
+    "id": "CRY-GV-047",
+    "name": "Cryptid Rehabilitation Center",
+    "type": "ZONE",
+    "faction": "government",
+    "rarity": "common",
+    "cost": 4,
+    "effects": {
+      "pressureDelta": 1
+    },
+    "extId": "cryptids",
+    "flavor": "\"CLASSIFIED INTELLIGENCE: Situation normal—memo drafted and archived.\"",
+    "target": {
+      "scope": "state",
+      "count": 1
+    }
+  },
+  {
+    "id": "CRY-GV-048",
+    "name": "Mind Probe Study",
+    "type": "ATTACK",
+    "faction": "government",
+    "rarity": "uncommon",
+    "cost": 3,
+    "effects": {
+      "ipDelta": {
+        "opponent": 2
+      }
+    },
+    "extId": "cryptids",
+    "flavor": "\"CLASSIFIED INTELLIGENCE: Filed under routine wildlife misidentification.\""
+  },
+  {
+    "id": "CRY-GV-049",
+    "name": "Subliminal Broadcast Network",
+    "type": "ZONE",
+    "faction": "government",
+    "rarity": "rare",
+    "cost": 6,
+    "effects": {
+      "pressureDelta": 3
+    },
+    "extId": "cryptids",
+    "flavor": "\"CLASSIFIED INTELLIGENCE: Situation normal—memo drafted and archived.\"",
+    "target": {
+      "scope": "state",
+      "count": 1
+    }
+  },
+  {
+    "id": "CRY-GV-050",
+    "name": "Fake Moon Landing Set",
+    "type": "ZONE",
+    "faction": "government",
+    "rarity": "uncommon",
+    "cost": 5,
+    "effects": {
+      "pressureDelta": 2
+    },
+    "extId": "cryptids",
+    "flavor": "\"CLASSIFIED INTELLIGENCE: Filed under routine wildlife misidentification.\"",
+    "target": {
+      "scope": "state",
+      "count": 1
+    }
+  },
+  {
+    "id": "CRY-GV-051",
+    "name": "Neuralyzer Deployment",
+    "type": "MEDIA",
+    "faction": "government",
+    "rarity": "uncommon",
+    "cost": 4,
+    "effects": {
+      "truthDelta": 2
+    },
+    "extId": "cryptids",
+    "flavor": "\"CLASSIFIED INTELLIGENCE: Public guidance issued; no neuralyzer detected.\""
+  },
+  {
+    "id": "CRY-GV-052",
+    "name": "Shadow Government HQ",
+    "type": "ATTACK",
+    "faction": "government",
+    "rarity": "legendary",
+    "cost": 5,
+    "effects": {
+      "ipDelta": {
+        "opponent": 4
+      },
+      "discardOpponent": 2
+    },
+    "extId": "cryptids",
+    "flavor": "\"CLASSIFIED INTELLIGENCE: Field note logged; further action unnecessary.\""
+  },
+  {
+    "id": "CRY-GV-053",
+    "name": "Operation Paperclip II",
+    "type": "MEDIA",
+    "faction": "government",
+    "rarity": "uncommon",
+    "cost": 4,
+    "effects": {
+      "truthDelta": 2
+    },
+    "extId": "cryptids",
+    "flavor": "\"CLASSIFIED INTELLIGENCE: Public guidance issued; no operation detected.\""
+  },
+  {
+    "id": "CRY-GV-054",
+    "name": "Holographic UFO Display",
+    "type": "MEDIA",
+    "faction": "government",
+    "rarity": "uncommon",
+    "cost": 4,
+    "effects": {
+      "truthDelta": 2
+    },
+    "extId": "cryptids",
+    "flavor": "\"CLASSIFIED INTELLIGENCE: Public guidance issued; no holographic detected.\""
+  },
+  {
+    "id": "CRY-GV-055",
+    "name": "Cryptid Breeding Program",
+    "type": "MEDIA",
+    "faction": "government",
+    "rarity": "rare",
+    "cost": 5,
+    "effects": {
+      "truthDelta": 3
+    },
+    "extId": "cryptids",
+    "flavor": "\"CLASSIFIED INTELLIGENCE: Situation normal—memo drafted and archived.\""
+  },
+  {
+    "id": "CRY-GV-056",
+    "name": "False Flag Cryptid Attack",
+    "type": "ATTACK",
+    "faction": "government",
+    "rarity": "legendary",
+    "cost": 5,
+    "effects": {
+      "ipDelta": {
+        "opponent": 4
+      },
+      "discardOpponent": 2
+    },
+    "extId": "cryptids",
+    "flavor": "\"CLASSIFIED INTELLIGENCE: Filed under routine wildlife misidentification.\""
+  },
+  {
+    "id": "CRY-GV-057",
+    "name": "Extraterrestrial Non-Disclosure Treaty",
+    "type": "ZONE",
+    "faction": "government",
+    "rarity": "uncommon",
+    "cost": 5,
+    "effects": {
+      "pressureDelta": 2
+    },
+    "extId": "cryptids",
+    "flavor": "\"CLASSIFIED INTELLIGENCE: Field note logged; further action unnecessary.\"",
+    "target": {
+      "scope": "state",
+      "count": 1
+    }
+  },
+  {
+    "id": "CRY-GV-058",
+    "name": "Quantum Bigfoot Experiment",
+    "type": "ZONE",
+    "faction": "government",
+    "rarity": "rare",
+    "cost": 6,
+    "effects": {
+      "pressureDelta": 3
+    },
+    "extId": "cryptids",
+    "flavor": "\"CLASSIFIED INTELLIGENCE: Filed under routine wildlife misidentification.\"",
+    "target": {
+      "scope": "state",
+      "count": 1
+    }
+  },
+  {
+    "id": "CRY-GV-059",
+    "name": "Interdimensional Customs",
+    "type": "ZONE",
+    "faction": "government",
+    "rarity": "uncommon",
+    "cost": 5,
+    "effects": {
+      "pressureDelta": 2
+    },
+    "extId": "cryptids",
+    "flavor": "\"CLASSIFIED INTELLIGENCE: Filed under routine wildlife misidentification.\"",
+    "target": {
+      "scope": "state",
+      "count": 1
+    }
+  },
+  {
+    "id": "CRY-GV-060",
+    "name": "Cosmic Horror Containment",
+    "type": "MEDIA",
+    "faction": "government",
+    "rarity": "rare",
+    "cost": 5,
+    "effects": {
+      "truthDelta": 3
+    },
+    "extId": "cryptids",
+    "flavor": "\"CLASSIFIED INTELLIGENCE: Public guidance issued; no cosmic detected.\""
+  },
+  {
+    "id": "CRY-GV-061",
+    "name": "Reptilian Shapeshifter Agent",
+    "type": "ATTACK",
+    "faction": "government",
+    "rarity": "uncommon",
+    "cost": 3,
+    "effects": {
+      "ipDelta": {
+        "opponent": 2
+      }
+    },
+    "extId": "cryptids",
+    "flavor": "\"CLASSIFIED INTELLIGENCE: Situation normal—memo drafted and archived.\""
+  },
+  {
+    "id": "CRY-GV-062",
+    "name": "Memory Modification Clinic",
+    "type": "ATTACK",
+    "faction": "government",
+    "rarity": "rare",
+    "cost": 4,
+    "effects": {
+      "ipDelta": {
+        "opponent": 3
+      },
+      "discardOpponent": 1
+    },
+    "extId": "cryptids",
+    "flavor": "\"CLASSIFIED INTELLIGENCE: Situation normal—memo drafted and archived.\""
+  },
+  {
+    "id": "CRY-GV-063",
+    "name": "Psy-Ops Division",
+    "type": "MEDIA",
+    "faction": "government",
+    "rarity": "uncommon",
+    "cost": 4,
+    "effects": {
+      "truthDelta": 2
+    },
+    "extId": "cryptids",
+    "flavor": "\"CLASSIFIED INTELLIGENCE: Situation normal—memo drafted and archived.\""
+  },
+  {
+    "id": "CRY-GV-064",
+    "name": "Cryptid Witness Protection",
+    "type": "MEDIA",
+    "faction": "government",
+    "rarity": "uncommon",
+    "cost": 4,
+    "effects": {
+      "truthDelta": 2
+    },
+    "extId": "cryptids",
+    "flavor": "\"CLASSIFIED INTELLIGENCE: Public guidance issued; no cryptid detected.\""
+  },
+  {
+    "id": "CRY-GV-065",
+    "name": "Underground Bunker Network",
+    "type": "ZONE",
+    "faction": "government",
+    "rarity": "uncommon",
+    "cost": 5,
+    "effects": {
+      "pressureDelta": 2
+    },
+    "extId": "cryptids",
+    "flavor": "\"CLASSIFIED INTELLIGENCE: Filed under routine wildlife misidentification.\"",
+    "target": {
+      "scope": "state",
+      "count": 1
+    }
+  },
+  {
+    "id": "CRY-GV-066",
+    "name": "Orbital Mind Control Platform",
+    "type": "ZONE",
+    "faction": "government",
+    "rarity": "uncommon",
+    "cost": 5,
+    "effects": {
+      "pressureDelta": 2
+    },
+    "extId": "cryptids",
+    "flavor": "\"CLASSIFIED INTELLIGENCE: Awaiting lab results; likely weather and shadows.\"",
+    "target": {
+      "scope": "state",
+      "count": 1
+    }
+  },
+  {
+    "id": "CRY-GV-067",
+    "name": "Temporal Loop Device",
+    "type": "MEDIA",
+    "faction": "government",
+    "rarity": "rare",
+    "cost": 5,
+    "effects": {
+      "truthDelta": 3
+    },
+    "extId": "cryptids",
+    "flavor": "\"CLASSIFIED INTELLIGENCE: Awaiting lab results; likely weather and shadows.\""
+  },
+  {
+    "id": "CRY-GV-068",
+    "name": "Anomalous Materials Division",
+    "type": "ZONE",
+    "faction": "government",
+    "rarity": "uncommon",
+    "cost": 5,
+    "effects": {
+      "pressureDelta": 2
+    },
+    "extId": "cryptids",
+    "flavor": "\"CLASSIFIED INTELLIGENCE: Field note logged; further action unnecessary.\"",
+    "target": {
+      "scope": "state",
+      "count": 1
+    }
+  },
+  {
+    "id": "CRY-GV-069",
+    "name": "Phantom Helicopter Squadron",
+    "type": "ZONE",
+    "faction": "government",
+    "rarity": "common",
+    "cost": 4,
+    "effects": {
+      "pressureDelta": 1
+    },
+    "extId": "cryptids",
+    "flavor": "\"CLASSIFIED INTELLIGENCE: Public guidance issued; no phantom detected.\"",
+    "target": {
+      "scope": "state",
+      "count": 1
+    }
+  },
+  {
+    "id": "CRY-GV-070",
+    "name": "Reality Distortion Field",
+    "type": "ZONE",
+    "faction": "government",
+    "rarity": "uncommon",
+    "cost": 5,
+    "effects": {
+      "pressureDelta": 2
+    },
+    "extId": "cryptids",
+    "flavor": "\"CLASSIFIED INTELLIGENCE: Awaiting lab results; likely weather and shadows.\"",
+    "target": {
+      "scope": "state",
+      "count": 1
+    }
+  },
+  {
+    "id": "CRY-GV-071",
+    "name": "Cryptid DNA Database",
+    "type": "ZONE",
+    "faction": "government",
+    "rarity": "rare",
+    "cost": 6,
+    "effects": {
+      "pressureDelta": 3
+    },
+    "extId": "cryptids",
+    "flavor": "\"CLASSIFIED INTELLIGENCE: Filed under routine wildlife misidentification.\"",
+    "target": {
+      "scope": "state",
+      "count": 1
+    }
+  },
+  {
+    "id": "CRY-GV-072",
+    "name": "Phantom Satellite Grid",
+    "type": "ZONE",
+    "faction": "government",
+    "rarity": "rare",
+    "cost": 6,
+    "effects": {
+      "pressureDelta": 3
+    },
+    "extId": "cryptids",
+    "flavor": "\"CLASSIFIED INTELLIGENCE: Field note logged; further action unnecessary.\"",
+    "target": {
+      "scope": "state",
+      "count": 1
+    }
+  },
+  {
+    "id": "CRY-GV-073",
+    "name": "Consciousness Transfer Lab",
+    "type": "ATTACK",
+    "faction": "government",
+    "rarity": "uncommon",
+    "cost": 3,
+    "effects": {
+      "ipDelta": {
+        "opponent": 2
+      }
+    },
+    "extId": "cryptids",
+    "flavor": "\"CLASSIFIED INTELLIGENCE: Awaiting lab results; likely weather and shadows.\""
+  },
+  {
+    "id": "CRY-GV-074",
+    "name": "Multidimensional Embassy",
+    "type": "ZONE",
+    "faction": "government",
+    "rarity": "uncommon",
+    "cost": 5,
+    "effects": {
+      "pressureDelta": 2
+    },
+    "extId": "cryptids",
+    "flavor": "\"CLASSIFIED INTELLIGENCE: Filed under routine wildlife misidentification.\"",
+    "target": {
+      "scope": "state",
+      "count": 1
+    }
+  },
+  {
+    "id": "CRY-GV-075",
+    "name": "Alabama Wildlife Advisory",
+    "type": "MEDIA",
+    "faction": "government",
+    "rarity": "common",
+    "cost": 3,
+    "effects": {
+      "truthDelta": 1
+    },
+    "extId": "cryptids",
+    "flavor": "\"CLASSIFIED INTELLIGENCE: Public bulletin: Do not feed the alabama cryptid.\""
+  },
+  {
+    "id": "CRY-GV-076",
+    "name": "Alaska Wildlife Advisory",
+    "type": "MEDIA",
+    "faction": "government",
+    "rarity": "common",
+    "cost": 3,
+    "effects": {
+      "truthDelta": 1
+    },
+    "extId": "cryptids",
+    "flavor": "\"CLASSIFIED INTELLIGENCE: Public bulletin: Do not feed the tizheruk.\""
+  },
+  {
+    "id": "CRY-GV-077",
+    "name": "Arizona Wildlife Advisory",
+    "type": "ATTACK",
+    "faction": "government",
+    "rarity": "common",
+    "cost": 2,
+    "effects": {
+      "ipDelta": {
+        "opponent": 1
+      }
+    },
+    "extId": "cryptids",
+    "flavor": "\"CLASSIFIED INTELLIGENCE: Public bulletin: Do not feed the thunderbird.\""
+  },
+  {
+    "id": "CRY-GV-078",
+    "name": "Arkansas Wildlife Advisory",
+    "type": "MEDIA",
+    "faction": "government",
+    "rarity": "common",
+    "cost": 3,
+    "effects": {
+      "truthDelta": 1
+    },
+    "extId": "cryptids",
+    "flavor": "\"CLASSIFIED INTELLIGENCE: Public bulletin: Do not feed the fouke monster.\""
+  },
+  {
+    "id": "CRY-GV-079",
+    "name": "California Wildlife Advisory",
+    "type": "ZONE",
+    "faction": "government",
+    "rarity": "common",
+    "cost": 4,
+    "effects": {
+      "pressureDelta": 1
+    },
+    "extId": "cryptids",
+    "flavor": "\"CLASSIFIED INTELLIGENCE: Public bulletin: Do not feed the bigfoot.\"",
+    "target": {
+      "scope": "state",
+      "count": 1
+    }
+  },
+  {
+    "id": "CRY-GV-080",
+    "name": "Colorado Wildlife Advisory",
+    "type": "ZONE",
+    "faction": "government",
+    "rarity": "common",
+    "cost": 4,
+    "effects": {
+      "pressureDelta": 1
+    },
+    "extId": "cryptids",
+    "flavor": "\"CLASSIFIED INTELLIGENCE: Public bulletin: Do not feed the colorado cryptid.\"",
+    "target": {
+      "scope": "state",
+      "count": 1
+    }
+  },
+  {
+    "id": "CRY-GV-081",
+    "name": "Connecticut Wildlife Advisory",
+    "type": "MEDIA",
+    "faction": "government",
+    "rarity": "common",
+    "cost": 3,
+    "effects": {
+      "truthDelta": 1
+    },
+    "extId": "cryptids",
+    "flavor": "\"CLASSIFIED INTELLIGENCE: Public bulletin: Do not feed the connecticut cryptid.\""
+  },
+  {
+    "id": "CRY-GV-082",
+    "name": "Delaware Wildlife Advisory",
+    "type": "MEDIA",
+    "faction": "government",
+    "rarity": "common",
+    "cost": 3,
+    "effects": {
+      "truthDelta": 1
+    },
+    "extId": "cryptids",
+    "flavor": "\"CLASSIFIED INTELLIGENCE: Public bulletin: Do not feed the delaware cryptid.\""
+  },
+  {
+    "id": "CRY-GV-083",
+    "name": "Florida Wildlife Advisory",
+    "type": "MEDIA",
+    "faction": "government",
+    "rarity": "common",
+    "cost": 3,
+    "effects": {
+      "truthDelta": 1
+    },
+    "extId": "cryptids",
+    "flavor": "\"CLASSIFIED INTELLIGENCE: Public bulletin: Do not feed the skunk ape.\""
+  },
+  {
+    "id": "CRY-GV-084",
+    "name": "Georgia Wildlife Advisory",
+    "type": "MEDIA",
+    "faction": "government",
+    "rarity": "common",
+    "cost": 3,
+    "effects": {
+      "truthDelta": 1
+    },
+    "extId": "cryptids",
+    "flavor": "\"CLASSIFIED INTELLIGENCE: Public bulletin: Do not feed the georgia cryptid.\""
+  },
+  {
+    "id": "CRY-GV-085",
+    "name": "Hawaii Wildlife Advisory",
+    "type": "MEDIA",
+    "faction": "government",
+    "rarity": "common",
+    "cost": 3,
+    "effects": {
+      "truthDelta": 1
+    },
+    "extId": "cryptids",
+    "flavor": "\"CLASSIFIED INTELLIGENCE: Public bulletin: Do not feed the hawaii cryptid.\""
+  },
+  {
+    "id": "CRY-GV-086",
+    "name": "Idaho Wildlife Advisory",
+    "type": "MEDIA",
+    "faction": "government",
+    "rarity": "common",
+    "cost": 3,
+    "effects": {
+      "truthDelta": 1
+    },
+    "extId": "cryptids",
+    "flavor": "\"CLASSIFIED INTELLIGENCE: Public bulletin: Do not feed the idaho cryptid.\""
+  },
+  {
+    "id": "CRY-GV-087",
+    "name": "Illinois Wildlife Advisory",
+    "type": "ZONE",
+    "faction": "government",
+    "rarity": "common",
+    "cost": 4,
+    "effects": {
+      "pressureDelta": 1
+    },
+    "extId": "cryptids",
+    "flavor": "\"CLASSIFIED INTELLIGENCE: Public bulletin: Do not feed the enfield horror.\"",
+    "target": {
+      "scope": "state",
+      "count": 1
+    }
+  },
+  {
+    "id": "CRY-GV-088",
+    "name": "Indiana Wildlife Advisory",
+    "type": "MEDIA",
+    "faction": "government",
+    "rarity": "common",
+    "cost": 3,
+    "effects": {
+      "truthDelta": 1
+    },
+    "extId": "cryptids",
+    "flavor": "\"CLASSIFIED INTELLIGENCE: Public bulletin: Do not feed the indiana cryptid.\""
+  },
+  {
+    "id": "CRY-GV-089",
+    "name": "Iowa Wildlife Advisory",
+    "type": "MEDIA",
+    "faction": "government",
+    "rarity": "common",
+    "cost": 3,
+    "effects": {
+      "truthDelta": 1
+    },
+    "extId": "cryptids",
+    "flavor": "\"CLASSIFIED INTELLIGENCE: Public bulletin: Do not feed the iowa cryptid.\""
+  },
+  {
+    "id": "CRY-GV-090",
+    "name": "Kansas Wildlife Advisory",
+    "type": "MEDIA",
+    "faction": "government",
+    "rarity": "common",
+    "cost": 3,
+    "effects": {
+      "truthDelta": 1
+    },
+    "extId": "cryptids",
+    "flavor": "\"CLASSIFIED INTELLIGENCE: Public bulletin: Do not feed the kansas cryptid.\""
+  },
+  {
+    "id": "CRY-GV-091",
+    "name": "Kentucky Wildlife Advisory",
+    "type": "MEDIA",
+    "faction": "government",
+    "rarity": "common",
+    "cost": 3,
+    "effects": {
+      "truthDelta": 1
+    },
+    "extId": "cryptids",
+    "flavor": "\"CLASSIFIED INTELLIGENCE: Public bulletin: Do not feed the kelly–hopkinsville goblins.\""
+  },
+  {
+    "id": "CRY-GV-092",
+    "name": "Louisiana Wildlife Advisory",
+    "type": "MEDIA",
+    "faction": "government",
+    "rarity": "common",
+    "cost": 3,
+    "effects": {
+      "truthDelta": 1
+    },
+    "extId": "cryptids",
+    "flavor": "\"CLASSIFIED INTELLIGENCE: Public bulletin: Do not feed the rougarou.\""
+  },
+  {
+    "id": "CRY-GV-093",
+    "name": "Maine Wildlife Advisory",
+    "type": "MEDIA",
+    "faction": "government",
+    "rarity": "common",
+    "cost": 3,
+    "effects": {
+      "truthDelta": 1
+    },
+    "extId": "cryptids",
+    "flavor": "\"CLASSIFIED INTELLIGENCE: Public bulletin: Do not feed the maine cryptid.\""
+  },
+  {
+    "id": "CRY-GV-094",
+    "name": "Maryland Wildlife Advisory",
+    "type": "MEDIA",
+    "faction": "government",
+    "rarity": "common",
+    "cost": 3,
+    "effects": {
+      "truthDelta": 1
+    },
+    "extId": "cryptids",
+    "flavor": "\"CLASSIFIED INTELLIGENCE: Public bulletin: Do not feed the snallygaster.\""
+  },
+  {
+    "id": "CRY-GV-095",
+    "name": "Massachusetts Wildlife Advisory",
+    "type": "MEDIA",
+    "faction": "government",
+    "rarity": "common",
+    "cost": 3,
+    "effects": {
+      "truthDelta": 1
+    },
+    "extId": "cryptids",
+    "flavor": "\"CLASSIFIED INTELLIGENCE: Public bulletin: Do not feed the dover demon.\""
+  },
+  {
+    "id": "CRY-GV-096",
+    "name": "Michigan Wildlife Advisory",
+    "type": "MEDIA",
+    "faction": "government",
+    "rarity": "common",
+    "cost": 3,
+    "effects": {
+      "truthDelta": 1
+    },
+    "extId": "cryptids",
+    "flavor": "\"CLASSIFIED INTELLIGENCE: Public bulletin: Do not feed the dogman.\""
+  },
+  {
+    "id": "CRY-GV-097",
+    "name": "Minnesota Wildlife Advisory",
+    "type": "ATTACK",
+    "faction": "government",
+    "rarity": "common",
+    "cost": 2,
+    "effects": {
+      "ipDelta": {
+        "opponent": 1
+      }
+    },
+    "extId": "cryptids",
+    "flavor": "\"CLASSIFIED INTELLIGENCE: Public bulletin: Do not feed the wendigo.\""
+  },
+  {
+    "id": "CRY-GV-098",
+    "name": "Mississippi Wildlife Advisory",
+    "type": "MEDIA",
+    "faction": "government",
+    "rarity": "common",
+    "cost": 3,
+    "effects": {
+      "truthDelta": 1
+    },
+    "extId": "cryptids",
+    "flavor": "\"CLASSIFIED INTELLIGENCE: Public bulletin: Do not feed the mississippi cryptid.\""
+  },
+  {
+    "id": "CRY-GV-099",
+    "name": "Missouri Wildlife Advisory",
+    "type": "MEDIA",
+    "faction": "government",
+    "rarity": "common",
+    "cost": 3,
+    "effects": {
+      "truthDelta": 1
+    },
+    "extId": "cryptids",
+    "flavor": "\"CLASSIFIED INTELLIGENCE: Public bulletin: Do not feed the missouri cryptid.\""
+  },
+  {
+    "id": "CRY-GV-100",
+    "name": "Montana Wildlife Advisory",
+    "type": "MEDIA",
+    "faction": "government",
+    "rarity": "common",
+    "cost": 3,
+    "effects": {
+      "truthDelta": 1
+    },
+    "extId": "cryptids",
+    "flavor": "\"CLASSIFIED INTELLIGENCE: Public bulletin: Do not feed the shunka warakin.\""
+  },
+  {
+    "id": "CRY-GV-101",
+    "name": "Nebraska Wildlife Advisory",
+    "type": "MEDIA",
+    "faction": "government",
+    "rarity": "common",
+    "cost": 3,
+    "effects": {
+      "truthDelta": 1
+    },
+    "extId": "cryptids",
+    "flavor": "\"CLASSIFIED INTELLIGENCE: Public bulletin: Do not feed the nebraska cryptid.\""
+  },
+  {
+    "id": "CRY-GV-102",
+    "name": "Nevada Wildlife Advisory",
+    "type": "MEDIA",
+    "faction": "government",
+    "rarity": "common",
+    "cost": 3,
+    "effects": {
+      "truthDelta": 1
+    },
+    "extId": "cryptids",
+    "flavor": "\"CLASSIFIED INTELLIGENCE: Public bulletin: Do not feed the tahoe tessie.\""
+  },
+  {
+    "id": "CRY-GV-103",
+    "name": "New Hampshire Wildlife Advisory",
+    "type": "MEDIA",
+    "faction": "government",
+    "rarity": "common",
+    "cost": 3,
+    "effects": {
+      "truthDelta": 1
+    },
+    "extId": "cryptids",
+    "flavor": "\"CLASSIFIED INTELLIGENCE: Public bulletin: Do not feed the wood devils.\""
+  },
+  {
+    "id": "CRY-GV-104",
+    "name": "New Jersey Wildlife Advisory",
+    "type": "ATTACK",
+    "faction": "government",
+    "rarity": "common",
+    "cost": 2,
+    "effects": {
+      "ipDelta": {
+        "opponent": 1
+      }
+    },
+    "extId": "cryptids",
+    "flavor": "\"CLASSIFIED INTELLIGENCE: Public bulletin: Do not feed the jersey devil.\""
+  },
+  {
+    "id": "CRY-GV-105",
+    "name": "New Mexico Wildlife Advisory",
+    "type": "ATTACK",
+    "faction": "government",
+    "rarity": "common",
+    "cost": 2,
+    "effects": {
+      "ipDelta": {
+        "opponent": 1
+      }
+    },
+    "extId": "cryptids",
+    "flavor": "\"CLASSIFIED INTELLIGENCE: Public bulletin: Do not feed the skinwalkers.\""
+  },
+  {
+    "id": "CRY-GV-106",
+    "name": "New York Wildlife Advisory",
+    "type": "MEDIA",
+    "faction": "government",
+    "rarity": "common",
+    "cost": 3,
+    "effects": {
+      "truthDelta": 1
+    },
+    "extId": "cryptids",
+    "flavor": "\"CLASSIFIED INTELLIGENCE: Public bulletin: Do not feed the montauk monster.\""
+  },
+  {
+    "id": "CRY-GV-107",
+    "name": "North Carolina Wildlife Advisory",
+    "type": "MEDIA",
+    "faction": "government",
+    "rarity": "common",
+    "cost": 3,
+    "effects": {
+      "truthDelta": 1
+    },
+    "extId": "cryptids",
+    "flavor": "\"CLASSIFIED INTELLIGENCE: Public bulletin: Do not feed the north carolina cryptid.\""
+  },
+  {
+    "id": "CRY-GV-108",
+    "name": "North Dakota Wildlife Advisory",
+    "type": "MEDIA",
+    "faction": "government",
+    "rarity": "common",
+    "cost": 3,
+    "effects": {
+      "truthDelta": 1
+    },
+    "extId": "cryptids",
+    "flavor": "\"CLASSIFIED INTELLIGENCE: Public bulletin: Do not feed the north dakota cryptid.\""
+  },
+  {
+    "id": "CRY-GV-109",
+    "name": "Ohio Wildlife Advisory",
+    "type": "MEDIA",
+    "faction": "government",
+    "rarity": "common",
+    "cost": 3,
+    "effects": {
+      "truthDelta": 1
+    },
+    "extId": "cryptids",
+    "flavor": "\"CLASSIFIED INTELLIGENCE: Public bulletin: Do not feed the loveland frogman.\""
+  },
+  {
+    "id": "CRY-GV-110",
+    "name": "Oklahoma Wildlife Advisory",
+    "type": "MEDIA",
+    "faction": "government",
+    "rarity": "common",
+    "cost": 3,
+    "effects": {
+      "truthDelta": 1
+    },
+    "extId": "cryptids",
+    "flavor": "\"CLASSIFIED INTELLIGENCE: Public bulletin: Do not feed the oklahoma cryptid.\""
+  },
+  {
+    "id": "CRY-GV-111",
+    "name": "Oregon Wildlife Advisory",
+    "type": "MEDIA",
+    "faction": "government",
+    "rarity": "common",
+    "cost": 3,
+    "effects": {
+      "truthDelta": 1
+    },
+    "extId": "cryptids",
+    "flavor": "\"CLASSIFIED INTELLIGENCE: Public bulletin: Do not feed the bigfoot.\""
+  },
+  {
+    "id": "CRY-GV-112",
+    "name": "Pennsylvania Wildlife Advisory",
+    "type": "MEDIA",
+    "faction": "government",
+    "rarity": "common",
+    "cost": 3,
+    "effects": {
+      "truthDelta": 1
+    },
+    "extId": "cryptids",
+    "flavor": "\"CLASSIFIED INTELLIGENCE: Public bulletin: Do not feed the pennsylvania cryptid.\""
+  },
+  {
+    "id": "CRY-GV-113",
+    "name": "Rhode Island Wildlife Advisory",
+    "type": "MEDIA",
+    "faction": "government",
+    "rarity": "common",
+    "cost": 3,
+    "effects": {
+      "truthDelta": 1
+    },
+    "extId": "cryptids",
+    "flavor": "\"CLASSIFIED INTELLIGENCE: Public bulletin: Do not feed the rhode island cryptid.\""
+  },
+  {
+    "id": "CRY-GV-114",
+    "name": "South Carolina Wildlife Advisory",
+    "type": "MEDIA",
+    "faction": "government",
+    "rarity": "common",
+    "cost": 3,
+    "effects": {
+      "truthDelta": 1
+    },
+    "extId": "cryptids",
+    "flavor": "\"CLASSIFIED INTELLIGENCE: Public bulletin: Do not feed the south carolina cryptid.\""
+  },
+  {
+    "id": "CRY-GV-115",
+    "name": "South Dakota Wildlife Advisory",
+    "type": "MEDIA",
+    "faction": "government",
+    "rarity": "common",
+    "cost": 3,
+    "effects": {
+      "truthDelta": 1
+    },
+    "extId": "cryptids",
+    "flavor": "\"CLASSIFIED INTELLIGENCE: Public bulletin: Do not feed the south dakota cryptid.\""
+  },
+  {
+    "id": "CRY-GV-116",
+    "name": "Tennessee Wildlife Advisory",
+    "type": "MEDIA",
+    "faction": "government",
+    "rarity": "common",
+    "cost": 3,
+    "effects": {
+      "truthDelta": 1
+    },
+    "extId": "cryptids",
+    "flavor": "\"CLASSIFIED INTELLIGENCE: Public bulletin: Do not feed the tennessee cryptid.\""
+  },
+  {
+    "id": "CRY-GV-117",
+    "name": "Texas Wildlife Advisory",
+    "type": "ATTACK",
+    "faction": "government",
+    "rarity": "common",
+    "cost": 2,
+    "effects": {
+      "ipDelta": {
+        "opponent": 1
+      }
+    },
+    "extId": "cryptids",
+    "flavor": "\"CLASSIFIED INTELLIGENCE: Public bulletin: Do not feed the chupacabra.\""
+  },
+  {
+    "id": "CRY-GV-118",
+    "name": "Utah Wildlife Advisory",
+    "type": "MEDIA",
+    "faction": "government",
+    "rarity": "common",
+    "cost": 3,
+    "effects": {
+      "truthDelta": 1
+    },
+    "extId": "cryptids",
+    "flavor": "\"CLASSIFIED INTELLIGENCE: Public bulletin: Do not feed the utah cryptid.\""
+  },
+  {
+    "id": "CRY-GV-119",
+    "name": "Vermont Wildlife Advisory",
+    "type": "MEDIA",
+    "faction": "government",
+    "rarity": "common",
+    "cost": 3,
+    "effects": {
+      "truthDelta": 1
+    },
+    "extId": "cryptids",
+    "flavor": "\"CLASSIFIED INTELLIGENCE: Public bulletin: Do not feed the champ.\""
+  },
+  {
+    "id": "CRY-GV-120",
+    "name": "Virginia Wildlife Advisory",
+    "type": "MEDIA",
+    "faction": "government",
+    "rarity": "common",
+    "cost": 3,
+    "effects": {
+      "truthDelta": 1
+    },
+    "extId": "cryptids",
+    "flavor": "\"CLASSIFIED INTELLIGENCE: Public bulletin: Do not feed the virginia cryptid.\""
+  },
+  {
+    "id": "CRY-GV-121",
+    "name": "Washington Wildlife Advisory",
+    "type": "MEDIA",
+    "faction": "government",
+    "rarity": "common",
+    "cost": 3,
+    "effects": {
+      "truthDelta": 1
+    },
+    "extId": "cryptids",
+    "flavor": "\"CLASSIFIED INTELLIGENCE: Public bulletin: Do not feed the bigfoot.\""
+  },
+  {
+    "id": "CRY-GV-122",
+    "name": "West Virginia Wildlife Advisory",
+    "type": "ATTACK",
+    "faction": "government",
+    "rarity": "common",
+    "cost": 2,
+    "effects": {
+      "ipDelta": {
+        "opponent": 1
+      }
+    },
+    "extId": "cryptids",
+    "flavor": "\"CLASSIFIED INTELLIGENCE: Public bulletin: Do not feed the mothman.\""
+  },
+  {
+    "id": "CRY-GV-123",
+    "name": "Wisconsin Wildlife Advisory",
+    "type": "ATTACK",
+    "faction": "government",
+    "rarity": "common",
+    "cost": 2,
+    "effects": {
+      "ipDelta": {
+        "opponent": 1
+      }
+    },
+    "extId": "cryptids",
+    "flavor": "\"CLASSIFIED INTELLIGENCE: Public bulletin: Do not feed the beast of bray road.\""
+  },
+  {
+    "id": "CRY-GV-124",
+    "name": "Wyoming Wildlife Advisory",
+    "type": "MEDIA",
+    "faction": "government",
+    "rarity": "common",
+    "cost": 3,
+    "effects": {
+      "truthDelta": 1
+    },
+    "extId": "cryptids",
+    "flavor": "\"CLASSIFIED INTELLIGENCE: Public bulletin: Do not feed the wyoming cryptid.\""
+  },
+  {
+    "id": "CRY-GV-125",
+    "name": "Chupacabra Area Closure",
+    "type": "ATTACK",
+    "faction": "government",
+    "rarity": "common",
+    "cost": 2,
+    "effects": {
+      "ipDelta": {
+        "opponent": 1
+      }
+    },
+    "extId": "cryptids",
+    "flavor": "\"CLASSIFIED INTELLIGENCE: Standard operating procedure, nothing to see.\""
+  },
+  {
+    "id": "CRY-GV-126",
+    "name": "Skunk Ape Area Closure",
+    "type": "ZONE",
+    "faction": "government",
+    "rarity": "common",
+    "cost": 4,
+    "effects": {
+      "pressureDelta": 1
+    },
+    "extId": "cryptids",
+    "flavor": "\"CLASSIFIED INTELLIGENCE: Standard operating procedure, nothing to see.\"",
+    "target": {
+      "scope": "state",
+      "count": 1
+    }
+  },
+  {
+    "id": "CRY-GV-127",
+    "name": "Snallygaster Perimeter Lockdown",
+    "type": "MEDIA",
+    "faction": "government",
+    "rarity": "common",
+    "cost": 3,
+    "effects": {
+      "truthDelta": 1
+    },
+    "extId": "cryptids",
+    "flavor": "\"CLASSIFIED INTELLIGENCE: Standard operating procedure, nothing to see.\""
+  },
+  {
+    "id": "CRY-GV-128",
+    "name": "Snallygaster Budget Audit",
+    "type": "ATTACK",
+    "faction": "government",
+    "rarity": "common",
+    "cost": 2,
+    "effects": {
+      "ipDelta": {
+        "opponent": 1
+      }
+    },
+    "extId": "cryptids",
+    "flavor": "\"CLASSIFIED INTELLIGENCE: Standard operating procedure, nothing to see.\""
+  },
+  {
+    "id": "CRY-GV-129",
+    "name": "Bigfoot Area Closure",
+    "type": "ZONE",
+    "faction": "government",
+    "rarity": "common",
+    "cost": 4,
+    "effects": {
+      "pressureDelta": 1
+    },
+    "extId": "cryptids",
+    "flavor": "\"CLASSIFIED INTELLIGENCE: Standard operating procedure, nothing to see.\"",
+    "target": {
+      "scope": "state",
+      "count": 1
+    }
+  },
+  {
+    "id": "CRY-GV-130",
+    "name": "Thunderbird Area Closure",
+    "type": "ATTACK",
+    "faction": "government",
+    "rarity": "common",
+    "cost": 2,
+    "effects": {
+      "ipDelta": {
+        "opponent": 1
+      }
+    },
+    "extId": "cryptids",
+    "flavor": "\"CLASSIFIED INTELLIGENCE: Standard operating procedure, nothing to see.\""
+  },
+  {
+    "id": "CRY-GV-131",
+    "name": "Montauk Monster Area Closure",
+    "type": "ZONE",
+    "faction": "government",
+    "rarity": "common",
+    "cost": 4,
+    "effects": {
+      "pressureDelta": 1
+    },
+    "extId": "cryptids",
+    "flavor": "\"CLASSIFIED INTELLIGENCE: Standard operating procedure, nothing to see.\"",
+    "target": {
+      "scope": "state",
+      "count": 1
+    }
+  },
+  {
+    "id": "CRY-GV-132",
+    "name": "Dogman Area Closure",
+    "type": "ZONE",
+    "faction": "government",
+    "rarity": "common",
+    "cost": 4,
+    "effects": {
+      "pressureDelta": 1
+    },
+    "extId": "cryptids",
+    "flavor": "\"CLASSIFIED INTELLIGENCE: Standard operating procedure, nothing to see.\"",
+    "target": {
+      "scope": "state",
+      "count": 1
+    }
+  },
+  {
+    "id": "CRY-GV-133",
+    "name": "Champ Budget Audit",
+    "type": "ATTACK",
+    "faction": "government",
+    "rarity": "common",
+    "cost": 2,
+    "effects": {
+      "ipDelta": {
+        "opponent": 1
+      }
+    },
+    "extId": "cryptids",
+    "flavor": "\"CLASSIFIED INTELLIGENCE: Standard operating procedure, nothing to see.\""
+  },
+  {
+    "id": "CRY-GV-134",
+    "name": "Montauk Monster Area Closure",
+    "type": "ZONE",
+    "faction": "government",
+    "rarity": "common",
+    "cost": 4,
+    "effects": {
+      "pressureDelta": 1
+    },
+    "extId": "cryptids",
+    "flavor": "\"CLASSIFIED INTELLIGENCE: Standard operating procedure, nothing to see.\"",
+    "target": {
+      "scope": "state",
+      "count": 1
+    }
+  },
+  {
+    "id": "CRY-GV-135",
+    "name": "Dover Demon Area Closure",
+    "type": "ZONE",
+    "faction": "government",
+    "rarity": "common",
+    "cost": 4,
+    "effects": {
+      "pressureDelta": 1
+    },
+    "extId": "cryptids",
+    "flavor": "\"CLASSIFIED INTELLIGENCE: Standard operating procedure, nothing to see.\"",
+    "target": {
+      "scope": "state",
+      "count": 1
+    }
+  },
+  {
+    "id": "CRY-GV-136",
+    "name": "Tahoe Tessie Area Closure",
+    "type": "ZONE",
+    "faction": "government",
+    "rarity": "common",
+    "cost": 4,
+    "effects": {
+      "pressureDelta": 1
+    },
+    "extId": "cryptids",
+    "flavor": "\"CLASSIFIED INTELLIGENCE: Standard operating procedure, nothing to see.\"",
+    "target": {
+      "scope": "state",
+      "count": 1
+    }
+  },
+  {
+    "id": "CRY-GV-137",
+    "name": "Beast of Bray Road Budget Audit",
+    "type": "ATTACK",
+    "faction": "government",
+    "rarity": "common",
+    "cost": 2,
+    "effects": {
+      "ipDelta": {
+        "opponent": 1
+      }
+    },
+    "extId": "cryptids",
+    "flavor": "\"CLASSIFIED INTELLIGENCE: Standard operating procedure, nothing to see.\""
+  },
+  {
+    "id": "CRY-GV-138",
+    "name": "Thunderbird Perimeter Lockdown",
+    "type": "ATTACK",
+    "faction": "government",
+    "rarity": "common",
+    "cost": 2,
+    "effects": {
+      "ipDelta": {
+        "opponent": 1
+      }
+    },
+    "extId": "cryptids",
+    "flavor": "\"CLASSIFIED INTELLIGENCE: Standard operating procedure, nothing to see.\""
+  },
+  {
+    "id": "CRY-GV-139",
+    "name": "Rougarou Perimeter Lockdown",
+    "type": "MEDIA",
+    "faction": "government",
+    "rarity": "common",
+    "cost": 3,
+    "effects": {
+      "truthDelta": 1
+    },
+    "extId": "cryptids",
+    "flavor": "\"CLASSIFIED INTELLIGENCE: Standard operating procedure, nothing to see.\""
+  },
+  {
+    "id": "CRY-GV-140",
+    "name": "Jersey Devil Area Closure",
+    "type": "ATTACK",
+    "faction": "government",
+    "rarity": "common",
+    "cost": 2,
+    "effects": {
+      "ipDelta": {
+        "opponent": 1
+      }
+    },
+    "extId": "cryptids",
+    "flavor": "\"CLASSIFIED INTELLIGENCE: Standard operating procedure, nothing to see.\""
+  },
+  {
+    "id": "CRY-GV-141",
+    "name": "Dogman Area Closure",
+    "type": "ZONE",
+    "faction": "government",
+    "rarity": "common",
+    "cost": 4,
+    "effects": {
+      "pressureDelta": 1
+    },
+    "extId": "cryptids",
+    "flavor": "\"CLASSIFIED INTELLIGENCE: Standard operating procedure, nothing to see.\"",
+    "target": {
+      "scope": "state",
+      "count": 1
+    }
+  },
+  {
+    "id": "CRY-GV-142",
+    "name": "Wendigo Perimeter Lockdown",
+    "type": "ATTACK",
+    "faction": "government",
+    "rarity": "common",
+    "cost": 2,
+    "effects": {
+      "ipDelta": {
+        "opponent": 1
+      }
+    },
+    "extId": "cryptids",
+    "flavor": "\"CLASSIFIED INTELLIGENCE: Standard operating procedure, nothing to see.\""
+  },
+  {
+    "id": "CRY-GV-143",
+    "name": "Shunka Warakin Area Closure",
+    "type": "ZONE",
+    "faction": "government",
+    "rarity": "common",
+    "cost": 4,
+    "effects": {
+      "pressureDelta": 1
+    },
+    "extId": "cryptids",
+    "flavor": "\"CLASSIFIED INTELLIGENCE: Standard operating procedure, nothing to see.\"",
+    "target": {
+      "scope": "state",
+      "count": 1
+    }
+  },
+  {
+    "id": "CRY-GV-144",
+    "name": "Dover Demon Budget Audit",
+    "type": "ATTACK",
+    "faction": "government",
+    "rarity": "common",
+    "cost": 2,
+    "effects": {
+      "ipDelta": {
+        "opponent": 1
+      }
+    },
+    "extId": "cryptids",
+    "flavor": "\"CLASSIFIED INTELLIGENCE: Standard operating procedure, nothing to see.\""
+  },
+  {
+    "id": "CRY-GV-145",
+    "name": "Thunderbird Perimeter Lockdown",
+    "type": "ATTACK",
+    "faction": "government",
+    "rarity": "common",
+    "cost": 2,
+    "effects": {
+      "ipDelta": {
+        "opponent": 1
+      }
+    },
+    "extId": "cryptids",
+    "flavor": "\"CLASSIFIED INTELLIGENCE: Standard operating procedure, nothing to see.\""
+  },
+  {
+    "id": "CRY-GV-146",
+    "name": "Skunk Ape Area Closure",
+    "type": "ZONE",
+    "faction": "government",
+    "rarity": "common",
+    "cost": 4,
+    "effects": {
+      "pressureDelta": 1
+    },
+    "extId": "cryptids",
+    "flavor": "\"CLASSIFIED INTELLIGENCE: Standard operating procedure, nothing to see.\"",
+    "target": {
+      "scope": "state",
+      "count": 1
+    }
+  },
+  {
+    "id": "CRY-GV-147",
+    "name": "Rougarou Budget Audit",
+    "type": "ATTACK",
+    "faction": "government",
+    "rarity": "common",
+    "cost": 2,
+    "effects": {
+      "ipDelta": {
+        "opponent": 1
+      }
+    },
+    "extId": "cryptids",
+    "flavor": "\"CLASSIFIED INTELLIGENCE: Standard operating procedure, nothing to see.\""
+  },
+  {
+    "id": "CRY-GV-148",
+    "name": "Chupacabra Budget Audit",
+    "type": "ATTACK",
+    "faction": "government",
+    "rarity": "common",
+    "cost": 2,
+    "effects": {
+      "ipDelta": {
+        "opponent": 1
+      }
+    },
+    "extId": "cryptids",
+    "flavor": "\"CLASSIFIED INTELLIGENCE: Standard operating procedure, nothing to see.\""
+  },
+  {
+    "id": "CRY-GV-149",
+    "name": "Dover Demon Budget Audit",
+    "type": "ATTACK",
+    "faction": "government",
+    "rarity": "common",
+    "cost": 2,
+    "effects": {
+      "ipDelta": {
+        "opponent": 1
+      }
+    },
+    "extId": "cryptids",
+    "flavor": "\"CLASSIFIED INTELLIGENCE: Standard operating procedure, nothing to see.\""
+  },
+  {
+    "id": "CRY-GV-150",
+    "name": "Jersey Devil Perimeter Lockdown",
+    "type": "ATTACK",
+    "faction": "government",
+    "rarity": "common",
+    "cost": 2,
+    "effects": {
+      "ipDelta": {
+        "opponent": 1
+      }
+    },
+    "extId": "cryptids",
+    "flavor": "\"CLASSIFIED INTELLIGENCE: Standard operating procedure, nothing to see.\""
+  }
+];
+
+export default cards;

--- a/src/data/expansions/halloween_MVP.ts
+++ b/src/data/expansions/halloween_MVP.ts
@@ -1,0 +1,3088 @@
+import type { GameCard } from '@/rules/mvp';
+
+const cards: GameCard[] = [
+  {
+    "id": "hallo-gov-graveyard-flyer-protocol-001",
+    "name": "Graveyard Flyer Protocol",
+    "type": "ATTACK",
+    "faction": "government",
+    "rarity": "common",
+    "cost": 2,
+    "effects": {
+      "ipDelta": {
+        "opponent": 1
+      }
+    },
+    "extId": "halloween",
+    "text": "Opponent −1 IP.",
+    "flavor": "Someone left the portal open again."
+  },
+  {
+    "id": "hallo-gov-spider-scare-incident-002",
+    "name": "Spider Scare Incident",
+    "type": "ATTACK",
+    "faction": "government",
+    "rarity": "common",
+    "cost": 2,
+    "effects": {
+      "ipDelta": {
+        "opponent": 1
+      }
+    },
+    "extId": "halloween",
+    "text": "Opponent −1 IP.",
+    "flavor": "Bring a flashlight and plausible deniability."
+  },
+  {
+    "id": "hallo-gov-cauldron-whispers-incident-003",
+    "name": "Cauldron Whispers Incident",
+    "type": "ATTACK",
+    "faction": "government",
+    "rarity": "common",
+    "cost": 2,
+    "effects": {
+      "ipDelta": {
+        "opponent": 1
+      }
+    },
+    "extId": "halloween",
+    "text": "Opponent −1 IP.",
+    "flavor": "All treats, suspicious tricks."
+  },
+  {
+    "id": "hallo-gov-ouija-shuffle-incident-004",
+    "name": "Ouija Shuffle Incident",
+    "type": "MEDIA",
+    "faction": "government",
+    "rarity": "common",
+    "cost": 3,
+    "effects": {
+      "truthDelta": 1
+    },
+    "extId": "halloween",
+    "text": "+1% Truth.",
+    "flavor": "Approved by the Council of Shadows."
+  },
+  {
+    "id": "hallo-gov-report-of-the-fog-machine-005",
+    "name": "Report of the Fog Machine",
+    "type": "ATTACK",
+    "faction": "government",
+    "rarity": "common",
+    "cost": 2,
+    "effects": {
+      "ipDelta": {
+        "opponent": 1
+      }
+    },
+    "extId": "halloween",
+    "text": "Opponent −1 IP.",
+    "flavor": "Someone left the portal open again."
+  },
+  {
+    "id": "hallo-gov-dracula-shuffle-protocol-006",
+    "name": "Dracula Shuffle Protocol",
+    "type": "MEDIA",
+    "faction": "government",
+    "rarity": "common",
+    "cost": 3,
+    "effects": {
+      "truthDelta": 1
+    },
+    "extId": "halloween",
+    "text": "+1% Truth.",
+    "flavor": "Do not taunt the poltergeist."
+  },
+  {
+    "id": "hallo-gov-wolfman-shenanigans-007",
+    "name": "Wolfman Shenanigans",
+    "type": "MEDIA",
+    "faction": "government",
+    "rarity": "common",
+    "cost": 3,
+    "effects": {
+      "truthDelta": 1
+    },
+    "extId": "halloween",
+    "text": "+1% Truth.",
+    "flavor": "Rated PG‑Paranoid."
+  },
+  {
+    "id": "hallo-gov-press-release-of-the-full-moon-008",
+    "name": "Press Release of the Full Moon",
+    "type": "MEDIA",
+    "faction": "government",
+    "rarity": "common",
+    "cost": 3,
+    "effects": {
+      "truthDelta": 1
+    },
+    "extId": "halloween",
+    "text": "+1% Truth.",
+    "flavor": "Whispers from the cornfield."
+  },
+  {
+    "id": "hallo-gov-scare-of-the-midnight-009",
+    "name": "Scare of the Midnight",
+    "type": "ATTACK",
+    "faction": "government",
+    "rarity": "common",
+    "cost": 2,
+    "effects": {
+      "ipDelta": {
+        "opponent": 1
+      }
+    },
+    "extId": "halloween",
+    "text": "Opponent −1 IP.",
+    "flavor": "Batteries not included."
+  },
+  {
+    "id": "hallo-gov-bat-boy-shuffle-protocol-010",
+    "name": "Bat Boy Shuffle Protocol",
+    "type": "ZONE",
+    "faction": "government",
+    "rarity": "common",
+    "cost": 4,
+    "effects": {
+      "pressureDelta": 1
+    },
+    "extId": "halloween",
+    "text": "+1 Pressure in a chosen state.",
+    "flavor": "Red eyes in the rear-view mirror.",
+    "target": {
+      "scope": "state",
+      "count": 1
+    }
+  },
+  {
+    "id": "hallo-gov-skeleton-press-release-files-011",
+    "name": "Skeleton Press Release Files",
+    "type": "ATTACK",
+    "faction": "government",
+    "rarity": "common",
+    "cost": 2,
+    "effects": {
+      "ipDelta": {
+        "opponent": 1
+      }
+    },
+    "extId": "halloween",
+    "text": "Opponent −1 IP.",
+    "flavor": "Approved by the Council of Shadows."
+  },
+  {
+    "id": "hallo-gov-trick-or-treat-pamphlet-files-012",
+    "name": "Trick-or-Treat Pamphlet Files",
+    "type": "MEDIA",
+    "faction": "government",
+    "rarity": "common",
+    "cost": 3,
+    "effects": {
+      "truthDelta": 1
+    },
+    "extId": "halloween",
+    "text": "+1% Truth.",
+    "flavor": "Whispers from the cornfield."
+  },
+  {
+    "id": "hallo-gov-haunted-rally-protocol-013",
+    "name": "Haunted Rally Protocol",
+    "type": "ATTACK",
+    "faction": "government",
+    "rarity": "common",
+    "cost": 2,
+    "effects": {
+      "ipDelta": {
+        "opponent": 1
+      }
+    },
+    "extId": "halloween",
+    "text": "Opponent −1 IP.",
+    "flavor": "Bring a flashlight and plausible deniability."
+  },
+  {
+    "id": "hallo-gov-raven-flyer-protocol-014",
+    "name": "Raven Flyer Protocol",
+    "type": "MEDIA",
+    "faction": "government",
+    "rarity": "common",
+    "cost": 3,
+    "effects": {
+      "truthDelta": 1
+    },
+    "extId": "halloween",
+    "text": "+1% Truth.",
+    "flavor": "They came for the candy, stayed for the cover‑up."
+  },
+  {
+    "id": "hallo-gov-poltergeist-alert-protocol-015",
+    "name": "Poltergeist Alert Protocol",
+    "type": "ATTACK",
+    "faction": "government",
+    "rarity": "common",
+    "cost": 2,
+    "effects": {
+      "ipDelta": {
+        "opponent": 1
+      }
+    },
+    "extId": "halloween",
+    "text": "Opponent −1 IP.",
+    "flavor": "Mind the ectoplasm."
+  },
+  {
+    "id": "hallo-gov-scarecrow-shenanigans-incident-016",
+    "name": "Scarecrow Shenanigans Incident",
+    "type": "MEDIA",
+    "faction": "government",
+    "rarity": "common",
+    "cost": 3,
+    "effects": {
+      "truthDelta": 1
+    },
+    "extId": "halloween",
+    "text": "+1% Truth.",
+    "flavor": "‘It was just the wind,’ said the intern."
+  },
+  {
+    "id": "hallo-gov-scare-of-the-ghost-017",
+    "name": "Scare of the Ghost",
+    "type": "MEDIA",
+    "faction": "government",
+    "rarity": "common",
+    "cost": 3,
+    "effects": {
+      "truthDelta": 1
+    },
+    "extId": "halloween",
+    "text": "+1% Truth.",
+    "flavor": "Smells like fog machine and fear."
+  },
+  {
+    "id": "hallo-gov-banshee-shenanigans-incident-018",
+    "name": "Banshee Shenanigans Incident",
+    "type": "ATTACK",
+    "faction": "government",
+    "rarity": "common",
+    "cost": 2,
+    "effects": {
+      "ipDelta": {
+        "opponent": 1
+      }
+    },
+    "extId": "halloween",
+    "text": "Opponent −1 IP.",
+    "flavor": "The veil is thin tonight."
+  },
+  {
+    "id": "hallo-gov-wolfman-pamphlet-incident-019",
+    "name": "Wolfman Pamphlet Incident",
+    "type": "ATTACK",
+    "faction": "government",
+    "rarity": "common",
+    "cost": 2,
+    "effects": {
+      "ipDelta": {
+        "opponent": 1
+      }
+    },
+    "extId": "halloween",
+    "text": "Opponent −1 IP.",
+    "flavor": "Someone left the portal open again."
+  },
+  {
+    "id": "hallo-gov-bat-boy-shuffle-020",
+    "name": "Bat Boy Shuffle",
+    "type": "ATTACK",
+    "faction": "government",
+    "rarity": "common",
+    "cost": 2,
+    "effects": {
+      "ipDelta": {
+        "opponent": 1
+      }
+    },
+    "extId": "halloween",
+    "text": "Opponent −1 IP.",
+    "flavor": "‘It was just the wind,’ said the intern."
+  },
+  {
+    "id": "hallo-gov-moonlight-scare-files-021",
+    "name": "Moonlight Scare Files",
+    "type": "ZONE",
+    "faction": "government",
+    "rarity": "common",
+    "cost": 4,
+    "effects": {
+      "pressureDelta": 1
+    },
+    "extId": "halloween",
+    "text": "+1 Pressure in a chosen state.",
+    "flavor": "‘It was just the wind,’ said the intern.",
+    "target": {
+      "scope": "state",
+      "count": 1
+    }
+  },
+  {
+    "id": "hallo-gov-shuffle-of-the-mummy-022",
+    "name": "Shuffle of the Mummy",
+    "type": "ATTACK",
+    "faction": "government",
+    "rarity": "common",
+    "cost": 2,
+    "effects": {
+      "ipDelta": {
+        "opponent": 1
+      }
+    },
+    "extId": "halloween",
+    "text": "Opponent −1 IP.",
+    "flavor": "The veil is thin tonight."
+  },
+  {
+    "id": "hallo-gov-haunted-mansion-whispers-023",
+    "name": "Haunted Mansion Whispers",
+    "type": "ATTACK",
+    "faction": "government",
+    "rarity": "common",
+    "cost": 2,
+    "effects": {
+      "ipDelta": {
+        "opponent": 1
+      }
+    },
+    "extId": "halloween",
+    "text": "Opponent −1 IP.",
+    "flavor": "We can neither confirm nor deny the howling."
+  },
+  {
+    "id": "hallo-gov-raven-scare-024",
+    "name": "Raven Scare",
+    "type": "MEDIA",
+    "faction": "government",
+    "rarity": "common",
+    "cost": 3,
+    "effects": {
+      "truthDelta": 1
+    },
+    "extId": "halloween",
+    "text": "+1% Truth.",
+    "flavor": "Mind the ectoplasm."
+  },
+  {
+    "id": "hallo-gov-frankenstein-pamphlet-initiative-025",
+    "name": "Frankenstein Pamphlet Initiative",
+    "type": "ZONE",
+    "faction": "government",
+    "rarity": "common",
+    "cost": 4,
+    "effects": {
+      "pressureDelta": 1
+    },
+    "extId": "halloween",
+    "text": "+1 Pressure in a chosen state.",
+    "flavor": "Red eyes in the rear-view mirror.",
+    "target": {
+      "scope": "state",
+      "count": 1
+    }
+  },
+  {
+    "id": "hallo-gov-shenanigans-of-the-cauldron-026",
+    "name": "Shenanigans of the Cauldron",
+    "type": "MEDIA",
+    "faction": "government",
+    "rarity": "common",
+    "cost": 3,
+    "effects": {
+      "truthDelta": 1
+    },
+    "extId": "halloween",
+    "text": "+1% Truth.",
+    "flavor": "Bring a flashlight and plausible deniability."
+  },
+  {
+    "id": "hallo-gov-headless-horseman-pamphlet-files-027",
+    "name": "Headless Horseman Pamphlet Files",
+    "type": "ATTACK",
+    "faction": "government",
+    "rarity": "common",
+    "cost": 2,
+    "effects": {
+      "ipDelta": {
+        "opponent": 1
+      }
+    },
+    "extId": "halloween",
+    "text": "Opponent −1 IP.",
+    "flavor": "Licensed spooktacular."
+  },
+  {
+    "id": "hallo-gov-ouija-scare-protocol-028",
+    "name": "Ouija Scare Protocol",
+    "type": "MEDIA",
+    "faction": "government",
+    "rarity": "common",
+    "cost": 3,
+    "effects": {
+      "truthDelta": 1
+    },
+    "extId": "halloween",
+    "text": "+1% Truth.",
+    "flavor": "Try not to scream on camera."
+  },
+  {
+    "id": "hallo-gov-skeleton-flyer-files-029",
+    "name": "Skeleton Flyer Files",
+    "type": "ATTACK",
+    "faction": "government",
+    "rarity": "common",
+    "cost": 2,
+    "effects": {
+      "ipDelta": {
+        "opponent": 1
+      }
+    },
+    "extId": "halloween",
+    "text": "Opponent −1 IP.",
+    "flavor": "Whispers from the cornfield."
+  },
+  {
+    "id": "hallo-gov-brief-of-the-skeleton-030",
+    "name": "Brief of the Skeleton",
+    "type": "MEDIA",
+    "faction": "government",
+    "rarity": "common",
+    "cost": 3,
+    "effects": {
+      "truthDelta": 1
+    },
+    "extId": "halloween",
+    "text": "+1% Truth.",
+    "flavor": "They came for the candy, stayed for the cover‑up."
+  },
+  {
+    "id": "hallo-gov-frankenstein-flyer-incident-031",
+    "name": "Frankenstein Flyer Incident",
+    "type": "MEDIA",
+    "faction": "government",
+    "rarity": "common",
+    "cost": 3,
+    "effects": {
+      "truthDelta": 1
+    },
+    "extId": "halloween",
+    "text": "+1% Truth.",
+    "flavor": "They came for the candy, stayed for the cover‑up."
+  },
+  {
+    "id": "hallo-gov-coven-scare-032",
+    "name": "Coven Scare",
+    "type": "ZONE",
+    "faction": "government",
+    "rarity": "common",
+    "cost": 4,
+    "effects": {
+      "pressureDelta": 1
+    },
+    "extId": "halloween",
+    "text": "+1 Pressure in a chosen state.",
+    "flavor": "The crypt Wi‑Fi is excellent.",
+    "target": {
+      "scope": "state",
+      "count": 1
+    }
+  },
+  {
+    "id": "hallo-gov-poltergeist-flyer-033",
+    "name": "Poltergeist Flyer",
+    "type": "ATTACK",
+    "faction": "government",
+    "rarity": "common",
+    "cost": 2,
+    "effects": {
+      "ipDelta": {
+        "opponent": 1
+      }
+    },
+    "extId": "halloween",
+    "text": "Opponent −1 IP.",
+    "flavor": "Someone left the portal open again."
+  },
+  {
+    "id": "hallo-gov-fog-machine-rally-034",
+    "name": "Fog Machine Rally",
+    "type": "MEDIA",
+    "faction": "government",
+    "rarity": "common",
+    "cost": 3,
+    "effects": {
+      "truthDelta": 1
+    },
+    "extId": "halloween",
+    "text": "+1% Truth.",
+    "flavor": "Mind the ectoplasm."
+  },
+  {
+    "id": "hallo-gov-ghoul-alert-protocol-035",
+    "name": "Ghoul Alert Protocol",
+    "type": "MEDIA",
+    "faction": "government",
+    "rarity": "common",
+    "cost": 3,
+    "effects": {
+      "truthDelta": 1
+    },
+    "extId": "halloween",
+    "text": "+1% Truth.",
+    "flavor": "Licensed spooktacular."
+  },
+  {
+    "id": "hallo-gov-cobweb-scare-036",
+    "name": "Cobweb Scare",
+    "type": "ZONE",
+    "faction": "government",
+    "rarity": "common",
+    "cost": 4,
+    "effects": {
+      "pressureDelta": 1
+    },
+    "extId": "halloween",
+    "text": "+1 Pressure in a chosen state.",
+    "flavor": "The veil is thin tonight.",
+    "target": {
+      "scope": "state",
+      "count": 1
+    }
+  },
+  {
+    "id": "hallo-gov-seance-alert-initiative-037",
+    "name": "Seance Alert Initiative",
+    "type": "ZONE",
+    "faction": "government",
+    "rarity": "common",
+    "cost": 4,
+    "effects": {
+      "pressureDelta": 1
+    },
+    "extId": "halloween",
+    "text": "+1 Pressure in a chosen state.",
+    "flavor": "Bring a flashlight and plausible deniability.",
+    "target": {
+      "scope": "state",
+      "count": 1
+    }
+  },
+  {
+    "id": "hallo-gov-ghost-alert-initiative-038",
+    "name": "Ghost Alert Initiative",
+    "type": "MEDIA",
+    "faction": "government",
+    "rarity": "common",
+    "cost": 3,
+    "effects": {
+      "truthDelta": 1
+    },
+    "extId": "halloween",
+    "text": "+1% Truth.",
+    "flavor": "Red eyes in the rear-view mirror."
+  },
+  {
+    "id": "hallo-gov-poltergeist-report-initiative-039",
+    "name": "Poltergeist Report Initiative",
+    "type": "MEDIA",
+    "faction": "government",
+    "rarity": "common",
+    "cost": 3,
+    "effects": {
+      "truthDelta": 1
+    },
+    "extId": "halloween",
+    "text": "+1% Truth.",
+    "flavor": "Mind the ectoplasm."
+  },
+  {
+    "id": "hallo-gov-alert-of-the-haunted-mansion-040",
+    "name": "Alert of the Haunted Mansion",
+    "type": "ATTACK",
+    "faction": "government",
+    "rarity": "common",
+    "cost": 2,
+    "effects": {
+      "ipDelta": {
+        "opponent": 1
+      }
+    },
+    "extId": "halloween",
+    "text": "Opponent −1 IP.",
+    "flavor": "Try not to scream on camera."
+  },
+  {
+    "id": "hallo-gov-ghost-flyer-protocol-041",
+    "name": "Ghost Flyer Protocol",
+    "type": "ZONE",
+    "faction": "government",
+    "rarity": "common",
+    "cost": 4,
+    "effects": {
+      "pressureDelta": 1
+    },
+    "extId": "halloween",
+    "text": "+1 Pressure in a chosen state.",
+    "flavor": "Try not to scream on camera.",
+    "target": {
+      "scope": "state",
+      "count": 1
+    }
+  },
+  {
+    "id": "hallo-gov-jack-o-lantern-alert-042",
+    "name": "Jack-o-Lantern Alert",
+    "type": "MEDIA",
+    "faction": "government",
+    "rarity": "common",
+    "cost": 3,
+    "effects": {
+      "truthDelta": 1
+    },
+    "extId": "halloween",
+    "text": "+1% Truth.",
+    "flavor": "Keep garlic handy."
+  },
+  {
+    "id": "hallo-gov-seance-shenanigans-043",
+    "name": "Seance Shenanigans",
+    "type": "ATTACK",
+    "faction": "government",
+    "rarity": "common",
+    "cost": 2,
+    "effects": {
+      "ipDelta": {
+        "opponent": 1
+      }
+    },
+    "extId": "halloween",
+    "text": "Opponent −1 IP.",
+    "flavor": "Whispers from the cornfield."
+  },
+  {
+    "id": "hallo-gov-zombie-pamphlet-incident-044",
+    "name": "Zombie Pamphlet Incident",
+    "type": "ATTACK",
+    "faction": "government",
+    "rarity": "common",
+    "cost": 2,
+    "effects": {
+      "ipDelta": {
+        "opponent": 1
+      }
+    },
+    "extId": "halloween",
+    "text": "Opponent −1 IP.",
+    "flavor": "Bring a flashlight and plausible deniability."
+  },
+  {
+    "id": "hallo-gov-crypt-rumor-protocol-045",
+    "name": "Crypt Rumor Protocol",
+    "type": "ATTACK",
+    "faction": "government",
+    "rarity": "common",
+    "cost": 2,
+    "effects": {
+      "ipDelta": {
+        "opponent": 1
+      }
+    },
+    "extId": "halloween",
+    "text": "Opponent −1 IP.",
+    "flavor": "Sticky with sugar and secrets."
+  },
+  {
+    "id": "hallo-gov-skeleton-whispers-initiative-046",
+    "name": "Skeleton Whispers Initiative",
+    "type": "MEDIA",
+    "faction": "government",
+    "rarity": "common",
+    "cost": 3,
+    "effects": {
+      "truthDelta": 1
+    },
+    "extId": "halloween",
+    "text": "+1% Truth.",
+    "flavor": "Keep garlic handy."
+  },
+  {
+    "id": "hallo-gov-report-of-the-moonlight-047",
+    "name": "Report of the Moonlight",
+    "type": "MEDIA",
+    "faction": "government",
+    "rarity": "common",
+    "cost": 3,
+    "effects": {
+      "truthDelta": 1
+    },
+    "extId": "halloween",
+    "text": "+1% Truth.",
+    "flavor": "The crypt Wi‑Fi is excellent."
+  },
+  {
+    "id": "hallo-gov-ectoplasm-brief-files-048",
+    "name": "Ectoplasm Brief Files",
+    "type": "ATTACK",
+    "faction": "government",
+    "rarity": "common",
+    "cost": 2,
+    "effects": {
+      "ipDelta": {
+        "opponent": 1
+      }
+    },
+    "extId": "halloween",
+    "text": "Opponent −1 IP.",
+    "flavor": "‘It was just the wind,’ said the intern."
+  },
+  {
+    "id": "hallo-gov-cobweb-report-files-049",
+    "name": "Cobweb Report Files",
+    "type": "MEDIA",
+    "faction": "government",
+    "rarity": "common",
+    "cost": 3,
+    "effects": {
+      "truthDelta": 1
+    },
+    "extId": "halloween",
+    "text": "+1% Truth.",
+    "flavor": "Someone left the portal open again."
+  },
+  {
+    "id": "hallo-gov-cobweb-alert-protocol-050",
+    "name": "Cobweb Alert Protocol",
+    "type": "MEDIA",
+    "faction": "government",
+    "rarity": "common",
+    "cost": 3,
+    "effects": {
+      "truthDelta": 1
+    },
+    "extId": "halloween",
+    "text": "+1% Truth.",
+    "flavor": "Bring a flashlight and plausible deniability."
+  },
+  {
+    "id": "hallo-gov-omen-pamphlet-files-051",
+    "name": "Omen Pamphlet Files",
+    "type": "ZONE",
+    "faction": "government",
+    "rarity": "common",
+    "cost": 4,
+    "effects": {
+      "pressureDelta": 1
+    },
+    "extId": "halloween",
+    "text": "+1 Pressure in a chosen state.",
+    "flavor": "They came for the candy, stayed for the cover‑up.",
+    "target": {
+      "scope": "state",
+      "count": 1
+    }
+  },
+  {
+    "id": "hallo-gov-ghost-scare-files-052",
+    "name": "Ghost Scare Files",
+    "type": "ATTACK",
+    "faction": "government",
+    "rarity": "common",
+    "cost": 2,
+    "effects": {
+      "ipDelta": {
+        "opponent": 1
+      }
+    },
+    "extId": "halloween",
+    "text": "Opponent −1 IP.",
+    "flavor": "The veil is thin tonight."
+  },
+  {
+    "id": "hallo-gov-frankenstein-pamphlet-protocol-053",
+    "name": "Frankenstein Pamphlet Protocol",
+    "type": "ATTACK",
+    "faction": "government",
+    "rarity": "common",
+    "cost": 2,
+    "effects": {
+      "ipDelta": {
+        "opponent": 1
+      }
+    },
+    "extId": "halloween",
+    "text": "Opponent −1 IP.",
+    "flavor": "Mind the ectoplasm."
+  },
+  {
+    "id": "hallo-gov-cobweb-whispers-054",
+    "name": "Cobweb Whispers",
+    "type": "ATTACK",
+    "faction": "government",
+    "rarity": "common",
+    "cost": 2,
+    "effects": {
+      "ipDelta": {
+        "opponent": 1
+      }
+    },
+    "extId": "halloween",
+    "text": "Opponent −1 IP.",
+    "flavor": "Do not feed after midnight."
+  },
+  {
+    "id": "hallo-gov-full-moon-press-release-incident-055",
+    "name": "Full Moon Press Release Incident",
+    "type": "MEDIA",
+    "faction": "government",
+    "rarity": "common",
+    "cost": 3,
+    "effects": {
+      "truthDelta": 1
+    },
+    "extId": "halloween",
+    "text": "+1% Truth.",
+    "flavor": "Sticky with sugar and secrets."
+  },
+  {
+    "id": "hallo-gov-shuffle-of-the-haunted-056",
+    "name": "Shuffle of the Haunted",
+    "type": "ATTACK",
+    "faction": "government",
+    "rarity": "common",
+    "cost": 2,
+    "effects": {
+      "ipDelta": {
+        "opponent": 1
+      }
+    },
+    "extId": "halloween",
+    "text": "Opponent −1 IP.",
+    "flavor": "Someone left the portal open again."
+  },
+  {
+    "id": "hallo-gov-cobweb-shenanigans-incident-057",
+    "name": "Cobweb Shenanigans Incident",
+    "type": "ATTACK",
+    "faction": "government",
+    "rarity": "common",
+    "cost": 2,
+    "effects": {
+      "ipDelta": {
+        "opponent": 1
+      }
+    },
+    "extId": "halloween",
+    "text": "Opponent −1 IP.",
+    "flavor": "Approved by the Council of Shadows."
+  },
+  {
+    "id": "hallo-gov-witch-shenanigans-058",
+    "name": "Witch Shenanigans",
+    "type": "ZONE",
+    "faction": "government",
+    "rarity": "common",
+    "cost": 4,
+    "effects": {
+      "pressureDelta": 1
+    },
+    "extId": "halloween",
+    "text": "+1 Pressure in a chosen state.",
+    "flavor": "This is fine. Probably.",
+    "target": {
+      "scope": "state",
+      "count": 1
+    }
+  },
+  {
+    "id": "hallo-gov-zombie-rally-files-059",
+    "name": "Zombie Rally Files",
+    "type": "ZONE",
+    "faction": "government",
+    "rarity": "common",
+    "cost": 4,
+    "effects": {
+      "pressureDelta": 1
+    },
+    "extId": "halloween",
+    "text": "+1 Pressure in a chosen state.",
+    "flavor": "Red eyes in the rear-view mirror.",
+    "target": {
+      "scope": "state",
+      "count": 1
+    }
+  },
+  {
+    "id": "hallo-gov-dracula-shenanigans-060",
+    "name": "Dracula Shenanigans",
+    "type": "MEDIA",
+    "faction": "government",
+    "rarity": "common",
+    "cost": 3,
+    "effects": {
+      "truthDelta": 1
+    },
+    "extId": "halloween",
+    "text": "+1% Truth.",
+    "flavor": "Licensed spooktacular."
+  },
+  {
+    "id": "hallo-gov-ouija-rumor-061",
+    "name": "Ouija Rumor",
+    "type": "ATTACK",
+    "faction": "government",
+    "rarity": "common",
+    "cost": 2,
+    "effects": {
+      "ipDelta": {
+        "opponent": 1
+      }
+    },
+    "extId": "halloween",
+    "text": "Opponent −1 IP.",
+    "flavor": "This is fine. Probably."
+  },
+  {
+    "id": "hallo-gov-skeleton-rally-protocol-062",
+    "name": "Skeleton Rally Protocol",
+    "type": "ATTACK",
+    "faction": "government",
+    "rarity": "common",
+    "cost": 2,
+    "effects": {
+      "ipDelta": {
+        "opponent": 1
+      }
+    },
+    "extId": "halloween",
+    "text": "Opponent −1 IP.",
+    "flavor": "Haunting sponsored by a totally normal NGO."
+  },
+  {
+    "id": "hallo-gov-spider-shuffle-063",
+    "name": "Spider Shuffle",
+    "type": "ATTACK",
+    "faction": "government",
+    "rarity": "common",
+    "cost": 2,
+    "effects": {
+      "ipDelta": {
+        "opponent": 1
+      }
+    },
+    "extId": "halloween",
+    "text": "Opponent −1 IP.",
+    "flavor": "Approved by the Council of Shadows."
+  },
+  {
+    "id": "hallo-gov-candy-corn-whispers-064",
+    "name": "Candy Corn Whispers",
+    "type": "ATTACK",
+    "faction": "government",
+    "rarity": "common",
+    "cost": 2,
+    "effects": {
+      "ipDelta": {
+        "opponent": 1
+      }
+    },
+    "extId": "halloween",
+    "text": "Opponent −1 IP.",
+    "flavor": "This is fine. Probably."
+  },
+  {
+    "id": "hallo-gov-moonlight-scare-initiative-065",
+    "name": "Moonlight Scare Initiative",
+    "type": "MEDIA",
+    "faction": "government",
+    "rarity": "common",
+    "cost": 3,
+    "effects": {
+      "truthDelta": 1
+    },
+    "extId": "halloween",
+    "text": "+1% Truth.",
+    "flavor": "All treats, suspicious tricks."
+  },
+  {
+    "id": "hallo-gov-jack-o-lantern-rally-incident-066",
+    "name": "Jack-o-Lantern Rally Incident",
+    "type": "MEDIA",
+    "faction": "government",
+    "rarity": "common",
+    "cost": 3,
+    "effects": {
+      "truthDelta": 1
+    },
+    "extId": "halloween",
+    "text": "+1% Truth.",
+    "flavor": "Do not taunt the poltergeist."
+  },
+  {
+    "id": "hallo-gov-full-moon-shenanigans-067",
+    "name": "Full Moon Shenanigans",
+    "type": "ATTACK",
+    "faction": "government",
+    "rarity": "common",
+    "cost": 2,
+    "effects": {
+      "ipDelta": {
+        "opponent": 1
+      }
+    },
+    "extId": "halloween",
+    "text": "Opponent −1 IP.",
+    "flavor": "This is fine. Probably."
+  },
+  {
+    "id": "hallo-gov-wolfman-flyer-protocol-068",
+    "name": "Wolfman Flyer Protocol",
+    "type": "ATTACK",
+    "faction": "government",
+    "rarity": "common",
+    "cost": 2,
+    "effects": {
+      "ipDelta": {
+        "opponent": 1
+      }
+    },
+    "extId": "halloween",
+    "text": "Opponent −1 IP.",
+    "flavor": "This is fine. Probably."
+  },
+  {
+    "id": "hallo-gov-brief-of-the-midnight-069",
+    "name": "Brief of the Midnight",
+    "type": "ATTACK",
+    "faction": "government",
+    "rarity": "common",
+    "cost": 2,
+    "effects": {
+      "ipDelta": {
+        "opponent": 1
+      }
+    },
+    "extId": "halloween",
+    "text": "Opponent −1 IP.",
+    "flavor": "Haunting sponsored by a totally normal NGO."
+  },
+  {
+    "id": "hallo-gov-witch-press-release-incident-070",
+    "name": "Witch Press Release Incident",
+    "type": "ATTACK",
+    "faction": "government",
+    "rarity": "common",
+    "cost": 2,
+    "effects": {
+      "ipDelta": {
+        "opponent": 1
+      }
+    },
+    "extId": "halloween",
+    "text": "Opponent −1 IP.",
+    "flavor": "Sticky with sugar and secrets."
+  },
+  {
+    "id": "hallo-gov-ghoul-sweep-initiative-001",
+    "name": "Ghoul Sweep Initiative",
+    "type": "ATTACK",
+    "faction": "government",
+    "rarity": "uncommon",
+    "cost": 3,
+    "effects": {
+      "ipDelta": {
+        "opponent": 2
+      }
+    },
+    "extId": "halloween",
+    "text": "Opponent −2 IP.",
+    "flavor": "Bring a flashlight and plausible deniability."
+  },
+  {
+    "id": "hallo-gov-bat-boy-operation-protocol-002",
+    "name": "Bat Boy Operation Protocol",
+    "type": "MEDIA",
+    "faction": "government",
+    "rarity": "uncommon",
+    "cost": 4,
+    "effects": {
+      "truthDelta": 2
+    },
+    "extId": "halloween",
+    "text": "+2% Truth.",
+    "flavor": "This is fine. Probably."
+  },
+  {
+    "id": "hallo-gov-broadcast-of-the-seance-003",
+    "name": "Broadcast of the Seance",
+    "type": "MEDIA",
+    "faction": "government",
+    "rarity": "uncommon",
+    "cost": 4,
+    "effects": {
+      "truthDelta": 2
+    },
+    "extId": "halloween",
+    "text": "+2% Truth.",
+    "flavor": "Whispers from the cornfield."
+  },
+  {
+    "id": "hallo-gov-spooky-hayride-operation-initiative-004",
+    "name": "Spooky Hayride Operation Initiative",
+    "type": "ATTACK",
+    "faction": "government",
+    "rarity": "uncommon",
+    "cost": 3,
+    "effects": {
+      "ipDelta": {
+        "opponent": 2
+      }
+    },
+    "extId": "halloween",
+    "text": "Opponent −2 IP.",
+    "flavor": "All treats, suspicious tricks."
+  },
+  {
+    "id": "hallo-gov-ploy-of-the-headless-horseman-005",
+    "name": "Ploy of the Headless Horseman",
+    "type": "ATTACK",
+    "faction": "government",
+    "rarity": "uncommon",
+    "cost": 3,
+    "effects": {
+      "ipDelta": {
+        "opponent": 2
+      }
+    },
+    "extId": "halloween",
+    "text": "Opponent −2 IP.",
+    "flavor": "Smells like fog machine and fear."
+  },
+  {
+    "id": "hallo-gov-jack-o-lantern-stakeout-006",
+    "name": "Jack-o-Lantern Stakeout",
+    "type": "ATTACK",
+    "faction": "government",
+    "rarity": "uncommon",
+    "cost": 3,
+    "effects": {
+      "ipDelta": {
+        "opponent": 2
+      }
+    },
+    "extId": "halloween",
+    "text": "Opponent −2 IP.",
+    "flavor": "Licensed spooktacular."
+  },
+  {
+    "id": "hallo-gov-poltergeist-murmur-network-incident-007",
+    "name": "Poltergeist Murmur Network Incident",
+    "type": "MEDIA",
+    "faction": "government",
+    "rarity": "uncommon",
+    "cost": 4,
+    "effects": {
+      "truthDelta": 2
+    },
+    "extId": "halloween",
+    "text": "+2% Truth.",
+    "flavor": "Rated PG‑Paranoid."
+  },
+  {
+    "id": "hallo-gov-moonlight-expedition-incident-008",
+    "name": "Moonlight Expedition Incident",
+    "type": "MEDIA",
+    "faction": "government",
+    "rarity": "uncommon",
+    "cost": 4,
+    "effects": {
+      "truthDelta": 2
+    },
+    "extId": "halloween",
+    "text": "+2% Truth.",
+    "flavor": "They came for the candy, stayed for the cover‑up."
+  },
+  {
+    "id": "hallo-gov-seance-broadcast-incident-009",
+    "name": "Seance Broadcast Incident",
+    "type": "MEDIA",
+    "faction": "government",
+    "rarity": "uncommon",
+    "cost": 4,
+    "effects": {
+      "truthDelta": 2
+    },
+    "extId": "halloween",
+    "text": "+2% Truth.",
+    "flavor": "Licensed spooktacular."
+  },
+  {
+    "id": "hallo-gov-midnight-ploy-protocol-010",
+    "name": "Midnight Ploy Protocol",
+    "type": "MEDIA",
+    "faction": "government",
+    "rarity": "uncommon",
+    "cost": 4,
+    "effects": {
+      "truthDelta": 2
+    },
+    "extId": "halloween",
+    "text": "+2% Truth.",
+    "flavor": "Do not feed after midnight."
+  },
+  {
+    "id": "hallo-gov-banshee-investigation-files-011",
+    "name": "Banshee Investigation Files",
+    "type": "MEDIA",
+    "faction": "government",
+    "rarity": "uncommon",
+    "cost": 4,
+    "effects": {
+      "truthDelta": 2
+    },
+    "extId": "halloween",
+    "text": "+2% Truth.",
+    "flavor": "Smells like fog machine and fear."
+  },
+  {
+    "id": "hallo-gov-poltergeist-expedition-012",
+    "name": "Poltergeist Expedition",
+    "type": "ATTACK",
+    "faction": "government",
+    "rarity": "uncommon",
+    "cost": 3,
+    "effects": {
+      "ipDelta": {
+        "opponent": 2
+      }
+    },
+    "extId": "halloween",
+    "text": "Opponent −2 IP.",
+    "flavor": "Try not to scream on camera."
+  },
+  {
+    "id": "hallo-gov-graveyard-expedition-initiative-013",
+    "name": "Graveyard Expedition Initiative",
+    "type": "ZONE",
+    "faction": "government",
+    "rarity": "uncommon",
+    "cost": 5,
+    "effects": {
+      "pressureDelta": 2
+    },
+    "extId": "halloween",
+    "text": "+2 Pressure in a chosen state.",
+    "flavor": "Sticky with sugar and secrets.",
+    "target": {
+      "scope": "state",
+      "count": 1
+    }
+  },
+  {
+    "id": "hallo-gov-zombie-murmur-network-files-014",
+    "name": "Zombie Murmur Network Files",
+    "type": "ZONE",
+    "faction": "government",
+    "rarity": "uncommon",
+    "cost": 5,
+    "effects": {
+      "pressureDelta": 2
+    },
+    "extId": "halloween",
+    "text": "+2 Pressure in a chosen state.",
+    "flavor": "Rated PG‑Paranoid.",
+    "target": {
+      "scope": "state",
+      "count": 1
+    }
+  },
+  {
+    "id": "hallo-gov-haunted-mansion-ploy-protocol-015",
+    "name": "Haunted Mansion Ploy Protocol",
+    "type": "MEDIA",
+    "faction": "government",
+    "rarity": "uncommon",
+    "cost": 4,
+    "effects": {
+      "truthDelta": 2
+    },
+    "extId": "halloween",
+    "text": "+2% Truth.",
+    "flavor": "This is fine. Probably."
+  },
+  {
+    "id": "hallo-gov-headless-horseman-investigation-initiative-016",
+    "name": "Headless Horseman Investigation Initiative",
+    "type": "ZONE",
+    "faction": "government",
+    "rarity": "uncommon",
+    "cost": 5,
+    "effects": {
+      "pressureDelta": 2
+    },
+    "extId": "halloween",
+    "text": "+2 Pressure in a chosen state.",
+    "flavor": "Mind the ectoplasm.",
+    "target": {
+      "scope": "state",
+      "count": 1
+    }
+  },
+  {
+    "id": "hallo-gov-headless-horseman-gambit-017",
+    "name": "Headless Horseman Gambit",
+    "type": "MEDIA",
+    "faction": "government",
+    "rarity": "uncommon",
+    "cost": 4,
+    "effects": {
+      "truthDelta": 2
+    },
+    "extId": "halloween",
+    "text": "+2% Truth.",
+    "flavor": "Licensed spooktacular."
+  },
+  {
+    "id": "hallo-gov-candy-corn-expedition-protocol-018",
+    "name": "Candy Corn Expedition Protocol",
+    "type": "MEDIA",
+    "faction": "government",
+    "rarity": "uncommon",
+    "cost": 4,
+    "effects": {
+      "truthDelta": 2
+    },
+    "extId": "halloween",
+    "text": "+2% Truth.",
+    "flavor": "This is fine. Probably."
+  },
+  {
+    "id": "hallo-gov-banshee-broadcast-initiative-019",
+    "name": "Banshee Broadcast Initiative",
+    "type": "ZONE",
+    "faction": "government",
+    "rarity": "uncommon",
+    "cost": 5,
+    "effects": {
+      "pressureDelta": 2
+    },
+    "extId": "halloween",
+    "text": "+2 Pressure in a chosen state.",
+    "flavor": "They came for the candy, stayed for the cover‑up.",
+    "target": {
+      "scope": "state",
+      "count": 1
+    }
+  },
+  {
+    "id": "hallo-gov-spider-gambit-protocol-020",
+    "name": "Spider Gambit Protocol",
+    "type": "MEDIA",
+    "faction": "government",
+    "rarity": "uncommon",
+    "cost": 4,
+    "effects": {
+      "truthDelta": 2
+    },
+    "extId": "halloween",
+    "text": "+2% Truth.",
+    "flavor": "Batteries not included."
+  },
+  {
+    "id": "hallo-gov-revelation-of-the-graveyard-001",
+    "name": "Revelation of the Graveyard",
+    "type": "MEDIA",
+    "faction": "government",
+    "rarity": "rare",
+    "cost": 5,
+    "effects": {
+      "truthDelta": 3
+    },
+    "extId": "halloween",
+    "text": "+3% Truth.",
+    "flavor": "They came for the candy, stayed for the cover‑up."
+  },
+  {
+    "id": "hallo-gov-raven-revelation-initiative-002",
+    "name": "Raven Revelation Initiative",
+    "type": "MEDIA",
+    "faction": "government",
+    "rarity": "rare",
+    "cost": 5,
+    "effects": {
+      "truthDelta": 3
+    },
+    "extId": "halloween",
+    "text": "+3% Truth.",
+    "flavor": "The crypt Wi‑Fi is excellent."
+  },
+  {
+    "id": "hallo-gov-containment-of-the-cauldron-003",
+    "name": "Containment of the Cauldron",
+    "type": "ATTACK",
+    "faction": "government",
+    "rarity": "rare",
+    "cost": 4,
+    "effects": {
+      "ipDelta": {
+        "opponent": 3
+      },
+      "discardOpponent": 1
+    },
+    "extId": "halloween",
+    "text": "Opponent −3 IP, discard 1.",
+    "flavor": "Try not to scream on camera."
+  },
+  {
+    "id": "hallo-gov-banshee-prime-directive-files-004",
+    "name": "Banshee Prime Directive Files",
+    "type": "MEDIA",
+    "faction": "government",
+    "rarity": "rare",
+    "cost": 5,
+    "effects": {
+      "truthDelta": 3
+    },
+    "extId": "halloween",
+    "text": "+3% Truth.",
+    "flavor": "Try not to scream on camera."
+  },
+  {
+    "id": "hallo-gov-seance-containment-files-005",
+    "name": "Seance Containment Files",
+    "type": "MEDIA",
+    "faction": "government",
+    "rarity": "rare",
+    "cost": 5,
+    "effects": {
+      "truthDelta": 3
+    },
+    "extId": "halloween",
+    "text": "+3% Truth.",
+    "flavor": "Rated PG‑Paranoid."
+  },
+  {
+    "id": "hallo-gov-raven-project-protocol-006",
+    "name": "Raven Project Protocol",
+    "type": "MEDIA",
+    "faction": "government",
+    "rarity": "rare",
+    "cost": 5,
+    "effects": {
+      "truthDelta": 3
+    },
+    "extId": "halloween",
+    "text": "+3% Truth.",
+    "flavor": "Filed under ‘Seasonal Anomalies’."
+  },
+  {
+    "id": "hallo-gov-moonlight-deep-cover-007",
+    "name": "Moonlight Deep Cover",
+    "type": "MEDIA",
+    "faction": "government",
+    "rarity": "rare",
+    "cost": 5,
+    "effects": {
+      "truthDelta": 3
+    },
+    "extId": "halloween",
+    "text": "+3% Truth.",
+    "flavor": "Someone left the portal open again."
+  },
+  {
+    "id": "hallo-truth-full-moon-pamphlet-initiative-001",
+    "name": "Full Moon Pamphlet Initiative",
+    "type": "MEDIA",
+    "faction": "truth",
+    "rarity": "common",
+    "cost": 3,
+    "effects": {
+      "truthDelta": 1
+    },
+    "extId": "halloween",
+    "text": "+1% Truth.",
+    "flavor": "Do not taunt the poltergeist."
+  },
+  {
+    "id": "hallo-truth-trick-or-treat-press-release-incident-002",
+    "name": "Trick-or-Treat Press Release Incident",
+    "type": "MEDIA",
+    "faction": "truth",
+    "rarity": "common",
+    "cost": 3,
+    "effects": {
+      "truthDelta": 1
+    },
+    "extId": "halloween",
+    "text": "+1% Truth.",
+    "flavor": "Try not to scream on camera."
+  },
+  {
+    "id": "hallo-truth-seance-scare-protocol-003",
+    "name": "Seance Scare Protocol",
+    "type": "ATTACK",
+    "faction": "truth",
+    "rarity": "common",
+    "cost": 2,
+    "effects": {
+      "ipDelta": {
+        "opponent": 1
+      }
+    },
+    "extId": "halloween",
+    "text": "Opponent −1 IP.",
+    "flavor": "Try not to scream on camera."
+  },
+  {
+    "id": "hallo-truth-banshee-shuffle-004",
+    "name": "Banshee Shuffle",
+    "type": "ATTACK",
+    "faction": "truth",
+    "rarity": "common",
+    "cost": 2,
+    "effects": {
+      "ipDelta": {
+        "opponent": 1
+      }
+    },
+    "extId": "halloween",
+    "text": "Opponent −1 IP.",
+    "flavor": "They came for the candy, stayed for the cover‑up."
+  },
+  {
+    "id": "hallo-truth-candy-corn-shuffle-protocol-005",
+    "name": "Candy Corn Shuffle Protocol",
+    "type": "MEDIA",
+    "faction": "truth",
+    "rarity": "common",
+    "cost": 3,
+    "effects": {
+      "truthDelta": 1
+    },
+    "extId": "halloween",
+    "text": "+1% Truth.",
+    "flavor": "Mind the ectoplasm."
+  },
+  {
+    "id": "hallo-truth-scare-of-the-coven-006",
+    "name": "Scare of the Coven",
+    "type": "MEDIA",
+    "faction": "truth",
+    "rarity": "common",
+    "cost": 3,
+    "effects": {
+      "truthDelta": 1
+    },
+    "extId": "halloween",
+    "text": "+1% Truth.",
+    "flavor": "Mind the ectoplasm."
+  },
+  {
+    "id": "hallo-truth-spooky-hayride-pamphlet-files-007",
+    "name": "Spooky Hayride Pamphlet Files",
+    "type": "ZONE",
+    "faction": "truth",
+    "rarity": "common",
+    "cost": 4,
+    "effects": {
+      "pressureDelta": 1
+    },
+    "extId": "halloween",
+    "text": "+1 Pressure in a chosen state.",
+    "flavor": "The veil is thin tonight.",
+    "target": {
+      "scope": "state",
+      "count": 1
+    }
+  },
+  {
+    "id": "hallo-truth-ouija-shenanigans-files-008",
+    "name": "Ouija Shenanigans Files",
+    "type": "MEDIA",
+    "faction": "truth",
+    "rarity": "common",
+    "cost": 3,
+    "effects": {
+      "truthDelta": 1
+    },
+    "extId": "halloween",
+    "text": "+1% Truth.",
+    "flavor": "They came for the candy, stayed for the cover‑up."
+  },
+  {
+    "id": "hallo-truth-black-cat-shenanigans-files-009",
+    "name": "Black Cat Shenanigans Files",
+    "type": "MEDIA",
+    "faction": "truth",
+    "rarity": "common",
+    "cost": 3,
+    "effects": {
+      "truthDelta": 1
+    },
+    "extId": "halloween",
+    "text": "+1% Truth.",
+    "flavor": "Licensed spooktacular."
+  },
+  {
+    "id": "hallo-truth-candy-corn-rumor-010",
+    "name": "Candy Corn Rumor",
+    "type": "ATTACK",
+    "faction": "truth",
+    "rarity": "common",
+    "cost": 2,
+    "effects": {
+      "ipDelta": {
+        "opponent": 1
+      }
+    },
+    "extId": "halloween",
+    "text": "Opponent −1 IP.",
+    "flavor": "Someone left the portal open again."
+  },
+  {
+    "id": "hallo-truth-rumor-of-the-witch-011",
+    "name": "Rumor of the Witch",
+    "type": "ZONE",
+    "faction": "truth",
+    "rarity": "common",
+    "cost": 4,
+    "effects": {
+      "pressureDelta": 1
+    },
+    "extId": "halloween",
+    "text": "+1 Pressure in a chosen state.",
+    "flavor": "Red eyes in the rear-view mirror.",
+    "target": {
+      "scope": "state",
+      "count": 1
+    }
+  },
+  {
+    "id": "hallo-truth-jack-o-lantern-press-release-protocol-012",
+    "name": "Jack-o-Lantern Press Release Protocol",
+    "type": "ZONE",
+    "faction": "truth",
+    "rarity": "common",
+    "cost": 4,
+    "effects": {
+      "pressureDelta": 1
+    },
+    "extId": "halloween",
+    "text": "+1 Pressure in a chosen state.",
+    "flavor": "Sticky with sugar and secrets.",
+    "target": {
+      "scope": "state",
+      "count": 1
+    }
+  },
+  {
+    "id": "hallo-truth-witch-report-013",
+    "name": "Witch Report",
+    "type": "ATTACK",
+    "faction": "truth",
+    "rarity": "common",
+    "cost": 2,
+    "effects": {
+      "ipDelta": {
+        "opponent": 1
+      }
+    },
+    "extId": "halloween",
+    "text": "Opponent −1 IP.",
+    "flavor": "Red eyes in the rear-view mirror."
+  },
+  {
+    "id": "hallo-truth-ghost-brief-protocol-014",
+    "name": "Ghost Brief Protocol",
+    "type": "MEDIA",
+    "faction": "truth",
+    "rarity": "common",
+    "cost": 3,
+    "effects": {
+      "truthDelta": 1
+    },
+    "extId": "halloween",
+    "text": "+1% Truth.",
+    "flavor": "Someone left the portal open again."
+  },
+  {
+    "id": "hallo-truth-raven-report-initiative-015",
+    "name": "Raven Report Initiative",
+    "type": "MEDIA",
+    "faction": "truth",
+    "rarity": "common",
+    "cost": 3,
+    "effects": {
+      "truthDelta": 1
+    },
+    "extId": "halloween",
+    "text": "+1% Truth.",
+    "flavor": "This is fine. Probably."
+  },
+  {
+    "id": "hallo-truth-ghost-report-initiative-016",
+    "name": "Ghost Report Initiative",
+    "type": "MEDIA",
+    "faction": "truth",
+    "rarity": "common",
+    "cost": 3,
+    "effects": {
+      "truthDelta": 1
+    },
+    "extId": "halloween",
+    "text": "+1% Truth.",
+    "flavor": "They came for the candy, stayed for the cover‑up."
+  },
+  {
+    "id": "hallo-truth-alert-of-the-ghost-017",
+    "name": "Alert of the Ghost",
+    "type": "MEDIA",
+    "faction": "truth",
+    "rarity": "common",
+    "cost": 3,
+    "effects": {
+      "truthDelta": 1
+    },
+    "extId": "halloween",
+    "text": "+1% Truth.",
+    "flavor": "We can neither confirm nor deny the howling."
+  },
+  {
+    "id": "hallo-truth-zombie-press-release-incident-018",
+    "name": "Zombie Press Release Incident",
+    "type": "MEDIA",
+    "faction": "truth",
+    "rarity": "common",
+    "cost": 3,
+    "effects": {
+      "truthDelta": 1
+    },
+    "extId": "halloween",
+    "text": "+1% Truth.",
+    "flavor": "Licensed spooktacular."
+  },
+  {
+    "id": "hallo-truth-cemetery-press-release-initiative-019",
+    "name": "Cemetery Press Release Initiative",
+    "type": "MEDIA",
+    "faction": "truth",
+    "rarity": "common",
+    "cost": 3,
+    "effects": {
+      "truthDelta": 1
+    },
+    "extId": "halloween",
+    "text": "+1% Truth.",
+    "flavor": "Rated PG‑Paranoid."
+  },
+  {
+    "id": "hallo-truth-rally-of-the-dracula-020",
+    "name": "Rally of the Dracula",
+    "type": "MEDIA",
+    "faction": "truth",
+    "rarity": "common",
+    "cost": 3,
+    "effects": {
+      "truthDelta": 1
+    },
+    "extId": "halloween",
+    "text": "+1% Truth.",
+    "flavor": "Filed under ‘Seasonal Anomalies’."
+  },
+  {
+    "id": "hallo-truth-seance-alert-incident-021",
+    "name": "Seance Alert Incident",
+    "type": "MEDIA",
+    "faction": "truth",
+    "rarity": "common",
+    "cost": 3,
+    "effects": {
+      "truthDelta": 1
+    },
+    "extId": "halloween",
+    "text": "+1% Truth.",
+    "flavor": "Smells like fog machine and fear."
+  },
+  {
+    "id": "hallo-truth-cauldron-shuffle-protocol-022",
+    "name": "Cauldron Shuffle Protocol",
+    "type": "MEDIA",
+    "faction": "truth",
+    "rarity": "common",
+    "cost": 3,
+    "effects": {
+      "truthDelta": 1
+    },
+    "extId": "halloween",
+    "text": "+1% Truth.",
+    "flavor": "Sticky with sugar and secrets."
+  },
+  {
+    "id": "hallo-truth-poltergeist-scare-files-023",
+    "name": "Poltergeist Scare Files",
+    "type": "ATTACK",
+    "faction": "truth",
+    "rarity": "common",
+    "cost": 2,
+    "effects": {
+      "ipDelta": {
+        "opponent": 1
+      }
+    },
+    "extId": "halloween",
+    "text": "Opponent −1 IP.",
+    "flavor": "Try not to scream on camera."
+  },
+  {
+    "id": "hallo-truth-coven-shenanigans-024",
+    "name": "Coven Shenanigans",
+    "type": "ATTACK",
+    "faction": "truth",
+    "rarity": "common",
+    "cost": 2,
+    "effects": {
+      "ipDelta": {
+        "opponent": 1
+      }
+    },
+    "extId": "halloween",
+    "text": "Opponent −1 IP.",
+    "flavor": "Red eyes in the rear-view mirror."
+  },
+  {
+    "id": "hallo-truth-whispers-of-the-skeleton-025",
+    "name": "Whispers of the Skeleton",
+    "type": "ZONE",
+    "faction": "truth",
+    "rarity": "common",
+    "cost": 4,
+    "effects": {
+      "pressureDelta": 1
+    },
+    "extId": "halloween",
+    "text": "+1 Pressure in a chosen state.",
+    "flavor": "Do not taunt the poltergeist.",
+    "target": {
+      "scope": "state",
+      "count": 1
+    }
+  },
+  {
+    "id": "hallo-truth-midnight-shuffle-026",
+    "name": "Midnight Shuffle",
+    "type": "ZONE",
+    "faction": "truth",
+    "rarity": "common",
+    "cost": 4,
+    "effects": {
+      "pressureDelta": 1
+    },
+    "extId": "halloween",
+    "text": "+1 Pressure in a chosen state.",
+    "flavor": "Sticky with sugar and secrets.",
+    "target": {
+      "scope": "state",
+      "count": 1
+    }
+  },
+  {
+    "id": "hallo-truth-trick-or-treat-brief-incident-027",
+    "name": "Trick-or-Treat Brief Incident",
+    "type": "ATTACK",
+    "faction": "truth",
+    "rarity": "common",
+    "cost": 2,
+    "effects": {
+      "ipDelta": {
+        "opponent": 1
+      }
+    },
+    "extId": "halloween",
+    "text": "Opponent −1 IP.",
+    "flavor": "Whispers from the cornfield."
+  },
+  {
+    "id": "hallo-truth-crypt-press-release-protocol-028",
+    "name": "Crypt Press Release Protocol",
+    "type": "MEDIA",
+    "faction": "truth",
+    "rarity": "common",
+    "cost": 3,
+    "effects": {
+      "truthDelta": 1
+    },
+    "extId": "halloween",
+    "text": "+1% Truth.",
+    "flavor": "We can neither confirm nor deny the howling."
+  },
+  {
+    "id": "hallo-truth-raven-press-release-029",
+    "name": "Raven Press Release",
+    "type": "ZONE",
+    "faction": "truth",
+    "rarity": "common",
+    "cost": 4,
+    "effects": {
+      "pressureDelta": 1
+    },
+    "extId": "halloween",
+    "text": "+1 Pressure in a chosen state.",
+    "flavor": "Try not to scream on camera.",
+    "target": {
+      "scope": "state",
+      "count": 1
+    }
+  },
+  {
+    "id": "hallo-truth-witch-shuffle-incident-030",
+    "name": "Witch Shuffle Incident",
+    "type": "MEDIA",
+    "faction": "truth",
+    "rarity": "common",
+    "cost": 3,
+    "effects": {
+      "truthDelta": 1
+    },
+    "extId": "halloween",
+    "text": "+1% Truth.",
+    "flavor": "Approved by the Council of Shadows."
+  },
+  {
+    "id": "hallo-truth-ghoul-pamphlet-initiative-031",
+    "name": "Ghoul Pamphlet Initiative",
+    "type": "ZONE",
+    "faction": "truth",
+    "rarity": "common",
+    "cost": 4,
+    "effects": {
+      "pressureDelta": 1
+    },
+    "extId": "halloween",
+    "text": "+1 Pressure in a chosen state.",
+    "flavor": "The crypt Wi‑Fi is excellent.",
+    "target": {
+      "scope": "state",
+      "count": 1
+    }
+  },
+  {
+    "id": "hallo-truth-crypt-pamphlet-032",
+    "name": "Crypt Pamphlet",
+    "type": "ATTACK",
+    "faction": "truth",
+    "rarity": "common",
+    "cost": 2,
+    "effects": {
+      "ipDelta": {
+        "opponent": 1
+      }
+    },
+    "extId": "halloween",
+    "text": "Opponent −1 IP.",
+    "flavor": "All treats, suspicious tricks."
+  },
+  {
+    "id": "hallo-truth-headless-horseman-rally-incident-033",
+    "name": "Headless Horseman Rally Incident",
+    "type": "MEDIA",
+    "faction": "truth",
+    "rarity": "common",
+    "cost": 3,
+    "effects": {
+      "truthDelta": 1
+    },
+    "extId": "halloween",
+    "text": "+1% Truth.",
+    "flavor": "Red eyes in the rear-view mirror."
+  },
+  {
+    "id": "hallo-truth-headless-horseman-brief-034",
+    "name": "Headless Horseman Brief",
+    "type": "ATTACK",
+    "faction": "truth",
+    "rarity": "common",
+    "cost": 2,
+    "effects": {
+      "ipDelta": {
+        "opponent": 1
+      }
+    },
+    "extId": "halloween",
+    "text": "Opponent −1 IP.",
+    "flavor": "Smells like fog machine and fear."
+  },
+  {
+    "id": "hallo-truth-jack-o-lantern-shuffle-incident-035",
+    "name": "Jack-o-Lantern Shuffle Incident",
+    "type": "MEDIA",
+    "faction": "truth",
+    "rarity": "common",
+    "cost": 3,
+    "effects": {
+      "truthDelta": 1
+    },
+    "extId": "halloween",
+    "text": "+1% Truth.",
+    "flavor": "Whispers from the cornfield."
+  },
+  {
+    "id": "hallo-truth-cobweb-alert-protocol-036",
+    "name": "Cobweb Alert Protocol",
+    "type": "MEDIA",
+    "faction": "truth",
+    "rarity": "common",
+    "cost": 3,
+    "effects": {
+      "truthDelta": 1
+    },
+    "extId": "halloween",
+    "text": "+1% Truth.",
+    "flavor": "Someone left the portal open again."
+  },
+  {
+    "id": "hallo-truth-rally-of-the-cauldron-037",
+    "name": "Rally of the Cauldron",
+    "type": "MEDIA",
+    "faction": "truth",
+    "rarity": "common",
+    "cost": 3,
+    "effects": {
+      "truthDelta": 1
+    },
+    "extId": "halloween",
+    "text": "+1% Truth.",
+    "flavor": "Mind the ectoplasm."
+  },
+  {
+    "id": "hallo-truth-scare-of-the-zombie-038",
+    "name": "Scare of the Zombie",
+    "type": "MEDIA",
+    "faction": "truth",
+    "rarity": "common",
+    "cost": 3,
+    "effects": {
+      "truthDelta": 1
+    },
+    "extId": "halloween",
+    "text": "+1% Truth.",
+    "flavor": "Batteries not included."
+  },
+  {
+    "id": "hallo-truth-haunted-mansion-flyer-protocol-039",
+    "name": "Haunted Mansion Flyer Protocol",
+    "type": "ZONE",
+    "faction": "truth",
+    "rarity": "common",
+    "cost": 4,
+    "effects": {
+      "pressureDelta": 1
+    },
+    "extId": "halloween",
+    "text": "+1 Pressure in a chosen state.",
+    "flavor": "Red eyes in the rear-view mirror.",
+    "target": {
+      "scope": "state",
+      "count": 1
+    }
+  },
+  {
+    "id": "hallo-truth-shuffle-of-the-spooky-hayride-040",
+    "name": "Shuffle of the Spooky Hayride",
+    "type": "ATTACK",
+    "faction": "truth",
+    "rarity": "common",
+    "cost": 2,
+    "effects": {
+      "ipDelta": {
+        "opponent": 1
+      }
+    },
+    "extId": "halloween",
+    "text": "Opponent −1 IP.",
+    "flavor": "Haunting sponsored by a totally normal NGO."
+  },
+  {
+    "id": "hallo-truth-cauldron-brief-files-041",
+    "name": "Cauldron Brief Files",
+    "type": "MEDIA",
+    "faction": "truth",
+    "rarity": "common",
+    "cost": 3,
+    "effects": {
+      "truthDelta": 1
+    },
+    "extId": "halloween",
+    "text": "+1% Truth.",
+    "flavor": "Smells like fog machine and fear."
+  },
+  {
+    "id": "hallo-truth-moonlight-report-042",
+    "name": "Moonlight Report",
+    "type": "ATTACK",
+    "faction": "truth",
+    "rarity": "common",
+    "cost": 2,
+    "effects": {
+      "ipDelta": {
+        "opponent": 1
+      }
+    },
+    "extId": "halloween",
+    "text": "Opponent −1 IP.",
+    "flavor": "Try not to scream on camera."
+  },
+  {
+    "id": "hallo-truth-haunted-mansion-alert-initiative-043",
+    "name": "Haunted Mansion Alert Initiative",
+    "type": "ATTACK",
+    "faction": "truth",
+    "rarity": "common",
+    "cost": 2,
+    "effects": {
+      "ipDelta": {
+        "opponent": 1
+      }
+    },
+    "extId": "halloween",
+    "text": "Opponent −1 IP.",
+    "flavor": "Mind the ectoplasm."
+  },
+  {
+    "id": "hallo-truth-banshee-shuffle-protocol-044",
+    "name": "Banshee Shuffle Protocol",
+    "type": "ZONE",
+    "faction": "truth",
+    "rarity": "common",
+    "cost": 4,
+    "effects": {
+      "pressureDelta": 1
+    },
+    "extId": "halloween",
+    "text": "+1 Pressure in a chosen state.",
+    "flavor": "We can neither confirm nor deny the howling.",
+    "target": {
+      "scope": "state",
+      "count": 1
+    }
+  },
+  {
+    "id": "hallo-truth-ouija-rally-initiative-045",
+    "name": "Ouija Rally Initiative",
+    "type": "ATTACK",
+    "faction": "truth",
+    "rarity": "common",
+    "cost": 2,
+    "effects": {
+      "ipDelta": {
+        "opponent": 1
+      }
+    },
+    "extId": "halloween",
+    "text": "Opponent −1 IP.",
+    "flavor": "All treats, suspicious tricks."
+  },
+  {
+    "id": "hallo-truth-banshee-shenanigans-files-046",
+    "name": "Banshee Shenanigans Files",
+    "type": "MEDIA",
+    "faction": "truth",
+    "rarity": "common",
+    "cost": 3,
+    "effects": {
+      "truthDelta": 1
+    },
+    "extId": "halloween",
+    "text": "+1% Truth.",
+    "flavor": "They came for the candy, stayed for the cover‑up."
+  },
+  {
+    "id": "hallo-truth-frankenstein-brief-incident-047",
+    "name": "Frankenstein Brief Incident",
+    "type": "ZONE",
+    "faction": "truth",
+    "rarity": "common",
+    "cost": 4,
+    "effects": {
+      "pressureDelta": 1
+    },
+    "extId": "halloween",
+    "text": "+1 Pressure in a chosen state.",
+    "flavor": "Licensed spooktacular.",
+    "target": {
+      "scope": "state",
+      "count": 1
+    }
+  },
+  {
+    "id": "hallo-truth-poltergeist-whispers-files-048",
+    "name": "Poltergeist Whispers Files",
+    "type": "MEDIA",
+    "faction": "truth",
+    "rarity": "common",
+    "cost": 3,
+    "effects": {
+      "truthDelta": 1
+    },
+    "extId": "halloween",
+    "text": "+1% Truth.",
+    "flavor": "Keep garlic handy."
+  },
+  {
+    "id": "hallo-truth-candy-corn-shuffle-incident-049",
+    "name": "Candy Corn Shuffle Incident",
+    "type": "MEDIA",
+    "faction": "truth",
+    "rarity": "common",
+    "cost": 3,
+    "effects": {
+      "truthDelta": 1
+    },
+    "extId": "halloween",
+    "text": "+1% Truth.",
+    "flavor": "This is fine. Probably."
+  },
+  {
+    "id": "hallo-truth-spider-shenanigans-protocol-050",
+    "name": "Spider Shenanigans Protocol",
+    "type": "ZONE",
+    "faction": "truth",
+    "rarity": "common",
+    "cost": 4,
+    "effects": {
+      "pressureDelta": 1
+    },
+    "extId": "halloween",
+    "text": "+1 Pressure in a chosen state.",
+    "flavor": "They came for the candy, stayed for the cover‑up.",
+    "target": {
+      "scope": "state",
+      "count": 1
+    }
+  },
+  {
+    "id": "hallo-truth-haunted-press-release-051",
+    "name": "Haunted Press Release",
+    "type": "MEDIA",
+    "faction": "truth",
+    "rarity": "common",
+    "cost": 3,
+    "effects": {
+      "truthDelta": 1
+    },
+    "extId": "halloween",
+    "text": "+1% Truth.",
+    "flavor": "Filed under ‘Seasonal Anomalies’."
+  },
+  {
+    "id": "hallo-truth-ouija-flyer-052",
+    "name": "Ouija Flyer",
+    "type": "MEDIA",
+    "faction": "truth",
+    "rarity": "common",
+    "cost": 3,
+    "effects": {
+      "truthDelta": 1
+    },
+    "extId": "halloween",
+    "text": "+1% Truth.",
+    "flavor": "Batteries not included."
+  },
+  {
+    "id": "hallo-truth-shuffle-of-the-dracula-053",
+    "name": "Shuffle of the Dracula",
+    "type": "ATTACK",
+    "faction": "truth",
+    "rarity": "common",
+    "cost": 2,
+    "effects": {
+      "ipDelta": {
+        "opponent": 1
+      }
+    },
+    "extId": "halloween",
+    "text": "Opponent −1 IP.",
+    "flavor": "Whispers from the cornfield."
+  },
+  {
+    "id": "hallo-truth-ghost-report-protocol-054",
+    "name": "Ghost Report Protocol",
+    "type": "ATTACK",
+    "faction": "truth",
+    "rarity": "common",
+    "cost": 2,
+    "effects": {
+      "ipDelta": {
+        "opponent": 1
+      }
+    },
+    "extId": "halloween",
+    "text": "Opponent −1 IP.",
+    "flavor": "We can neither confirm nor deny the howling."
+  },
+  {
+    "id": "hallo-truth-pamphlet-of-the-raven-055",
+    "name": "Pamphlet of the Raven",
+    "type": "MEDIA",
+    "faction": "truth",
+    "rarity": "common",
+    "cost": 3,
+    "effects": {
+      "truthDelta": 1
+    },
+    "extId": "halloween",
+    "text": "+1% Truth.",
+    "flavor": "Haunting sponsored by a totally normal NGO."
+  },
+  {
+    "id": "hallo-truth-seance-shuffle-incident-056",
+    "name": "Seance Shuffle Incident",
+    "type": "ATTACK",
+    "faction": "truth",
+    "rarity": "common",
+    "cost": 2,
+    "effects": {
+      "ipDelta": {
+        "opponent": 1
+      }
+    },
+    "extId": "halloween",
+    "text": "Opponent −1 IP.",
+    "flavor": "Red eyes in the rear-view mirror."
+  },
+  {
+    "id": "hallo-truth-pumpkin-rally-initiative-057",
+    "name": "Pumpkin Rally Initiative",
+    "type": "MEDIA",
+    "faction": "truth",
+    "rarity": "common",
+    "cost": 3,
+    "effects": {
+      "truthDelta": 1
+    },
+    "extId": "halloween",
+    "text": "+1% Truth.",
+    "flavor": "Keep garlic handy."
+  },
+  {
+    "id": "hallo-truth-black-cat-press-release-protocol-058",
+    "name": "Black Cat Press Release Protocol",
+    "type": "MEDIA",
+    "faction": "truth",
+    "rarity": "common",
+    "cost": 3,
+    "effects": {
+      "truthDelta": 1
+    },
+    "extId": "halloween",
+    "text": "+1% Truth.",
+    "flavor": "Red eyes in the rear-view mirror."
+  },
+  {
+    "id": "hallo-truth-cemetery-rumor-initiative-059",
+    "name": "Cemetery Rumor Initiative",
+    "type": "MEDIA",
+    "faction": "truth",
+    "rarity": "common",
+    "cost": 3,
+    "effects": {
+      "truthDelta": 1
+    },
+    "extId": "halloween",
+    "text": "+1% Truth.",
+    "flavor": "Try not to scream on camera."
+  },
+  {
+    "id": "hallo-truth-midnight-flyer-protocol-060",
+    "name": "Midnight Flyer Protocol",
+    "type": "ATTACK",
+    "faction": "truth",
+    "rarity": "common",
+    "cost": 2,
+    "effects": {
+      "ipDelta": {
+        "opponent": 1
+      }
+    },
+    "extId": "halloween",
+    "text": "Opponent −1 IP.",
+    "flavor": "Red eyes in the rear-view mirror."
+  },
+  {
+    "id": "hallo-truth-ghost-press-release-files-061",
+    "name": "Ghost Press Release Files",
+    "type": "MEDIA",
+    "faction": "truth",
+    "rarity": "common",
+    "cost": 3,
+    "effects": {
+      "truthDelta": 1
+    },
+    "extId": "halloween",
+    "text": "+1% Truth.",
+    "flavor": "Rated PG‑Paranoid."
+  },
+  {
+    "id": "hallo-truth-pamphlet-of-the-ouija-062",
+    "name": "Pamphlet of the Ouija",
+    "type": "ZONE",
+    "faction": "truth",
+    "rarity": "common",
+    "cost": 4,
+    "effects": {
+      "pressureDelta": 1
+    },
+    "extId": "halloween",
+    "text": "+1 Pressure in a chosen state.",
+    "flavor": "Filed under ‘Seasonal Anomalies’.",
+    "target": {
+      "scope": "state",
+      "count": 1
+    }
+  },
+  {
+    "id": "hallo-truth-frankenstein-pamphlet-063",
+    "name": "Frankenstein Pamphlet",
+    "type": "ZONE",
+    "faction": "truth",
+    "rarity": "common",
+    "cost": 4,
+    "effects": {
+      "pressureDelta": 1
+    },
+    "extId": "halloween",
+    "text": "+1 Pressure in a chosen state.",
+    "flavor": "Whispers from the cornfield.",
+    "target": {
+      "scope": "state",
+      "count": 1
+    }
+  },
+  {
+    "id": "hallo-truth-ectoplasm-whispers-incident-064",
+    "name": "Ectoplasm Whispers Incident",
+    "type": "ATTACK",
+    "faction": "truth",
+    "rarity": "common",
+    "cost": 2,
+    "effects": {
+      "ipDelta": {
+        "opponent": 1
+      }
+    },
+    "extId": "halloween",
+    "text": "Opponent −1 IP.",
+    "flavor": "Keep garlic handy."
+  },
+  {
+    "id": "hallo-truth-crypt-flyer-initiative-065",
+    "name": "Crypt Flyer Initiative",
+    "type": "MEDIA",
+    "faction": "truth",
+    "rarity": "common",
+    "cost": 3,
+    "effects": {
+      "truthDelta": 1
+    },
+    "extId": "halloween",
+    "text": "+1% Truth.",
+    "flavor": "Do not feed after midnight."
+  },
+  {
+    "id": "hallo-truth-full-moon-brief-incident-066",
+    "name": "Full Moon Brief Incident",
+    "type": "ZONE",
+    "faction": "truth",
+    "rarity": "common",
+    "cost": 4,
+    "effects": {
+      "pressureDelta": 1
+    },
+    "extId": "halloween",
+    "text": "+1 Pressure in a chosen state.",
+    "flavor": "Red eyes in the rear-view mirror.",
+    "target": {
+      "scope": "state",
+      "count": 1
+    }
+  },
+  {
+    "id": "hallo-truth-spooky-hayride-rally-protocol-067",
+    "name": "Spooky Hayride Rally Protocol",
+    "type": "MEDIA",
+    "faction": "truth",
+    "rarity": "common",
+    "cost": 3,
+    "effects": {
+      "truthDelta": 1
+    },
+    "extId": "halloween",
+    "text": "+1% Truth.",
+    "flavor": "Someone left the portal open again."
+  },
+  {
+    "id": "hallo-truth-alert-of-the-skeleton-068",
+    "name": "Alert of the Skeleton",
+    "type": "MEDIA",
+    "faction": "truth",
+    "rarity": "common",
+    "cost": 3,
+    "effects": {
+      "truthDelta": 1
+    },
+    "extId": "halloween",
+    "text": "+1% Truth.",
+    "flavor": "Mind the ectoplasm."
+  },
+  {
+    "id": "hallo-truth-headless-horseman-whispers-protocol-069",
+    "name": "Headless Horseman Whispers Protocol",
+    "type": "ATTACK",
+    "faction": "truth",
+    "rarity": "common",
+    "cost": 2,
+    "effects": {
+      "ipDelta": {
+        "opponent": 1
+      }
+    },
+    "extId": "halloween",
+    "text": "Opponent −1 IP.",
+    "flavor": "The crypt Wi‑Fi is excellent."
+  },
+  {
+    "id": "hallo-truth-candy-corn-press-release-initiative-070",
+    "name": "Candy Corn Press Release Initiative",
+    "type": "ATTACK",
+    "faction": "truth",
+    "rarity": "common",
+    "cost": 2,
+    "effects": {
+      "ipDelta": {
+        "opponent": 1
+      }
+    },
+    "extId": "halloween",
+    "text": "Opponent −1 IP.",
+    "flavor": "Filed under ‘Seasonal Anomalies’."
+  },
+  {
+    "id": "hallo-truth-graveyard-murmur-network-protocol-001",
+    "name": "Graveyard Murmur Network Protocol",
+    "type": "ATTACK",
+    "faction": "truth",
+    "rarity": "uncommon",
+    "cost": 3,
+    "effects": {
+      "ipDelta": {
+        "opponent": 2
+      }
+    },
+    "extId": "halloween",
+    "text": "Opponent −2 IP.",
+    "flavor": "Keep garlic handy."
+  },
+  {
+    "id": "hallo-truth-poltergeist-broadcast-files-002",
+    "name": "Poltergeist Broadcast Files",
+    "type": "ATTACK",
+    "faction": "truth",
+    "rarity": "uncommon",
+    "cost": 3,
+    "effects": {
+      "ipDelta": {
+        "opponent": 2
+      }
+    },
+    "extId": "halloween",
+    "text": "Opponent −2 IP.",
+    "flavor": "Whispers from the cornfield."
+  },
+  {
+    "id": "hallo-truth-haunted-mansion-operation-003",
+    "name": "Haunted Mansion Operation",
+    "type": "ATTACK",
+    "faction": "truth",
+    "rarity": "uncommon",
+    "cost": 3,
+    "effects": {
+      "ipDelta": {
+        "opponent": 2
+      }
+    },
+    "extId": "halloween",
+    "text": "Opponent −2 IP.",
+    "flavor": "Licensed spooktacular."
+  },
+  {
+    "id": "hallo-truth-spider-expedition-incident-004",
+    "name": "Spider Expedition Incident",
+    "type": "ATTACK",
+    "faction": "truth",
+    "rarity": "uncommon",
+    "cost": 3,
+    "effects": {
+      "ipDelta": {
+        "opponent": 2
+      }
+    },
+    "extId": "halloween",
+    "text": "Opponent −2 IP.",
+    "flavor": "Batteries not included."
+  },
+  {
+    "id": "hallo-truth-haunted-mansion-expedition-protocol-005",
+    "name": "Haunted Mansion Expedition Protocol",
+    "type": "MEDIA",
+    "faction": "truth",
+    "rarity": "uncommon",
+    "cost": 4,
+    "effects": {
+      "truthDelta": 2
+    },
+    "extId": "halloween",
+    "text": "+2% Truth.",
+    "flavor": "Bring a flashlight and plausible deniability."
+  },
+  {
+    "id": "hallo-truth-seance-sweep-006",
+    "name": "Seance Sweep",
+    "type": "MEDIA",
+    "faction": "truth",
+    "rarity": "uncommon",
+    "cost": 4,
+    "effects": {
+      "truthDelta": 2
+    },
+    "extId": "halloween",
+    "text": "+2% Truth.",
+    "flavor": "The crypt Wi‑Fi is excellent."
+  },
+  {
+    "id": "hallo-truth-trick-or-treat-ploy-007",
+    "name": "Trick-or-Treat Ploy",
+    "type": "MEDIA",
+    "faction": "truth",
+    "rarity": "uncommon",
+    "cost": 4,
+    "effects": {
+      "truthDelta": 2
+    },
+    "extId": "halloween",
+    "text": "+2% Truth.",
+    "flavor": "Batteries not included."
+  },
+  {
+    "id": "hallo-truth-graveyard-gambit-protocol-008",
+    "name": "Graveyard Gambit Protocol",
+    "type": "ATTACK",
+    "faction": "truth",
+    "rarity": "uncommon",
+    "cost": 3,
+    "effects": {
+      "ipDelta": {
+        "opponent": 2
+      }
+    },
+    "extId": "halloween",
+    "text": "Opponent −2 IP.",
+    "flavor": "Bring a flashlight and plausible deniability."
+  },
+  {
+    "id": "hallo-truth-cobweb-ploy-incident-009",
+    "name": "Cobweb Ploy Incident",
+    "type": "MEDIA",
+    "faction": "truth",
+    "rarity": "uncommon",
+    "cost": 4,
+    "effects": {
+      "truthDelta": 2
+    },
+    "extId": "halloween",
+    "text": "+2% Truth.",
+    "flavor": "Do not feed after midnight."
+  },
+  {
+    "id": "hallo-truth-cauldron-gambit-protocol-010",
+    "name": "Cauldron Gambit Protocol",
+    "type": "ZONE",
+    "faction": "truth",
+    "rarity": "uncommon",
+    "cost": 5,
+    "effects": {
+      "pressureDelta": 2
+    },
+    "extId": "halloween",
+    "text": "+2 Pressure in a chosen state.",
+    "flavor": "Mind the ectoplasm.",
+    "target": {
+      "scope": "state",
+      "count": 1
+    }
+  },
+  {
+    "id": "hallo-truth-witch-operation-files-011",
+    "name": "Witch Operation Files",
+    "type": "ATTACK",
+    "faction": "truth",
+    "rarity": "uncommon",
+    "cost": 3,
+    "effects": {
+      "ipDelta": {
+        "opponent": 2
+      }
+    },
+    "extId": "halloween",
+    "text": "Opponent −2 IP.",
+    "flavor": "The crypt Wi‑Fi is excellent."
+  },
+  {
+    "id": "hallo-truth-seance-sweep-012",
+    "name": "Seance Sweep",
+    "type": "ZONE",
+    "faction": "truth",
+    "rarity": "uncommon",
+    "cost": 5,
+    "effects": {
+      "pressureDelta": 2
+    },
+    "extId": "halloween",
+    "text": "+2 Pressure in a chosen state.",
+    "flavor": "Whispers from the cornfield.",
+    "target": {
+      "scope": "state",
+      "count": 1
+    }
+  },
+  {
+    "id": "hallo-truth-zombie-murmur-network-013",
+    "name": "Zombie Murmur Network",
+    "type": "MEDIA",
+    "faction": "truth",
+    "rarity": "uncommon",
+    "cost": 4,
+    "effects": {
+      "truthDelta": 2
+    },
+    "extId": "halloween",
+    "text": "+2% Truth.",
+    "flavor": "Licensed spooktacular."
+  },
+  {
+    "id": "hallo-truth-moonlight-operation-initiative-014",
+    "name": "Moonlight Operation Initiative",
+    "type": "ZONE",
+    "faction": "truth",
+    "rarity": "uncommon",
+    "cost": 5,
+    "effects": {
+      "pressureDelta": 2
+    },
+    "extId": "halloween",
+    "text": "+2 Pressure in a chosen state.",
+    "flavor": "Rated PG‑Paranoid.",
+    "target": {
+      "scope": "state",
+      "count": 1
+    }
+  },
+  {
+    "id": "hallo-truth-jack-o-lantern-broadcast-initiative-015",
+    "name": "Jack-o-Lantern Broadcast Initiative",
+    "type": "MEDIA",
+    "faction": "truth",
+    "rarity": "uncommon",
+    "cost": 4,
+    "effects": {
+      "truthDelta": 2
+    },
+    "extId": "halloween",
+    "text": "+2% Truth.",
+    "flavor": "They came for the candy, stayed for the cover‑up."
+  },
+  {
+    "id": "hallo-truth-ghoul-operation-initiative-016",
+    "name": "Ghoul Operation Initiative",
+    "type": "MEDIA",
+    "faction": "truth",
+    "rarity": "uncommon",
+    "cost": 4,
+    "effects": {
+      "truthDelta": 2
+    },
+    "extId": "halloween",
+    "text": "+2% Truth.",
+    "flavor": "Keep garlic handy."
+  },
+  {
+    "id": "hallo-truth-operation-of-the-mummy-017",
+    "name": "Operation of the Mummy",
+    "type": "ATTACK",
+    "faction": "truth",
+    "rarity": "uncommon",
+    "cost": 3,
+    "effects": {
+      "ipDelta": {
+        "opponent": 2
+      }
+    },
+    "extId": "halloween",
+    "text": "Opponent −2 IP.",
+    "flavor": "Rated PG‑Paranoid."
+  },
+  {
+    "id": "hallo-truth-poltergeist-murmur-network-incident-018",
+    "name": "Poltergeist Murmur Network Incident",
+    "type": "MEDIA",
+    "faction": "truth",
+    "rarity": "uncommon",
+    "cost": 4,
+    "effects": {
+      "truthDelta": 2
+    },
+    "extId": "halloween",
+    "text": "+2% Truth.",
+    "flavor": "Someone left the portal open again."
+  },
+  {
+    "id": "hallo-truth-cobweb-ploy-initiative-019",
+    "name": "Cobweb Ploy Initiative",
+    "type": "MEDIA",
+    "faction": "truth",
+    "rarity": "uncommon",
+    "cost": 4,
+    "effects": {
+      "truthDelta": 2
+    },
+    "extId": "halloween",
+    "text": "+2% Truth.",
+    "flavor": "This is fine. Probably."
+  },
+  {
+    "id": "hallo-truth-headless-horseman-expedition-files-020",
+    "name": "Headless Horseman Expedition Files",
+    "type": "MEDIA",
+    "faction": "truth",
+    "rarity": "uncommon",
+    "cost": 4,
+    "effects": {
+      "truthDelta": 2
+    },
+    "extId": "halloween",
+    "text": "+2% Truth.",
+    "flavor": "Filed under ‘Seasonal Anomalies’."
+  },
+  {
+    "id": "hallo-truth-mummy-sanction-001",
+    "name": "Mummy Sanction",
+    "type": "ATTACK",
+    "faction": "truth",
+    "rarity": "rare",
+    "cost": 4,
+    "effects": {
+      "ipDelta": {
+        "opponent": 3
+      },
+      "discardOpponent": 1
+    },
+    "extId": "halloween",
+    "text": "Opponent −3 IP, discard 1.",
+    "flavor": "Do not taunt the poltergeist."
+  },
+  {
+    "id": "hallo-truth-frankenstein-project-incident-002",
+    "name": "Frankenstein Project Incident",
+    "type": "MEDIA",
+    "faction": "truth",
+    "rarity": "rare",
+    "cost": 5,
+    "effects": {
+      "truthDelta": 3
+    },
+    "extId": "halloween",
+    "text": "+3% Truth.",
+    "flavor": "This is fine. Probably."
+  },
+  {
+    "id": "hallo-truth-zombie-deep-cover-files-003",
+    "name": "Zombie Deep Cover Files",
+    "type": "MEDIA",
+    "faction": "truth",
+    "rarity": "rare",
+    "cost": 5,
+    "effects": {
+      "truthDelta": 3
+    },
+    "extId": "halloween",
+    "text": "+3% Truth.",
+    "flavor": "Whispers from the cornfield."
+  },
+  {
+    "id": "hallo-truth-cauldron-grand-ritual-protocol-004",
+    "name": "Cauldron Grand Ritual Protocol",
+    "type": "ZONE",
+    "faction": "truth",
+    "rarity": "rare",
+    "cost": 6,
+    "effects": {
+      "pressureDelta": 3
+    },
+    "extId": "halloween",
+    "text": "+3 Pressure in a chosen state.",
+    "flavor": "‘It was just the wind,’ said the intern.",
+    "target": {
+      "scope": "state",
+      "count": 1
+    }
+  },
+  {
+    "id": "hallo-truth-spooky-hayride-revelation-005",
+    "name": "Spooky Hayride Revelation",
+    "type": "ATTACK",
+    "faction": "truth",
+    "rarity": "rare",
+    "cost": 4,
+    "effects": {
+      "ipDelta": {
+        "opponent": 3
+      },
+      "discardOpponent": 1
+    },
+    "extId": "halloween",
+    "text": "Opponent −3 IP, discard 1.",
+    "flavor": "Try not to scream on camera."
+  },
+  {
+    "id": "hallo-truth-ghoul-project-incident-006",
+    "name": "Ghoul Project Incident",
+    "type": "ATTACK",
+    "faction": "truth",
+    "rarity": "rare",
+    "cost": 4,
+    "effects": {
+      "ipDelta": {
+        "opponent": 3
+      },
+      "discardOpponent": 1
+    },
+    "extId": "halloween",
+    "text": "Opponent −3 IP, discard 1.",
+    "flavor": "Red eyes in the rear-view mirror."
+  },
+  {
+    "id": "hallo-truth-cemetery-deep-cover-protocol-007",
+    "name": "Cemetery Deep Cover Protocol",
+    "type": "MEDIA",
+    "faction": "truth",
+    "rarity": "rare",
+    "cost": 5,
+    "effects": {
+      "truthDelta": 3
+    },
+    "extId": "halloween",
+    "text": "+3% Truth.",
+    "flavor": "Do not feed after midnight."
+  },
+  {
+    "id": "hallo-gov-operation-pumpkin-spice-legendary",
+    "name": "Operation Pumpkin Spice",
+    "type": "MEDIA",
+    "faction": "government",
+    "rarity": "legendary",
+    "cost": 6,
+    "effects": {
+      "truthDelta": 4
+    },
+    "extId": "halloween",
+    "text": "+4% Truth.",
+    "flavor": "Approved by the Starbucks Council of Shadows."
+  },
+  {
+    "id": "hallo-gov-containment-protocol-dracula-legendary",
+    "name": "Containment Protocol: Dracula",
+    "type": "MEDIA",
+    "faction": "government",
+    "rarity": "rare",
+    "cost": 5,
+    "effects": {
+      "truthDelta": 3
+    },
+    "extId": "halloween",
+    "text": "+3% Truth.",
+    "flavor": "Stake, garlic, plausible deniability."
+  },
+  {
+    "id": "hallo-gov-the-skeleton-army-rises-legendary",
+    "name": "The Skeleton Army Rises",
+    "type": "ZONE",
+    "faction": "government",
+    "rarity": "rare",
+    "cost": 6,
+    "effects": {
+      "pressureDelta": 3
+    },
+    "extId": "halloween",
+    "text": "+3 Pressure in a chosen state.",
+    "flavor": "From the boneyard to the ballot box.",
+    "target": {
+      "scope": "state",
+      "count": 1
+    }
+  },
+  {
+    "id": "hallo-truth-elvira-mistress-of-the-leaks-legendary",
+    "name": "Elvira, Mistress of the Leaks",
+    "type": "MEDIA",
+    "faction": "truth",
+    "rarity": "legendary",
+    "cost": 6,
+    "effects": {
+      "truthDelta": 4
+    },
+    "extId": "halloween",
+    "text": "+4% Truth.",
+    "flavor": "Late-night camp, early-morning chaos."
+  },
+  {
+    "id": "hallo-truth-bat-boy-s-rebellion-legendary",
+    "name": "Bat Boy’s Rebellion",
+    "type": "ATTACK",
+    "faction": "truth",
+    "rarity": "legendary",
+    "cost": 5,
+    "effects": {
+      "ipDelta": {
+        "opponent": 4
+      },
+      "discardOpponent": 2
+    },
+    "extId": "halloween",
+    "text": "Opponent −4 IP, discard 2.",
+    "flavor": "Finally escaped the tabloids — and he’s pissed."
+  },
+  {
+    "id": "hallo-truth-candy-apocalypse-legendary",
+    "name": "Candy Apocalypse",
+    "type": "ATTACK",
+    "faction": "truth",
+    "rarity": "rare",
+    "cost": 4,
+    "effects": {
+      "ipDelta": {
+        "opponent": 3
+      },
+      "discardOpponent": 1
+    },
+    "extId": "halloween",
+    "text": "Opponent −3 IP, discard 1.",
+    "flavor": "Too much sugar unleashes the truth."
+  }
+];
+
+export default cards;

--- a/src/data/expansions/index.ts
+++ b/src/data/expansions/index.ts
@@ -1,0 +1,47 @@
+import type { GameCard } from '@/rules/mvp';
+import { validateMvpCard } from '@/utils/validate-mvp';
+
+export type ExpansionPack = { id: string; title: string; files: string[] };
+
+export const EXPANSION_MANIFEST: ExpansionPack[] = [
+  { id: 'cryptids', title: 'Cryptids', files: ['./cryptids_MVP.ts'] },
+  { id: 'halloween', title: 'Halloween Spooktacular', files: ['./halloween_MVP.ts'] },
+];
+
+export async function loadEnabledExpansions(enabledIds: string[]): Promise<GameCard[]> {
+  const files: string[] = [];
+
+  for (const pack of EXPANSION_MANIFEST) {
+    if (!enabledIds.includes(pack.id)) continue;
+    files.push(...pack.files);
+  }
+
+  if (files.length === 0) {
+    console.info('[EXPANSIONS]', { enabled: enabledIds, total: 0 });
+    return [];
+  }
+
+  const mods = await Promise.all(files.map(file => import(/* @vite-ignore */ file)));
+  const seen = new Set<string>();
+  const out: GameCard[] = [];
+
+  for (const mod of mods) {
+    const arr = (mod as any).default ?? Object.values(mod)[0];
+    if (!Array.isArray(arr)) continue;
+
+    for (const card of arr) {
+      if (!card?.id || seen.has(card.id)) continue;
+      seen.add(card.id);
+
+      const validation = validateMvpCard(card);
+      if (validation.ok) {
+        out.push(card as GameCard);
+      } else {
+        console.warn('[EXPANSION INVALID]', card?.id, validation.issues);
+      }
+    }
+  }
+
+  console.info('[EXPANSIONS]', { enabled: enabledIds, total: out.length });
+  return out;
+}

--- a/src/data/expansions/state.ts
+++ b/src/data/expansions/state.ts
@@ -1,0 +1,127 @@
+import type { GameCard } from '@/rules/mvp';
+import { EXPANSION_MANIFEST, loadEnabledExpansions } from './index';
+
+const STORAGE_KEY = 'sg:expansions';
+const MANIFEST_IDS = new Set(EXPANSION_MANIFEST.map(pack => pack.id));
+
+let enabledIdsCache: string[] = [];
+let cachedCards: GameCard[] = [];
+let loadingPromise: Promise<GameCard[]> | null = null;
+const listeners = new Set<(payload: { ids: string[]; cards: GameCard[] }) => void>();
+
+const readStoredIds = (): string[] => {
+  if (typeof window === 'undefined') {
+    return [...enabledIdsCache];
+  }
+
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    if (!raw) {
+      return [];
+    }
+
+    const parsed = JSON.parse(raw);
+    if (Array.isArray(parsed)) {
+      return parsed.filter((value): value is string => typeof value === 'string');
+    }
+  } catch (error) {
+    console.warn('[EXPANSIONS] Failed to read stored expansions', error);
+  }
+
+  return [];
+};
+
+const normalizeIds = (ids: string[]): string[] => {
+  return Array.from(new Set(ids.filter(id => MANIFEST_IDS.has(id))));
+};
+
+const persistIds = (ids: string[]) => {
+  if (typeof window === 'undefined') {
+    return;
+  }
+
+  try {
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(ids));
+  } catch (error) {
+    console.warn('[EXPANSIONS] Failed to persist enabled expansions', error);
+  }
+};
+
+const notify = () => {
+  const snapshot = getExpansionCardsSnapshot();
+  const ids = getEnabledExpansionIdsSnapshot();
+  for (const listener of listeners) {
+    try {
+      listener({ ids, cards: snapshot });
+    } catch (error) {
+      console.warn('[EXPANSIONS] Listener error', error);
+    }
+  }
+};
+
+export const getEnabledExpansionIdsSnapshot = (): string[] => {
+  return [...enabledIdsCache];
+};
+
+export const getExpansionCardsSnapshot = (): GameCard[] => {
+  return [...cachedCards];
+};
+
+export const getStoredExpansionIds = (): string[] => {
+  const stored = readStoredIds();
+  enabledIdsCache = normalizeIds(stored);
+  return getEnabledExpansionIdsSnapshot();
+};
+
+export const subscribeToExpansionChanges = (
+  listener: (payload: { ids: string[]; cards: GameCard[] }) => void,
+): (() => void) => {
+  listeners.add(listener);
+  return () => {
+    listeners.delete(listener);
+  };
+};
+
+export const refreshExpansionCards = async (ids?: string[]): Promise<GameCard[]> => {
+  const normalized = normalizeIds(ids ?? getStoredExpansionIds());
+  enabledIdsCache = normalized;
+  persistIds(enabledIdsCache);
+
+  const loadPromise = loadEnabledExpansions(enabledIdsCache)
+    .then(cards => {
+      cachedCards = cards.map(card => ({ ...card }));
+      notify();
+      return cachedCards;
+    })
+    .catch(error => {
+      console.warn('[EXPANSIONS] Failed to load expansions', error);
+      cachedCards = [];
+      notify();
+      return cachedCards;
+    })
+    .finally(() => {
+      loadingPromise = null;
+    });
+
+  loadingPromise = loadPromise;
+  return loadPromise;
+};
+
+export const updateEnabledExpansions = async (ids: string[]): Promise<GameCard[]> => {
+  const normalized = normalizeIds(ids);
+  enabledIdsCache = normalized;
+  persistIds(enabledIdsCache);
+  if (loadingPromise) {
+    try {
+      await loadingPromise;
+    } catch {
+      // ignore errors from previous load
+    }
+  }
+  return refreshExpansionCards(enabledIdsCache);
+};
+
+export const initializeExpansions = async (): Promise<void> => {
+  enabledIdsCache = normalizeIds(readStoredIds());
+  await refreshExpansionCards(enabledIdsCache);
+};

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,5 +1,17 @@
-import { createRoot } from "react-dom/client";
-import App from "./App.tsx";
-import "./index.css";
+import { createRoot } from 'react-dom/client';
+import App from './App.tsx';
+import './index.css';
+import { initializeExpansions } from '@/data/expansions/state';
 
-createRoot(document.getElementById("root")!).render(<App />);
+const rootElement = document.getElementById('root');
+if (!rootElement) {
+  throw new Error('Root element not found');
+}
+
+initializeExpansions()
+  .catch(error => {
+    console.warn('[EXPANSIONS] Initialization failed', error);
+  })
+  .finally(() => {
+    createRoot(rootElement).render(<App />);
+  });


### PR DESCRIPTION
## Summary
- add sanitized MVP card lists for Cryptids and Halloween expansions with a manifest-driven loader
- introduce expansion state management to cache selections, initialize at startup, and feed deck building
- surface expansion toggles in Options, update Manage Expansions dashboard, and refresh balancing metrics with core/expansion totals

## Testing
- `npm run lint` *(fails: missing @eslint/js dependency and npm install blocked by 403 for ts-node)*

------
https://chatgpt.com/codex/tasks/task_e_68cadcd629c48320935035dcd0d95c3b