### PR TITLE
feat(expansions): auto-load JSON packs and refresh manager UI

### DIFF
--- a/src/data/expansions/index.ts
+++ b/src/data/expansions/index.ts
@@ -1,47 +1,140 @@
 import type { GameCard } from '@/rules/mvp';
 import { validateMvpCard } from '@/utils/validate-mvp';
 
-export type ExpansionPack = { id: string; title: string; files: string[] };
+type RawExpansion = {
+  cards?: unknown;
+  name?: string;
+  description?: string;
+  version?: string;
+  author?: string;
+  [key: string]: unknown;
+};
 
-export const EXPANSION_MANIFEST: ExpansionPack[] = [
-  { id: 'cryptids', title: 'Cryptids', files: ['./cryptids_MVP.ts'] },
-  { id: 'halloween', title: 'Halloween Spooktacular', files: ['./halloween_MVP.ts'] },
-];
+export type ExpansionPack = {
+  id: string;
+  title: string;
+  fileName: string;
+  cardCount: number;
+  cards: GameCard[];
+  metadata?: Pick<RawExpansion, 'name' | 'description' | 'version' | 'author'>;
+};
 
-export async function loadEnabledExpansions(enabledIds: string[]): Promise<GameCard[]> {
-  const files: string[] = [];
+const formatTitleFromFile = (baseName: string): string => {
+  if (!baseName) return 'Unnamed Expansion';
+  return baseName
+    .replace(/[-_]+/g, ' ')
+    .split(' ')
+    .map(segment => segment.charAt(0).toUpperCase() + segment.slice(1))
+    .join(' ')
+    .trim();
+};
 
-  for (const pack of EXPANSION_MANIFEST) {
-    if (!enabledIds.includes(pack.id)) continue;
-    files.push(...pack.files);
+const expansionModules = import.meta.glob('../../../public/extensions/*.json', {
+  eager: true,
+}) as Record<string, unknown>;
+
+const extractMetadata = (raw: unknown): ExpansionPack['metadata'] => {
+  if (!raw || typeof raw !== 'object') return undefined;
+  const source = raw as RawExpansion;
+  const metadata = {
+    name: typeof source.name === 'string' ? source.name : undefined,
+    description: typeof source.description === 'string' ? source.description : undefined,
+    version: typeof source.version === 'string' ? source.version : undefined,
+    author: typeof source.author === 'string' ? source.author : undefined,
+  };
+  if (!metadata.name && !metadata.description && !metadata.version && !metadata.author) {
+    return undefined;
+  }
+  return metadata;
+};
+
+const buildManifest = (): ExpansionPack[] => {
+  const entries = Object.entries(expansionModules).sort(([a], [b]) => a.localeCompare(b));
+  const manifest: ExpansionPack[] = [];
+
+  for (const [path, mod] of entries) {
+    const fileName = path.split('/').pop() ?? 'expansion.json';
+    const id = fileName.replace(/\.json$/i, '');
+    const title = formatTitleFromFile(id);
+    const raw = (mod as any)?.default ?? mod;
+
+    let cardSources: unknown = undefined;
+    if (Array.isArray(raw)) {
+      cardSources = raw;
+    } else if (raw && typeof raw === 'object' && Array.isArray((raw as RawExpansion).cards)) {
+      cardSources = (raw as RawExpansion).cards;
+    }
+
+    if (!Array.isArray(cardSources)) {
+      console.warn('[EXPANSIONS] No cards found for expansion file', fileName);
+      manifest.push({
+        id,
+        title,
+        fileName,
+        cardCount: 0,
+        cards: [],
+        metadata: extractMetadata(raw),
+      });
+      continue;
+    }
+
+    const cards: GameCard[] = [];
+    const seen = new Set<string>();
+
+    for (const source of cardSources) {
+      if (!source || typeof source !== 'object') continue;
+      const validation = validateMvpCard(source);
+      if (!validation.ok) {
+        console.warn('[EXPANSION INVALID]', id, validation.issues);
+        continue;
+      }
+
+      const card = { ...(source as GameCard), extId: id };
+      if (!card.id || seen.has(card.id)) {
+        continue;
+      }
+      seen.add(card.id);
+      cards.push(card);
+    }
+
+    manifest.push({
+      id,
+      title,
+      fileName,
+      cards,
+      cardCount: cards.length,
+      metadata: extractMetadata(raw),
+    });
   }
 
-  if (files.length === 0) {
+  if (manifest.length === 0) {
+    console.info('[EXPANSIONS] No expansion files found.');
+  }
+
+  return manifest;
+};
+
+export const EXPANSION_MANIFEST: ExpansionPack[] = buildManifest();
+
+export async function loadEnabledExpansions(enabledIds: string[]): Promise<GameCard[]> {
+  if (!enabledIds.length) {
     console.info('[EXPANSIONS]', { enabled: enabledIds, total: 0 });
     return [];
   }
 
-  const mods = await Promise.all(files.map(file => import(/* @vite-ignore */ file)));
+  const cards: GameCard[] = [];
   const seen = new Set<string>();
-  const out: GameCard[] = [];
 
-  for (const mod of mods) {
-    const arr = (mod as any).default ?? Object.values(mod)[0];
-    if (!Array.isArray(arr)) continue;
+  for (const pack of EXPANSION_MANIFEST) {
+    if (!enabledIds.includes(pack.id)) continue;
 
-    for (const card of arr) {
-      if (!card?.id || seen.has(card.id)) continue;
+    for (const card of pack.cards) {
+      if (!card.id || seen.has(card.id)) continue;
       seen.add(card.id);
-
-      const validation = validateMvpCard(card);
-      if (validation.ok) {
-        out.push(card as GameCard);
-      } else {
-        console.warn('[EXPANSION INVALID]', card?.id, validation.issues);
-      }
+      cards.push({ ...card });
     }
   }
 
-  console.info('[EXPANSIONS]', { enabled: enabledIds, total: out.length });
-  return out;
+  console.info('[EXPANSIONS]', { enabled: enabledIds, total: cards.length });
+  return cards;
 }


### PR DESCRIPTION
## Summary
- auto-discover expansion JSON files from `/extensions` and build a manifest from their card data
- attach metadata and extIds while validating cards so enabling packs immediately augments the deck pool
- redesign the expansion manager with collapsible cards, core deck summary, and empty-state messaging

## Testing
- npm run lint *(fails: missing dependencies and npm registry 403)*

------
https://chatgpt.com/codex/tasks/task_e_68cb02c33e5c8320a55428c196051a4c