### PR TITLE
Add UI hooks for AI plays and capture feedback

### DIFF
--- a/src/engine/applyEffects-mvp.ts
+++ b/src/engine/applyEffects-mvp.ts
@@ -52,6 +52,10 @@ function applyAttackEffect(
   const damage = Math.max(0, effects.ipDelta?.opponent ?? 0);
   const before = state.players[opponent].ip;
   state.players[opponent].ip = clampIP(before - damage);
+  const delta = state.players[opponent].ip - before;
+  if (delta !== 0 && typeof window !== 'undefined' && window.uiToastIp) {
+    window.uiToastIp(opponent, delta);
+  }
   state.log.push(`Opponent loses ${damage} IP (${before} → ${state.players[opponent].ip})`);
 
   if ((effects.discardOpponent ?? 0) > 0) {
@@ -81,7 +85,8 @@ function applyZoneEffect(
   };
 
   const defense = state.stateDefense[targetStateId] ?? Infinity;
-  if (updatedOwnerPressure >= defense) {
+  const captured = updatedOwnerPressure >= defense;
+  if (captured) {
     pressureByState = {
       ...pressureByState,
       [targetStateId]: { P1: 0, P2: 0 },
@@ -106,6 +111,10 @@ function applyZoneEffect(
 
   state.players = updatedPlayers;
   state.pressureByState = pressureByState;
+
+  if (captured && typeof window !== 'undefined' && window.uiFlashState) {
+    window.uiFlashState(targetStateId, owner);
+  }
 }
 
 export function applyEffectsMvp(

--- a/src/hooks/useGameState.ts
+++ b/src/hooks/useGameState.ts
@@ -606,6 +606,10 @@ export const useGameState = (aiDifficultyOverride?: AIDifficulty) => {
     const card = gameState.aiHand.find(c => c.id === cardId);
     if (!card) return;
 
+    if (typeof window !== "undefined" && window.uiShowOpponentCard) {
+      window.uiShowOpponentCard(card);
+    }
+
     setGameState(prev => {
       const resolution = resolveCardMVP(prev, card, targetState ?? null, 'ai', achievements);
       const logEntries = [...prev.log, ...resolution.logEntries];

--- a/src/index.css
+++ b/src/index.css
@@ -677,3 +677,9 @@ html, body, #root {
   min-width: 48px;
   min-height: 48px;
 }
+
+.capture-glow {
+  outline: 3px solid #000;
+  box-shadow: 0 0 0 4px rgba(255, 255, 255, 0.85), 0 0 12px rgba(0, 0, 0, 0.8);
+  transition: outline 0.2s ease, box-shadow 0.2s ease;
+}

--- a/src/ui/UiOverlays.tsx
+++ b/src/ui/UiOverlays.tsx
@@ -60,10 +60,28 @@ export default function UiOverlays() {
       window.setTimeout(() => setToasts((t) => t.filter((x) => x.id !== id)), 900);
     };
 
+    window.uiFlashState = (stateId: string, by: "P1" | "P2") => {
+      const el =
+        document.querySelector(`[data-state="${stateId}"]`) ||
+        document.getElementById(`state-${stateId}`) ||
+        document.querySelector(`[data-usps="${stateId}"]`);
+
+      if (el) {
+        el.classList.add("capture-glow");
+        window.setTimeout(() => el.classList.remove("capture-glow"), 900);
+      } else {
+        const id = Date.now() + Math.random();
+        const text = `Captured ${stateId}`;
+        setToasts((t) => [...t, { id, text, slot: "truth" }]);
+        window.setTimeout(() => setToasts((t) => t.filter((x) => x.id !== id)), 1100);
+      }
+    };
+
     return () => {
       delete window.uiShowOpponentCard;
       delete window.uiToastTruth;
       delete window.uiToastIp;
+      delete window.uiFlashState;
     };
   }, []);
 

--- a/src/utils/truth.ts
+++ b/src/utils/truth.ts
@@ -26,6 +26,10 @@ export function applyTruthDelta<T extends TruthMutable>(
   const before = gs.truth;
   const after = clampTruth(before + delta);
   gs.truth = after;
+  const change = after - before;
+  if (change !== 0 && typeof window !== 'undefined' && window.uiToastTruth) {
+    window.uiToastTruth(change);
+  }
   const arrow = delta >= 0 ? '↑' : '↓';
   gs.log.push(`Truth manipulation ${arrow} (${before}% → ${after}%)`);
   return gs;


### PR DESCRIPTION
## Summary
- trigger the card reveal overlay whenever the AI plays a card
- hook truth, IP, and state capture changes to toast/flash helpers, with a fallback glow style
- extend UI overlays to handle capture flashes and add the capture glow styling

## Testing
- `npm run lint` *(fails: missing @eslint/js because dependencies could not be installed in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cb2cab6cb48320b966b339815f0dc2