### PR TITLE
Adjust card frame scaling and modal styling

### DIFF
--- a/src/components/game/CardDetailOverlay.tsx
+++ b/src/components/game/CardDetailOverlay.tsx
@@ -58,7 +58,9 @@ const TabloidCardDetail: React.FC<CardDetailOverlayProps> = ({
           </Button>
         </div>
 
-        <BaseCard card={card} polaroidHover={false} />
+        <div className="modal-wrapper">
+          <BaseCard card={card} polaroidHover={false} frameClassName="modal-card" />
+        </div>
 
         <div className="flex w-full flex-col items-center gap-2 sm:gap-3">
           <Button

--- a/src/components/game/PlayedCardsDock.tsx
+++ b/src/components/game/PlayedCardsDock.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { cn } from '@/lib/utils';
 import type { GameCard } from '@/rules/mvp';
 import BaseCard from '@/components/game/cards/BaseCard';
 
@@ -11,19 +12,15 @@ interface PlayedCardsDockProps {
   playedCards: PlayedCard[];
 }
 
-const CardsInPlayCard = ({ card }: { card: GameCard }) => {
-  return (
-    <div className="flex justify-center">
-      <BaseCard
-        card={card}
-        hideStamp
-        polaroidHover={false}
-        size="boardMini"
-        className="pointer-events-none select-none"
-      />
-    </div>
-  );
-};
+const CardsInPlayCard = ({ card }: { card: GameCard }) => (
+  <BaseCard
+    card={card}
+    hideStamp
+    polaroidHover={false}
+    size="boardMini"
+    className="pointer-events-none select-none"
+  />
+);
 
 interface SectionProps {
   title: string;
@@ -33,27 +30,25 @@ interface SectionProps {
   ariaLabel: string;
 }
 
-const PlayedCardsSection: React.FC<SectionProps> = ({ title, toneClass, cards, emptyMessage, ariaLabel }) => {
-  return (
-    <section
-      aria-label={ariaLabel}
-      className={`rounded-md border border-black/10 p-3 text-black ${toneClass}`}
-    >
-      <h4 className="mb-2 text-[12px] font-bold uppercase tracking-[0.2em] text-black/70">{title}</h4>
-      {cards.length > 0 ? (
-        <div className="grid grid-cols-3 gap-2 place-items-start content-start">
-          {cards.map((entry, index) => (
-            <CardsInPlayCard key={`${entry.card.id}-${index}`} card={entry.card} />
-          ))}
-        </div>
-      ) : (
-        <div className="grid min-h-[120px] place-items-center rounded border border-dashed border-black/20 bg-white/40 p-4 text-center text-[11px] font-mono uppercase tracking-wide text-black/50">
-          {emptyMessage}
-        </div>
-      )}
-    </section>
-  );
-};
+const PlayedCardsSection: React.FC<SectionProps> = ({ title, toneClass, cards, emptyMessage, ariaLabel }) => (
+  <section
+    aria-label={ariaLabel}
+    className={cn('rounded-md p-3 text-black', toneClass)}
+  >
+    <h4 className="mb-2 text-[12px] font-extrabold uppercase tracking-[0.2em] text-black/70">{title}</h4>
+    {cards.length > 0 ? (
+      <div className="grid grid-cols-3 gap-2 place-items-start">
+        {cards.map((entry, index) => (
+          <CardsInPlayCard key={`${entry.card.id}-${index}`} card={entry.card} />
+        ))}
+      </div>
+    ) : (
+      <div className="grid min-h-[120px] place-items-center rounded border border-dashed border-black/20 bg-white/40 p-4 text-center text-[11px] font-mono uppercase tracking-wide text-black/50">
+        {emptyMessage}
+      </div>
+    )}
+  </section>
+);
 
 const PlayedCardsDock: React.FC<PlayedCardsDockProps> = ({ playedCards }) => {
   const humanCards = playedCards.filter(card => card.player === 'human');
@@ -61,12 +56,10 @@ const PlayedCardsDock: React.FC<PlayedCardsDockProps> = ({ playedCards }) => {
 
   return (
     <div className="flex h-full min-h-0 flex-col">
-      <header className="border-b border-newspaper-border/60 px-4 py-3">
-        <h3 className="text-xs font-semibold uppercase tracking-[0.3em] text-newspaper-text">
-          CARDS IN PLAY THIS ROUND
-        </h3>
+      <header className="border-b border-black/10 px-3 py-2 text-sm font-extrabold tracking-wide text-newspaper-text">
+        CARDS IN PLAY THIS ROUND
       </header>
-      <div className="grid grid-cols-1 gap-3 p-3 lg:grid-cols-2 max-h-[clamp(180px,28vh,320px)] overflow-y-auto">
+      <div className="grid grid-cols-1 gap-2 p-2 lg:grid-cols-2">
         <PlayedCardsSection
           title="OPPONENT"
           ariaLabel="Opponent Cards"

--- a/src/components/game/cards/BaseCard.tsx
+++ b/src/components/game/cards/BaseCard.tsx
@@ -1,4 +1,4 @@
-import type { ReactNode } from 'react';
+import type { CSSProperties, ReactNode } from 'react';
 import { cn } from '@/lib/utils';
 import CardImage from '@/components/game/CardImage';
 import type { GameCard } from '@/rules/mvp';
@@ -11,7 +11,15 @@ import {
   getRarityVar,
   normalizeCardType,
 } from '@/lib/cardUi';
-import { CardFrame, type CardFrameSize } from '@/ui/CardFrame';
+import CardFrame from '@/ui/CardFrame';
+
+export type CardFrameSize = 'modal' | 'boardMini' | 'handMini';
+
+const SIZE_TO_SCALE: Record<CardFrameSize, number> = {
+  modal: 1,
+  boardMini: 0.56,
+  handMini: 0.78,
+};
 
 interface BaseCardProps {
   card: GameCard;
@@ -40,78 +48,76 @@ export const BaseCard = ({
   const typeLabel = normalizeCardType(card.type);
   const showCardText = card.text && card.text !== effectText;
 
+  const wrapperStyle = { '--card-scale': String(SIZE_TO_SCALE[size]) } as CSSProperties;
+
   return (
-    <CardFrame
-      size={size}
-      className={frameClassName}
-      cardClassName={cn(
-        'relative pt-card-surface shadow-tabloid rounded-tabloid border overflow-hidden pt-card-wrap',
-        polaroidHover && 'group',
-        className,
-      )}
-      cardStyle={{ borderColor: 'var(--pt-border)' }}
-      overlay={overlay}
-      cardProps={{ 'data-testid': 'tabloid-card' }}
+    <div
+      className={cn('card-frame-wrapper', polaroidHover && 'group', frameClassName, className)}
+      style={wrapperStyle}
+      data-testid="tabloid-card"
     >
-      <>
-        <div className="card-header px-3 pt-3 text-[color:var(--pt-ink)]">
-          <div className="text-3xl leading-none uppercase font-headline">
-            {card.name}
+      <CardFrame size={size}>
+        <>
+          <div className="card-header px-3 pt-3 text-[color:var(--pt-ink)]">
+            <div className="text-3xl leading-none uppercase font-headline">
+              {card.name}
+            </div>
+            <div className="mt-2 flex items-center gap-2">
+              <span
+                className="px-2 py-0.5 text-[11px] uppercase tracking-wide text-white rounded font-tabloid"
+                style={{ background: getFactionVar(card.faction) }}
+              >
+                {getFactionLabel(card.faction)}
+              </span>
+              <span
+                className="px-2 py-0.5 text-[11px] uppercase tracking-wide text-white rounded font-tabloid"
+                style={{ background: getRarityVar(card.rarity) }}
+              >
+                {rarityLabel}
+              </span>
+              <span
+                className="ml-auto text-xs font-semibold px-2 py-0.5 rounded"
+                style={{ background: 'var(--pt-ink)', color: 'var(--pt-paper)' }}
+              >
+                IP {card.cost}
+              </span>
+            </div>
           </div>
-          <div className="mt-2 flex items-center gap-2">
-            <span
-              className="px-2 py-0.5 text-[11px] uppercase tracking-wide text-white rounded font-tabloid"
-              style={{ background: getFactionVar(card.faction) }}
-            >
-              {getFactionLabel(card.faction)}
-            </span>
-            <span
-              className="px-2 py-0.5 text-[11px] uppercase tracking-wide text-white rounded font-tabloid"
-              style={{ background: getRarityVar(card.rarity) }}
-            >
-              {rarityLabel}
-            </span>
-            <span
-              className="ml-auto text-xs font-semibold px-2 py-0.5 rounded"
-              style={{ background: 'var(--pt-ink)', color: 'var(--pt-paper)' }}
-            >
-              IP {card.cost}
-            </span>
-          </div>
-        </div>
 
-        <div
-          className={cn(
-            'card-art mt-3 mx-3 pt-polaroid transition-transform duration-200',
-            polaroidHover && 'group-hover:-rotate-[0.75deg] group-hover:-translate-y-1',
+          <div
+            className={cn(
+              'card-art mt-3 mx-3 pt-polaroid transition-transform duration-200',
+              polaroidHover && 'group-hover:-rotate-[0.75deg] group-hover:-translate-y-1',
+            )}
+          >
+            <div className="aspect-[4/3] w-full overflow-hidden">
+              <CardImage cardId={card.id} className="h-full w-full grayscale" />
+            </div>
+          </div>
+
+          <div
+            className="card-effects m-3 space-y-2 rounded border bg-black/80 p-3 text-sm leading-snug text-white"
+            style={{ borderColor: 'var(--pt-border-soft)' }}
+          >
+            <div className="text-[11px] uppercase tracking-[0.18em] text-white/70">{typeLabel}</div>
+            <div className="font-semibold">{effectText}</div>
+            {showCardText && <div className="text-xs leading-snug text-white/80">{card.text}</div>}
+          </div>
+
+          {flavor && (
+            <div className="card-flavor mx-3 mb-3 text-[12px] italic text-[color:var(--pt-ink)] opacity-80">
+              <span className="mr-1 font-mono not-italic uppercase tracking-wide opacity-70 text-[color:var(--pt-ink)]">
+                CLASSIFIED INTELLIGENCE:
+              </span>
+              {flavor}
+            </div>
           )}
-        >
-          <div className="aspect-[4/3] w-full overflow-hidden">
-            <CardImage cardId={card.id} className="h-full w-full grayscale" />
-          </div>
-        </div>
 
-        <div
-          className="card-effects m-3 space-y-2 rounded border bg-black/80 p-3 text-sm leading-snug text-white"
-          style={{ borderColor: 'var(--pt-border-soft)' }}
-        >
-          <div className="text-[11px] uppercase tracking-[0.18em] text-white/70">{typeLabel}</div>
-          <div className="font-semibold">{effectText}</div>
-          {showCardText && <div className="text-xs leading-snug text-white/80">{card.text}</div>}
-        </div>
-
-        {flavor && (
-          <div className="card-flavor mx-3 mb-3 text-[12px] italic text-[color:var(--pt-ink)] opacity-80">
-            <span className="mr-1 font-mono not-italic uppercase tracking-wide opacity-70 text-[color:var(--pt-ink)]">
-              CLASSIFIED INTELLIGENCE:
-            </span>
-            {flavor}
-          </div>
-        )}
-
-        {!hideStamp && <div className="pt-stamp select-none">{stampText}</div>}
-      </>
-    </CardFrame>
+          {!hideStamp && <div className="pt-stamp select-none">{stampText}</div>}
+        </>
+      </CardFrame>
+      {overlay ? <div className="card-frame-overlay">{overlay}</div> : null}
+    </div>
   );
 };
 

--- a/src/index.css
+++ b/src/index.css
@@ -535,26 +535,33 @@ All colors MUST be HSL.
   backface-visibility: hidden;
 }
 
+/* Fullkort baseline — YTRE størrelse inkl. border */
 .card-shell {
   box-sizing: border-box;
   width: 320px;
   height: 460px;
+  position: relative;
   display: flex;
   flex-direction: column;
-  border-radius: var(--pt-radius);
-  padding: var(--card-shell-padding, 12px);
   background: var(--card-shell-bg, #111111);
   color: var(--card-shell-fg, #ffffff);
-  border: var(--card-shell-border-width, 3px) solid var(--card-shell-border, #000000);
+  border: 3px solid var(--card-shell-border, #000000);
+  border-radius: var(--card-shell-radius, 10px);
+  padding: var(--card-shell-padding, 12px);
   font-size: 14px;
   line-height: 1.2;
   box-shadow: 0 2px 0 #000000, 0 8px 24px rgba(0, 0, 0, 0.35);
+  overflow: hidden;
 }
 
-.card-header,
-.card-art,
+.card-header {
+  width: 100%;
+  margin-bottom: 8px;
+}
+
 .card-effects {
   width: 100%;
+  margin-bottom: 8px;
 }
 
 .card-effects,
@@ -567,11 +574,45 @@ All colors MUST be HSL.
 
 .card-flavor {
   margin-top: auto;
+  padding-top: 8px;
+  border-top: 1px solid rgba(255, 255, 255, 0.12);
+  font-style: italic;
+  opacity: 0.85;
 }
 
-.card-cell .card-overlay {
+/* Når kortet rendres i modal: gi en overlay-ramme som ikke klippes */
+.modal-card {
+  position: relative;
+  overflow: visible;
+}
+
+.modal-card .card-shell {
+  border: 0;
+}
+
+.modal-card::after {
+  content: "";
+  position: absolute;
+  inset: -3px;
+  border: 3px solid #000000;
+  border-radius: 12px;
+  pointer-events: none;
+  box-shadow: 0 2px 0 #000000, 0 8px 24px rgba(0, 0, 0, 0.35);
+}
+
+.modal-wrapper {
+  overflow: visible !important;
+}
+
+.card-frame-wrapper {
+  position: relative;
+  display: inline-block;
+}
+
+.card-frame-wrapper .card-frame-overlay {
   position: absolute;
   inset: 0;
+  pointer-events: none;
 }
 
 /* Polaroid frame */

--- a/src/ui/CardFrame.tsx
+++ b/src/ui/CardFrame.tsx
@@ -1,37 +1,17 @@
 import React from "react";
-import { cn } from "@/lib/utils";
 
-export type CardFrameSize = "modal" | "boardMini" | "handMini";
+type Size = "modal" | "boardMini" | "handMini";
+type Props = { children: React.ReactNode; size?: Size };
 
-type CardFrameProps = {
-  children: React.ReactNode;
-  size?: CardFrameSize;
-  className?: string;
-  cardClassName?: string;
-  cardStyle?: React.CSSProperties;
-  overlay?: React.ReactNode;
-  cardProps?: Omit<React.HTMLAttributes<HTMLDivElement>, "className" | "style">;
-};
+export default function CardFrame({ children, size = "modal" }: Props) {
+  // FINJUSTÉR SKALA HER:
+  // - boardMini: senket til 0.56 for å unngå scroll i "Cards in Play"
+  // - handMini: beholdt 0.78 (god lesbarhet i Your Hand)
+  const scale = size === "modal" ? 1 : size === "boardMini" ? 0.56 : 0.78;
 
-const SIZE_TO_SCALE: Record<CardFrameSize, number> = {
-  modal: 1,
-  boardMini: 0.6,
-  handMini: 0.78,
-};
-
-const BASE_W = 320;
-const BASE_H = 460;
-
-export function CardFrame({
-  children,
-  size = "modal",
-  className,
-  cardClassName,
-  cardStyle,
-  overlay,
-  cardProps,
-}: CardFrameProps) {
-  const scale = SIZE_TO_SCALE[size];
+  // Basemål MÅ matche fullkortets outer size (inkl. border)
+  const BASE_W = 320;
+  const BASE_H = 460;
 
   const cellStyle: React.CSSProperties = {
     width: `calc(${BASE_W}px * ${scale})`,
@@ -39,7 +19,6 @@ export function CardFrame({
     position: "relative",
     flex: "0 0 auto",
     overflow: "hidden",
-    ["--card-scale" as any]: scale,
   };
 
   const innerStyle: React.CSSProperties = {
@@ -52,15 +31,10 @@ export function CardFrame({
   };
 
   return (
-    <div className={cn("card-cell", className)} style={cellStyle} aria-label={`card-${size}`}>
+    <div className="card-cell" style={cellStyle} aria-label={`card-${size}`}>
       <div className="card-inner" style={innerStyle}>
-        <div className={cn("card-shell", cardClassName)} style={cardStyle} {...cardProps}>
-          {children}
-        </div>
+        <div className="card-shell">{children}</div>
       </div>
-      {overlay ? <div className="card-overlay">{overlay}</div> : null}
     </div>
   );
 }
-
-export default CardFrame;


### PR DESCRIPTION
## Summary
- replace the card frame component with a fixed-size cell that scales mini cards to 0.56 and 0.78 so Cards in Play fits without overflow
- update the base card wrapper and global card styles to provide consistent shell sizing, modal borders, and overlay handling with the new frame
- refresh the Cards in Play panel and card modal markup to use the new classes and keep mini cards on a single row

## Testing
- `npm run lint` *(fails: missing @eslint/js dependency; npm install blocked by 403 when fetching ts-node)*

------
https://chatgpt.com/codex/tasks/task_e_68cbe200dbac832095dc4cb9fd039018