### PR TITLE
feat(start): redesign tabloid start screen

### DIFF
--- a/src/components/game/GameMenu.tsx
+++ b/src/components/game/GameMenu.tsx
@@ -9,7 +9,7 @@ import CardCollection from './CardCollection';
 import CreditsTableoid from './CreditsTableoid';
 import HowToPlayTabloid from './HowToPlayTabloid';
 import CardCollectionTabloid from './CardCollectionTabloid';
-import StartScreenTabloid from './StartScreenTabloid';
+import StartScreen from '@/components/start/StartScreen';
 import FactionSelectTabloid from './FactionSelectTabloid';
 import { useUiTheme } from '@/hooks/useTheme';
 
@@ -319,8 +319,10 @@ const GameMenu = ({ onStartGame, onFactionHover, audio, onBackToMainMenu, onSave
 
   return uiTheme === 'tabloid_bw' ? (
     <>
-      <StartScreenTabloid
-        onStartGame={() => setShowFactionSelect(true)}
+      <StartScreen
+        onStartGame={async (faction) => {
+          await onStartGame(faction);
+        }}
         onManageExpansions={() => setShowManageExpansions(true)}
         onHowToPlay={() => setShowHowToPlay(true)}
         onOptions={() => setShowOptions(true)}
@@ -329,6 +331,7 @@ const GameMenu = ({ onStartGame, onFactionHover, audio, onBackToMainMenu, onSave
         onLoadGame={onLoadGame}
         getSaveInfo={getSaveInfo}
         audio={audio}
+        onStartNewGameFallback={() => setShowFactionSelect(true)}
       />
       {uiTheme === 'tabloid_bw' ? (
         <CardCollectionTabloid open={showCollection} onOpenChange={setShowCollection} />

--- a/src/components/start/ArticleButton.tsx
+++ b/src/components/start/ArticleButton.tsx
@@ -1,0 +1,30 @@
+import { MouseEventHandler } from 'react';
+
+export type ArticleButtonProps = {
+  label: string;
+  onClick: MouseEventHandler<HTMLButtonElement>;
+  variant?: 'article' | 'ad';
+  sub?: string;
+};
+
+const ArticleButton = ({ label, onClick, variant = 'article', sub }: ArticleButtonProps) => {
+  const accentClasses =
+    variant === 'ad'
+      ? 'text-[var(--accent)] border-[var(--accent)]'
+      : 'text-[var(--ink)] border-[var(--rule)]';
+
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={`print-border ${accentClasses} px-4 py-3 md:py-4 bg-[var(--paper)] hover:bg-black/5 active:translate-y-[1px] font-[800] tracking-[0.08em] text-xl md:text-2xl uppercase transition-colors focus:outline-none focus-visible:ring-4 focus-visible:ring-black/40 flex flex-col gap-1 text-left`}
+    >
+      <span className="font-['Bebas Neue',sans-serif] leading-none">{label}</span>
+      {sub ? (
+        <span className="text-sm md:text-base font-sans tracking-normal uppercase text-[var(--ink-weak)]">{sub}</span>
+      ) : null}
+    </button>
+  );
+};
+
+export default ArticleButton;

--- a/src/components/start/FactionCard.tsx
+++ b/src/components/start/FactionCard.tsx
@@ -1,0 +1,54 @@
+import { forwardRef, KeyboardEvent } from 'react';
+
+export type FactionCardProps = {
+  faction: 'government' | 'truth';
+  title: string;
+  imageSrc: string;
+  onSelect: () => void;
+  caption?: string;
+};
+
+const FactionCard = forwardRef<HTMLDivElement, FactionCardProps>(
+  ({ faction, title, imageSrc, onSelect, caption }, ref) => {
+    const handleKeyDown = (event: KeyboardEvent<HTMLDivElement>) => {
+      if (event.key === 'Enter' || event.key === ' ') {
+        event.preventDefault();
+        onSelect();
+      }
+    };
+
+    return (
+      <article
+        ref={ref}
+        role="button"
+        tabIndex={0}
+        data-faction-card={faction}
+        onClick={onSelect}
+        onKeyDown={handleKeyDown}
+        className="print-border bg-[var(--paper)] flex flex-col h-full overflow-hidden cursor-pointer transition-transform duration-200 hover:-translate-y-1 focus:outline-none focus-visible:ring-4 focus-visible:ring-black/50"
+        aria-label={`Start as ${title}`}
+      >
+        <div className="relative aspect-[4/3] overflow-hidden">
+          <img src={imageSrc} alt={title} className="h-full w-full object-cover" />
+          <span className="badge absolute top-3 left-3 bg-[var(--paper)] text-[var(--ink)] text-sm tracking-[0.08em]">
+            EXCLUSIVE
+          </span>
+        </div>
+        <div className="flex flex-col gap-1 px-4 py-5 bg-[var(--paper)]">
+          <h3 className="font-['Anton',sans-serif] text-3xl sm:text-4xl tracking-[0.06em] uppercase">
+            {title}
+          </h3>
+          {caption ? (
+            <p className="font-['Bebas Neue',sans-serif] text-lg sm:text-xl uppercase tracking-[0.08em] text-[var(--ink-weak)]">
+              {caption}
+            </p>
+          ) : null}
+        </div>
+      </article>
+    );
+  }
+);
+
+FactionCard.displayName = 'FactionCard';
+
+export default FactionCard;

--- a/src/components/start/StartScreen.tsx
+++ b/src/components/start/StartScreen.tsx
@@ -1,0 +1,215 @@
+import { useMemo, useRef } from 'react';
+import FactionCard from './FactionCard';
+import ArticleButton from './ArticleButton';
+import '@/styles/newspaper.css';
+
+type StartScreenProps = {
+  onStartGame: (faction: 'government' | 'truth') => void | Promise<void>;
+  onManageExpansions: () => void;
+  onHowToPlay: () => void;
+  onOptions: () => void;
+  onCredits: () => void;
+  onCardCollection: () => void;
+  onLoadGame?: () => boolean;
+  getSaveInfo?: () => { turn?: number } | undefined;
+  audio?: { playSFX?: (key: string) => void };
+  onStartNewGameFallback?: () => void;
+};
+
+const featureHeadlines = [
+  'SHOCKING: ELVIS JOINS THE ILLUMINATI!',
+  'LIZARD PEOPLE WIN BIG IN LOCAL ELECTION!',
+  'MOON OFFICIALLY DECLARED A HOLOGRAM!',
+  'GOVERNMENT ADMITS BIRDS ARE DRONES!',
+  'TIME TRAVELER WARNS ABOUT LAST TUESDAY!',
+  'ALIENS DEMAND RIGHT TO VOTE BY MAIL!',
+  'BIGFOOT SPOTTED RUNNING FOR PRESIDENT!'
+];
+
+const featureSubheads = [
+  'Mind-bending exclusives from sources we can definitely trust.',
+  'Alt-real news avoiding truth since this morning.',
+  'Citizens report wild scenes as reality gets optional.',
+  'Classified leaks suggest everything is absolutely true.'
+];
+
+const StartScreen = ({
+  onStartGame,
+  onManageExpansions,
+  onHowToPlay,
+  onOptions,
+  onCredits,
+  onCardCollection,
+  onLoadGame,
+  getSaveInfo,
+  audio,
+  onStartNewGameFallback
+}: StartScreenProps) => {
+  const headline = useMemo(
+    () => featureHeadlines[Math.floor(Math.random() * featureHeadlines.length)],
+    []
+  );
+  const subhead = useMemo(
+    () => featureSubheads[Math.floor(Math.random() * featureSubheads.length)],
+    []
+  );
+
+  const governmentCardRef = useRef<HTMLDivElement>(null);
+
+  const playClick = () => {
+    audio?.playSFX?.('click');
+  };
+
+  const handleFactionSelect = async (faction: 'government' | 'truth') => {
+    playClick();
+    await Promise.resolve(onStartGame(faction));
+  };
+
+  const handleArticleAction = (action: () => void) => () => {
+    playClick();
+    action();
+  };
+
+  const saveInfo = getSaveInfo?.();
+  const hasSave = Boolean(saveInfo);
+  const continueLabel = hasSave
+    ? `CONTINUE (TURN ${saveInfo?.turn ?? '?'})`
+    : 'START NEW GAME';
+
+  const focusHeroCards = () => {
+    if (governmentCardRef.current) {
+      governmentCardRef.current.scrollIntoView({ behavior: 'smooth', block: 'center' });
+      governmentCardRef.current.focus({ preventScroll: true });
+    }
+  };
+
+  const handleFeatureAction = () => {
+    if (hasSave) {
+      playClick();
+      if (onLoadGame) {
+        const success = onLoadGame();
+        if (success) {
+          const indicator = document.createElement('div');
+          indicator.textContent = '✓ GAME LOADED';
+          indicator.className =
+            'fixed top-4 right-4 bg-green-600 text-white px-4 py-2 rounded z-[60] animate-fade-in';
+          document.body.appendChild(indicator);
+          setTimeout(() => indicator.remove(), 2000);
+        }
+      }
+      return;
+    }
+
+    playClick();
+    if (onStartNewGameFallback) {
+      onStartNewGameFallback();
+    } else {
+      focusHeroCards();
+    }
+  };
+
+  return (
+    <div className="newspaper-bg min-h-dvh text-[var(--ink)]">
+      <div className="max-w-[1200px] mx-auto px-3 sm:px-4 md:px-6 lg:px-8 py-4 md:py-6 space-y-6">
+        <header className="print-border bg-[var(--paper)] px-4 sm:px-6 py-4 md:py-6">
+          <div className="flex flex-wrap items-center justify-between gap-4">
+            <h1 className="font-['Anton',sans-serif] text-3xl sm:text-4xl md:text-5xl lg:text-6xl tracking-[0.05em] uppercase">
+              THE PARANOID TIMES
+            </h1>
+            <span className="badge text-sm uppercase tracking-[0.08em] bg-[var(--paper)] text-[var(--ink)]">TIMES</span>
+          </div>
+          <div className="hr-rule my-4" aria-hidden="true" />
+          <p className="font-['Bebas Neue',sans-serif] text-base sm:text-lg md:text-xl uppercase tracking-[0.1em] text-center">
+            MIND-BLOWING NEWS YOU WON'T BELIEVE!
+          </p>
+        </header>
+
+        <section className="grid gap-4 md:grid-cols-2" aria-label="Choose your faction">
+          <FactionCard
+            ref={governmentCardRef}
+            faction="government"
+            title="GOVERNMENT"
+            caption="Control the narrative."
+            imageSrc="/assets/start/start-gov.jpg"
+            onSelect={() => handleFactionSelect('government')}
+          />
+          <FactionCard
+            faction="truth"
+            title="TRUTH SEEKERS"
+            caption="Expose the deception."
+            imageSrc="/assets/start/start-truth.jpg"
+            onSelect={() => handleFactionSelect('truth')}
+          />
+        </section>
+
+        <section className="print-border bg-[var(--paper)] px-4 sm:px-6 py-6 text-center space-y-3">
+          <span className="font-['Bebas Neue',sans-serif] text-sm sm:text-base uppercase tracking-[0.12em] text-[var(--accent)]">
+            BREAKING NEWS
+          </span>
+          <h2 className="font-['Anton',sans-serif] text-3xl sm:text-4xl md:text-5xl lg:text-6xl uppercase tracking-[0.05em]">
+            {headline}
+          </h2>
+          <p className="font-['Bebas Neue',sans-serif] text-base sm:text-lg uppercase tracking-[0.1em] text-[var(--ink-weak)]">
+            {subhead}
+          </p>
+        </section>
+
+        <section className="grid gap-6 lg:grid-cols-[minmax(0,2fr)_minmax(0,1fr)]">
+          <div className="space-y-4">
+            <div className="print-border overflow-hidden bg-[var(--paper)]">
+              <img
+                src="/assets/start/start-continue.jpg"
+                alt="Continue your conspiracies"
+                className="w-full h-full object-cover"
+              />
+            </div>
+            <button
+              type="button"
+              onClick={handleFeatureAction}
+              className="print-border w-full bg-[var(--paper)] px-4 py-4 font-['Bebas Neue',sans-serif] text-2xl md:text-3xl uppercase tracking-[0.12em] hover:bg-black/5 transition-colors focus:outline-none focus-visible:ring-4 focus-visible:ring-black/40"
+            >
+              {continueLabel}
+            </button>
+          </div>
+
+          <aside className="grid gap-4 sm:grid-cols-2 lg:grid-cols-1" aria-label="Menu options">
+            <ArticleButton
+              label="OPTIONS"
+              onClick={handleArticleAction(onOptions)}
+              sub="Tune your paranoia settings"
+            />
+            <ArticleButton
+              label="MANAGE EXPANSIONS"
+              onClick={handleArticleAction(onManageExpansions)}
+              sub="Sell expansions!"
+            />
+            <ArticleButton
+              label="HOW TO PLAY"
+              onClick={handleArticleAction(onHowToPlay)}
+              sub="Top secret dossier"
+            />
+            <ArticleButton
+              label="CARD COLLECTION"
+              onClick={handleArticleAction(onCardCollection)}
+              sub="Evidence archive"
+            />
+            <ArticleButton
+              label="CREDITS"
+              onClick={handleArticleAction(onCredits)}
+              variant="ad"
+              sub="Who\'s behind the curtain?"
+            />
+          </aside>
+        </section>
+
+        <footer className="print-border bg-[var(--paper)] px-3 py-3 text-center">
+          <span className="font-['Bebas Neue',sans-serif] text-lg sm:text-xl uppercase tracking-[0.14em]">
+            PHONY MOON CONTINUES TO SHINE IN NIGHT SKY!
+          </span>
+        </footer>
+      </div>
+    </div>
+  );
+};
+
+export default StartScreen;

--- a/src/styles/newspaper.css
+++ b/src/styles/newspaper.css
@@ -1,0 +1,24 @@
+.newspaper-bg {
+  background: var(--paper);
+  background-image:
+    radial-gradient(var(--halftone-dot) 1px, transparent 1px),
+    radial-gradient(var(--halftone-dot) 1px, transparent 1px);
+  background-position: 0 0, 3px 3px;
+  background-size: 6px 6px, 6px 6px;
+}
+
+.print-border {
+  border: 3px solid var(--rule);
+  box-shadow: 0 0 0 2px #000 inset;
+}
+
+.hr-rule {
+  border-top: 4px solid var(--rule);
+}
+
+.badge {
+  border: 2px solid var(--rule);
+  padding: 2px 6px;
+  font-family: 'Bebas Neue', sans-serif;
+  letter-spacing: .5px;
+}


### PR DESCRIPTION
## Summary
- build a responsive newspaper-inspired start screen with direct faction selection, feature headline, and ticker
- add reusable FactionCard and ArticleButton components and shared newspaper background styles
- hook GameMenu into the new layout while keeping expansion, how-to, credits, and save handlers intact

## Testing
- npm run lint *(fails: missing local @eslint/js package because dependencies cannot be installed in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cbebce1efc83208f7dec71c7f663bb