### PR TITLE
Adjust start screen layout to fit viewport height

### DIFF
--- a/src/components/start/FactionCard.tsx
+++ b/src/components/start/FactionCard.tsx
@@ -25,16 +25,16 @@ const FactionCard = forwardRef<HTMLDivElement, FactionCardProps>(
         data-faction-card={faction}
         onClick={onSelect}
         onKeyDown={handleKeyDown}
-        className="group cursor-pointer select-none bg-[var(--paper)] print-border focus:outline-none focus:ring-4 focus:ring-black/60"
+        className="group flex h-full flex-col cursor-pointer select-none bg-[var(--paper)] print-border focus:outline-none focus:ring-4 focus:ring-black/60"
         aria-label={`${title} — select faction`}
       >
-        <div className="relative w-full aspect-[4/3] overflow-hidden bg-black/10">
+        <div className="relative flex-1 overflow-hidden bg-black/10">
           <span className="absolute top-2 left-2 z-10 badge text-[10px] leading-none bg-[var(--paper)]">EXCLUSIVE</span>
           <img
             src={imageSrc}
             alt={title}
             loading="eager"
-            className="w-full h-full object-cover object-center transition-transform duration-200 group-hover:scale-[1.02]"
+            className="h-full w-full object-cover object-center transition-transform duration-200 group-hover:scale-[1.02]"
           />
         </div>
         <div className="px-3 py-3">

--- a/src/components/start/StartScreen.tsx
+++ b/src/components/start/StartScreen.tsx
@@ -109,85 +109,93 @@ const StartScreen = ({
   };
 
   return (
-    <main className="newspaper-bg min-h-dvh text-[var(--ink)]">
-      <div className="max-w-[1200px] mx-auto px-3 sm:px-4 md:px-6 lg:px-8 py-4 md:py-6">
-        <header className="print-border bg-[var(--paper)] px-3 md:px-4 py-3 md:py-4 mb-4 md:mb-6">
-          <div className="flex items-end justify-between">
-            <h1 className="font-[Anton] text-4xl md:text-6xl tracking-wide uppercase">THE PARANOID TIMES</h1>
-            <span className="badge text-xs md:text-sm">TIMES</span>
-          </div>
-          <div className="mt-2 bg-[var(--ink)] text-[var(--paper)] text-[11px] md:text-sm font-[Bebas Neue] px-2 py-1 inline-block tracking-wider uppercase">
-            MIND-BLOWING NEWS YOU WON'T BELIEVE!
-          </div>
-        </header>
-
-        <section className="grid grid-cols-1 md:grid-cols-2 gap-4 md:gap-6">
-          <FactionCard
-            ref={governmentCardRef}
-            faction="government"
-            title="GOVERNMENT"
-            caption="CONTROL THE NARRATIVE."
-            imageSrc="/assets/start/start-gov.jpeg"
-            onSelect={() => handleFactionSelect('government')}
-          />
-          <FactionCard
-            faction="truth"
-            title="TRUTH SEEKERS"
-            caption="EXPOSE THE DECEPTION."
-            imageSrc="/assets/start/start-truth.jpeg"
-            onSelect={() => handleFactionSelect('truth')}
-          />
-        </section>
-
-        <section className="mt-4 md:mt-6 print-border px-3 md:px-4 py-4">
-          <h2 className="font-[Anton] text-2xl sm:text-4xl md:text-5xl leading-tight tracking-wide uppercase">{headline}</h2>
-          <p className="mt-2 text-[11px] md:text-sm text-[var(--ink-weak)] uppercase tracking-wide">{subhead}</p>
-          <div className="mt-3 hr-rule" />
-        </section>
-
-        <section className="mt-4 md:mt-6 grid grid-cols-1 md:grid-cols-3 gap-4 md:gap-6">
-          <div className="md:col-span-2 print-border bg-[var(--paper)]">
-            <div className="aspect-[4/3] bg-black/10">
-              <img
-                src="/assets/start/start-continue.jpeg"
-                alt="Continue your conspiracies"
-                loading="lazy"
-                className="w-full h-full object-cover object-center"
-              />
+    <main className="newspaper-bg flex h-screen flex-col overflow-hidden text-[var(--ink)]">
+      <div className="mx-auto flex h-full max-w-[1200px] flex-1 flex-col overflow-hidden px-3 py-2 sm:px-4 md:px-6 md:py-4 lg:px-8">
+        <div className="flex flex-1 flex-col overflow-hidden">
+          <header className="print-border bg-[var(--paper)] px-3 py-3 md:px-4 md:py-4 [flex:0_0_15%] sm:[flex:0_0_14%] lg:[flex:0_0_12%]">
+            <div className="flex h-full flex-col justify-center gap-2">
+              <div className="flex items-end justify-between gap-2">
+                <h1 className="font-[Anton] text-4xl tracking-wide uppercase md:text-6xl">THE PARANOID TIMES</h1>
+                <span className="badge text-xs md:text-sm">TIMES</span>
+              </div>
+              <div className="inline-block bg-[var(--ink)] px-2 py-1 font-[Bebas Neue] text-[11px] uppercase tracking-wider text-[var(--paper)] md:text-sm">
+                MIND-BLOWING NEWS YOU WON'T BELIEVE!
+              </div>
             </div>
-            <div className="p-3 md:p-4">
-              <ArticleButton label={continueLabel} onClick={handleFeatureAction} />
+          </header>
+
+          <div className="flex-1 overflow-hidden">
+            <div className="grid h-full grid-rows-[0.4fr_minmax(0,0.2fr)_0.4fr] gap-3 overflow-hidden md:gap-4 lg:grid-rows-[0.32fr_minmax(0,0.2fr)_0.48fr]">
+              <section className="grid min-h-0 grid-cols-1 gap-3 md:grid-cols-2 md:gap-4" aria-label="Faction selection">
+                <FactionCard
+                  ref={governmentCardRef}
+                  faction="government"
+                  title="GOVERNMENT"
+                  caption="CONTROL THE NARRATIVE."
+                  imageSrc="/assets/start/start-gov.jpeg"
+                  onSelect={() => handleFactionSelect('government')}
+                />
+                <FactionCard
+                  faction="truth"
+                  title="TRUTH SEEKERS"
+                  caption="EXPOSE THE DECEPTION."
+                  imageSrc="/assets/start/start-truth.jpeg"
+                  onSelect={() => handleFactionSelect('truth')}
+                />
+              </section>
+
+              <section className="print-border min-h-0 px-3 py-3 md:px-4 md:py-4">
+                <h2 className="font-[Anton] text-2xl leading-tight tracking-wide uppercase sm:text-4xl md:text-5xl">{headline}</h2>
+                <p className="mt-2 text-[11px] uppercase tracking-wide text-[var(--ink-weak)] md:text-sm">{subhead}</p>
+                <div className="mt-3 hr-rule" />
+              </section>
+
+              <section className="grid min-h-0 grid-cols-1 gap-3 md:grid-cols-[minmax(0,2fr)_minmax(0,1fr)] md:gap-4" aria-label="Main actions">
+                <div className="flex min-h-0 flex-col overflow-hidden print-border bg-[var(--paper)]">
+                  <div className="flex-1 overflow-hidden bg-black/10">
+                    <img
+                      src="/assets/start/start-continue.jpeg"
+                      alt="Continue your conspiracies"
+                      loading="lazy"
+                      className="h-full w-full object-cover object-center"
+                    />
+                  </div>
+                  <div className="px-3 py-3 md:px-4 md:py-4">
+                    <ArticleButton label={continueLabel} onClick={handleFeatureAction} />
+                  </div>
+                </div>
+
+                <aside className="flex min-h-0 flex-col justify-evenly gap-2 md:gap-3 lg:gap-4" aria-label="Menu options">
+                  <ArticleButton
+                    label="SELL EXPANSIONS!"
+                    sub="STORY ON PAGE 6"
+                    onClick={handleArticleAction(onManageExpansions)}
+                  />
+                  <ArticleButton
+                    label="TOP SECRET SETTINGS"
+                    onClick={handleArticleAction(onOptions)}
+                  />
+                  <ArticleButton
+                    label="LEAKED HOW-TO GUIDE"
+                    onClick={handleArticleAction(onHowToPlay)}
+                  />
+                  <ArticleButton
+                    label="EVIDENCE ARCHIVE"
+                    onClick={handleArticleAction(onCardCollection)}
+                  />
+                  <ArticleButton
+                    label="FOLLOW THE MONEY"
+                    onClick={handleArticleAction(onCredits)}
+                  />
+                </aside>
+              </section>
             </div>
           </div>
 
-          <aside className="space-y-3 md:space-y-4" aria-label="Menu options">
-            <ArticleButton
-              label="SELL EXPANSIONS!"
-              sub="STORY ON PAGE 6"
-              onClick={handleArticleAction(onManageExpansions)}
-            />
-            <ArticleButton
-              label="TOP SECRET SETTINGS"
-              onClick={handleArticleAction(onOptions)}
-            />
-            <ArticleButton
-              label="LEAKED HOW-TO GUIDE"
-              onClick={handleArticleAction(onHowToPlay)}
-            />
-            <ArticleButton
-              label="EVIDENCE ARCHIVE"
-              onClick={handleArticleAction(onCardCollection)}
-            />
-            <ArticleButton
-              label="FOLLOW THE MONEY"
-              onClick={handleArticleAction(onCredits)}
-            />
-          </aside>
-        </section>
-
-        <footer className="mt-4 md:mt-6 print-border px-3 py-2 font-[Bebas Neue] tracking-widest text-base md:text-lg uppercase text-center">
-          PHONY MOON CONTINUES TO SHINE IN NIGHT SKY!
-        </footer>
+          <footer className="print-border px-3 py-2 text-center font-[Bebas Neue] text-base uppercase tracking-widest md:px-4 md:text-lg [flex:0_0_10%] sm:[flex:0_0_9%] lg:[flex:0_0_7%]">
+            PHONY MOON CONTINUES TO SHINE IN NIGHT SKY!
+          </footer>
+        </div>
       </div>
     </main>
   );


### PR DESCRIPTION
## Summary
- restructure the start screen container to use a full-height flex layout without scroll overflow
- rebalance the factions, headline, and feature grid so each section scales proportionally with the viewport
- update faction cards and feature media to stretch with their allotted space while keeping responsive imagery

## Testing
- npm run lint *(fails: missing `@eslint/js` because dependencies cannot be installed — npm install blocked by 403 from registry)*

------
https://chatgpt.com/codex/tasks/task_e_68cbf93de1c483208ce550183a3caa12