### PR TITLE
Refine card rendering for hand and play panels

### DIFF
--- a/src/components/game/EnhancedGameHand.tsx
+++ b/src/components/game/EnhancedGameHand.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useRef } from 'react';
 import clsx from 'clsx';
 import CardDetailOverlay from './CardDetailOverlay';
+import BaseCard from '@/components/game/cards/BaseCard';
 import { Card } from '@/components/ui/card';
 import type { GameCard, MVPCardType } from '@/rules/mvp';
 import { MVP_CARD_TYPES } from '@/rules/mvp';
@@ -11,7 +12,6 @@ import { useHapticFeedback } from '@/hooks/useHapticFeedback';
 import { useSwipeGestures } from '@/hooks/useSwipeGestures';
 import { useIsMobile } from '@/hooks/use-mobile';
 import { ExtensionCardBadge } from './ExtensionCardBadge';
-import { CardTextGenerator } from '@/systems/CardTextGenerator';
 
 interface EnhancedGameHandProps {
   cards: GameCard[];
@@ -114,7 +114,7 @@ const EnhancedGameHand: React.FC<EnhancedGameHandProps> = ({
       ref={handRef}
       onPointerLeave={() => onCardHover?.(null)}
     >
-      <div className="grid grid-cols-2 gap-3 overflow-y-auto p-3 lg:grid-cols-3 max-h-[calc(100vh-220px)]">
+      <div className="grid grid-cols-3 items-start gap-4 overflow-y-auto p-3 max-h-[calc(100vh-220px)]">
         {cards.length === 0 ? (
           <div className="col-span-full flex min-h-[160px] items-center justify-center rounded border border-dashed border-neutral-700 bg-neutral-900/60 p-6 text-sm font-mono text-white/60">
             No assets available
@@ -126,26 +126,57 @@ const EnhancedGameHand: React.FC<EnhancedGameHandProps> = ({
             const isLoading = loadingCard === card.id;
             const canAfford = canAffordCard(card);
             const displayType = normalizeCardType(card.type);
-            const rarityLabel = (card.rarity || 'common').toUpperCase();
-            const flavorText = card.flavor ?? card.flavorTruth ?? card.flavorGov ?? '';
-            const effectLines = card.effects ? CardTextGenerator.renderEffects(card.effects) : [];
-            const details = effectLines.length > 0
-              ? effectLines
-              : card.text
-                ? card.text.split('\n')
-                : card.effects
-                  ? [CardTextGenerator.generateRulesText(card.effects)]
-                  : [];
+
+            const overlay = (
+              <>
+                {(isLoading || isPlaying || isSelected) && (
+                  <div
+                    className={clsx(
+                      'pointer-events-none absolute inset-0 z-20 flex flex-col items-center justify-center bg-black/60 text-white backdrop-blur-sm',
+                      isSelected && !isPlaying && !isLoading && 'bg-yellow-400/15 text-yellow-100'
+                    )}
+                    style={{ borderRadius: 'calc(var(--pt-radius) * var(--card-scale))' }}
+                  >
+                    <Loader2
+                      className={clsx(
+                        'mb-1 h-5 w-5',
+                        isSelected ? 'animate-pulse text-yellow-200' : 'animate-spin text-primary'
+                      )}
+                    />
+                    <span className="text-xs font-mono font-bold">
+                      {isPlaying
+                        ? 'DEPLOYING'
+                        : isSelected && displayType === 'ZONE'
+                          ? 'TARGETING'
+                          : 'PROCESSING'}
+                    </span>
+                  </div>
+                )}
+
+                {isSelected && displayType === 'ZONE' && (
+                  <div className="absolute -top-1 -right-1 flex h-5 w-5 items-center justify-center rounded-full bg-yellow-400 text-xs font-bold text-black ring-2 ring-yellow-300 animate-pulse">
+                    🎯
+                  </div>
+                )}
+
+                {isSelected && displayType !== 'ZONE' && (
+                  <div className="absolute -top-1 -right-1 h-3 w-3 rounded-full bg-yellow-300 ring-2 ring-yellow-200" />
+                )}
+
+                <div className="pointer-events-none">
+                  <ExtensionCardBadge cardId={card.id} card={card} variant="overlay" />
+                </div>
+              </>
+            );
 
             return (
               <button
                 key={`${card.id}-${index}`}
                 type="button"
                 className={clsx(
-                  'group relative flex h-full flex-col rounded-lg border border-neutral-700 bg-neutral-900 p-2 text-left text-white shadow-sm transition-transform duration-200 hover:-translate-y-0.5 hover:shadow-lg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/80',
-                  (isPlaying || isLoading) && 'ring-2 ring-primary shadow-primary/40',
-                  isSelected && 'ring-2 ring-yellow-400 shadow-yellow-400/40',
-                  !canAfford && !disabled && 'cursor-not-allowed opacity-60 saturate-50 hover:translate-y-0 hover:shadow-none'
+                  'group/card relative flex items-start justify-center bg-transparent p-0 text-left transition-transform duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/80',
+                  !canAfford && !disabled && 'cursor-not-allowed opacity-60 saturate-50',
+                  disabled && 'cursor-default'
                 )}
                 style={{ animationDelay: `${index * 0.03}s` }}
                 onClick={(e) => {
@@ -182,58 +213,20 @@ const EnhancedGameHand: React.FC<EnhancedGameHandProps> = ({
                   onCardHover?.(null);
                 }}
               >
-                {(isLoading || isPlaying || isSelected) && (
-                  <div className="absolute inset-0 z-20 flex flex-col items-center justify-center rounded-lg bg-primary/15 backdrop-blur-sm">
-                    <Loader2 className={clsx('mb-1 h-5 w-5', isSelected ? 'animate-pulse' : 'animate-spin', 'text-primary')} />
-                    <span className="text-xs font-mono font-bold text-primary">
-                      {isPlaying ? 'DEPLOYING' : isSelected && displayType === 'ZONE' ? 'TARGETING' : 'PROCESSING'}
-                    </span>
-                  </div>
-                )}
-
-                <div className="flex flex-col h-full">
-                  <header className="mb-1">
-                    <div className="text-[13px] font-extrabold leading-tight line-clamp-2">{card.name}</div>
-                    <div className="flex items-center justify-between text-[11px] uppercase opacity-80">
-                      <span className="truncate">
-                        {displayType} · {rarityLabel}
-                      </span>
-                      <span>IP {card.cost}</span>
-                    </div>
-                  </header>
-
-                  <div className="mb-2 space-y-1 text-[12px]">
-                    {details.length > 0 ? (
-                      details.map((line, detailIndex) => (
-                        <p key={`${card.id}-detail-${detailIndex}`} className="leading-snug">
-                          {line}
-                        </p>
-                      ))
-                    ) : (
-                      <p className="opacity-80">No effect data</p>
-                    )}
-                  </div>
-
-                  <div className="mt-auto" />
-
-                  {flavorText && (
-                    <div className="border-t border-white/10 pt-1 text-[11px] italic opacity-80 line-clamp-2">
-                      “{flavorText}”
-                    </div>
+                <BaseCard
+                  card={card}
+                  hideStamp
+                  polaroidHover={false}
+                  size="handMini"
+                  className="pointer-events-none select-none"
+                  frameClassName={clsx(
+                    'drop-shadow-[0_12px_22px_rgba(0,0,0,0.32)] transition-transform duration-200',
+                    !disabled && canAfford && 'group-hover/card:-translate-y-1 group-hover/card:drop-shadow-[0_22px_30px_rgba(0,0,0,0.35)]',
+                    (isPlaying || isLoading) && 'ring-2 ring-primary shadow-primary/40',
+                    isSelected && 'ring-2 ring-yellow-400 shadow-yellow-400/40'
                   )}
-                </div>
-
-                {isSelected && displayType === 'ZONE' && (
-                  <div className="absolute -top-1 -right-1 flex h-5 w-5 items-center justify-center rounded-full bg-yellow-400 text-xs font-bold text-black ring-2 ring-yellow-300 animate-pulse">
-                    🎯
-                  </div>
-                )}
-
-                {isSelected && displayType !== 'ZONE' && (
-                  <div className="absolute -top-1 -right-1 h-3 w-3 rounded-full bg-yellow-300 ring-2 ring-yellow-200" />
-                )}
-
-                <ExtensionCardBadge cardId={card.id} card={card} variant="overlay" />
+                  overlay={overlay}
+                />
               </button>
             );
           })

--- a/src/components/game/PlayedCardsDock.tsx
+++ b/src/components/game/PlayedCardsDock.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import type { GameCard } from '@/rules/mvp';
-import { CardTextGenerator } from '@/systems/CardTextGenerator';
-import { ExtensionCardBadge } from '@/components/game/ExtensionCardBadge';
+import BaseCard from '@/components/game/cards/BaseCard';
 
 interface PlayedCard {
   card: GameCard;
@@ -12,46 +11,16 @@ interface PlayedCardsDockProps {
   playedCards: PlayedCard[];
 }
 
-const summarizeCard = (card: GameCard): string[] => {
-  if (card.effects) {
-    const summary = CardTextGenerator.renderEffects(card.effects);
-    if (summary.length > 0) {
-      return summary;
-    }
-    return [CardTextGenerator.generateRulesText(card.effects)];
-  }
-
-  if (card.text) {
-    return card.text.split('\n');
-  }
-
-  return [];
-};
-
-const PlayedCardTile = ({ card }: { card: GameCard }) => {
-  const displayType = (card.type || 'MEDIA').toString().toUpperCase();
-  const rarityLabel = (card.rarity || 'common').toUpperCase();
-  const flavorText = card.flavor ?? card.flavorTruth ?? card.flavorGov ?? '';
-  const details = summarizeCard(card);
-
+const CardsInPlayCard = ({ card }: { card: GameCard }) => {
   return (
-    <div className="relative flex h-full flex-col rounded-lg border border-neutral-700 bg-neutral-900 p-2 text-white shadow-sm">
-      <div className="text-[11px] font-bold leading-tight line-clamp-2 pr-6">{card.name}</div>
-      <div className="mt-0.5 flex items-center justify-between text-[10px] uppercase tracking-wide opacity-70">
-        <span className="truncate">{displayType} · {rarityLabel}</span>
-        <span>IP {card.cost}</span>
-      </div>
-      <div className="mt-1 space-y-1 text-[10px] leading-snug">
-        {(details.length > 0 ? details.slice(0, 3) : ['No effect data']).map((line, index) => (
-          <p key={`${card.id}-detail-${index}`}>{line}</p>
-        ))}
-      </div>
-      {flavorText && (
-        <div className="mt-auto pt-1 text-[10px] italic opacity-70 line-clamp-2">
-          “{flavorText}”
-        </div>
-      )}
-      <ExtensionCardBadge cardId={card.id} card={card} variant="overlay" />
+    <div className="flex justify-center">
+      <BaseCard
+        card={card}
+        hideStamp
+        polaroidHover={false}
+        size="boardMini"
+        className="pointer-events-none select-none"
+      />
     </div>
   );
 };
@@ -72,9 +41,9 @@ const PlayedCardsSection: React.FC<SectionProps> = ({ title, toneClass, cards, e
     >
       <h4 className="mb-2 text-[12px] font-bold uppercase tracking-[0.2em] text-black/70">{title}</h4>
       {cards.length > 0 ? (
-        <div className="grid grid-cols-2 gap-2 sm:grid-cols-3">
+        <div className="grid grid-cols-3 items-start gap-3">
           {cards.map((entry, index) => (
-            <PlayedCardTile key={`${entry.card.id}-${index}`} card={entry.card} />
+            <CardsInPlayCard key={`${entry.card.id}-${index}`} card={entry.card} />
           ))}
         </div>
       ) : (

--- a/src/components/game/cards/BaseCard.tsx
+++ b/src/components/game/cards/BaseCard.tsx
@@ -1,3 +1,4 @@
+import type { ReactNode } from 'react';
 import { cn } from '@/lib/utils';
 import CardImage from '@/components/game/CardImage';
 import type { GameCard } from '@/rules/mvp';
@@ -10,6 +11,7 @@ import {
   getRarityVar,
   normalizeCardType,
 } from '@/lib/cardUi';
+import { CardFrame, type CardFrameSize } from '@/ui/CardFrame';
 
 interface BaseCardProps {
   card: GameCard;
@@ -17,6 +19,9 @@ interface BaseCardProps {
   stampText?: string;
   hideStamp?: boolean;
   polaroidHover?: boolean;
+  size?: CardFrameSize;
+  frameClassName?: string;
+  overlay?: ReactNode;
 }
 
 export const BaseCard = ({
@@ -25,6 +30,9 @@ export const BaseCard = ({
   stampText = 'CLASSIFIED',
   hideStamp = false,
   polaroidHover = false,
+  size = 'modal',
+  frameClassName,
+  overlay,
 }: BaseCardProps) => {
   const effectText = formatEffect(card);
   const flavor = getFlavorText(card);
@@ -33,72 +41,75 @@ export const BaseCard = ({
   const showCardText = card.text && card.text !== effectText;
 
   return (
-    <div
-      className={cn(
-        'relative w-cardW h-cardH pt-card-surface shadow-tabloid rounded-tabloid border overflow-hidden pt-card-wrap',
-        polaroidHover && 'group',
-        className,
-      )}
-      style={{ borderColor: 'var(--pt-border)' }}
-      data-testid="tabloid-card"
-    >
-      <div className="px-3 pt-3 text-[color:var(--pt-ink)]">
-        <div className="text-3xl leading-none uppercase font-headline">
-          {card.name}
-        </div>
-        <div className="mt-2 flex items-center gap-2">
-          <span
-            className="px-2 py-0.5 text-[11px] uppercase tracking-wide text-white rounded font-tabloid"
-            style={{ background: getFactionVar(card.faction) }}
-          >
-            {getFactionLabel(card.faction)}
-          </span>
-          <span
-            className="px-2 py-0.5 text-[11px] uppercase tracking-wide text-white rounded font-tabloid"
-            style={{ background: getRarityVar(card.rarity) }}
-          >
-            {rarityLabel}
-          </span>
-          <span
-            className="ml-auto text-xs font-semibold px-2 py-0.5 rounded"
-            style={{ background: 'var(--pt-ink)', color: 'var(--pt-paper)' }}
-          >
-            IP {card.cost}
-          </span>
-        </div>
-      </div>
-
+    <CardFrame size={size} className={frameClassName}>
       <div
         className={cn(
-          'mt-3 mx-3 pt-polaroid transition-transform duration-200',
-          polaroidHover && 'group-hover:-rotate-[0.75deg] group-hover:-translate-y-1',
+          'card-shell relative w-cardW h-cardH pt-card-surface shadow-tabloid rounded-tabloid border overflow-hidden pt-card-wrap',
+          polaroidHover && 'group',
+          className,
         )}
+        style={{ borderColor: 'var(--pt-border)' }}
+        data-testid="tabloid-card"
       >
-        <div className="aspect-[4/3] w-full overflow-hidden">
-          <CardImage cardId={card.id} className="w-full h-full grayscale" />
+        <div className="card-header px-3 pt-3 text-[color:var(--pt-ink)]">
+          <div className="text-3xl leading-none uppercase font-headline">
+            {card.name}
+          </div>
+          <div className="mt-2 flex items-center gap-2">
+            <span
+              className="px-2 py-0.5 text-[11px] uppercase tracking-wide text-white rounded font-tabloid"
+              style={{ background: getFactionVar(card.faction) }}
+            >
+              {getFactionLabel(card.faction)}
+            </span>
+            <span
+              className="px-2 py-0.5 text-[11px] uppercase tracking-wide text-white rounded font-tabloid"
+              style={{ background: getRarityVar(card.rarity) }}
+            >
+              {rarityLabel}
+            </span>
+            <span
+              className="ml-auto text-xs font-semibold px-2 py-0.5 rounded"
+              style={{ background: 'var(--pt-ink)', color: 'var(--pt-paper)' }}
+            >
+              IP {card.cost}
+            </span>
+          </div>
         </div>
-      </div>
 
-      <div
-        className="m-3 p-3 rounded border bg-black/80 text-white text-sm leading-snug space-y-2"
-        style={{ borderColor: 'var(--pt-border-soft)' }}
-      >
-        <div className="text-[11px] uppercase tracking-[0.18em] text-white/70">{typeLabel}</div>
-        <div className="font-semibold">{effectText}</div>
-        {showCardText && <div className="text-xs text-white/80 leading-snug">{card.text}</div>}
-      </div>
-
-      {flavor && (
-        <div className="mx-3 mb-3 text-[12px] italic pt-redacted text-[color:var(--pt-ink)] opacity-80">
-          <span className="font-mono not-italic mr-1 uppercase tracking-wide opacity-70 text-[color:var(--pt-ink)]">
-            CLASSIFIED INTELLIGENCE:
-          </span>
-          {flavor}
+        <div
+          className={cn(
+            'card-art mt-3 mx-3 pt-polaroid transition-transform duration-200',
+            polaroidHover && 'group-hover:-rotate-[0.75deg] group-hover:-translate-y-1',
+          )}
+        >
+          <div className="aspect-[4/3] w-full overflow-hidden">
+            <CardImage cardId={card.id} className="h-full w-full grayscale" />
+          </div>
         </div>
-      )}
 
-      {!hideStamp && <div className="pt-stamp select-none">{stampText}</div>}
-    </div>
+        <div
+          className="card-effects m-3 space-y-2 rounded border bg-black/80 p-3 text-sm leading-snug text-white"
+          style={{ borderColor: 'var(--pt-border-soft)' }}
+        >
+          <div className="text-[11px] uppercase tracking-[0.18em] text-white/70">{typeLabel}</div>
+          <div className="font-semibold">{effectText}</div>
+          {showCardText && <div className="text-xs leading-snug text-white/80">{card.text}</div>}
+        </div>
+
+        {flavor && (
+          <div className="card-flavor mx-3 mb-3 text-[12px] italic text-[color:var(--pt-ink)] opacity-80">
+            <span className="mr-1 font-mono not-italic uppercase tracking-wide opacity-70 text-[color:var(--pt-ink)]">
+              CLASSIFIED INTELLIGENCE:
+            </span>
+            {flavor}
+          </div>
+        )}
+
+        {!hideStamp && <div className="pt-stamp select-none">{stampText}</div>}
+      </div>
+      {overlay}
+    </CardFrame>
   );
 };
 

--- a/src/index.css
+++ b/src/index.css
@@ -521,6 +521,37 @@ All colors MUST be HSL.
     var(--pt-paper);
 }
 
+.card-frame {
+  --card-scale: 1;
+  position: relative;
+  display: inline-block;
+  overflow: visible;
+  border-radius: calc(var(--pt-radius) * var(--card-scale));
+}
+
+.card-frame > .card-shell {
+  transform: scale(var(--card-scale));
+  transform-origin: top left;
+}
+
+.card-shell {
+  width: var(--pt-card-w);
+  min-height: var(--pt-card-h);
+  display: flex;
+  flex-direction: column;
+  border-radius: var(--pt-radius);
+}
+
+.card-header,
+.card-art,
+.card-effects {
+  width: 100%;
+}
+
+.card-flavor {
+  margin-top: auto;
+}
+
 /* Polaroid frame */
 .pt-polaroid {
   background: #ffffff;

--- a/src/ui/CardFrame.tsx
+++ b/src/ui/CardFrame.tsx
@@ -1,0 +1,110 @@
+import React from 'react';
+import { cn } from '@/lib/utils';
+
+export type CardFrameSize = 'modal' | 'boardMini' | 'handMini';
+
+type CardFrameProps = {
+  children: React.ReactNode;
+  size?: CardFrameSize;
+  className?: string;
+};
+
+const SIZE_TO_SCALE: Record<CardFrameSize, number> = {
+  modal: 1,
+  boardMini: 0.72,
+  handMini: 0.78,
+};
+
+export function CardFrame({ children, size = 'modal', className }: CardFrameProps) {
+  const scale = SIZE_TO_SCALE[size];
+  const frameRef = React.useRef<HTMLDivElement>(null);
+  const [dimensions, setDimensions] = React.useState<{ width: number; height: number }>({
+    width: 320,
+    height: 450,
+  });
+
+  React.useLayoutEffect(() => {
+    const frameEl = frameRef.current;
+    if (!frameEl) {
+      return;
+    }
+
+    const child = frameEl.firstElementChild as HTMLElement | null;
+    if (!child) {
+      return;
+    }
+
+    const updateDimensions = () => {
+      setDimensions(prev => {
+        const next = {
+          width: child.offsetWidth || prev.width,
+          height: child.offsetHeight || prev.height,
+        };
+
+        if (prev.width === next.width && prev.height === next.height) {
+          return prev;
+        }
+
+        return next;
+      });
+    };
+
+    updateDimensions();
+
+    if (typeof ResizeObserver === 'function') {
+      const observer = new ResizeObserver(entries => {
+        for (const entry of entries) {
+          const { width, height } = entry.contentRect;
+          setDimensions(prev => {
+            const next = {
+              width: width || prev.width,
+              height: height || prev.height,
+            };
+
+            if (prev.width === next.width && prev.height === next.height) {
+              return prev;
+            }
+
+            return next;
+          });
+        }
+      });
+
+      observer.observe(child);
+
+      return () => {
+        observer.disconnect();
+      };
+    }
+
+    if (typeof window !== 'undefined') {
+      const resizeHandler = () => updateDimensions();
+      window.addEventListener('resize', resizeHandler);
+
+      return () => {
+        window.removeEventListener('resize', resizeHandler);
+      };
+    }
+
+    return undefined;
+  }, [children]);
+
+  const scaledWidth = dimensions.width * scale;
+  const scaledHeight = dimensions.height * scale;
+
+  return (
+    <div
+      ref={frameRef}
+      className={cn('card-frame', className)}
+      style={{
+        width: `${scaledWidth}px`,
+        height: `${scaledHeight}px`,
+        ['--card-scale' as any]: scale,
+      }}
+      aria-label={size === 'modal' ? 'Card (full)' : 'Card (mini)'}
+    >
+      {children}
+    </div>
+  );
+}
+


### PR DESCRIPTION
## Summary
- add a reusable `CardFrame` component and supporting styles so full-size and mini cards share identical markup and scale via CSS variables
- wrap `BaseCard` content with the new frame and expose overlay hooks for status badges and loaders
- render real mini cards in the hand and cards-in-play panels using the shared markup with three-column grids

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js' because dependencies could not be installed in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cbc205938c83209f22ab97be42040d