### PR TITLE
Update card scaling and hand layout

### DIFF
--- a/src/components/game/EnhancedGameHand.tsx
+++ b/src/components/game/EnhancedGameHand.tsx
@@ -110,11 +110,11 @@ const EnhancedGameHand: React.FC<EnhancedGameHandProps> = ({
 
   return (
     <div
-      className="relative flex h-full flex-col"
+      className="relative h-full"
       ref={handRef}
       onPointerLeave={() => onCardHover?.(null)}
     >
-      <div className="grid grid-cols-3 items-start gap-4 overflow-y-auto p-3 max-h-[calc(100vh-220px)]">
+      <div className="grid w-full grid-cols-3 gap-3 place-items-start content-start">
         {cards.length === 0 ? (
           <div className="col-span-full flex min-h-[160px] items-center justify-center rounded border border-dashed border-neutral-700 bg-neutral-900/60 p-6 text-sm font-mono text-white/60">
             No assets available
@@ -174,7 +174,7 @@ const EnhancedGameHand: React.FC<EnhancedGameHandProps> = ({
                 key={`${card.id}-${index}`}
                 type="button"
                 className={clsx(
-                  'group/card relative flex items-start justify-center bg-transparent p-0 text-left transition-transform duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/80',
+                  'group/card relative flex w-full items-start justify-center bg-transparent p-0 text-left transition-transform duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/80',
                   !canAfford && !disabled && 'cursor-not-allowed opacity-60 saturate-50',
                   disabled && 'cursor-default'
                 )}

--- a/src/components/game/PlayedCardsDock.tsx
+++ b/src/components/game/PlayedCardsDock.tsx
@@ -41,7 +41,7 @@ const PlayedCardsSection: React.FC<SectionProps> = ({ title, toneClass, cards, e
     >
       <h4 className="mb-2 text-[12px] font-bold uppercase tracking-[0.2em] text-black/70">{title}</h4>
       {cards.length > 0 ? (
-        <div className="grid grid-cols-3 items-start gap-3">
+        <div className="grid grid-cols-3 gap-3 place-items-start content-start">
           {cards.map((entry, index) => (
             <CardsInPlayCard key={`${entry.card.id}-${index}`} card={entry.card} />
           ))}

--- a/src/components/game/cards/BaseCard.tsx
+++ b/src/components/game/cards/BaseCard.tsx
@@ -41,16 +41,19 @@ export const BaseCard = ({
   const showCardText = card.text && card.text !== effectText;
 
   return (
-    <CardFrame size={size} className={frameClassName}>
-      <div
-        className={cn(
-          'card-shell relative w-cardW h-cardH pt-card-surface shadow-tabloid rounded-tabloid border overflow-hidden pt-card-wrap',
-          polaroidHover && 'group',
-          className,
-        )}
-        style={{ borderColor: 'var(--pt-border)' }}
-        data-testid="tabloid-card"
-      >
+    <CardFrame
+      size={size}
+      className={frameClassName}
+      cardClassName={cn(
+        'relative pt-card-surface shadow-tabloid rounded-tabloid border overflow-hidden pt-card-wrap',
+        polaroidHover && 'group',
+        className,
+      )}
+      cardStyle={{ borderColor: 'var(--pt-border)' }}
+      overlay={overlay}
+      cardProps={{ 'data-testid': 'tabloid-card' }}
+    >
+      <>
         <div className="card-header px-3 pt-3 text-[color:var(--pt-ink)]">
           <div className="text-3xl leading-none uppercase font-headline">
             {card.name}
@@ -107,8 +110,7 @@ export const BaseCard = ({
         )}
 
         {!hideStamp && <div className="pt-stamp select-none">{stampText}</div>}
-      </div>
-      {overlay}
+      </>
     </CardFrame>
   );
 };

--- a/src/index.css
+++ b/src/index.css
@@ -521,25 +521,23 @@ All colors MUST be HSL.
     var(--pt-paper);
 }
 
-.card-frame {
-  --card-scale: 1;
+.card-cell {
   position: relative;
-  display: inline-block;
   overflow: visible;
-  border-radius: calc(var(--pt-radius) * var(--card-scale));
 }
 
-.card-frame > .card-shell {
-  transform: scale(var(--card-scale));
-  transform-origin: top left;
+.card-inner {
+  position: absolute;
+  inset: 0;
 }
 
 .card-shell {
-  width: var(--pt-card-w);
-  min-height: var(--pt-card-h);
+  width: 320px;
+  height: 450px;
   display: flex;
   flex-direction: column;
   border-radius: var(--pt-radius);
+  box-sizing: border-box;
 }
 
 .card-header,
@@ -548,8 +546,21 @@ All colors MUST be HSL.
   width: 100%;
 }
 
+.card-effects,
+.card-flavor {
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 3;
+  overflow: hidden;
+}
+
 .card-flavor {
   margin-top: auto;
+}
+
+.card-cell .card-overlay {
+  position: absolute;
+  inset: 0;
 }
 
 /* Polaroid frame */

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -875,12 +875,12 @@ const Index = () => {
   );
 
   const rightPaneContent = (
-    <div className="flex h-full flex-col rounded border-2 border-newspaper-border bg-newspaper-text text-newspaper-bg shadow-lg">
-      <div className="flex items-center justify-between gap-2 border-b border-newspaper-border/60 px-4 py-3">
+    <aside className="h-full min-h-0 min-w-0 flex flex-col rounded border-2 border-newspaper-border bg-newspaper-text text-newspaper-bg shadow-lg">
+      <header className="flex items-center justify-between gap-2 border-b border-newspaper-border/60 px-4 py-3">
         <h3 className="text-xs font-bold uppercase tracking-[0.35em]">Your Hand</h3>
         <span className="text-xs font-mono">IP {gameState.ip}</span>
-      </div>
-      <div className="flex-1 min-h-0">
+      </header>
+      <div className="flex-1 min-h-0 min-w-0 overflow-y-auto overflow-x-hidden px-3 py-3">
         <EnhancedGameHand
           cards={gameState.hand}
           onPlayCard={handlePlayCard}
@@ -892,7 +892,7 @@ const Index = () => {
           onCardHover={setHoveredCard}
         />
       </div>
-      <div className="border-t border-newspaper-border/60 px-3 pb-3 pt-2 sm:pt-3">
+      <footer className="border-t border-newspaper-border/60 px-3 pb-3 pt-2 sm:pt-3">
         <Button
           onClick={handleEndTurn}
           className="touch-target w-full border-2 border-black bg-black py-3 font-bold uppercase tracking-wide text-white transition duration-200 hover:bg-white hover:text-black disabled:opacity-60"
@@ -907,8 +907,8 @@ const Index = () => {
             'End Turn'
           )}
         </Button>
-      </div>
-    </div>
+      </footer>
+    </aside>
   );
 
   return (


### PR DESCRIPTION
## Summary
- replace the CardFrame implementation with a fixed-size shell that scales mini cards predictably
- update card styling helpers and BaseCard to render inside the new frame
- reorganize the hand panel and cards-in-play grids so mini cards align without overlap and the hand only scrolls once

## Testing
- npm run lint *(fails: missing @eslint/js because dependencies could not be installed in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cbcb079c8c832095ff568a78fe110b