### PR TITLE
Refactor game layout for redesigned hand and cards in play

### DIFF
--- a/src/components/game/EnhancedGameHand.tsx
+++ b/src/components/game/EnhancedGameHand.tsx
@@ -1,18 +1,17 @@
 import React, { useState, useRef } from 'react';
-import CardImage from './CardImage';
+import clsx from 'clsx';
 import CardDetailOverlay from './CardDetailOverlay';
 import { Card } from '@/components/ui/card';
-import { Button } from '@/components/ui/button';
-import { Badge } from '@/components/ui/badge';
 import type { GameCard, MVPCardType } from '@/rules/mvp';
 import { MVP_CARD_TYPES } from '@/rules/mvp';
 import { useAudioContext } from '@/contexts/AudioContext';
 import { toast } from '@/hooks/use-toast';
-import { Loader2, Zap, Target, X, Eye, Megaphone } from 'lucide-react';
+import { Loader2 } from 'lucide-react';
 import { useHapticFeedback } from '@/hooks/useHapticFeedback';
 import { useSwipeGestures } from '@/hooks/useSwipeGestures';
 import { useIsMobile } from '@/hooks/use-mobile';
 import { ExtensionCardBadge } from './ExtensionCardBadge';
+import { CardTextGenerator } from '@/systems/CardTextGenerator';
 
 interface EnhancedGameHandProps {
   cards: GameCard[];
@@ -20,19 +19,17 @@ interface EnhancedGameHandProps {
   disabled?: boolean;
   selectedCard?: string | null;
   onSelectCard?: (cardId: string) => void;
-  maxCards?: number;
   currentIP: number;
   loadingCard?: string | null;
   onCardHover?: (card: (GameCard & { _hoverPosition?: { x: number; y: number } }) | null) => void;
 }
 
-const EnhancedGameHand: React.FC<EnhancedGameHandProps> = ({ 
-  cards, 
-  onPlayCard, 
-  disabled, 
+const EnhancedGameHand: React.FC<EnhancedGameHandProps> = ({
+  cards,
+  onPlayCard,
+  disabled,
   selectedCard,
   onSelectCard,
-  maxCards = 7,
   currentIP,
   loadingCard,
   onCardHover
@@ -44,79 +41,8 @@ const EnhancedGameHand: React.FC<EnhancedGameHandProps> = ({
   const isMobile = useIsMobile();
   const handRef = useRef<HTMLDivElement>(null);
 
-  const getRarityGlow = (rarity: string) => {
-    switch (rarity) {
-      case 'common': return 'shadow-md';
-      case 'uncommon': return 'shadow-md shadow-emerald-400/40';
-      case 'rare': return 'shadow-lg shadow-blue-400/50';
-      case 'legendary': return 'shadow-xl shadow-amber-400/60 animate-pulse';
-      default: return 'shadow-md';
-    }
-  };
-
-  const getRarityBorder = (rarity: string) => {
-    switch (rarity) {
-      case 'common': return 'border-zinc-600';
-      case 'uncommon': return 'border-emerald-400';
-      case 'rare': return 'border-blue-400';
-      case 'legendary': return 'border-amber-400';
-      default: return 'border-zinc-600';
-    }
-  };
-
-  const getRarityAccent = (rarity: string) => {
-    switch (rarity) {
-      case 'common': return 'bg-zinc-100 text-zinc-800';
-      case 'uncommon': return 'bg-emerald-100 text-emerald-800';
-      case 'rare': return 'bg-blue-100 text-blue-800';
-      case 'legendary': return 'bg-gradient-to-r from-amber-100 to-yellow-100 text-amber-800 font-bold';
-      default: return 'bg-zinc-100 text-zinc-800';
-    }
-  };
-
   const normalizeCardType = (type: string): MVPCardType => {
     return MVP_CARD_TYPES.includes(type as MVPCardType) ? type as MVPCardType : 'MEDIA';
-  };
-
-  const getTypeBadgeClass = (type: MVPCardType, faction: string) => {
-    if (type === 'MEDIA') {
-      return faction === 'government'
-        ? 'bg-government-blue/20 border-government-blue text-government-blue shadow-sm'
-        : 'bg-truth-red/20 border-truth-red text-truth-red shadow-sm';
-    }
-
-    if (type === 'ZONE') {
-      return 'bg-warning/20 border-warning text-warning shadow-sm';
-    }
-
-    return 'bg-destructive/20 border-destructive text-destructive shadow-sm';
-  };
-
-  const getTypeIcon = (type: MVPCardType) => {
-    switch (type) {
-      case 'MEDIA':
-        return <Megaphone className="w-3 h-3" />;
-      case 'ZONE':
-        return <Target className="w-3 h-3" />;
-      case 'ATTACK':
-      default:
-        return <Zap className="w-3 h-3" />;
-    }
-  };
-
-  const getCardFaction = (card: GameCard) => {
-    // First check if card has a direct faction property (for extension cards)
-    if (card.faction) {
-      return card.faction.toLowerCase();
-    }
-    
-    // Fallback to determining faction based on card text effects (for base game cards)
-    if (card.text && typeof card.text === 'string') {
-      if (card.text.includes('Truth +')) return 'truth';
-      if (card.text.includes('Truth -')) return 'government';
-    }
-    
-    return 'neutral';
   };
 
   const handlePlayCard = async (cardId: string) => {
@@ -183,171 +109,136 @@ const EnhancedGameHand: React.FC<EnhancedGameHandProps> = ({
   });
 
   return (
-    <div className="space-y-2" ref={handRef} onPointerLeave={() => onCardHover?.(null)}>
-      
-      {/* Minimized hand cards - Compact List */}
-      <div className="space-y-1">
-        {cards.map((card, index) => {
-          const isSelected = selectedCard === card.id;
-          const isPlaying = playingCard === card.id;
-          const isLoading = loadingCard === card.id;
-          const canAfford = canAffordCard(card);
-          const faction = getCardFaction(card);
-          const displayType = normalizeCardType(card.type);
-          
-          return (
-            <div 
-              key={`${card.id}-${index}`}
-              data-card-id={card.id}
-              aria-describedby={`hand-tooltip-${card.id}`}
-              className={`
-                enhanced-button card-hover-glow group relative cursor-pointer transition-all duration-300
-                bg-card border-2 rounded-lg flex items-center gap-2 overflow-visible
-                ${isMobile ? 'p-4 min-h-[80px]' : 'p-2'}
-                ${isSelected ? 'ring-2 ring-warning scale-105 z-10 shadow-lg shadow-warning/50' : ''}
-                ${isPlaying || isLoading ? 'animate-pulse scale-105 z-50 ring-2 ring-primary shadow-lg shadow-primary/50' : 'hover:scale-[1.03] hover:shadow-md'}
-                ${!canAfford && !disabled ? 'opacity-60 saturate-50 cursor-not-allowed' : 'hover:bg-accent/20'}
-                ${getRarityBorder(card.rarity)}
-                ${getRarityGlow(card.rarity)}
-                active:scale-95 hover:-translate-y-0.5
-              `}
-              style={{ 
-                animationDelay: `${index * 0.05}s`,
-                transform: (isPlaying || isLoading) ? 'scale(1.05) translateY(-2px)' : undefined,
-                zIndex: (isPlaying || isLoading) ? 1000 : undefined,
-                overflow: 'visible'
-              }}
-              onClick={(e) => {
-                e.preventDefault();
-                // Only open examination modal, don't select for targeting
-                audio.playSFX('click');
-                triggerHaptic('selection');
-                if (examinedCard === card.id) {
-                  setExaminedCard(null);
-                } else {
-                  setExaminedCard(card.id);
-                  // Don't auto-select the card for targeting when opening modal
-                }
-              }}
-              onPointerEnter={(e) => {
-                const handEl = handRef.current;
-                if (handEl) {
-                  const hb = handEl.getBoundingClientRect();
-                  const mx = e.clientX;
-                  const my = e.clientY;
-                  if (mx < hb.left || mx > hb.right || my < hb.top || my > hb.bottom) {
-                    return;
+    <div
+      className="relative flex h-full flex-col"
+      ref={handRef}
+      onPointerLeave={() => onCardHover?.(null)}
+    >
+      <div className="grid grid-cols-2 gap-3 overflow-y-auto p-3 lg:grid-cols-3 max-h-[calc(100vh-220px)]">
+        {cards.length === 0 ? (
+          <div className="col-span-full flex min-h-[160px] items-center justify-center rounded border border-dashed border-neutral-700 bg-neutral-900/60 p-6 text-sm font-mono text-white/60">
+            No assets available
+          </div>
+        ) : (
+          cards.map((card, index) => {
+            const isSelected = selectedCard === card.id;
+            const isPlaying = playingCard === card.id;
+            const isLoading = loadingCard === card.id;
+            const canAfford = canAffordCard(card);
+            const displayType = normalizeCardType(card.type);
+            const rarityLabel = (card.rarity || 'common').toUpperCase();
+            const flavorText = card.flavor ?? card.flavorTruth ?? card.flavorGov ?? '';
+            const effectLines = card.effects ? CardTextGenerator.renderEffects(card.effects) : [];
+            const details = effectLines.length > 0
+              ? effectLines
+              : card.text
+                ? card.text.split('\n')
+                : card.effects
+                  ? [CardTextGenerator.generateRulesText(card.effects)]
+                  : [];
+
+            return (
+              <button
+                key={`${card.id}-${index}`}
+                type="button"
+                className={clsx(
+                  'group relative flex h-full flex-col rounded-lg border border-neutral-700 bg-neutral-900 p-2 text-left text-white shadow-sm transition-transform duration-200 hover:-translate-y-0.5 hover:shadow-lg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/80',
+                  (isPlaying || isLoading) && 'ring-2 ring-primary shadow-primary/40',
+                  isSelected && 'ring-2 ring-yellow-400 shadow-yellow-400/40',
+                  !canAfford && !disabled && 'cursor-not-allowed opacity-60 saturate-50 hover:translate-y-0 hover:shadow-none'
+                )}
+                style={{ animationDelay: `${index * 0.03}s` }}
+                onClick={(e) => {
+                  e.preventDefault();
+                  audio.playSFX('click');
+                  triggerHaptic('selection');
+                  setExaminedCard(prev => (prev === card.id ? null : card.id));
+                }}
+                onPointerEnter={(e) => {
+                  const handEl = handRef.current;
+                  if (handEl) {
+                    const hb = handEl.getBoundingClientRect();
+                    const mx = e.clientX;
+                    const my = e.clientY;
+                    if (mx < hb.left || mx > hb.right || my < hb.top || my > hb.bottom) {
+                      return;
+                    }
                   }
-                }
-                audio.playSFX('lightClick');
-                const rect = (e.currentTarget as HTMLElement).getBoundingClientRect();
-                const tooltipWidth = 300; // ~max-w-xs incl. padding
-                let left = rect.right + 10;
-                if (left + tooltipWidth > window.innerWidth) {
-                  left = Math.max(16, rect.left - tooltipWidth - 10);
-                }
-                let top = rect.top + rect.height / 2;
-                top = Math.min(window.innerHeight - 16, Math.max(16, top));
-                onCardHover?.({
-                  ...card,
-                  _hoverPosition: { x: left, y: top }
-                });
-              }}
-              onPointerLeave={() => {
-                onCardHover?.(null);
-              }}
-            >
-               {/* Enhanced loading/targeting overlay */}
-               {(isLoading || isPlaying || isSelected) && (
-                 <div className="absolute inset-0 bg-primary/20 backdrop-blur-sm rounded-lg flex flex-col items-center justify-center z-20">
-                   <Loader2 className={`w-5 h-5 ${isSelected ? 'animate-pulse' : 'animate-spin'} text-primary mb-1`} />
-                   <span className="text-xs font-mono text-primary font-bold">
-                     {isPlaying ? 'DEPLOYING' : isSelected && displayType === 'ZONE' ? 'TARGETING' : 'PROCESSING'}
-                   </span>
-                 </div>
-               )}
-              
-               {/* Enhanced Cost Badge */}
-               <div className={`rounded-full flex items-center justify-center text-xs font-bold flex-shrink-0 border-2 transition-all duration-200 ${
-                 isMobile ? 'w-12 h-12 text-sm' : 'w-8 h-8'
-               } ${
-                 canAfford ? 'bg-primary text-primary-foreground border-primary shadow-md shadow-primary/30' : 'bg-destructive text-destructive-foreground border-destructive shadow-md shadow-destructive/30 animate-pulse'
-               }`}>
-                 {card.cost}
-               </div>
-               
-               {/* Card Name and Rarity */}
-                <div className="flex-1 min-w-0">
-                  <div className="flex items-center gap-2">
-                    <span className={`font-bold text-foreground truncate ${isMobile ? 'text-base' : 'text-sm'}`}>{card.name}</span>
-                    <span className={`px-1.5 py-0.5 rounded-full ${isMobile ? 'text-xs' : 'text-xs'} ${getRarityAccent(card.rarity)}`}>
-                      {card.rarity.toUpperCase()}
-                    </span>
-                    <ExtensionCardBadge cardId={card.id} card={card} variant="inline" />
-                  </div>
-                  <div className={`text-muted-foreground truncate max-w-[200px] ${isMobile ? 'text-sm' : 'text-xs'}`}>{card.text}</div>
-                </div>
-              
-              {/* Enhanced Type Badge */}
-              <Badge
-                variant="outline"
-                className={`text-xs px-2 py-1 flex-shrink-0 flex items-center gap-1 transition-all duration-200 ${getTypeBadgeClass(displayType, faction)}`}
+                  audio.playSFX('lightClick');
+                  const rect = (e.currentTarget as HTMLElement).getBoundingClientRect();
+                  const tooltipWidth = 300;
+                  let left = rect.right + 10;
+                  if (left + tooltipWidth > window.innerWidth) {
+                    left = Math.max(16, rect.left - tooltipWidth - 10);
+                  }
+                  let top = rect.top + rect.height / 2;
+                  top = Math.min(window.innerHeight - 16, Math.max(16, top));
+                  onCardHover?.({
+                    ...card,
+                    _hoverPosition: { x: left, y: top }
+                  });
+                }}
+                onPointerLeave={() => {
+                  onCardHover?.(null);
+                }}
               >
-                {getTypeIcon(displayType)}
-                {displayType}
-              </Badge>
+                {(isLoading || isPlaying || isSelected) && (
+                  <div className="absolute inset-0 z-20 flex flex-col items-center justify-center rounded-lg bg-primary/15 backdrop-blur-sm">
+                    <Loader2 className={clsx('mb-1 h-5 w-5', isSelected ? 'animate-pulse' : 'animate-spin', 'text-primary')} />
+                    <span className="text-xs font-mono font-bold text-primary">
+                      {isPlaying ? 'DEPLOYING' : isSelected && displayType === 'ZONE' ? 'TARGETING' : 'PROCESSING'}
+                    </span>
+                  </div>
+                )}
 
-               {/* Selection indicator for zone targeting */}
-               {isSelected && displayType === 'ZONE' && (
-                 <div className="absolute -top-1 -right-1 w-4 h-4 rounded-full bg-warning text-warning-foreground text-xs font-bold flex items-center justify-center ring-2 ring-warning/50 animate-pulse">
-                   🎯
-                 </div>
-               )}
-               {/* Regular selection indicator */}
-               {isSelected && displayType !== 'ZONE' && (
-                 <div className="absolute -top-1 -right-1 w-3 h-3 rounded-full bg-yellow-400 ring-2 ring-yellow-400/50" />
-               )}
-               
-                {/* Extension badge overlay */}
+                <div className="flex flex-col h-full">
+                  <header className="mb-1">
+                    <div className="text-[13px] font-extrabold leading-tight line-clamp-2">{card.name}</div>
+                    <div className="flex items-center justify-between text-[11px] uppercase opacity-80">
+                      <span className="truncate">
+                        {displayType} · {rarityLabel}
+                      </span>
+                      <span>IP {card.cost}</span>
+                    </div>
+                  </header>
+
+                  <div className="mb-2 space-y-1 text-[12px]">
+                    {details.length > 0 ? (
+                      details.map((line, detailIndex) => (
+                        <p key={`${card.id}-detail-${detailIndex}`} className="leading-snug">
+                          {line}
+                        </p>
+                      ))
+                    ) : (
+                      <p className="opacity-80">No effect data</p>
+                    )}
+                  </div>
+
+                  <div className="mt-auto" />
+
+                  {flavorText && (
+                    <div className="border-t border-white/10 pt-1 text-[11px] italic opacity-80 line-clamp-2">
+                      “{flavorText}”
+                    </div>
+                  )}
+                </div>
+
+                {isSelected && displayType === 'ZONE' && (
+                  <div className="absolute -top-1 -right-1 flex h-5 w-5 items-center justify-center rounded-full bg-yellow-400 text-xs font-bold text-black ring-2 ring-yellow-300 animate-pulse">
+                    🎯
+                  </div>
+                )}
+
+                {isSelected && displayType !== 'ZONE' && (
+                  <div className="absolute -top-1 -right-1 h-3 w-3 rounded-full bg-yellow-300 ring-2 ring-yellow-200" />
+                )}
+
                 <ExtensionCardBadge cardId={card.id} card={card} variant="overlay" />
-
-               {/* Inline hover tooltip right of the card */}
-               <div
-                 id={`hand-tooltip-${card.id}`}
-                 role="tooltip"
-                 className="absolute left-full top-1/2 -translate-y-1/2 ml-2 opacity-0 group-hover:opacity-100 transition-opacity duration-150 z-[99999] pointer-events-none"
-               >
-                 <div className="bg-popover border border-border rounded-lg p-3 shadow-xl max-w-xs">
-                   <div className="font-bold text-sm text-foreground mb-1">{card.name}</div>
-                   <div className="text-xs text-muted-foreground mb-2">{displayType} • Cost: {card.cost}</div>
-                   <div className="text-xs text-foreground">{card.text}</div>
-                 </div>
-               </div>
-
-               {/* Hover info button */}
-               <button
-                 type="button"
-                 className="absolute right-2 top-1/2 -translate-y-1/2 opacity-0 group-hover:opacity-100 transition-all duration-150 bg-accent text-accent-foreground border border-accent/30 rounded-full p-1.5 shadow-sm hover:scale-105"
-                 onClick={(e) => {
-                   e.stopPropagation();
-                   audio.playSFX('click');
-                   setExaminedCard(card.id);
-                 }}
-                 aria-label="Vis kortdetaljer"
-               >
-                 <Eye className="w-4 h-4" />
-               </button>
-
-            </div>
-          );
-        })}
+              </button>
+            );
+          })
+        )}
       </div>
-      
-      {cards.length === 0 && (
-        <div className="text-center text-muted-foreground text-sm font-mono py-8 border border-dashed border-muted rounded-lg">
-          No assets available
-        </div>
-      )}
 
       {/* Card Detail Overlay - Redesigned */}
       {examinedCard && (

--- a/src/components/game/PlayedCardsDock.tsx
+++ b/src/components/game/PlayedCardsDock.tsx
@@ -1,9 +1,6 @@
 import React from 'react';
-import { Badge } from '@/components/ui/badge';
-import CardImage from '@/components/game/CardImage';
 import type { GameCard } from '@/rules/mvp';
-import BaseCard from '@/components/game/cards/BaseCard';
-import { useUiTheme } from '@/hooks/useTheme';
+import { CardTextGenerator } from '@/systems/CardTextGenerator';
 import { ExtensionCardBadge } from '@/components/game/ExtensionCardBadge';
 
 interface PlayedCard {
@@ -15,313 +12,109 @@ interface PlayedCardsDockProps {
   playedCards: PlayedCard[];
 }
 
-interface PlayerColumnsProps {
-  humanCards: PlayedCard[];
-  aiCards: PlayedCard[];
+const summarizeCard = (card: GameCard): string[] => {
+  if (card.effects) {
+    const summary = CardTextGenerator.renderEffects(card.effects);
+    if (summary.length > 0) {
+      return summary;
+    }
+    return [CardTextGenerator.generateRulesText(card.effects)];
+  }
+
+  if (card.text) {
+    return card.text.split('\n');
+  }
+
+  return [];
+};
+
+const PlayedCardTile = ({ card }: { card: GameCard }) => {
+  const displayType = (card.type || 'MEDIA').toString().toUpperCase();
+  const rarityLabel = (card.rarity || 'common').toUpperCase();
+  const flavorText = card.flavor ?? card.flavorTruth ?? card.flavorGov ?? '';
+  const details = summarizeCard(card);
+
+  return (
+    <div className="relative flex h-full flex-col rounded-lg border border-neutral-700 bg-neutral-900 p-2 text-white shadow-sm">
+      <div className="text-[11px] font-bold leading-tight line-clamp-2 pr-6">{card.name}</div>
+      <div className="mt-0.5 flex items-center justify-between text-[10px] uppercase tracking-wide opacity-70">
+        <span className="truncate">{displayType} · {rarityLabel}</span>
+        <span>IP {card.cost}</span>
+      </div>
+      <div className="mt-1 space-y-1 text-[10px] leading-snug">
+        {(details.length > 0 ? details.slice(0, 3) : ['No effect data']).map((line, index) => (
+          <p key={`${card.id}-detail-${index}`}>{line}</p>
+        ))}
+      </div>
+      {flavorText && (
+        <div className="mt-auto pt-1 text-[10px] italic opacity-70 line-clamp-2">
+          “{flavorText}”
+        </div>
+      )}
+      <ExtensionCardBadge cardId={card.id} card={card} variant="overlay" />
+    </div>
+  );
+};
+
+interface SectionProps {
+  title: string;
+  toneClass: string;
+  cards: PlayedCard[];
+  emptyMessage: string;
+  ariaLabel: string;
 }
 
-const TabloidColumn = ({
-  cards,
-  label,
-  colorVar,
-  emptyMessage,
-}: {
-  cards: PlayedCard[];
-  label: string;
-  colorVar: string;
-  emptyMessage: string;
-}) => {
+const PlayedCardsSection: React.FC<SectionProps> = ({ title, toneClass, cards, emptyMessage, ariaLabel }) => {
   return (
     <section
-      className="pt-card-surface border rounded-tabloid shadow-sm p-3"
-      style={{ borderColor: 'var(--pt-border)' }}
+      aria-label={ariaLabel}
+      className={`rounded-md border border-black/10 p-3 text-black ${toneClass}`}
     >
-      <div className="flex items-center gap-2 mb-3">
-        <span
-          className="px-2 py-0.5 text-[11px] uppercase tracking-wide text-white rounded font-tabloid"
-          style={{ background: colorVar }}
-        >
-          {label}
-        </span>
-        <span className="text-[11px] uppercase tracking-wide font-tabloid text-[color:var(--pt-ink)] opacity-60">
-          ({cards.length}/3)
-        </span>
-      </div>
-
+      <h4 className="mb-2 text-[12px] font-bold uppercase tracking-[0.2em] text-black/70">{title}</h4>
       {cards.length > 0 ? (
-        <div className="flex flex-wrap gap-4">
-          {cards.map((playedCard, index) => (
-            <div
-              key={`${label}-${playedCard.card.id}-${index}`}
-              className="flex flex-col items-center gap-2"
-              style={{ width: 'calc(var(--pt-card-w) * 0.55)' }}
-            >
-              <div
-                className="relative"
-                style={{
-                  width: 'calc(var(--pt-card-w) * 0.55)',
-                  height: 'calc(var(--pt-card-h) * 0.55)',
-                }}
-              >
-                <div className="scale-[0.55] origin-top-left">
-                  <BaseCard card={playedCard.card} polaroidHover />
-                </div>
-              </div>
-              <ExtensionCardBadge cardId={playedCard.card.id} card={playedCard.card} />
-            </div>
+        <div className="grid grid-cols-2 gap-2 sm:grid-cols-3">
+          {cards.map((entry, index) => (
+            <PlayedCardTile key={`${entry.card.id}-${index}`} card={entry.card} />
           ))}
         </div>
       ) : (
-        <p className="text-[12px] italic text-[color:var(--pt-ink)] opacity-65">
+        <div className="grid min-h-[120px] place-items-center rounded border border-dashed border-black/20 bg-white/40 p-4 text-center text-[11px] font-mono uppercase tracking-wide text-black/50">
           {emptyMessage}
-        </p>
+        </div>
       )}
     </section>
   );
 };
 
-const TabloidPlayedCardsDock: React.FC<PlayerColumnsProps> = ({ humanCards, aiCards }) => {
-  return (
-    <div className="h-full flex flex-col">
-      <div className="flex-1 p-2 overflow-y-auto">
-        <h4 className="text-xs font-semibold uppercase tracking-[0.3em] mb-3 text-[color:var(--pt-ink)] font-headline">
-          CARDS IN PLAY THIS ROUND
-        </h4>
-
-        <div className="grid gap-4">
-          <TabloidColumn
-            cards={humanCards}
-            label="YOUR CARDS"
-            colorVar="var(--pt-truth)"
-            emptyMessage="No cards deployed this turn."
-          />
-          <TabloidColumn
-            cards={aiCards}
-            label="OPPONENT CARDS"
-            colorVar="var(--pt-gov)"
-            emptyMessage="Opponent has no cards in play."
-          />
-        </div>
-      </div>
-    </div>
-  );
-};
-
-const LegacyPlayedCardsDock: React.FC<PlayerColumnsProps> = ({ humanCards, aiCards }) => {
-  const normalizeCardType = (type: string) => {
-    if (type === 'ATTACK' || type === 'MEDIA' || type === 'ZONE') {
-      return type;
-    }
-    return 'MEDIA';
-  };
-
-  const getTypeColor = (type: string, isAI: boolean) => {
-    const normalized = normalizeCardType(type);
-    const truthColors: Record<'ATTACK' | 'MEDIA' | 'ZONE', string> = {
-      MEDIA: 'text-truth-red border-truth-red',
-      ZONE: 'text-yellow-600 border-yellow-600',
-      ATTACK: 'text-red-600 border-red-600',
-    };
-
-    const govColors: Record<'ATTACK' | 'MEDIA' | 'ZONE', string> = {
-      MEDIA: 'text-government-blue border-government-blue',
-      ZONE: 'text-yellow-600 border-yellow-600',
-      ATTACK: 'text-red-600 border-red-600',
-    };
-
-    return isAI ? govColors[normalized] : truthColors[normalized];
-  };
-
-  const getRarityBg = (rarity?: string) => {
-    switch (rarity) {
-      case 'legendary':
-        return 'from-yellow-600/20 to-orange-600/20 border-yellow-500/30';
-      case 'rare':
-        return 'from-purple-600/20 to-blue-600/20 border-purple-500/30';
-      case 'uncommon':
-        return 'from-green-600/20 to-blue-600/20 border-green-500/30';
-      default:
-        return 'from-gray-600/20 to-gray-500/20 border-gray-500/30';
-    }
-  };
-
-  return (
-    <div className="h-full flex flex-col">
-      <div className="flex-1 p-2 overflow-y-auto">
-        <h4 className="text-xs font-semibold text-newspaper-text mb-2 font-mono">
-          CARDS IN PLAY THIS ROUND
-        </h4>
-
-        <div className="flex gap-2">
-          <div className="flex-1">
-            {humanCards.length > 0 && (
-              <div>
-                <div className="flex items-center gap-2 mb-2">
-                  <Badge variant="outline" className="border-truth-red text-truth-red text-[10px] px-1 py-0">
-                    YOUR CARDS
-                  </Badge>
-                  <span className="text-[10px] text-newspaper-text/70">({humanCards.length}/3)</span>
-                </div>
-                <div className="flex flex-wrap gap-2">
-                  {humanCards.map((playedCard, index) => {
-                    const displayType = normalizeCardType(playedCard.card.type);
-                    return (
-                      <div key={`human-${playedCard.card.id}-${index}`} className="group relative">
-                        <div
-                          className={`w-24 h-32 bg-gradient-to-b ${getRarityBg(playedCard.card.rarity)} border rounded shadow-sm animate-scale-in overflow-hidden`}
-                        >
-                          <div className="bg-newspaper-text text-newspaper-bg text-center py-0.5 border-b">
-                            <div className="text-[6px] font-bold leading-none">PARANOID TIMES</div>
-                          </div>
-
-                          <div className="px-1 py-0.5 bg-gradient-to-r from-card to-card/80">
-                            <div className="text-[7px] font-bold text-center line-clamp-1 leading-tight">
-                              {playedCard.card.name}
-                            </div>
-                          </div>
-
-                          <div className="h-8 overflow-hidden border-y">
-                            <CardImage cardId={playedCard.card.id} className="w-full h-full object-cover" />
-                          </div>
-
-                          <div className="px-1 py-0.5 flex-1">
-                            <div className="text-[5px] font-semibold mb-0.5">Effect</div>
-                            <div className="text-[4px] text-muted-foreground line-clamp-2 leading-tight">
-                              {playedCard.card.text}
-                            </div>
-                          </div>
-
-                          <div className="bg-truth-red/10 border-t border-truth-red/20 px-1 py-0.5">
-                            <div className="text-[4px] font-bold text-muted-foreground mb-0.5">CLASSIFIED INTELLIGENCE</div>
-                            <div className="text-[4px] italic line-clamp-1 leading-tight">
-                              "{playedCard.card.flavor ?? playedCard.card.flavorGov ?? playedCard.card.flavorTruth}"
-                            </div>
-                          </div>
-
-                          <div className="absolute top-5 left-0.5">
-                            <Badge variant="outline" className={`text-[5px] px-0.5 py-0 ${getTypeColor(playedCard.card.type, false)}`}>
-                              {displayType}
-                            </Badge>
-                          </div>
-                          <div className="absolute top-5 right-0.5 bg-primary text-primary-foreground text-[6px] font-bold px-1 py-0.5 rounded">
-                            {playedCard.card.cost}
-                          </div>
-                        </div>
-
-                        <div className="absolute bottom-full left-1/2 transform -translate-x-1/2 mb-2 opacity-0 group-hover:opacity-100 transition-opacity duration-200 pointer-events-none z-50">
-                          <div className="bg-popover border border-border rounded-lg p-3 shadow-xl max-w-xs">
-                            <div className="font-bold text-sm text-foreground mb-1">{playedCard.card.name}</div>
-                            <div className="text-xs text-muted-foreground mb-2">
-                              {displayType} • Cost: {playedCard.card.cost} IP
-                            </div>
-                            <div className="text-xs text-foreground mb-2">{playedCard.card.text}</div>
-                            <div className="text-xs italic text-muted-foreground border-l-4 border-truth-red bg-truth-red/10 rounded-r border border-truth-red/20 pl-2 pr-2 py-1">
-                              "{playedCard.card.flavor ?? playedCard.card.flavorGov ?? playedCard.card.flavorTruth}"
-                            </div>
-                          </div>
-                        </div>
-                      </div>
-                    );
-                  })}
-                </div>
-              </div>
-            )}
-          </div>
-
-          <div className="flex-1">
-            {aiCards.length > 0 && (
-              <div>
-                <div className="flex items-center gap-2 mb-2">
-                  <Badge variant="outline" className="border-government-blue text-government-blue text-[10px] px-1 py-0">
-                    OPPONENT CARDS
-                  </Badge>
-                  <span className="text-[10px] text-newspaper-text/70">({aiCards.length}/3)</span>
-                </div>
-                <div className="flex flex-wrap gap-2">
-                  {aiCards.map((playedCard, index) => {
-                    const displayType = normalizeCardType(playedCard.card.type);
-                    return (
-                      <div key={`ai-${playedCard.card.id}-${index}`} className="group relative">
-                        <div
-                          className={`w-24 h-32 bg-gradient-to-b ${getRarityBg(playedCard.card.rarity)} border rounded shadow-sm animate-scale-in overflow-hidden`}
-                        >
-                          <div className="bg-newspaper-text text-newspaper-bg text-center py-0.5 border-b">
-                            <div className="text-[6px] font-bold leading-none">PARANOID TIMES</div>
-                          </div>
-
-                          <div className="px-1 py-0.5 bg-gradient-to-r from-card to-card/80">
-                            <div className="text-[7px] font-bold text-center line-clamp-1 leading-tight">
-                              {playedCard.card.name}
-                            </div>
-                          </div>
-
-                          <div className="h-8 overflow-hidden border-y">
-                            <CardImage cardId={playedCard.card.id} className="w-full h-full object-cover" />
-                          </div>
-
-                          <div className="px-1 py-0.5 flex-1">
-                            <div className="text-[5px] font-semibold mb-0.5">Effect</div>
-                            <div className="text-[4px] text-muted-foreground line-clamp-2 leading-tight">
-                              {playedCard.card.text}
-                            </div>
-                          </div>
-
-                          <div className="bg-government-blue/10 border-t border-government-blue/20 px-1 py-0.5">
-                            <div className="text-[4px] font-bold text-muted-foreground mb-0.5">CLASSIFIED INTELLIGENCE</div>
-                            <div className="text-[4px] italic line-clamp-1 leading-tight">
-                              "{playedCard.card.flavor ?? playedCard.card.flavorGov ?? playedCard.card.flavorTruth}"
-                            </div>
-                          </div>
-
-                          <div className="absolute top-5 left-0.5">
-                            <Badge variant="outline" className={`text-[5px] px-0.5 py-0 ${getTypeColor(playedCard.card.type, true)}`}>
-                              {displayType}
-                            </Badge>
-                          </div>
-                          <div className="absolute top-5 right-0.5 bg-primary text-primary-foreground text-[6px] font-bold px-1 py-0.5 rounded">
-                            {playedCard.card.cost}
-                          </div>
-                        </div>
-
-                        <div className="absolute bottom-full left-1/2 transform -translate-x-1/2 mb-2 opacity-0 group-hover:opacity-100 transition-opacity duration-200 pointer-events-none z-50">
-                          <div className="bg-popover border border-border rounded-lg p-3 shadow-xl max-w-xs">
-                            <div className="font-bold text-sm text-foreground mb-1">{playedCard.card.name}</div>
-                            <div className="text-xs text-muted-foreground mb-2">
-                              {displayType} • Cost: {playedCard.card.cost} IP
-                            </div>
-                            <div className="text-xs text-foreground mb-2">{playedCard.card.text}</div>
-                            <div className="text-xs italic text-muted-foreground border-l-4 border-government-blue bg-government-blue/10 rounded-r border border-government-blue/20 pl-2 pr-2 py-1">
-                              "{playedCard.card.flavor ?? playedCard.card.flavorGov ?? playedCard.card.flavorTruth}"
-                            </div>
-                          </div>
-                        </div>
-                      </div>
-                    );
-                  })}
-                </div>
-              </div>
-            )}
-          </div>
-        </div>
-
-        {humanCards.length === 0 && aiCards.length === 0 && (
-          <div className="text-xs text-newspaper-text/60">No cards played this round</div>
-        )}
-      </div>
-    </div>
-  );
-};
-
 const PlayedCardsDock: React.FC<PlayedCardsDockProps> = ({ playedCards }) => {
-  const [uiTheme] = useUiTheme();
-  const humanCards = playedCards.filter((pc) => pc.player === 'human');
-  const aiCards = playedCards.filter((pc) => pc.player === 'ai');
+  const humanCards = playedCards.filter(card => card.player === 'human');
+  const aiCards = playedCards.filter(card => card.player === 'ai');
 
-  if (uiTheme === 'tabloid_bw') {
-    return <TabloidPlayedCardsDock humanCards={humanCards} aiCards={aiCards} />;
-  }
-
-  return <LegacyPlayedCardsDock humanCards={humanCards} aiCards={aiCards} />;
+  return (
+    <div className="flex h-full flex-col">
+      <header className="border-b border-newspaper-border/60 px-4 py-3">
+        <h3 className="text-xs font-semibold uppercase tracking-[0.3em] text-newspaper-text">
+          CARDS IN PLAY THIS ROUND
+        </h3>
+      </header>
+      <div className="grid grid-cols-1 gap-3 p-3 lg:grid-cols-2">
+        <PlayedCardsSection
+          title="OPPONENT"
+          ariaLabel="Opponent Cards"
+          cards={aiCards}
+          emptyMessage="Opponent has no cards in play."
+          toneClass="bg-[image:var(--halftone-red)] bg-[length:8px_8px] bg-repeat bg-red-50/40"
+        />
+        <PlayedCardsSection
+          title="YOU"
+          ariaLabel="Your Cards"
+          cards={humanCards}
+          emptyMessage="No cards deployed this turn."
+          toneClass="bg-[image:var(--halftone-blue)] bg-[length:8px_8px] bg-repeat bg-blue-50/40"
+        />
+      </div>
+    </div>
+  );
 };
 
 export default PlayedCardsDock;

--- a/src/components/layout/ResponsiveLayout.tsx
+++ b/src/components/layout/ResponsiveLayout.tsx
@@ -3,14 +3,20 @@ import clsx from "clsx";
 
 type Props = {
   masthead?: React.ReactNode;
-  main?: React.ReactNode; // spillbrett/kart/avisside
-  sidebar?: React.ReactNode; // minimerte kort, statspanel, logg
-  tray?: React.ReactNode; // Your Hand / card tray nederst
+  leftPane?: React.ReactNode; // spillbrett/kart/avisside + paneler
+  rightPane?: React.ReactNode; // spillerhånd, handlinger
 };
 
-export default function ResponsiveLayout({ masthead, main, sidebar, tray }: Props) {
+export default function ResponsiveLayout({ masthead, leftPane, rightPane }: Props) {
+  const hasRightPane = Boolean(rightPane);
+
   return (
-    <div className="app-shell flex flex-col" style={{ paddingTop: "var(--safe-top)" }}>
+    <div
+      className="app-shell flex flex-col"
+      style={{
+        paddingTop: "var(--safe-top)",
+      }}
+    >
       {/* Masthead */}
       <header
         className="shrink-0"
@@ -21,51 +27,29 @@ export default function ResponsiveLayout({ masthead, main, sidebar, tray }: Prop
 
       {/* Content area */}
       <div className="flex-1 min-h-0">
-        {/* Desktop / Tablet layout */}
-        <div className="hidden md:grid h-full grid-cols-12 gap-3">
-          {/* Main area */}
-          <main className="col-span-12 md:col-span-8 lg:col-span-9 xl:col-span-8 min-h-0">
-            <div className="app-scroll h-full p-2 sm:p-4 md:p-6">
-              {main}
+        <div
+          className="h-full"
+          style={{
+            paddingLeft: "var(--safe-left)",
+            paddingRight: "var(--safe-right)",
+          }}
+        >
+          <div className="app-scroll h-full p-2 sm:p-4 md:p-6">
+            <div
+              className={clsx(
+                "grid h-full gap-4",
+                "grid-cols-1",
+                hasRightPane && "lg:grid-cols-[1fr_420px] xl:grid-cols-[1fr_480px]"
+              )}
+            >
+              <main className="min-h-0">{leftPane}</main>
+              {hasRightPane && (
+                <aside className="min-h-0">{rightPane}</aside>
+              )}
             </div>
-          </main>
-
-          {/* Sidebar (vises fra md og opp) */}
-          <aside className="hidden md:block col-span-4 lg:col-span-3 xl:col-span-4 min-h-0">
-            <div className="app-scroll h-full p-2 sm:p-3 md:p-4">
-              {sidebar}
-            </div>
-          </aside>
-        </div>
-
-        {/* Mobil layout (stack) */}
-        <div className="md:hidden h-full">
-          <div className="app-scroll h-full p-2">
-            {main}
           </div>
-
-          {/* Sidebar som overlay på mobil – implementer en Drawer senere */}
-          {/* Legg inn en fast plasseringscontainer for drawer mount */}
-          <div id="mobile-sidebar-portal" />
         </div>
       </div>
-
-      {/* Tray nederst */}
-      <footer
-        className={clsx(
-          "shrink-0 border-t",
-          "bg-background"
-        )}
-        style={{
-          height: "var(--tray-h-sm)",
-          paddingLeft: "var(--safe-left)",
-          paddingRight: "var(--safe-right)",
-        }}
-      >
-        <div className="h-full md:h-[var(--tray-h-md)] lg:h-[var(--tray-h-lg)] p-2 sm:p-3 md:p-4">
-          {tray}
-        </div>
-      </footer>
     </div>
   );
 }

--- a/src/index.css
+++ b/src/index.css
@@ -649,6 +649,9 @@ All colors MUST be HSL.
   --tray-h-md: 160px;
   --tray-h-lg: 200px;
 
+  --halftone-red: radial-gradient(circle at 1px 1px, rgba(220, 38, 38, 0.25) 1px, transparent 1px);
+  --halftone-blue: radial-gradient(circle at 1px 1px, rgba(37, 99, 235, 0.23) 1px, transparent 1px);
+
   /* iOS safe area */
   --safe-top: env(safe-area-inset-top);
   --safe-right: env(safe-area-inset-right);

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -674,53 +674,6 @@ const Index = () => {
           <div className="mt-2">{renderIntelLog(6)}</div>
         </div>
       </div>
-
-      <div className="flex min-h-0 flex-1 flex-col gap-3 rounded border border-newspaper-border bg-newspaper-text p-3 text-newspaper-bg shadow-sm">
-        <div className="flex items-center justify-between gap-2">
-          <h3 className="text-xs font-bold uppercase tracking-wide">Your Hand</h3>
-          <span className="text-xs font-mono">IP {gameState.ip}</span>
-        </div>
-        <div className="min-h-0 flex-1 overflow-visible">
-          <EnhancedGameHand
-            cards={gameState.hand}
-            onPlayCard={handlePlayCard}
-            onSelectCard={handleSelectCard}
-            selectedCard={gameState.selectedCard}
-            disabled={handInteractionDisabled}
-            currentIP={gameState.ip}
-            loadingCard={loadingCard}
-            onCardHover={setHoveredCard}
-          />
-        </div>
-      </div>
-
-      <div className="space-y-2">
-        <Button
-          onClick={handleEndTurn}
-          className="touch-target w-full bg-newspaper-text text-newspaper-bg transition-all duration-200 hover:bg-newspaper-text/80"
-          disabled={isPlayerActionLocked}
-        >
-          {gameState.currentPlayer === 'ai' ? (
-            <span className="flex items-center justify-center gap-2 text-sm">
-              <span className="h-2 w-2 animate-pulse rounded-full bg-current" />
-              AI Thinking...
-            </span>
-          ) : (
-            'End Turn'
-          )}
-        </Button>
-        <Button
-          onClick={() => {
-            setShowInGameOptions(true);
-            setIsSidebarOpen(false);
-            audio.playSFX('click');
-          }}
-          variant="outline"
-          className="touch-target w-full border-newspaper-border text-newspaper-text hover:bg-newspaper-bg/60"
-        >
-          Options & Settings
-        </Button>
-      </div>
     </div>
   );
 
@@ -849,10 +802,10 @@ const Index = () => {
     </div>
   );
 
-  const mainContent = (
+  const leftPaneContent = (
     <div className="flex h-full flex-col gap-4">
-      <div className="flex h-full flex-col gap-4 xl:flex-row">
-        <div className="hidden xl:flex xl:w-64 xl:flex-col xl:gap-4">
+      <div className="flex flex-1 flex-col gap-4 xl:flex-row">
+        <div className="hidden xl:flex xl:w-72 xl:flex-col xl:gap-4">
           <div className="rounded border border-newspaper-border bg-newspaper-bg p-3 shadow-sm">
             <VictoryConditions
               controlledStates={gameState.controlledStates.length}
@@ -912,10 +865,8 @@ const Index = () => {
               />
             </div>
           </div>
-          <div className="shrink-0 rounded border-2 border-newspaper-border bg-newspaper-bg">
-            <div className="h-[200px] md:h-[220px] lg:h-[240px] xl:h-[260px]">
-              <PlayedCardsDock playedCards={gameState.cardsPlayedThisRound} />
-            </div>
+          <div className="rounded border-2 border-newspaper-border bg-newspaper-bg shadow-sm">
+            <PlayedCardsDock playedCards={gameState.cardsPlayedThisRound} />
           </div>
         </div>
       </div>
@@ -923,56 +874,39 @@ const Index = () => {
     </div>
   );
 
-  const trayContent = (
-    <div className="flex h-full flex-col gap-2">
-      <div className="flex items-center justify-between gap-2">
-        <span className="text-xs font-semibold uppercase tracking-wide text-newspaper-text/70">Command Tray</span>
-        <Button
-          variant="outline"
-          className="touch-target md:hidden"
-          onClick={() => setIsSidebarOpen(true)}
-        >
-          Open Panel
-        </Button>
+  const rightPaneContent = (
+    <div className="flex h-full flex-col rounded border-2 border-newspaper-border bg-newspaper-text text-newspaper-bg shadow-lg">
+      <div className="flex items-center justify-between gap-2 border-b border-newspaper-border/60 px-4 py-3">
+        <h3 className="text-xs font-bold uppercase tracking-[0.35em]">Your Hand</h3>
+        <span className="text-xs font-mono">IP {gameState.ip}</span>
       </div>
       <div className="flex-1 min-h-0">
-        <div className="h-full flex items-stretch gap-3 overflow-x-auto overflow-y-hidden">
-          {gameState.hand.map(card => {
-            const canPlay = !handInteractionDisabled && gameState.ip >= card.cost;
-            return (
-              <div
-                key={card.id}
-                className="touch-target flex w-44 flex-shrink-0 flex-col justify-between rounded-lg border border-newspaper-border bg-newspaper-bg p-3 shadow-sm"
-              >
-                <button
-                  type="button"
-                  className="flex-1 text-left focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-newspaper-border focus-visible:ring-offset-2 focus-visible:ring-offset-newspaper-bg"
-                  onClick={() => {
-                    handleSelectCard(card.id);
-                    setIsSidebarOpen(true);
-                  }}
-                >
-                  <div className="text-[11px] font-mono text-newspaper-text/70">IP {card.cost}</div>
-                  <div className="mt-1 text-sm font-bold leading-tight text-newspaper-text">{card.name}</div>
-                  <div className="mt-1 line-clamp-2 text-xs leading-snug text-newspaper-text/70">{card.text}</div>
-                </button>
-                <Button
-                  type="button"
-                  onClick={() => handlePlayCard(card.id)}
-                  disabled={!canPlay}
-                  className="touch-target mt-2 w-full bg-newspaper-text text-newspaper-bg hover:bg-newspaper-text/80 disabled:opacity-60"
-                >
-                  Play
-                </Button>
-              </div>
-            );
-          })}
-          {gameState.hand.length === 0 && (
-            <div className="flex w-full items-center justify-center rounded-lg border border-dashed border-newspaper-border bg-newspaper-bg/80 p-4 text-sm font-mono text-newspaper-text/60">
-              No cards in hand
-            </div>
+        <EnhancedGameHand
+          cards={gameState.hand}
+          onPlayCard={handlePlayCard}
+          onSelectCard={handleSelectCard}
+          selectedCard={gameState.selectedCard}
+          disabled={handInteractionDisabled}
+          currentIP={gameState.ip}
+          loadingCard={loadingCard}
+          onCardHover={setHoveredCard}
+        />
+      </div>
+      <div className="border-t border-newspaper-border/60 px-3 pb-3 pt-2 sm:pt-3">
+        <Button
+          onClick={handleEndTurn}
+          className="touch-target w-full border-2 border-black bg-black py-3 font-bold uppercase tracking-wide text-white transition duration-200 hover:bg-white hover:text-black disabled:opacity-60"
+          disabled={isPlayerActionLocked}
+        >
+          {gameState.currentPlayer === 'ai' ? (
+            <span className="flex items-center justify-center gap-2 text-sm">
+              <span className="h-2 w-2 animate-pulse rounded-full bg-current" />
+              AI Thinking...
+            </span>
+          ) : (
+            'End Turn'
           )}
-        </div>
+        </Button>
       </div>
     </div>
   );
@@ -981,9 +915,8 @@ const Index = () => {
     <>
       <ResponsiveLayout
         masthead={mastheadContent}
-        main={mainContent}
-        sidebar={renderSidebar()}
-        tray={trayContent}
+        leftPane={leftPaneContent}
+        rightPane={rightPaneContent}
       />
 
       <Toaster


### PR DESCRIPTION
## Summary
- refactor the responsive layout shell to support distinct left and right panes and remove the legacy command tray
- reorganize the main game screen into a two-column grid with the map and cards-in-play panel on the left and a redesigned hand panel plus end-turn action on the right
- rebuild the hand and cards-in-play components to render 3×N card grids with updated card styling and halftone backgrounds, including new global CSS tokens

## Testing
- `npm run lint` *(fails: missing `@eslint/js`; dependency install blocked by 403 when fetching `ts-node`)*

------
https://chatgpt.com/codex/tasks/task_e_68cbb1b8aad883209bd608d0555a7825