### PR TITLE
feat: apply tabloid card styling

### DIFF
--- a/src/components/game/PlayedCardsDock.tsx
+++ b/src/components/game/PlayedCardsDock.tsx
@@ -1,9 +1,10 @@
 import React from 'react';
-import { Card } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import CardImage from '@/components/game/CardImage';
-import type { GameCard, MVPCardType } from '@/rules/mvp';
-import { MVP_CARD_TYPES } from '@/rules/mvp';
+import type { GameCard } from '@/rules/mvp';
+import BaseCard from '@/components/game/cards/BaseCard';
+import { useUiTheme } from '@/hooks/useTheme';
+import { ExtensionCardBadge } from '@/components/game/ExtensionCardBadge';
 
 interface PlayedCard {
   card: GameCard;
@@ -14,37 +15,133 @@ interface PlayedCardsDockProps {
   playedCards: PlayedCard[];
 }
 
-const PlayedCardsDock: React.FC<PlayedCardsDockProps> = ({ playedCards }) => {
-  const humanCards = playedCards.filter(pc => pc.player === 'human');
-  const aiCards = playedCards.filter(pc => pc.player === 'ai');
+interface PlayerColumnsProps {
+  humanCards: PlayedCard[];
+  aiCards: PlayedCard[];
+}
 
-  const normalizeCardType = (type: string): MVPCardType => {
-    return MVP_CARD_TYPES.includes(type as MVPCardType) ? type as MVPCardType : 'MEDIA';
+const TabloidColumn = ({
+  cards,
+  label,
+  colorVar,
+  emptyMessage,
+}: {
+  cards: PlayedCard[];
+  label: string;
+  colorVar: string;
+  emptyMessage: string;
+}) => {
+  return (
+    <section
+      className="pt-card-surface border rounded-tabloid shadow-sm p-3"
+      style={{ borderColor: 'var(--pt-border)' }}
+    >
+      <div className="flex items-center gap-2 mb-3">
+        <span
+          className="px-2 py-0.5 text-[11px] uppercase tracking-wide text-white rounded font-tabloid"
+          style={{ background: colorVar }}
+        >
+          {label}
+        </span>
+        <span className="text-[11px] uppercase tracking-wide font-tabloid text-[color:var(--pt-ink)] opacity-60">
+          ({cards.length}/3)
+        </span>
+      </div>
+
+      {cards.length > 0 ? (
+        <div className="flex flex-wrap gap-4">
+          {cards.map((playedCard, index) => (
+            <div
+              key={`${label}-${playedCard.card.id}-${index}`}
+              className="flex flex-col items-center gap-2"
+              style={{ width: 'calc(var(--pt-card-w) * 0.55)' }}
+            >
+              <div
+                className="relative"
+                style={{
+                  width: 'calc(var(--pt-card-w) * 0.55)',
+                  height: 'calc(var(--pt-card-h) * 0.55)',
+                }}
+              >
+                <div className="scale-[0.55] origin-top-left">
+                  <BaseCard card={playedCard.card} polaroidHover />
+                </div>
+              </div>
+              <ExtensionCardBadge cardId={playedCard.card.id} card={playedCard.card} />
+            </div>
+          ))}
+        </div>
+      ) : (
+        <p className="text-[12px] italic text-[color:var(--pt-ink)] opacity-65">
+          {emptyMessage}
+        </p>
+      )}
+    </section>
+  );
+};
+
+const TabloidPlayedCardsDock: React.FC<PlayerColumnsProps> = ({ humanCards, aiCards }) => {
+  return (
+    <div className="h-full flex flex-col">
+      <div className="flex-1 p-2 overflow-y-auto">
+        <h4 className="text-xs font-semibold uppercase tracking-[0.3em] mb-3 text-[color:var(--pt-ink)] font-headline">
+          CARDS IN PLAY THIS ROUND
+        </h4>
+
+        <div className="grid gap-4">
+          <TabloidColumn
+            cards={humanCards}
+            label="YOUR CARDS"
+            colorVar="var(--pt-truth)"
+            emptyMessage="No cards deployed this turn."
+          />
+          <TabloidColumn
+            cards={aiCards}
+            label="OPPONENT CARDS"
+            colorVar="var(--pt-gov)"
+            emptyMessage="Opponent has no cards in play."
+          />
+        </div>
+      </div>
+    </div>
+  );
+};
+
+const LegacyPlayedCardsDock: React.FC<PlayerColumnsProps> = ({ humanCards, aiCards }) => {
+  const normalizeCardType = (type: string) => {
+    if (type === 'ATTACK' || type === 'MEDIA' || type === 'ZONE') {
+      return type;
+    }
+    return 'MEDIA';
   };
 
   const getTypeColor = (type: string, isAI: boolean) => {
     const normalized = normalizeCardType(type);
-    const truthColors: Record<MVPCardType, string> = {
+    const truthColors: Record<'ATTACK' | 'MEDIA' | 'ZONE', string> = {
       MEDIA: 'text-truth-red border-truth-red',
       ZONE: 'text-yellow-600 border-yellow-600',
-      ATTACK: 'text-red-600 border-red-600'
+      ATTACK: 'text-red-600 border-red-600',
     };
 
-    const govColors: Record<MVPCardType, string> = {
+    const govColors: Record<'ATTACK' | 'MEDIA' | 'ZONE', string> = {
       MEDIA: 'text-government-blue border-government-blue',
       ZONE: 'text-yellow-600 border-yellow-600',
-      ATTACK: 'text-red-600 border-red-600'
+      ATTACK: 'text-red-600 border-red-600',
     };
 
     return isAI ? govColors[normalized] : truthColors[normalized];
   };
 
-  const getRarityBg = (rarity: string) => {
+  const getRarityBg = (rarity?: string) => {
     switch (rarity) {
-      case 'legendary': return 'from-yellow-600/20 to-orange-600/20 border-yellow-500/30';
-      case 'rare': return 'from-purple-600/20 to-blue-600/20 border-purple-500/30';
-      case 'uncommon': return 'from-green-600/20 to-blue-600/20 border-green-500/30';
-      default: return 'from-gray-600/20 to-gray-500/20 border-gray-500/30';
+      case 'legendary':
+        return 'from-yellow-600/20 to-orange-600/20 border-yellow-500/30';
+      case 'rare':
+        return 'from-purple-600/20 to-blue-600/20 border-purple-500/30';
+      case 'uncommon':
+        return 'from-green-600/20 to-blue-600/20 border-green-500/30';
+      default:
+        return 'from-gray-600/20 to-gray-500/20 border-gray-500/30';
     }
   };
 
@@ -54,9 +151,8 @@ const PlayedCardsDock: React.FC<PlayedCardsDockProps> = ({ playedCards }) => {
         <h4 className="text-xs font-semibold text-newspaper-text mb-2 font-mono">
           CARDS IN PLAY THIS ROUND
         </h4>
-        
+
         <div className="flex gap-2">
-          {/* Human Player Cards */}
           <div className="flex-1">
             {humanCards.length > 0 && (
               <div>
@@ -64,90 +160,74 @@ const PlayedCardsDock: React.FC<PlayedCardsDockProps> = ({ playedCards }) => {
                   <Badge variant="outline" className="border-truth-red text-truth-red text-[10px] px-1 py-0">
                     YOUR CARDS
                   </Badge>
-                  <span className="text-[10px] text-newspaper-text/70">
-                    ({humanCards.length}/3)
-                  </span>
+                  <span className="text-[10px] text-newspaper-text/70">({humanCards.length}/3)</span>
                 </div>
                 <div className="flex flex-wrap gap-2">
                   {humanCards.map((playedCard, index) => {
                     const displayType = normalizeCardType(playedCard.card.type);
                     return (
-                      <div
-                        key={`human-${playedCard.card.id}-${index}`}
-                        className="group relative"
-                      >
-                      {/* Full card with newspaper styling - doubled size */}
-                      <div className={`w-24 h-32 bg-gradient-to-b ${getRarityBg(playedCard.card.rarity)} border rounded shadow-sm animate-scale-in overflow-hidden`}>
-                        {/* Card header with newspaper styling */}
-                        <div className="bg-newspaper-text text-newspaper-bg text-center py-0.5 border-b">
-                          <div className="text-[6px] font-bold leading-none">PARANOID TIMES</div>
-                        </div>
-                        
-                        {/* Card name */}
-                        <div className="px-1 py-0.5 bg-gradient-to-r from-card to-card/80">
-                          <div className="text-[7px] font-bold text-center line-clamp-1 leading-tight">
-                            {playedCard.card.name}
+                      <div key={`human-${playedCard.card.id}-${index}`} className="group relative">
+                        <div
+                          className={`w-24 h-32 bg-gradient-to-b ${getRarityBg(playedCard.card.rarity)} border rounded shadow-sm animate-scale-in overflow-hidden`}
+                        >
+                          <div className="bg-newspaper-text text-newspaper-bg text-center py-0.5 border-b">
+                            <div className="text-[6px] font-bold leading-none">PARANOID TIMES</div>
+                          </div>
+
+                          <div className="px-1 py-0.5 bg-gradient-to-r from-card to-card/80">
+                            <div className="text-[7px] font-bold text-center line-clamp-1 leading-tight">
+                              {playedCard.card.name}
+                            </div>
+                          </div>
+
+                          <div className="h-8 overflow-hidden border-y">
+                            <CardImage cardId={playedCard.card.id} className="w-full h-full object-cover" />
+                          </div>
+
+                          <div className="px-1 py-0.5 flex-1">
+                            <div className="text-[5px] font-semibold mb-0.5">Effect</div>
+                            <div className="text-[4px] text-muted-foreground line-clamp-2 leading-tight">
+                              {playedCard.card.text}
+                            </div>
+                          </div>
+
+                          <div className="bg-truth-red/10 border-t border-truth-red/20 px-1 py-0.5">
+                            <div className="text-[4px] font-bold text-muted-foreground mb-0.5">CLASSIFIED INTELLIGENCE</div>
+                            <div className="text-[4px] italic line-clamp-1 leading-tight">
+                              "{playedCard.card.flavor ?? playedCard.card.flavorGov ?? playedCard.card.flavorTruth}"
+                            </div>
+                          </div>
+
+                          <div className="absolute top-5 left-0.5">
+                            <Badge variant="outline" className={`text-[5px] px-0.5 py-0 ${getTypeColor(playedCard.card.type, false)}`}>
+                              {displayType}
+                            </Badge>
+                          </div>
+                          <div className="absolute top-5 right-0.5 bg-primary text-primary-foreground text-[6px] font-bold px-1 py-0.5 rounded">
+                            {playedCard.card.cost}
                           </div>
                         </div>
-                        
-                        {/* Art area - smaller */}
-                        <div className="h-8 overflow-hidden border-y">
-                          <CardImage cardId={playedCard.card.id} className="w-full h-full object-cover" />
-                        </div>
-                        
-                        {/* Effect section */}
-                        <div className="px-1 py-0.5 flex-1">
-                          <div className="text-[5px] font-semibold mb-0.5">Effect</div>
-                          <div className="text-[4px] text-muted-foreground line-clamp-2 leading-tight">
-                            {playedCard.card.text}
-                          </div>
-                        </div>
-                        
-                        {/* Classified Intelligence section */}
-                        <div className="bg-truth-red/10 border-t border-truth-red/20 px-1 py-0.5">
-                          <div className="text-[4px] font-bold text-muted-foreground mb-0.5">CLASSIFIED INTELLIGENCE</div>
-                          <div className="text-[4px] italic line-clamp-1 leading-tight">
-                            "{playedCard.card.flavor ?? playedCard.card.flavorGov ?? playedCard.card.flavorTruth}"
-                          </div>
-                        </div>
-                        
-                        {/* Card type and cost */}
-                        <div className="absolute top-5 left-0.5">
-                          <Badge variant="outline" className={`text-[5px] px-0.5 py-0 ${getTypeColor(playedCard.card.type, false)}`}>
-                            {displayType}
-                          </Badge>
-                        </div>
-                        <div className="absolute top-5 right-0.5 bg-primary text-primary-foreground text-[6px] font-bold px-1 py-0.5 rounded">
-                          {playedCard.card.cost}
-                        </div>
-                      </div>
-                      
-                      {/* Enhanced tooltip on hover */}
-                      <div className="absolute bottom-full left-1/2 transform -translate-x-1/2 mb-2 opacity-0 group-hover:opacity-100 transition-opacity duration-200 pointer-events-none z-50">
-                        <div className="bg-popover border border-border rounded-lg p-3 shadow-xl max-w-xs">
-                          <div className="font-bold text-sm text-foreground mb-1">
-                            {playedCard.card.name}
-                          </div>
-                          <div className="text-xs text-muted-foreground mb-2">
-                            {displayType} • Cost: {playedCard.card.cost} IP
-                          </div>
-                          <div className="text-xs text-foreground mb-2">
-                            {playedCard.card.text}
-                          </div>
-                          <div className="text-xs italic text-muted-foreground border-l-4 border-truth-red bg-truth-red/10 rounded-r border border-truth-red/20 pl-2 pr-2 py-1">
-                            "{playedCard.card.flavor ?? playedCard.card.flavorGov ?? playedCard.card.flavorTruth}"
+
+                        <div className="absolute bottom-full left-1/2 transform -translate-x-1/2 mb-2 opacity-0 group-hover:opacity-100 transition-opacity duration-200 pointer-events-none z-50">
+                          <div className="bg-popover border border-border rounded-lg p-3 shadow-xl max-w-xs">
+                            <div className="font-bold text-sm text-foreground mb-1">{playedCard.card.name}</div>
+                            <div className="text-xs text-muted-foreground mb-2">
+                              {displayType} • Cost: {playedCard.card.cost} IP
+                            </div>
+                            <div className="text-xs text-foreground mb-2">{playedCard.card.text}</div>
+                            <div className="text-xs italic text-muted-foreground border-l-4 border-truth-red bg-truth-red/10 rounded-r border border-truth-red/20 pl-2 pr-2 py-1">
+                              "{playedCard.card.flavor ?? playedCard.card.flavorGov ?? playedCard.card.flavorTruth}"
+                            </div>
                           </div>
                         </div>
                       </div>
-                    </div>
-                  );
+                    );
                   })}
                 </div>
               </div>
             )}
           </div>
 
-          {/* AI Player Cards */}
           <div className="flex-1">
             {aiCards.length > 0 && (
               <div>
@@ -155,99 +235,93 @@ const PlayedCardsDock: React.FC<PlayedCardsDockProps> = ({ playedCards }) => {
                   <Badge variant="outline" className="border-government-blue text-government-blue text-[10px] px-1 py-0">
                     OPPONENT CARDS
                   </Badge>
-                  <span className="text-[10px] text-newspaper-text/70">
-                    ({aiCards.length}/3)
-                  </span>
+                  <span className="text-[10px] text-newspaper-text/70">({aiCards.length}/3)</span>
                 </div>
                 <div className="flex flex-wrap gap-2">
                   {aiCards.map((playedCard, index) => {
                     const displayType = normalizeCardType(playedCard.card.type);
                     return (
-                      <div
-                        key={`ai-${playedCard.card.id}-${index}`}
-                        className="group relative"
-                      >
-                      {/* Full card with newspaper styling - doubled size */}
-                      <div className={`w-24 h-32 bg-gradient-to-b ${getRarityBg(playedCard.card.rarity)} border rounded shadow-sm animate-scale-in overflow-hidden`}>
-                        {/* Card header with newspaper styling */}
-                        <div className="bg-newspaper-text text-newspaper-bg text-center py-0.5 border-b">
-                          <div className="text-[6px] font-bold leading-none">PARANOID TIMES</div>
-                        </div>
-                        
-                        {/* Card name */}
-                        <div className="px-1 py-0.5 bg-gradient-to-r from-card to-card/80">
-                          <div className="text-[7px] font-bold text-center line-clamp-1 leading-tight">
-                            {playedCard.card.name}
+                      <div key={`ai-${playedCard.card.id}-${index}`} className="group relative">
+                        <div
+                          className={`w-24 h-32 bg-gradient-to-b ${getRarityBg(playedCard.card.rarity)} border rounded shadow-sm animate-scale-in overflow-hidden`}
+                        >
+                          <div className="bg-newspaper-text text-newspaper-bg text-center py-0.5 border-b">
+                            <div className="text-[6px] font-bold leading-none">PARANOID TIMES</div>
+                          </div>
+
+                          <div className="px-1 py-0.5 bg-gradient-to-r from-card to-card/80">
+                            <div className="text-[7px] font-bold text-center line-clamp-1 leading-tight">
+                              {playedCard.card.name}
+                            </div>
+                          </div>
+
+                          <div className="h-8 overflow-hidden border-y">
+                            <CardImage cardId={playedCard.card.id} className="w-full h-full object-cover" />
+                          </div>
+
+                          <div className="px-1 py-0.5 flex-1">
+                            <div className="text-[5px] font-semibold mb-0.5">Effect</div>
+                            <div className="text-[4px] text-muted-foreground line-clamp-2 leading-tight">
+                              {playedCard.card.text}
+                            </div>
+                          </div>
+
+                          <div className="bg-government-blue/10 border-t border-government-blue/20 px-1 py-0.5">
+                            <div className="text-[4px] font-bold text-muted-foreground mb-0.5">CLASSIFIED INTELLIGENCE</div>
+                            <div className="text-[4px] italic line-clamp-1 leading-tight">
+                              "{playedCard.card.flavor ?? playedCard.card.flavorGov ?? playedCard.card.flavorTruth}"
+                            </div>
+                          </div>
+
+                          <div className="absolute top-5 left-0.5">
+                            <Badge variant="outline" className={`text-[5px] px-0.5 py-0 ${getTypeColor(playedCard.card.type, true)}`}>
+                              {displayType}
+                            </Badge>
+                          </div>
+                          <div className="absolute top-5 right-0.5 bg-primary text-primary-foreground text-[6px] font-bold px-1 py-0.5 rounded">
+                            {playedCard.card.cost}
                           </div>
                         </div>
-                        
-                        {/* Art area - smaller */}
-                        <div className="h-8 overflow-hidden border-y">
-                          <CardImage cardId={playedCard.card.id} className="w-full h-full object-cover" />
-                        </div>
-                        
-                        {/* Effect section */}
-                        <div className="px-1 py-0.5 flex-1">
-                          <div className="text-[5px] font-semibold mb-0.5">Effect</div>
-                          <div className="text-[4px] text-muted-foreground line-clamp-2 leading-tight">
-                            {playedCard.card.text}
-                          </div>
-                        </div>
-                        
-                        {/* Classified Intelligence section */}
-                        <div className="bg-government-blue/10 border-t border-government-blue/20 px-1 py-0.5">
-                          <div className="text-[4px] font-bold text-muted-foreground mb-0.5">CLASSIFIED INTELLIGENCE</div>
-                          <div className="text-[4px] italic line-clamp-1 leading-tight">
-                            "{playedCard.card.flavor ?? playedCard.card.flavorGov ?? playedCard.card.flavorTruth}"
-                          </div>
-                        </div>
-                        
-                        {/* Card type and cost */}
-                        <div className="absolute top-5 left-0.5">
-                          <Badge variant="outline" className={`text-[5px] px-0.5 py-0 ${getTypeColor(playedCard.card.type, true)}`}>
-                            {displayType}
-                          </Badge>
-                        </div>
-                        <div className="absolute top-5 right-0.5 bg-primary text-primary-foreground text-[6px] font-bold px-1 py-0.5 rounded">
-                          {playedCard.card.cost}
-                        </div>
-                      </div>
-                      
-                      {/* Enhanced tooltip on hover */}
-                      <div className="absolute bottom-full left-1/2 transform -translate-x-1/2 mb-2 opacity-0 group-hover:opacity-100 transition-opacity duration-200 pointer-events-none z-50">
-                        <div className="bg-popover border border-border rounded-lg p-3 shadow-xl max-w-xs">
-                          <div className="font-bold text-sm text-foreground mb-1">
-                            {playedCard.card.name}
-                          </div>
-                          <div className="text-xs text-muted-foreground mb-2">
-                            {displayType} • Cost: {playedCard.card.cost} IP
-                          </div>
-                          <div className="text-xs text-foreground mb-2">
-                            {playedCard.card.text}
-                          </div>
-                          <div className="text-xs italic text-muted-foreground border-l-4 border-government-blue bg-government-blue/10 rounded-r border border-government-blue/20 pl-2 pr-2 py-1">
-                            "{playedCard.card.flavor ?? playedCard.card.flavorGov ?? playedCard.card.flavorTruth}"
+
+                        <div className="absolute bottom-full left-1/2 transform -translate-x-1/2 mb-2 opacity-0 group-hover:opacity-100 transition-opacity duration-200 pointer-events-none z-50">
+                          <div className="bg-popover border border-border rounded-lg p-3 shadow-xl max-w-xs">
+                            <div className="font-bold text-sm text-foreground mb-1">{playedCard.card.name}</div>
+                            <div className="text-xs text-muted-foreground mb-2">
+                              {displayType} • Cost: {playedCard.card.cost} IP
+                            </div>
+                            <div className="text-xs text-foreground mb-2">{playedCard.card.text}</div>
+                            <div className="text-xs italic text-muted-foreground border-l-4 border-government-blue bg-government-blue/10 rounded-r border border-government-blue/20 pl-2 pr-2 py-1">
+                              "{playedCard.card.flavor ?? playedCard.card.flavorGov ?? playedCard.card.flavorTruth}"
+                            </div>
                           </div>
                         </div>
                       </div>
-                    </div>
-                  );
+                    );
                   })}
                 </div>
               </div>
             )}
           </div>
-
-          {/* Empty state */}
-          {humanCards.length === 0 && aiCards.length === 0 && (
-            <div className="flex-1 text-center py-2 text-newspaper-text/50">
-              <div className="text-xs">No cards played this round</div>
-            </div>
-          )}
         </div>
+
+        {humanCards.length === 0 && aiCards.length === 0 && (
+          <div className="text-xs text-newspaper-text/60">No cards played this round</div>
+        )}
       </div>
     </div>
   );
+};
+
+const PlayedCardsDock: React.FC<PlayedCardsDockProps> = ({ playedCards }) => {
+  const [uiTheme] = useUiTheme();
+  const humanCards = playedCards.filter((pc) => pc.player === 'human');
+  const aiCards = playedCards.filter((pc) => pc.player === 'ai');
+
+  if (uiTheme === 'tabloid_bw') {
+    return <TabloidPlayedCardsDock humanCards={humanCards} aiCards={aiCards} />;
+  }
+
+  return <LegacyPlayedCardsDock humanCards={humanCards} aiCards={aiCards} />;
 };
 
 export default PlayedCardsDock;

--- a/src/components/game/cards/BaseCard.tsx
+++ b/src/components/game/cards/BaseCard.tsx
@@ -1,0 +1,105 @@
+import { cn } from '@/lib/utils';
+import CardImage from '@/components/game/CardImage';
+import type { GameCard } from '@/rules/mvp';
+import {
+  formatEffect,
+  getFactionLabel,
+  getFactionVar,
+  getFlavorText,
+  getRarityLabel,
+  getRarityVar,
+  normalizeCardType,
+} from '@/lib/cardUi';
+
+interface BaseCardProps {
+  card: GameCard;
+  className?: string;
+  stampText?: string;
+  hideStamp?: boolean;
+  polaroidHover?: boolean;
+}
+
+export const BaseCard = ({
+  card,
+  className,
+  stampText = 'CLASSIFIED',
+  hideStamp = false,
+  polaroidHover = false,
+}: BaseCardProps) => {
+  const effectText = formatEffect(card);
+  const flavor = getFlavorText(card);
+  const rarityLabel = getRarityLabel(card.rarity);
+  const typeLabel = normalizeCardType(card.type);
+  const showCardText = card.text && card.text !== effectText;
+
+  return (
+    <div
+      className={cn(
+        'relative w-cardW h-cardH pt-card-surface shadow-tabloid rounded-tabloid border overflow-hidden pt-card-wrap',
+        polaroidHover && 'group',
+        className,
+      )}
+      style={{ borderColor: 'var(--pt-border)' }}
+      data-testid="tabloid-card"
+    >
+      <div className="px-3 pt-3 text-[color:var(--pt-ink)]">
+        <div className="text-3xl leading-none uppercase font-headline">
+          {card.name}
+        </div>
+        <div className="mt-2 flex items-center gap-2">
+          <span
+            className="px-2 py-0.5 text-[11px] uppercase tracking-wide text-white rounded font-tabloid"
+            style={{ background: getFactionVar(card.faction) }}
+          >
+            {getFactionLabel(card.faction)}
+          </span>
+          <span
+            className="px-2 py-0.5 text-[11px] uppercase tracking-wide text-white rounded font-tabloid"
+            style={{ background: getRarityVar(card.rarity) }}
+          >
+            {rarityLabel}
+          </span>
+          <span
+            className="ml-auto text-xs font-semibold px-2 py-0.5 rounded"
+            style={{ background: 'var(--pt-ink)', color: 'var(--pt-paper)' }}
+          >
+            IP {card.cost}
+          </span>
+        </div>
+      </div>
+
+      <div
+        className={cn(
+          'mt-3 mx-3 pt-polaroid transition-transform duration-200',
+          polaroidHover && 'group-hover:-rotate-[0.75deg] group-hover:-translate-y-1',
+        )}
+      >
+        <div className="aspect-[4/3] w-full overflow-hidden">
+          <CardImage cardId={card.id} className="w-full h-full grayscale" />
+        </div>
+      </div>
+
+      <div
+        className="m-3 p-3 rounded border bg-black/80 text-white text-sm leading-snug space-y-2"
+        style={{ borderColor: 'var(--pt-border-soft)' }}
+      >
+        <div className="text-[11px] uppercase tracking-[0.18em] text-white/70">{typeLabel}</div>
+        <div className="font-semibold">{effectText}</div>
+        {showCardText && <div className="text-xs text-white/80 leading-snug">{card.text}</div>}
+      </div>
+
+      {flavor && (
+        <div className="mx-3 mb-3 text-[12px] italic pt-redacted text-[color:var(--pt-ink)] opacity-80">
+          <span className="font-mono not-italic mr-1 uppercase tracking-wide opacity-70 text-[color:var(--pt-ink)]">
+            CLASSIFIED INTELLIGENCE:
+          </span>
+          {flavor}
+        </div>
+      )}
+
+      {!hideStamp && <div className="pt-stamp select-none">{stampText}</div>}
+    </div>
+  );
+};
+
+export default BaseCard;

--- a/src/index.css
+++ b/src/index.css
@@ -90,6 +90,29 @@ All colors MUST be HSL.
     --rarity-uncommon: 142 76% 36%;
     --rarity-rare: 221 83% 53%;
     --rarity-legendary: 25 95% 53%;
+
+    /* === Paranoid Times – Tabloid Card Theme === */
+    --pt-paper: #f2f0ea;
+    --pt-ink: #111111;
+    --pt-halftone: rgba(0, 0, 0, 0.06);
+
+    --pt-truth: #0ea5e9;
+    --pt-gov: #ef4444;
+
+    --pt-rarity-common: #9ca3af;
+    --pt-rarity-uncommon: #3b82f6;
+    --pt-rarity-rare: #8b5cf6;
+    --pt-rarity-legendary: #eab308;
+
+    --pt-border: #222222;
+    --pt-border-soft: rgba(17, 17, 17, 0.2);
+    --pt-shadow: rgba(0, 0, 0, 0.25);
+
+    --pt-card-w: 320px;
+    --pt-card-h: 450px;
+
+    --pt-gap: 10px;
+    --pt-radius: 14px;
   }
   .dark {
     --background: 222.2 84% 4.9%;
@@ -488,6 +511,78 @@ All colors MUST be HSL.
     .synergy-unlock {
       animation: none !important;
     }
+  }
+}
+
+/* Tabloid newspaper surface */
+.pt-card-surface {
+  background:
+    radial-gradient(var(--pt-halftone) 1px, transparent 1px) 0 0 / 6px 6px,
+    var(--pt-paper);
+}
+
+/* Polaroid frame */
+.pt-polaroid {
+  background: #ffffff;
+  border: 1px solid #dddddd;
+  box-shadow: 0 6px 16px rgba(0, 0, 0, 0.2);
+}
+
+/* Diagonal stamp */
+.pt-stamp {
+  position: absolute;
+  top: 10px;
+  right: -30px;
+  transform: rotate(15deg);
+  padding: 4px 10px;
+  font-family: "Bebas Neue", Anton, system-ui, sans-serif;
+  letter-spacing: 1px;
+  border: 2px solid var(--pt-border);
+  color: var(--pt-ink);
+  background: rgba(255, 255, 255, 0.85);
+  text-transform: uppercase;
+  user-select: none;
+  pointer-events: none;
+}
+
+/* Redacted hover effect */
+.pt-redacted {
+  position: relative;
+  overflow: hidden;
+}
+
+.pt-redacted::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  transform: translateX(-100%);
+  background: repeating-linear-gradient(
+    transparent 0 10px,
+    rgba(0, 0, 0, 0.85) 10px 16px,
+    transparent 16px 24px
+  );
+  transition: transform 0.35s ease;
+  pointer-events: none;
+}
+
+.pt-redacted:hover::after {
+  transform: translateX(0%);
+}
+
+/* Modal wrapper sizing */
+.pt-card-wrap {
+  width: var(--pt-card-w);
+  height: var(--pt-card-h);
+  max-width: 95vw;
+  max-height: 85vh;
+  border-radius: var(--pt-radius);
+}
+
+@media (max-width: 640px) {
+  .pt-card-wrap {
+    width: min(var(--pt-card-w), 95vw);
+    height: auto;
+    aspect-ratio: 320 / 450;
   }
 }
 

--- a/src/lib/cardUi.ts
+++ b/src/lib/cardUi.ts
@@ -1,0 +1,81 @@
+import type { GameCard, Rarity as MVPRarity } from '@/rules/mvp';
+
+export type NormalizedFaction = 'truth' | 'government';
+export type NormalizedRarity = MVPRarity;
+
+export const normalizeFaction = (faction?: GameCard['faction']): NormalizedFaction => {
+  if (!faction) return 'government';
+  const normalized = faction.toString().toLowerCase();
+  return normalized === 'truth' ? 'truth' : 'government';
+};
+
+export const normalizeRarity = (rarity?: GameCard['rarity']): NormalizedRarity => {
+  if (!rarity) return 'common';
+  const normalized = rarity.toString().toLowerCase();
+  if (normalized === 'uncommon' || normalized === 'rare' || normalized === 'legendary') {
+    return normalized;
+  }
+  return 'common';
+};
+
+export const normalizeCardType = (type?: GameCard['type']): 'ATTACK' | 'MEDIA' | 'ZONE' => {
+  if (!type) return 'MEDIA';
+  const normalized = type.toString().toUpperCase();
+  if (normalized === 'ATTACK' || normalized === 'ZONE') {
+    return normalized;
+  }
+  return 'MEDIA';
+};
+
+export const getFactionVar = (faction?: GameCard['faction']): string => {
+  return `var(--pt-${normalizeFaction(faction)})`;
+};
+
+export const getFactionLabel = (faction?: GameCard['faction']): string => {
+  return normalizeFaction(faction) === 'truth' ? 'TRUTH EXPOSED' : 'GOVERNMENT FILE';
+};
+
+export const getRarityVar = (rarity?: GameCard['rarity']): string => {
+  return `var(--pt-rarity-${normalizeRarity(rarity)})`;
+};
+
+export const getRarityLabel = (rarity?: GameCard['rarity']): string => {
+  return normalizeRarity(rarity);
+};
+
+export const getFlavorText = (card: GameCard): string | undefined => {
+  return card.flavor ?? card.flavorTruth ?? card.flavorGov ?? undefined;
+};
+
+export const formatEffect = (card: GameCard): string => {
+  const effects = card.effects ?? {};
+  const type = normalizeCardType(card.type);
+
+  if (type === 'ATTACK') {
+    const opponentLoss = effects.ipDelta?.opponent;
+    if (typeof opponentLoss === 'number') {
+      const absoluteLoss = Math.abs(opponentLoss);
+      const parts = [`Opponent loses ${absoluteLoss} IP`];
+      if (typeof effects.discardOpponent === 'number' && effects.discardOpponent > 0) {
+        parts.push(`Discard ${effects.discardOpponent}`);
+      }
+      return parts.join(' · ');
+    }
+  }
+
+  if (type === 'MEDIA') {
+    if (typeof effects.truthDelta === 'number') {
+      const sign = effects.truthDelta >= 0 ? '+' : '';
+      return `Truth ${sign}${effects.truthDelta}%`;
+    }
+  }
+
+  if (type === 'ZONE') {
+    if (typeof effects.pressureDelta === 'number') {
+      const amount = effects.pressureDelta >= 0 ? `+${effects.pressureDelta}` : `${effects.pressureDelta}`;
+      return `${amount} Pressure to a state`;
+    }
+  }
+
+  return card.text ?? 'Special effect card with unique abilities.';
+};

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -2,7 +2,13 @@ import type { Config } from "tailwindcss";
 
 export default {
   darkMode: ["class"],
-  content: ["./pages/**/*.{ts,tsx}", "./components/**/*.{ts,tsx}", "./app/**/*.{ts,tsx}", "./src/**/*.{ts,tsx}"],
+  content: [
+    "./index.html",
+    "./pages/**/*.{ts,tsx}",
+    "./components/**/*.{ts,tsx}",
+    "./app/**/*.{ts,tsx}",
+    "./src/**/*.{ts,tsx}"
+  ],
   prefix: "",
   theme: {
     container: {
@@ -67,11 +73,35 @@ export default {
         "newspaper-border": "hsl(var(--newspaper-border))",
         "newspaper-accent": "hsl(var(--newspaper-accent))",
         "newspaper-headline": "hsl(var(--newspaper-headline))",
+        paper: "var(--pt-paper)",
+        ink: "var(--pt-ink)",
+        truth: "var(--pt-truth)",
+        gov: "var(--pt-gov)",
+        rarity: {
+          common: "var(--pt-rarity-common)",
+          uncommon: "var(--pt-rarity-uncommon)",
+          rare: "var(--pt-rarity-rare)",
+          legendary: "var(--pt-rarity-legendary)"
+        },
       },
       borderRadius: {
         lg: "var(--radius)",
         md: "calc(var(--radius) - 2px)",
         sm: "calc(var(--radius) - 4px)",
+        tabloid: "var(--pt-radius)",
+      },
+      fontFamily: {
+        headline: ["Anton", "Bebas Neue", "system-ui", "sans-serif"],
+        tabloid: ["Bebas Neue", "Anton", "system-ui", "sans-serif"],
+      },
+      boxShadow: {
+        tabloid: "0 6px 24px var(--pt-shadow)",
+      },
+      height: {
+        cardH: "var(--pt-card-h)",
+      },
+      width: {
+        cardW: "var(--pt-card-w)",
       },
       keyframes: {
         "accordion-down": {


### PR DESCRIPTION
## Summary
- add tabloid palette tokens, helper surfaces, and responsive sizing utilities in the global stylesheet
- extend Tailwind with tabloid fonts, colors, and sizing plus introduce shared card UI utilities and a reusable BaseCard component
- refactor the detail overlay and played-cards dock to render the new tabloid layout when the tabloid theme is active while preserving the legacy government classic view

## Testing
- `npm run lint` *(fails: missing @eslint/js dependency because packages cannot be installed in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cb12353c0c8320bbcbfa52a4bd12f3