### PR TITLE
Implement expansion auto-discovery and mix control UI

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,8 @@
     "lint": "eslint .",
     "test": "bun test --coverage --coverage-reporter=text",
     "preview": "vite preview",
+    "predev": "node scripts/generate-extension-index.mjs",
+    "prebuild": "node scripts/generate-extension-index.mjs",
     "ingest:core": "ts-node scripts/splitCoreToBatches.ts",
     "validate:mvp": "bun scripts/validate-mvp-batch.ts"
   },

--- a/public/extensions/index.json
+++ b/public/extensions/index.json
@@ -1,0 +1,4 @@
+[
+  "cryptids.json",
+  "halloween_spooktacular_with_temp_image.json"
+]

--- a/scripts/generate-extension-index.mjs
+++ b/scripts/generate-extension-index.mjs
@@ -1,0 +1,33 @@
+#!/usr/bin/env node
+import { promises as fs } from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const projectRoot = path.resolve(__dirname, '..');
+const extensionsDir = path.join(projectRoot, 'public', 'extensions');
+const indexPath = path.join(extensionsDir, 'index.json');
+
+async function main() {
+  try {
+    await fs.mkdir(extensionsDir, { recursive: true });
+    const entries = await fs.readdir(extensionsDir, { withFileTypes: true });
+    const files = entries
+      .filter(entry => entry.isFile())
+      .map(entry => entry.name)
+      .filter(name => name.toLowerCase().endsWith('.json'))
+      .filter(name => name !== 'manifest.json' && name !== 'index.json')
+      .sort((a, b) => a.localeCompare(b));
+
+    const payload = JSON.stringify(files, null, 2);
+    await fs.writeFile(indexPath, `${payload}\n`, 'utf8');
+
+    console.log(`Generated extensions index with ${files.length} file(s) at ${path.relative(projectRoot, indexPath)}`);
+  } catch (error) {
+    console.error('Failed to generate extensions index:', error);
+    process.exitCode = 1;
+  }
+}
+
+main();

--- a/src/components/expansions/ExpansionControl.tsx
+++ b/src/components/expansions/ExpansionControl.tsx
@@ -1,0 +1,459 @@
+import { useEffect, useMemo, useState, useCallback } from 'react';
+import {
+  Card as UICard,
+  CardContent,
+  CardHeader,
+  CardTitle,
+  CardDescription,
+} from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { Badge } from '@/components/ui/badge';
+import { Switch } from '@/components/ui/switch';
+import { Slider } from '@/components/ui/slider';
+import { Separator } from '@/components/ui/separator';
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from '@/components/ui/collapsible';
+import { ChevronDown } from 'lucide-react';
+import { buildDeck, buildSets, type Card, type MixMode } from '@/lib/decks/expansions';
+import { summarizeSet } from '@/lib/decks/analytics';
+import { discoverExpansions, type DiscoveredExpansion } from '@/lib/expansions/discover';
+import { loadPrefs, savePrefs } from '@/lib/persist';
+import { getCoreCards } from '@/data/cardDatabase';
+import type { GameCard } from '@/rules/mvp';
+import { cn } from '@/lib/utils';
+
+const DEFAULT_MODE: MixMode = 'BALANCED_MIX';
+const DEFAULT_WEIGHT = 100;
+
+const toCard = (card: GameCard): Card => ({
+  ...(card as Card),
+  extId: (card as Card).extId ?? 'core',
+  _setId: (card as Card)._setId ?? 'core',
+  _setName: (card as Card)._setName ?? 'Core Deck',
+});
+
+type StoredPrefs = {
+  mode?: MixMode;
+  enabled?: Record<string, boolean>;
+  customWeights?: Record<string, number>;
+};
+
+type ExpansionEntry = DiscoveredExpansion & {
+  enabled: boolean;
+  weight: number;
+};
+
+type PreviewState = {
+  weights: Record<string, number>;
+  poolsRemaining: Record<string, number>;
+  deckSize: number;
+};
+
+interface ExpansionControlProps {
+  onClose?: () => void;
+}
+
+const mixModes: Array<{ value: MixMode; label: string; description: string }> = [
+  { value: 'CORE_ONLY', label: 'Core Only', description: 'Pure baseline experience.' },
+  { value: 'BALANCED_MIX', label: 'Balanced Mix', description: 'Core floor with even expansion share.' },
+  { value: 'EXPANSION_ONLY', label: 'Expansion Only', description: 'Only enabled packs.' },
+  { value: 'CUSTOM_MIX', label: 'Custom Mix', description: 'Tune per-pack weights manually.' },
+];
+
+const buildEnabledMap = (entries: ExpansionEntry[]) =>
+  entries.reduce<Record<string, boolean>>((acc, entry) => {
+    acc[entry.id] = entry.enabled;
+    return acc;
+  }, {});
+
+const buildWeightMap = (entries: ExpansionEntry[], coreWeight: number) => {
+  const map: Record<string, number> = { core: coreWeight };
+  for (const entry of entries) {
+    map[entry.id] = entry.weight;
+  }
+  return map;
+};
+
+const coreCardsForPreview = (): Card[] => getCoreCards().map(toCard);
+
+const buildPreview = (
+  coreCards: Card[],
+  expansions: ExpansionEntry[],
+  mode: MixMode,
+  weights: Record<string, number>,
+): PreviewState => {
+  const sets = buildSets(
+    coreCards,
+    expansions.map(expansion => ({
+      id: expansion.id,
+      name: expansion.name,
+      enabled: expansion.enabled,
+      weight: expansion.weight,
+      cards: expansion.cards,
+    })),
+  );
+
+  const result = buildDeck({ sets, mode, customWeights: weights, deckSize: 40 });
+
+  return {
+    weights: result.weights,
+    poolsRemaining: result.poolsRemaining,
+    deckSize: result.deck.length,
+  };
+};
+
+const ExpansionControl = ({ onClose }: ExpansionControlProps) => {
+  const [mode, setMode] = useState<MixMode>(DEFAULT_MODE);
+  const [coreWeight] = useState<number>(DEFAULT_WEIGHT);
+  const [expansions, setExpansions] = useState<ExpansionEntry[]>([]);
+  const [preview, setPreview] = useState<PreviewState>({ weights: {}, poolsRemaining: {}, deckSize: 0 });
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const coreCards = useMemo(() => coreCardsForPreview(), []);
+
+  const recalcPreview = useCallback(
+    (nextMode: MixMode, nextEntries: ExpansionEntry[]) => {
+      const weights = buildWeightMap(nextEntries, coreWeight);
+      setPreview(buildPreview(coreCards, nextEntries, nextMode, weights));
+    },
+    [coreCards, coreWeight],
+  );
+
+  useEffect(() => {
+    let cancelled = false;
+
+    const init = async () => {
+      setLoading(true);
+      setError(null);
+
+      try {
+        const prefs = (loadPrefs<StoredPrefs>() ?? {}) as StoredPrefs;
+        const nextMode = prefs.mode ?? DEFAULT_MODE;
+        const enabled = prefs.enabled ?? {};
+        const weights = prefs.customWeights ?? {};
+
+        setMode(nextMode);
+
+        const discovered = await discoverExpansions();
+        if (cancelled) return;
+
+        const entries: ExpansionEntry[] = discovered.map(expansion => ({
+          ...expansion,
+          enabled: Boolean(enabled[expansion.id]),
+          weight: typeof weights[expansion.id] === 'number' ? weights[expansion.id] : DEFAULT_WEIGHT,
+        }));
+
+        setExpansions(entries);
+        recalcPreview(nextMode, entries);
+      } catch (err) {
+        console.warn('[ExpansionControl] failed to load expansions', err);
+        if (!cancelled) {
+          setError('Failed to load expansions.');
+        }
+      } finally {
+        if (!cancelled) {
+          setLoading(false);
+        }
+      }
+    };
+
+    void init();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [recalcPreview]);
+
+  const persist = useCallback(
+    (nextMode: MixMode, nextEntries: ExpansionEntry[]) => {
+      const prefs: StoredPrefs = {
+        mode: nextMode,
+        enabled: buildEnabledMap(nextEntries),
+        customWeights: buildWeightMap(nextEntries, coreWeight),
+      };
+      savePrefs(prefs);
+      recalcPreview(nextMode, nextEntries);
+    },
+    [coreWeight, recalcPreview],
+  );
+
+  const handleToggle = useCallback(
+    (id: string) => {
+      setExpansions(prev => {
+        const next = prev.map(entry =>
+          entry.id === id
+            ? { ...entry, enabled: !entry.enabled }
+            : entry,
+        );
+        persist(mode, next);
+        return next;
+      });
+    },
+    [mode, persist],
+  );
+
+  const handleWeightChange = useCallback(
+    (id: string, value: number) => {
+      setExpansions(prev => {
+        const next = prev.map(entry =>
+          entry.id === id
+            ? { ...entry, weight: value }
+            : entry,
+        );
+        persist(mode, next);
+        return next;
+      });
+    },
+    [mode, persist],
+  );
+
+  const handleModeChange = useCallback(
+    (nextMode: MixMode) => {
+      setMode(nextMode);
+      persist(nextMode, expansions);
+    },
+    [expansions, persist],
+  );
+
+  const totalCards = useMemo(() => {
+    const coreCount = coreCards.length;
+    const expansionCount = expansions
+      .filter(entry => entry.enabled)
+      .reduce((sum, entry) => sum + entry.cards.length, 0);
+    return { core: coreCount, expansions: expansionCount, total: coreCount + expansionCount };
+  }, [coreCards.length, expansions]);
+
+  const hasAnyExpansions = expansions.length > 0;
+  const hasEnabledExpansions = expansions.some(entry => entry.enabled);
+
+  return (
+    <div className="min-h-screen bg-newspaper-bg py-8 px-4">
+      <div className="mx-auto flex w-full max-w-5xl flex-col gap-6">
+        <header className="flex items-start justify-between gap-4">
+          <div>
+            <h1 className="text-3xl font-bold text-newspaper-text">Expansion Control Room</h1>
+            <p className="text-sm text-newspaper-text/70">
+              Configure which packs feed deck construction and preview the resulting mix.
+            </p>
+          </div>
+          {onClose && (
+            <Button variant="outline" onClick={onClose} aria-label="Close Expansion Control Room">
+              Close
+            </Button>
+          )}
+        </header>
+
+        {error && (
+          <UICard className="border-red-500/60 bg-red-500/5">
+            <CardContent className="py-4 text-sm text-red-600">{error}</CardContent>
+          </UICard>
+        )}
+
+        <div className="grid gap-4 md:grid-cols-2">
+          <UICard>
+            <CardHeader>
+              <CardTitle>Core Deck</CardTitle>
+              <CardDescription>Always available and compliant with MVP rules.</CardDescription>
+            </CardHeader>
+            <CardContent className="flex flex-col gap-3">
+              <Badge variant="outline" className="w-fit">
+                {coreCards.length} cards
+              </Badge>
+              <p className="text-sm text-newspaper-text/70">
+                Baseline ATTACK / MEDIA / ZONE cards. This supply is always included to guarantee a stable foundation.
+              </p>
+            </CardContent>
+          </UICard>
+
+          <UICard>
+            <CardHeader>
+              <CardTitle>Mix Mode</CardTitle>
+              <CardDescription>Select how the deck builder combines sets.</CardDescription>
+            </CardHeader>
+            <CardContent className="grid gap-2">
+              {mixModes.map(option => (
+                <Button
+                  key={option.value}
+                  variant={mode === option.value ? 'default' : 'outline'}
+                  className={cn('justify-start text-left', mode === option.value ? '' : 'bg-transparent')}
+                  onClick={() => handleModeChange(option.value)}
+                  disabled={
+                    (option.value === 'EXPANSION_ONLY' || option.value === 'CUSTOM_MIX') && !hasAnyExpansions
+                  }
+                  aria-pressed={mode === option.value}
+                >
+                  <div>
+                    <div className="font-semibold">{option.label}</div>
+                    <div className="text-xs text-newspaper-text/70">{option.description}</div>
+                  </div>
+                </Button>
+              ))}
+            </CardContent>
+          </UICard>
+        </div>
+
+        <section>
+          <div className="flex items-center justify-between gap-2">
+            <h2 className="text-xl font-semibold text-newspaper-text">Expansion Packs</h2>
+            <Badge variant="outline" className="whitespace-nowrap text-xs">
+              {expansions.length} detected
+            </Badge>
+          </div>
+          <p className="mt-1 text-sm text-newspaper-text/70">
+            Toggle expansions on or off. Custom weights appear when using the Custom Mix mode.
+          </p>
+
+          {loading ? (
+            <UICard className="mt-4">
+              <CardContent className="py-6 text-center text-sm text-newspaper-text/70">Scanning extensions…</CardContent>
+            </UICard>
+          ) : (
+            <div className="mt-4 grid gap-4 md:grid-cols-2">
+              {expansions.map(entry => {
+                const summary = summarizeSet(entry.cards);
+                return (
+                  <Collapsible key={entry.id} defaultOpen={entry.enabled}>
+                    <UICard className="border-newspaper-text/20 bg-newspaper-bg">
+                      <CardHeader className="flex flex-row items-start justify-between gap-3">
+                        <div className="space-y-1">
+                          <div className="flex items-center gap-2">
+                            <CollapsibleTrigger asChild>
+                              <button
+                                type="button"
+                                className="flex items-center gap-2 text-left font-semibold text-newspaper-text"
+                                aria-label={`Toggle details for ${entry.name}`}
+                              >
+                                <ChevronDown className="h-4 w-4" aria-hidden="true" />
+                                <span>{entry.name}</span>
+                              </button>
+                            </CollapsibleTrigger>
+                            <Badge variant="outline" className="text-xs">
+                              {entry.cards.length} cards
+                            </Badge>
+                          </div>
+                          <div className="text-xs text-newspaper-text/70">
+                            {entry.description ?? 'No description provided.'}
+                          </div>
+                        </div>
+                        <Switch
+                          checked={entry.enabled}
+                          onCheckedChange={() => handleToggle(entry.id)}
+                          aria-label={`Enable ${entry.name}`}
+                        />
+                      </CardHeader>
+                      <CollapsibleContent>
+                        <CardContent className="space-y-4 text-sm text-newspaper-text/80">
+                          <div className="grid grid-cols-2 gap-3 text-xs">
+                            <div>
+                              <div className="font-semibold text-newspaper-text">Type spread</div>
+                              <div className="mt-1 space-y-1">
+                                {(['ATTACK', 'MEDIA', 'ZONE'] as const).map(key => (
+                                  <div key={key} className="flex justify-between">
+                                    <span>{key}</span>
+                                    <span className="tabular-nums">{summary.byType[key]}</span>
+                                  </div>
+                                ))}
+                              </div>
+                            </div>
+                            <div>
+                              <div className="font-semibold text-newspaper-text">Rarity</div>
+                              <div className="mt-1 space-y-1">
+                                {(['common', 'uncommon', 'rare', 'legendary'] as const).map(key => (
+                                  <div key={key} className="flex justify-between">
+                                    <span className="capitalize">{key}</span>
+                                    <span className="tabular-nums">{summary.byRarity[key]}</span>
+                                  </div>
+                                ))}
+                              </div>
+                            </div>
+                          </div>
+
+                          <div className="text-xs text-newspaper-text/60">
+                            File: {entry.fileName}
+                            {entry.version ? ` • v${entry.version}` : ''}
+                            {entry.author ? ` • ${entry.author}` : ''}
+                          </div>
+
+                          {mode === 'CUSTOM_MIX' && (
+                            <div className="space-y-2">
+                              <div className="flex items-center justify-between text-xs text-newspaper-text/70">
+                                <span>Weight</span>
+                                <span className="tabular-nums">{entry.weight}</span>
+                              </div>
+                              <Slider
+                                value={[entry.weight]}
+                                onValueChange={values => handleWeightChange(entry.id, values[0] ?? DEFAULT_WEIGHT)}
+                                min={0}
+                                max={100}
+                                step={5}
+                                aria-label={`Weight for ${entry.name}`}
+                              />
+                            </div>
+                          )}
+                        </CardContent>
+                      </CollapsibleContent>
+                    </UICard>
+                  </Collapsible>
+                );
+              })}
+            </div>
+          )}
+        </section>
+
+        <UICard>
+          <CardHeader>
+            <CardTitle>Mix Preview</CardTitle>
+            <CardDescription>
+              Estimated share per set based on current selections. {preview.deckSize} unique cards available for draws.
+            </CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            <div className="space-y-3">
+              {[{ id: 'core', name: 'Core Deck' }, ...expansions.map(entry => ({ id: entry.id, name: entry.name }))]
+                .filter(entry => preview.weights[entry.id] !== undefined)
+                .map(entry => {
+                  const weight = preview.weights[entry.id] ?? 0;
+                  return (
+                    <div key={entry.id} className="space-y-1">
+                      <div className="flex items-center justify-between text-sm text-newspaper-text">
+                        <span>{entry.name}</span>
+                        <span className="tabular-nums">{Math.round(weight * 100)}%</span>
+                      </div>
+                      <div className="h-2 rounded-full bg-newspaper-text/10">
+                        <div
+                          className="h-full rounded-full bg-newspaper-text"
+                          style={{ width: `${Math.max(4, weight * 100)}%` }}
+                        />
+                      </div>
+                    </div>
+                  );
+                })}
+            </div>
+
+            <Separator />
+
+            <div className="text-xs text-newspaper-text/70">
+              Cards remaining in pools after build:{' '}
+              {Object.values(preview.poolsRemaining).reduce((sum, value) => sum + value, 0)}
+            </div>
+            <div className="text-xs text-newspaper-text/70">
+              Active pool size: core {totalCards.core} • expansions {totalCards.expansions} • total {totalCards.total}
+            </div>
+          </CardContent>
+        </UICard>
+
+        <div className="flex justify-end">
+          <Button variant="secondary" onClick={onClose} disabled={!onClose} aria-label="Close Expansion Control">
+            {onClose ? 'Save & Close' : 'Done'}
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default ExpansionControl;

--- a/src/components/game/GameMenu.tsx
+++ b/src/components/game/GameMenu.tsx
@@ -4,7 +4,7 @@ import { useState, useEffect } from 'react';
 import Credits from './Credits';
 import HowToPlay from './HowToPlay';
 import Options from './Options';
-import ManageExpansions from './ManageExpansions';
+import ExpansionControl from '@/components/expansions/ExpansionControl';
 import CardCollection from './CardCollection';
 import CreditsTableoid from './CreditsTableoid';
 import HowToPlayTabloid from './HowToPlayTabloid';
@@ -181,7 +181,7 @@ const GameMenu = ({ onStartGame, onFactionHover, audio, onBackToMainMenu, onSave
   }
 
   if (showManageExpansions) {
-    return <ManageExpansions onClose={() => setShowManageExpansions(false)} />;
+    return <ExpansionControl onClose={() => setShowManageExpansions(false)} />;
   }
 
   if (showFactionSelect) {

--- a/src/components/game/InGameOptions.tsx
+++ b/src/components/game/InGameOptions.tsx
@@ -6,7 +6,7 @@ import { X, Settings, FileText, Save, Upload, HelpCircle, Volume2, RotateCw, Hom
 import { AudioControls } from '@/components/ui/audio-controls';
 import { useAudioContext } from '@/contexts/AudioContext';
 import HowToPlay from './HowToPlay';
-import ManageExpansions from './ManageExpansions';
+import ExpansionControl from '@/components/expansions/ExpansionControl';
 
 interface InGameOptionsProps {
   onClose: () => void;
@@ -39,7 +39,7 @@ const InGameOptions = ({
   }
 
   if (activeTab === 'expansions') {
-    return <ManageExpansions onClose={() => setActiveTab('main')} />;
+    return <ExpansionControl onClose={() => setActiveTab('main')} />;
   }
 
   const handleSaveGame = () => {

--- a/src/hooks/useGameState.ts
+++ b/src/hooks/useGameState.ts
@@ -1,7 +1,7 @@
 import { useState, useCallback } from 'react';
 import type { GameCard } from '@/rules/mvp';
 import { CARD_DATABASE, getRandomCards } from '@/data/cardDatabase';
-import { generateWeightedDeck } from '@/data/weightedCardDistribution';
+import { generateMixedDeck } from '@/lib/decks/generator';
 import { USA_STATES, getInitialStateControl, getTotalIPFromStates, type StateData } from '@/data/usaStates';
 import { getRandomAgenda, SecretAgenda } from '@/data/agendaDatabase';
 import { AIStrategist, type AIDifficulty } from '@/data/aiStrategy';
@@ -129,7 +129,7 @@ const drawCardsFromDeck = (
 
   while (drawn.length < count) {
     if (nextDeck.length === 0) {
-      const replenished = generateWeightedDeck(40, faction);
+      const replenished = generateMixedDeck({ faction, deckSize: 40 }).deck;
       if (replenished.length === 0) {
         break;
       }
@@ -168,8 +168,8 @@ export const useGameState = (aiDifficultyOverride?: AIDifficulty) => {
     hand: getRandomCards(3, { faction: 'truth' }),
     aiHand: getRandomCards(3, { faction: 'government' }),
     isGameOver: false,
-    deck: generateWeightedDeck(40, 'truth'),
-    aiDeck: generateWeightedDeck(40, 'government'),
+    deck: generateMixedDeck({ faction: 'truth', deckSize: 40 }).deck,
+    aiDeck: generateMixedDeck({ faction: 'government', deckSize: 40 }).deck,
     cardsPlayedThisTurn: 0,
     cardsPlayedThisRound: [],
     controlledStates: [],
@@ -249,7 +249,7 @@ export const useGameState = (aiDifficultyOverride?: AIDifficulty) => {
     
     const handSize = getStartingHandSize(drawMode, faction);
     // CRITICAL: Pass faction to deck generation
-    const newDeck = generateWeightedDeck(40, faction);
+    const newDeck = generateMixedDeck({ faction, deckSize: 40 }).deck;
     const startingHand = newDeck.slice(0, handSize);
     const initialControl = getInitialStateControl(faction);
 
@@ -267,7 +267,10 @@ export const useGameState = (aiDifficultyOverride?: AIDifficulty) => {
       deck: newDeck.slice(handSize),
       // AI gets opposite faction cards
       aiHand: getRandomCards(handSize, { faction: faction === 'government' ? 'truth' : 'government' }),
-      aiDeck: generateWeightedDeck(40, faction === 'government' ? 'truth' : 'government'),
+      aiDeck: generateMixedDeck({
+        faction: faction === 'government' ? 'truth' : 'government',
+        deckSize: 40,
+      }).deck,
       controlledStates: initialControl.player,
       aiControlledStates: initialControl.ai,
       isGameOver: false, // CRITICAL: Reset game over state

--- a/src/lib/decks/analytics.ts
+++ b/src/lib/decks/analytics.ts
@@ -1,0 +1,38 @@
+import type { Card } from './expansions';
+
+type TypeKey = 'ATTACK' | 'MEDIA' | 'ZONE';
+type RarityKey = 'common' | 'uncommon' | 'rare' | 'legendary';
+
+type Summary = {
+  byType: Record<TypeKey, number>;
+  byRarity: Record<RarityKey, number>;
+  total: number;
+};
+
+export function summarizeSet(cards: Card[]): Summary {
+  const byType: Summary['byType'] = { ATTACK: 0, MEDIA: 0, ZONE: 0 };
+  const byRarity: Summary['byRarity'] = {
+    common: 0,
+    uncommon: 0,
+    rare: 0,
+    legendary: 0,
+  };
+
+  for (const card of cards) {
+    const type = card.type as TypeKey;
+    if (type in byType) {
+      byType[type] += 1;
+    }
+
+    const rarity = card.rarity as RarityKey;
+    if (rarity in byRarity) {
+      byRarity[rarity] += 1;
+    }
+  }
+
+  return {
+    byType,
+    byRarity,
+    total: cards.length,
+  };
+}

--- a/src/lib/decks/expansions.ts
+++ b/src/lib/decks/expansions.ts
@@ -1,0 +1,276 @@
+export type Card = {
+  id: string;
+  name: string;
+  faction?: 'truth' | 'government' | string;
+  type: 'ATTACK' | 'MEDIA' | 'ZONE';
+  rarity: 'common' | 'uncommon' | 'rare' | 'legendary';
+  cost: number;
+  effects: unknown;
+  extId?: string;
+  _setId?: string;
+  _setName?: string;
+};
+
+export type SetInfo = {
+  id: string;
+  name: string;
+  enabled: boolean;
+  weight?: number;
+  cards: Card[];
+};
+
+export type MixMode =
+  | 'CORE_ONLY'
+  | 'BALANCED_MIX'
+  | 'EXPANSION_ONLY'
+  | 'CUSTOM_MIX';
+
+const CORE_SET_ID = 'core';
+const CORE_SET_NAME = 'Core Deck';
+const CORE_FLOOR = 0.5; // TODO: expose via settings if playtesting demands a different baseline.
+
+type WeightMap = Record<string, number>;
+
+type BuildDeckOptions = {
+  sets: SetInfo[];
+  mode: MixMode;
+  customWeights?: Record<string, number>;
+  deckSize?: number;
+  rng?: () => number;
+};
+
+type BuildDeckResult = {
+  deck: Card[];
+  weights: Record<string, number>;
+  poolsRemaining: Record<string, number>;
+};
+
+const cloneCards = (cards: Card[]): Card[] => cards.map(card => ({ ...card }));
+
+const decorateCoreCard = (card: Card): Card => ({
+  ...card,
+  _setId: card._setId ?? CORE_SET_ID,
+  _setName: card._setName ?? CORE_SET_NAME,
+  extId: card.extId ?? CORE_SET_ID,
+});
+
+const decorateExpansionCard = (card: Card, setId: string, setName: string): Card => ({
+  ...card,
+  _setId: card._setId ?? setId,
+  _setName: card._setName ?? setName,
+  extId: card.extId ?? setId,
+});
+
+const normalizeWeight = (value: unknown): number => {
+  if (typeof value === 'number' && Number.isFinite(value) && value >= 0) {
+    return value;
+  }
+  return 0;
+};
+
+export function buildSets(
+  core: Card[],
+  expansions: Array<Omit<SetInfo, 'cards'> & { cards: Card[] }>,
+): SetInfo[] {
+  const coreSet: SetInfo = {
+    id: CORE_SET_ID,
+    name: CORE_SET_NAME,
+    enabled: true,
+    cards: core.map(decorateCoreCard),
+  };
+
+  const normalizedExpansions = expansions.map(expansion => ({
+    ...expansion,
+    cards: expansion.cards.map(card => decorateExpansionCard(card, expansion.id, expansion.name)),
+  }));
+
+  return [coreSet, ...normalizedExpansions];
+}
+
+const selectWeightedSet = (
+  availableSets: SetInfo[],
+  weights: WeightMap,
+  rng: () => number,
+): SetInfo | null => {
+  const weighted = availableSets.filter(set => weights[set.id] > 0 && set.cards.length > 0);
+  if (weighted.length === 0) {
+    return null;
+  }
+
+  const totalWeight = weighted.reduce((sum, set) => sum + weights[set.id], 0);
+  if (totalWeight <= 0) {
+    return null;
+  }
+
+  let roll = rng() * totalWeight;
+  let chosen: SetInfo | null = null;
+  for (const set of weighted) {
+    roll -= weights[set.id];
+    if (roll <= 0) {
+      chosen = set;
+      break;
+    }
+  }
+
+  return chosen ?? weighted[weighted.length - 1];
+};
+
+const buildWeightMap = (
+  sets: SetInfo[],
+  mode: MixMode,
+  customWeights?: Record<string, number>,
+): { selected: SetInfo[]; weights: WeightMap } => {
+  const weights: WeightMap = {};
+  const core = sets.find(set => set.id === CORE_SET_ID);
+  const expansions = sets.filter(set => set.id !== CORE_SET_ID && set.enabled);
+
+  const activeExpansions = expansions.filter(set => set.cards.length > 0);
+  const hasActiveExpansions = activeExpansions.length > 0;
+
+  const addSet = (set: SetInfo, weight: number) => {
+    if (set.cards.length === 0 || weight <= 0) {
+      return;
+    }
+    weights[set.id] = weight;
+  };
+
+  switch (mode) {
+    case 'CORE_ONLY': {
+      if (core) {
+        addSet(core, 1);
+        return { selected: [core], weights };
+      }
+      return { selected: [], weights };
+    }
+
+    case 'EXPANSION_ONLY': {
+      if (hasActiveExpansions) {
+        for (const set of activeExpansions) {
+          addSet(set, 1);
+        }
+        return { selected: activeExpansions, weights };
+      }
+      if (core) {
+        addSet(core, 1);
+        return { selected: [core], weights };
+      }
+      return { selected: [], weights };
+    }
+
+    case 'CUSTOM_MIX': {
+      const selections: SetInfo[] = [];
+      if (core) {
+        const weight = normalizeWeight(customWeights?.[CORE_SET_ID] ?? core.weight ?? 0);
+        if (weight > 0 && core.cards.length > 0) {
+          addSet(core, weight);
+          selections.push(core);
+        }
+      }
+      for (const set of expansions) {
+        const weight = normalizeWeight(customWeights?.[set.id] ?? set.weight ?? 0);
+        if (weight > 0 && set.cards.length > 0) {
+          addSet(set, weight);
+          selections.push(set);
+        }
+      }
+      if (selections.length === 0 && core) {
+        addSet(core, 1);
+        selections.push(core);
+      }
+      return { selected: selections, weights };
+    }
+
+    case 'BALANCED_MIX':
+    default: {
+      const selections: SetInfo[] = [];
+      if (core && core.cards.length > 0) {
+        selections.push(core);
+      }
+      selections.push(...activeExpansions);
+
+      if (selections.length === 0) {
+        return { selected: [], weights };
+      }
+
+      if (core && core.cards.length > 0) {
+        weights[core.id] = 1;
+      }
+      for (const set of activeExpansions) {
+        weights[set.id] = 1;
+      }
+
+      if (core && hasActiveExpansions) {
+        const expansionSum = activeExpansions.reduce((sum, set) => sum + weights[set.id], 0);
+        const requiredCoreWeight = (CORE_FLOOR * expansionSum) / (1 - CORE_FLOOR);
+        weights[core.id] = Math.max(weights[core.id], requiredCoreWeight);
+      }
+
+      if (!hasActiveExpansions && core && core.cards.length > 0) {
+        weights[core.id] = 1;
+      }
+
+      return { selected: selections, weights };
+    }
+  }
+};
+
+const normalizeWeights = (weights: WeightMap, sets: SetInfo[]): Record<string, number> => {
+  const relevant = sets.filter(set => weights[set.id] && weights[set.id] > 0 && set.cards.length > 0);
+  const total = relevant.reduce((sum, set) => sum + weights[set.id], 0);
+  if (total <= 0) {
+    return {};
+  }
+
+  return Object.fromEntries(
+    relevant.map(set => [set.id, weights[set.id] / total]),
+  );
+};
+
+export function buildDeck(options: BuildDeckOptions): BuildDeckResult {
+  const { sets, mode, customWeights, deckSize = 40, rng = Math.random } = options;
+  const { selected, weights } = buildWeightMap(sets, mode, customWeights);
+
+  if (selected.length === 0) {
+    return { deck: [], weights: {}, poolsRemaining: {} };
+  }
+
+  const workingSets = selected.map(set => ({
+    ...set,
+    cards: cloneCards(set.cards),
+  }));
+
+  const deck: Card[] = [];
+
+  for (let i = 0; i < deckSize; i++) {
+    const candidateSets = workingSets.filter(set => weights[set.id] > 0 && set.cards.length > 0);
+    if (candidateSets.length === 0) {
+      break;
+    }
+
+    const chosenSet = selectWeightedSet(candidateSets, weights, rng);
+    if (!chosenSet) {
+      break;
+    }
+
+    const pool = chosenSet.cards;
+    if (pool.length === 0) {
+      continue;
+    }
+
+    const cardIndex = Math.floor(rng() * pool.length);
+    const [card] = pool.splice(cardIndex, 1);
+    if (card) {
+      deck.push(card);
+    }
+  }
+
+  const poolsRemaining = Object.fromEntries(
+    workingSets.map(set => [set.id, set.cards.length]),
+  );
+
+  return {
+    deck,
+    weights: normalizeWeights(weights, workingSets),
+    poolsRemaining,
+  };
+}

--- a/src/lib/decks/generator.ts
+++ b/src/lib/decks/generator.ts
@@ -1,0 +1,85 @@
+import { getCoreCards } from '@/data/cardDatabase';
+import { normalizeFaction } from '@/data/mvpAnalysisUtils';
+import type { GameCard } from '@/rules/mvp';
+import { buildDeck, buildSets, type Card, type MixMode, type SetInfo } from './expansions';
+import { getCachedExpansions } from '@/lib/expansions/discover';
+import { loadPrefs } from '@/lib/persist';
+
+export interface DeckBuildResult {
+  deck: Card[];
+  weights: Record<string, number>;
+  poolsRemaining: Record<string, number>;
+  sets: SetInfo[];
+  mode: MixMode;
+  customWeights: Record<string, number>;
+}
+
+const toCard = (card: GameCard): Card => ({
+  ...(card as Card),
+  extId: (card as Card).extId ?? 'core',
+  _setId: (card as Card)._setId ?? 'core',
+  _setName: (card as Card)._setName ?? 'Core Deck',
+});
+
+const filterCardsForFaction = (cards: Card[], faction: 'truth' | 'government'): Card[] => {
+  return cards.filter(card => {
+    const normalized = normalizeFaction(card.faction as GameCard['faction']);
+    if (normalized === 'neutral') {
+      return true;
+    }
+    return normalized === faction;
+  });
+};
+
+type StoredPrefs = {
+  mode?: MixMode;
+  enabled?: Record<string, boolean>;
+  customWeights?: Record<string, number>;
+};
+
+const DEFAULT_MODE: MixMode = 'BALANCED_MIX';
+
+export function generateMixedDeck({
+  faction,
+  deckSize = 40,
+  rng,
+}: {
+  faction: 'truth' | 'government';
+  deckSize?: number;
+  rng?: () => number;
+}): DeckBuildResult {
+  const prefs = (loadPrefs<StoredPrefs>() ?? {}) as StoredPrefs;
+  const enabled = prefs.enabled ?? {};
+  const customWeights = prefs.customWeights ?? {};
+  const mode = prefs.mode ?? DEFAULT_MODE;
+
+  const coreCards = getCoreCards().map(toCard);
+  const expansions = getCachedExpansions();
+
+  const coreForFaction = filterCardsForFaction(coreCards, faction);
+  const expansionSets = expansions.map(expansion => ({
+    id: expansion.id,
+    name: expansion.name,
+    enabled: Boolean(enabled[expansion.id]),
+    weight: customWeights[expansion.id],
+    cards: filterCardsForFaction(expansion.cards, faction),
+  }));
+
+  const sets = buildSets(coreForFaction, expansionSets);
+  const result = buildDeck({
+    sets,
+    mode,
+    customWeights: customWeights,
+    deckSize,
+    rng,
+  });
+
+  return {
+    deck: result.deck,
+    weights: result.weights,
+    poolsRemaining: result.poolsRemaining,
+    sets,
+    mode,
+    customWeights,
+  };
+}

--- a/src/lib/expansions/discover.ts
+++ b/src/lib/expansions/discover.ts
@@ -1,0 +1,227 @@
+import type { Card } from '@/lib/decks/expansions';
+import type { GameCard } from '@/rules/mvp';
+import { validateMvpCard } from '@/utils/validate-mvp';
+
+const INDEX_PATH = '/extensions/index.json';
+const MANIFEST_PATH = '/extensions/manifest.json';
+const CACHE_BYPASS_PARAM = () => `t=${Date.now()}`;
+
+const FALLBACK_FILES = ['cryptids.json', 'halloween_spooktacular_with_temp_image.json'];
+
+interface RawExpansion {
+  id?: string;
+  name?: string;
+  title?: string;
+  description?: string;
+  version?: string;
+  author?: string;
+  cards?: unknown;
+  [key: string]: unknown;
+}
+
+export interface DiscoveredExpansion {
+  id: string;
+  name: string;
+  description?: string;
+  version?: string;
+  author?: string;
+  fileName: string;
+  cards: Card[];
+}
+
+let cachedExpansions: DiscoveredExpansion[] | null = null;
+let inflight: Promise<DiscoveredExpansion[]> | null = null;
+
+const cloneCard = (card: Card): Card => ({ ...card });
+
+const cloneExpansion = (expansion: DiscoveredExpansion): DiscoveredExpansion => ({
+  ...expansion,
+  cards: expansion.cards.map(cloneCard),
+});
+
+const formatNameFromId = (id: string): string =>
+  id
+    .replace(/[-_]+/g, ' ')
+    .split(' ')
+    .map(segment => segment.charAt(0).toUpperCase() + segment.slice(1))
+    .join(' ');
+
+const sanitizeId = (value: unknown, fallback: string): string => {
+  if (typeof value === 'string' && value.trim().length > 0) {
+    return value.trim();
+  }
+  return fallback;
+};
+
+const toCardArray = (raw: unknown): unknown[] => {
+  if (Array.isArray(raw)) {
+    return raw;
+  }
+  if (raw && typeof raw === 'object' && Array.isArray((raw as RawExpansion).cards)) {
+    return (raw as RawExpansion).cards as unknown[];
+  }
+  return [];
+};
+
+const decorateCard = (card: GameCard, setId: string, setName: string): Card => ({
+  ...(card as Card),
+  extId: (card as Card).extId ?? setId,
+  _setId: (card as Card)._setId ?? setId,
+  _setName: (card as Card)._setName ?? setName,
+});
+
+const readJsonList = async (url: string): Promise<string[]> => {
+  try {
+    const response = await fetch(`${url}?${CACHE_BYPASS_PARAM()}`, {
+      cache: 'no-store',
+      headers: { 'Cache-Control': 'no-cache' },
+    });
+    if (!response.ok) {
+      return [];
+    }
+    const data = await response.json();
+    if (Array.isArray(data)) {
+      return data.filter((item): item is string => typeof item === 'string');
+    }
+    if (data && typeof data === 'object' && Array.isArray((data as { files?: unknown }).files)) {
+      return ((data as { files?: unknown }).files as unknown[])
+        .filter((item): item is string => typeof item === 'string');
+    }
+    return [];
+  } catch (error) {
+    console.warn('[ExpansionDiscovery] Failed to fetch list from', url, error);
+    return [];
+  }
+};
+
+const loadFileList = async (): Promise<string[]> => {
+  const fromIndex = await readJsonList(INDEX_PATH);
+  if (fromIndex.length > 0) {
+    return fromIndex;
+  }
+
+  const fromManifest = await readJsonList(MANIFEST_PATH);
+  if (fromManifest.length > 0) {
+    return fromManifest;
+  }
+
+  return [...FALLBACK_FILES];
+};
+
+const parseExpansionFile = async (fileName: string): Promise<DiscoveredExpansion | null> => {
+  try {
+    const response = await fetch(`/extensions/${fileName}?${CACHE_BYPASS_PARAM()}`, {
+      cache: 'no-store',
+      headers: { 'Cache-Control': 'no-cache' },
+    });
+    if (!response.ok) {
+      console.warn(`[ExpansionDiscovery] Skipping ${fileName}, response: ${response.status}`);
+      return null;
+    }
+
+    const raw = (await response.json()) as RawExpansion | RawExpansion['cards'];
+    const cardSources = toCardArray(raw);
+
+    const baseName = fileName.replace(/\.json$/i, '');
+    const setId = sanitizeId((raw as RawExpansion)?.id, baseName);
+    const nameCandidate =
+      (raw as RawExpansion)?.name ||
+      (raw as RawExpansion)?.title ||
+      formatNameFromId(setId);
+
+    const cards: Card[] = [];
+    const seen = new Set<string>();
+
+    for (const entry of cardSources) {
+      if (!entry || typeof entry !== 'object') {
+        continue;
+      }
+
+      const card = { ...(entry as GameCard) };
+      const validation = validateMvpCard(card);
+      if (!validation.ok) {
+        console.warn(`[ExpansionDiscovery] Invalid card in ${fileName}:`, validation.issues);
+        continue;
+      }
+
+      if (!card.id || seen.has(card.id)) {
+        continue;
+      }
+
+      seen.add(card.id);
+      cards.push(decorateCard(card, setId, nameCandidate));
+    }
+
+    if (cards.length === 0) {
+      console.warn(`[ExpansionDiscovery] No valid cards found in ${fileName}`);
+      return null;
+    }
+
+    const metadata = raw as RawExpansion;
+
+    return {
+      id: setId,
+      name: nameCandidate,
+      description: typeof metadata?.description === 'string' ? metadata.description : undefined,
+      version: typeof metadata?.version === 'string' ? metadata.version : undefined,
+      author: typeof metadata?.author === 'string' ? metadata.author : undefined,
+      fileName,
+      cards,
+    };
+  } catch (error) {
+    console.warn(`[ExpansionDiscovery] Failed to parse ${fileName}:`, error);
+    return null;
+  }
+};
+
+const discoverInternal = async (): Promise<DiscoveredExpansion[]> => {
+  const files = await loadFileList();
+  const uniqueFiles = Array.from(
+    new Set(
+      files
+        .filter(name => name.toLowerCase().endsWith('.json'))
+        .filter(name => name !== 'manifest.json' && name !== 'index.json'),
+    ),
+  );
+
+  const discovered: DiscoveredExpansion[] = [];
+  for (const fileName of uniqueFiles) {
+    const expansion = await parseExpansionFile(fileName);
+    if (expansion) {
+      discovered.push(expansion);
+    }
+  }
+
+  discovered.sort((a, b) => a.name.localeCompare(b.name));
+  return discovered;
+};
+
+export async function discoverExpansions(force = false): Promise<DiscoveredExpansion[]> {
+  if (cachedExpansions && !force) {
+    return cachedExpansions.map(cloneExpansion);
+  }
+
+  if (inflight && !force) {
+    return inflight.then(expansions => expansions.map(cloneExpansion));
+  }
+
+  inflight = discoverInternal().then(expansions => {
+    cachedExpansions = expansions;
+    inflight = null;
+    return expansions;
+  });
+
+  try {
+    const result = await inflight;
+    return result.map(cloneExpansion);
+  } finally {
+    inflight = null;
+  }
+}
+
+export function getCachedExpansions(): DiscoveredExpansion[] {
+  if (!cachedExpansions) {
+    return [];
+  }
+  return cachedExpansions.map(cloneExpansion);
+}

--- a/src/lib/persist.ts
+++ b/src/lib/persist.ts
@@ -1,0 +1,32 @@
+const STORAGE_KEY = 'expansion_prefs_v2';
+
+type JsonValue = unknown;
+
+export function loadPrefs<T extends JsonValue = Record<string, unknown>>(): T {
+  if (typeof window === 'undefined') {
+    return {} as T;
+  }
+
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    if (!raw) {
+      return {} as T;
+    }
+    return JSON.parse(raw) as T;
+  } catch (error) {
+    console.warn('[ExpansionPrefs] Failed to parse stored preferences', error);
+    return {} as T;
+  }
+}
+
+export function savePrefs(value: JsonValue): void {
+  if (typeof window === 'undefined') {
+    return;
+  }
+
+  try {
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(value));
+  } catch (error) {
+    console.warn('[ExpansionPrefs] Failed to persist preferences', error);
+  }
+}


### PR DESCRIPTION
## Summary
- generate a build-time index for extension JSON files and use a runtime loader that validates cards and records their originating set
- add deck mixing helpers and a new Expansion Control Room UI for managing modes, toggles, custom weights, and mix previews with persisted preferences
- wire the new mixing logic into game initialization and menus so decks respect the configured expansion mix

## Testing
- npm run lint *(fails: missing @eslint/js because dependencies are unavailable in the sandbox)*
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68cb0ab42c648320a803850ba3dce9de