### PR TITLE
Adjust card styling and stabilize hand layout

### DIFF
--- a/src/components/game/CardDetailOverlay.tsx
+++ b/src/components/game/CardDetailOverlay.tsx
@@ -59,7 +59,9 @@ const TabloidCardDetail: React.FC<CardDetailOverlayProps> = ({
         </div>
 
         <div className="modal-wrapper">
-          <BaseCard card={card} polaroidHover={false} frameClassName="modal-card" />
+          <div className="modal-card">
+            <BaseCard card={card} polaroidHover={false} />
+          </div>
         </div>
 
         <div className="flex w-full flex-col items-center gap-2 sm:gap-3">

--- a/src/components/game/EnhancedGameHand.tsx
+++ b/src/components/game/EnhancedGameHand.tsx
@@ -114,7 +114,7 @@ const EnhancedGameHand: React.FC<EnhancedGameHandProps> = ({
       ref={handRef}
       onPointerLeave={() => onCardHover?.(null)}
     >
-      <div className="grid w-full grid-cols-3 gap-3 place-items-start content-start">
+      <div className="grid w-full grid-cols-3 gap-3 justify-items-start items-start content-start">
         {cards.length === 0 ? (
           <div className="col-span-full flex min-h-[160px] items-center justify-center rounded border border-dashed border-neutral-700 bg-neutral-900/60 p-6 text-sm font-mono text-white/60">
             No assets available

--- a/src/components/game/cards/BaseCard.tsx
+++ b/src/components/game/cards/BaseCard.tsx
@@ -58,7 +58,7 @@ export const BaseCard = ({
     >
       <CardFrame size={size}>
         <>
-          <div className="card-header px-3 pt-3 text-[color:var(--pt-ink)]">
+          <div className="card-header text-[color:var(--ink)]">
             <div className="text-3xl leading-none uppercase font-headline">
               {card.name}
             </div>
@@ -86,27 +86,24 @@ export const BaseCard = ({
 
           <div
             className={cn(
-              'card-art mt-3 mx-3 pt-polaroid transition-transform duration-200',
+              'card-art overflow-hidden transition-transform duration-200',
               polaroidHover && 'group-hover:-rotate-[0.75deg] group-hover:-translate-y-1',
             )}
           >
-            <div className="aspect-[4/3] w-full overflow-hidden">
+            <div className="aspect-[4/3] w-full">
               <CardImage cardId={card.id} className="h-full w-full grayscale" />
             </div>
           </div>
 
-          <div
-            className="card-effects m-3 space-y-2 rounded border bg-black/80 p-3 text-sm leading-snug text-white"
-            style={{ borderColor: 'var(--pt-border-soft)' }}
-          >
+          <div className="card-effects space-y-2 text-sm leading-snug">
             <div className="text-[11px] uppercase tracking-[0.18em] text-white/70">{typeLabel}</div>
             <div className="font-semibold">{effectText}</div>
             {showCardText && <div className="text-xs leading-snug text-white/80">{card.text}</div>}
           </div>
 
           {flavor && (
-            <div className="card-flavor mx-3 mb-3 text-[12px] italic text-[color:var(--pt-ink)] opacity-80">
-              <span className="mr-1 font-mono not-italic uppercase tracking-wide opacity-70 text-[color:var(--pt-ink)]">
+            <div className="card-flavor text-[12px]">
+              <span className="mr-1 font-mono not-italic uppercase tracking-wide opacity-70 text-[color:var(--ink)]">
                 CLASSIFIED INTELLIGENCE:
               </span>
               {flavor}

--- a/src/index.css
+++ b/src/index.css
@@ -44,8 +44,10 @@ All colors MUST be HSL.
     --sidebar-primary-foreground: 0 0% 98%;
 
     /* Tabloid newspaper theme tokens */
-    --ink: 0 0% 0%;
-    --paper: 0 0% 96.5%;
+    --paper: #f4f3f1;
+    --ink: #111111;
+    --ink-80: #1a1a1a;
+    --panel: #0b0b0b;
     --line: 0 0% 6.7%;
     --lineSoft: 0 0% 13.3%;
     --grey: 0 0% 80%;
@@ -540,28 +542,40 @@ All colors MUST be HSL.
   box-sizing: border-box;
   width: 320px;
   height: 460px;
-  position: relative;
+  background: var(--paper);
+  color: var(--ink);
+  border: 3px solid var(--ink);
+  border-radius: 10px;
+  padding: var(--card-shell-padding, 12px);
   display: flex;
   flex-direction: column;
-  background: var(--card-shell-bg, #111111);
-  color: var(--card-shell-fg, #ffffff);
-  border: 3px solid var(--card-shell-border, #000000);
-  border-radius: var(--card-shell-radius, 10px);
-  padding: var(--card-shell-padding, 12px);
   font-size: 14px;
   line-height: 1.2;
-  box-shadow: 0 2px 0 #000000, 0 8px 24px rgba(0, 0, 0, 0.35);
-  overflow: hidden;
+  box-shadow: 0 2px 0 var(--ink), 0 8px 24px rgba(0, 0, 0, 0.35);
 }
 
 .card-header {
-  width: 100%;
   margin-bottom: 8px;
 }
 
-.card-effects {
-  width: 100%;
+.card-art {
   margin-bottom: 8px;
+  background: #e9e7e4;
+}
+
+.card-art img {
+  display: block;
+  width: 100%;
+  height: auto;
+}
+
+.card-effects {
+  margin-top: auto;
+  margin-bottom: 8px;
+  background: #1b1b1b;
+  color: #eeeeee;
+  padding: 10px 12px;
+  border-radius: 6px;
 }
 
 .card-effects,
@@ -573,11 +587,11 @@ All colors MUST be HSL.
 }
 
 .card-flavor {
-  margin-top: auto;
   padding-top: 8px;
-  border-top: 1px solid rgba(255, 255, 255, 0.12);
+  border-top: 1px solid rgba(0, 0, 0, 0.12);
   font-style: italic;
   opacity: 0.85;
+  color: var(--ink-80);
 }
 
 /* Når kortet rendres i modal: gi en overlay-ramme som ikke klippes */
@@ -594,10 +608,10 @@ All colors MUST be HSL.
   content: "";
   position: absolute;
   inset: -3px;
-  border: 3px solid #000000;
+  border: 3px solid var(--ink);
   border-radius: 12px;
   pointer-events: none;
-  box-shadow: 0 2px 0 #000000, 0 8px 24px rgba(0, 0, 0, 0.35);
+  box-shadow: 0 2px 0 var(--ink), 0 8px 24px rgba(0, 0, 0, 0.35);
 }
 
 .modal-wrapper {


### PR DESCRIPTION
## Summary
- refresh global tabloid variables and card styling so shells use the light paper palette with a dark effect stripe and modal frame overlay
- align the BaseCard structure with the new styles for header, art, effect, and flavor sections
- adjust the hand grid and modal wrapper to keep cards aligned without overlap

## Testing
- npm run lint *(fails: Cannot find package '@eslint/js' imported from eslint.config.js)*

------
https://chatgpt.com/codex/tasks/task_e_68cbe70e60a883208ee9b71c8122b8c8