### PR TITLE
Ensure card scaling and layout use 100vh local scroll areas

### DIFF
--- a/src/components/game/PlayedCardsDock.tsx
+++ b/src/components/game/PlayedCardsDock.tsx
@@ -41,7 +41,7 @@ const PlayedCardsSection: React.FC<SectionProps> = ({ title, toneClass, cards, e
     >
       <h4 className="mb-2 text-[12px] font-bold uppercase tracking-[0.2em] text-black/70">{title}</h4>
       {cards.length > 0 ? (
-        <div className="grid grid-cols-3 gap-3 place-items-start content-start">
+        <div className="grid grid-cols-3 gap-2 place-items-start content-start">
           {cards.map((entry, index) => (
             <CardsInPlayCard key={`${entry.card.id}-${index}`} card={entry.card} />
           ))}
@@ -60,13 +60,13 @@ const PlayedCardsDock: React.FC<PlayedCardsDockProps> = ({ playedCards }) => {
   const aiCards = playedCards.filter(card => card.player === 'ai');
 
   return (
-    <div className="flex h-full flex-col">
+    <div className="flex h-full min-h-0 flex-col">
       <header className="border-b border-newspaper-border/60 px-4 py-3">
         <h3 className="text-xs font-semibold uppercase tracking-[0.3em] text-newspaper-text">
           CARDS IN PLAY THIS ROUND
         </h3>
       </header>
-      <div className="grid grid-cols-1 gap-3 p-3 lg:grid-cols-2">
+      <div className="grid grid-cols-1 gap-3 p-3 lg:grid-cols-2 max-h-[clamp(180px,28vh,320px)] overflow-y-auto">
         <PlayedCardsSection
           title="OPPONENT"
           ariaLabel="Opponent Cards"

--- a/src/components/layout/ResponsiveLayout.tsx
+++ b/src/components/layout/ResponsiveLayout.tsx
@@ -12,7 +12,7 @@ export default function ResponsiveLayout({ masthead, leftPane, rightPane }: Prop
 
   return (
     <div
-      className="app-shell flex flex-col"
+      className="app-shell flex h-screen min-h-0 flex-col"
       style={{
         paddingTop: "var(--safe-top)",
       }}
@@ -37,14 +37,18 @@ export default function ResponsiveLayout({ masthead, leftPane, rightPane }: Prop
           <div className="app-scroll h-full p-2 sm:p-4 md:p-6">
             <div
               className={clsx(
-                "grid h-full gap-4",
+                "grid h-full min-h-0 gap-4",
                 "grid-cols-1",
                 hasRightPane && "lg:grid-cols-[1fr_420px] xl:grid-cols-[1fr_480px]"
               )}
             >
-              <main className="min-h-0">{leftPane}</main>
+              <main className="flex h-full min-h-0 min-w-0 flex-col overflow-hidden">
+                <div className="flex h-full min-h-0 min-w-0 flex-col overflow-y-auto">
+                  {leftPane}
+                </div>
+              </main>
               {hasRightPane && (
-                <aside className="min-h-0">{rightPane}</aside>
+                <div className="flex h-full min-h-0 min-w-0 flex-col overflow-hidden">{rightPane}</div>
               )}
             </div>
           </div>

--- a/src/index.css
+++ b/src/index.css
@@ -109,7 +109,7 @@ All colors MUST be HSL.
     --pt-shadow: rgba(0, 0, 0, 0.25);
 
     --pt-card-w: 320px;
-    --pt-card-h: 450px;
+    --pt-card-h: 460px;
 
     --pt-gap: 10px;
     --pt-radius: 14px;
@@ -516,28 +516,39 @@ All colors MUST be HSL.
 
 /* Tabloid newspaper surface */
 .pt-card-surface {
-  background:
+  --card-shell-bg:
     radial-gradient(var(--pt-halftone) 1px, transparent 1px) 0 0 / 6px 6px,
     var(--pt-paper);
+  --card-shell-fg: var(--pt-ink);
+  --card-shell-border: var(--pt-border);
+  --card-shell-border-width: 3px;
 }
 
 .card-cell {
   position: relative;
-  overflow: visible;
+  overflow: hidden;
 }
 
 .card-inner {
   position: absolute;
   inset: 0;
+  backface-visibility: hidden;
 }
 
 .card-shell {
+  box-sizing: border-box;
   width: 320px;
-  height: 450px;
+  height: 460px;
   display: flex;
   flex-direction: column;
   border-radius: var(--pt-radius);
-  box-sizing: border-box;
+  padding: var(--card-shell-padding, 12px);
+  background: var(--card-shell-bg, #111111);
+  color: var(--card-shell-fg, #ffffff);
+  border: var(--card-shell-border-width, 3px) solid var(--card-shell-border, #000000);
+  font-size: 14px;
+  line-height: 1.2;
+  box-shadow: 0 2px 0 #000000, 0 8px 24px rgba(0, 0, 0, 0.35);
 }
 
 .card-header,
@@ -618,13 +629,14 @@ All colors MUST be HSL.
   max-width: 95vw;
   max-height: 85vh;
   border-radius: var(--pt-radius);
+  --card-shell-padding: 0px;
 }
 
 @media (max-width: 640px) {
   .pt-card-wrap {
     width: min(var(--pt-card-w), 95vw);
     height: auto;
-    aspect-ratio: 320 / 450;
+    aspect-ratio: 320 / 460;
   }
 }
 
@@ -703,17 +715,19 @@ All colors MUST be HSL.
 
 html, body, #root {
   height: 100%;
+  min-height: 100%;
 }
 
 /* Scroll-oppførsel – hovedcontainer får scroll, barn unngår nested scroll */
 .app-shell {
-  height: 100%;
+  min-height: 100vh;
+  height: 100vh;
   overflow: hidden;
 }
 
 .app-scroll {
   height: 100%;
-  overflow-y: auto;
+  overflow: hidden;
   -webkit-overflow-scrolling: touch;
   padding-bottom: var(--safe-bottom);
 }

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -803,8 +803,8 @@ const Index = () => {
   );
 
   const leftPaneContent = (
-    <div className="flex h-full flex-col gap-4">
-      <div className="flex flex-1 flex-col gap-4 xl:flex-row">
+    <div className="flex h-full min-h-0 flex-col gap-4">
+      <div className="flex min-h-0 flex-1 flex-col gap-4 xl:flex-row">
         <div className="hidden xl:flex xl:w-72 xl:flex-col xl:gap-4">
           <div className="rounded border border-newspaper-border bg-newspaper-bg p-3 shadow-sm">
             <VictoryConditions

--- a/src/ui/CardFrame.tsx
+++ b/src/ui/CardFrame.tsx
@@ -20,7 +20,7 @@ const SIZE_TO_SCALE: Record<CardFrameSize, number> = {
 };
 
 const BASE_W = 320;
-const BASE_H = 450;
+const BASE_H = 460;
 
 export function CardFrame({
   children,
@@ -38,6 +38,7 @@ export function CardFrame({
     height: `calc(${BASE_H}px * ${scale})`,
     position: "relative",
     flex: "0 0 auto",
+    overflow: "hidden",
     ["--card-scale" as any]: scale,
   };
 
@@ -47,6 +48,7 @@ export function CardFrame({
     transform: `scale(${scale})`,
     transformOrigin: "top left",
     willChange: "transform",
+    backfaceVisibility: "hidden",
   };
 
   return (


### PR DESCRIPTION
## Summary
- align the shared card frame with a 320x460 baseline and hide overflow so scaled borders render evenly
- update the global card shell styles and app layout CSS for border-box sizing and a 100vh viewport shell with local column scroll
- clamp the cards-in-play panel height and wrap the responsive layout panes to deliver scoped scrolling

## Testing
- npm run lint *(fails: Cannot find package '@eslint/js' imported from eslint.config.js)*

------
https://chatgpt.com/codex/tasks/task_e_68cbd434d6d483209d29616b535a07f4