### PR TITLE
Adjust start screen layout for laptop heights

### DIFF
--- a/src/components/start/ArticleButton.tsx
+++ b/src/components/start/ArticleButton.tsx
@@ -13,17 +13,11 @@ export default function ArticleButton({ label, onClick, sub }: ArticleButtonProp
       onClick={onClick}
       className="w-full print-border bg-[var(--paper)] px-4 py-3 md:py-4 text-left transition-colors hover:bg-black/5 active:translate-y-[1px] focus:outline-none focus-visible:ring-4 focus-visible:ring-black/60"
     >
-      <div
-        className="font-[Anton] uppercase leading-none tracking-wide"
-        style={{ fontSize: 'clamp(16px, 2.6vh, 28px)' }}
-      >
+      <div className="font-[Anton] uppercase leading-none tracking-wide" style={{ fontSize: 'var(--btn)' }}>
         {label}
       </div>
       {sub ? (
-        <div
-          className="mt-1 uppercase tracking-wide text-[var(--ink-weak)]"
-          style={{ fontSize: 'clamp(10px, 1.6vh, 14px)' }}
-        >
+        <div className="mt-1 uppercase tracking-wide text-[var(--ink-weak)]" style={{ fontSize: 'var(--cap)' }}>
           {sub}
         </div>
       ) : null}

--- a/src/components/start/FactionCard.tsx
+++ b/src/components/start/FactionCard.tsx
@@ -34,21 +34,15 @@ const FactionCard = forwardRef<HTMLDivElement, FactionCardProps>(
             src={imageSrc}
             alt={title}
             loading="eager"
-            className="h-full w-full object-cover object-center transition-transform duration-200 group-hover:scale-[1.02]"
+            className="absolute inset-0 w-full h-full object-cover object-center transition-transform duration-200 group-hover:scale-[1.02]"
           />
         </div>
         <div className="px-3 py-2">
-          <h3
-            className="font-[Anton] uppercase tracking-wide"
-            style={{ fontSize: 'clamp(18px, 2.2vh, 32px)' }}
-          >
+          <h3 className="font-[Anton] uppercase tracking-wide" style={{ fontSize: 'var(--h2)' }}>
             {title}
           </h3>
           {caption ? (
-            <p
-              className="mt-1 uppercase tracking-wide text-[var(--ink-weak)]"
-              style={{ fontSize: 'clamp(10px, 1.5vh, 13px)' }}
-            >
+            <p className="mt-1 uppercase tracking-wide text-[var(--ink-weak)]" style={{ fontSize: 'var(--cap)' }}>
               {caption}
             </p>
           ) : null}

--- a/src/components/start/StartScreen.tsx
+++ b/src/components/start/StartScreen.tsx
@@ -110,24 +110,23 @@ const StartScreen = ({
 
   return (
     <main className="newspaper-bg h-[100dvh] overflow-hidden text-[var(--ink)]">
-      <div className="mx-auto h-full max-w-[1200px] px-3 pt-[var(--gut)] pb-[var(--gut)] sm:px-4 md:px-6 lg:px-8">
+      <div className="max-w-[1200px] mx-auto h-full px-3 sm:px-4 md:px-6 lg:px-8 pt-[var(--gut)] pb-[var(--gut)]">
         <header
-          className="print-border mb-[var(--gut)] bg-[var(--paper)] px-3 py-2 md:px-4 md:py-3"
+          className="print-border bg-[var(--paper)] px-3 md:px-4 mb-[var(--gut)] flex items-end"
           style={{ height: 'var(--hdr)' }}
         >
-          <div className="flex h-full flex-col justify-center gap-2">
-            <div className="flex items-end justify-between gap-2">
-              <h1
-                className="font-[Anton] uppercase tracking-wide"
-                style={{ fontSize: 'clamp(28px, 6vh, 64px)' }}
-              >
+          <div className="w-full flex flex-col gap-2">
+            <div className="w-full flex items-end justify-between">
+              <h1 className="font-[Anton] uppercase tracking-wide" style={{ fontSize: 'var(--h1)' }}>
                 THE PARANOID TIMES
               </h1>
-              <span className="badge text-[clamp(9px,1.3vh,12px)]">TIMES</span>
+              <span className="badge" style={{ fontSize: 'var(--cap)' }}>
+                TIMES
+              </span>
             </div>
             <div
               className="inline-block bg-[var(--ink)] px-2 py-1 font-[Bebas Neue] uppercase tracking-wider text-[var(--paper)]"
-              style={{ fontSize: 'clamp(11px, 1.6vh, 16px)' }}
+              style={{ fontSize: 'var(--btn)' }}
             >
               MIND-BLOWING NEWS YOU WON'T BELIEVE!
             </div>
@@ -166,20 +165,20 @@ const StartScreen = ({
                 <img
                   src="/assets/start/start-continue.jpeg"
                   alt="Continue your conspiracies"
-                  className="absolute inset-0 h-full w-full object-cover"
+                  className="absolute inset-0 w-full h-full object-cover object-center"
                   loading="lazy"
                 />
               </div>
               <div className="flex flex-col gap-2 p-3 md:p-4">
                 <h2
                   className="font-[Anton] uppercase tracking-wide text-[var(--ink)]"
-                  style={{ fontSize: 'clamp(18px, 3.4vh, 36px)' }}
+                  style={{ fontSize: 'var(--h2)' }}
                 >
                   {headline}
                 </h2>
                 <p
                   className="uppercase tracking-wide text-[var(--ink-weak)]"
-                  style={{ fontSize: 'clamp(10px, 1.4vh, 14px)' }}
+                  style={{ fontSize: 'var(--cap)' }}
                 >
                   {subhead}
                 </p>
@@ -215,7 +214,7 @@ const StartScreen = ({
 
         <footer
           className="print-border mt-[var(--gut)] px-3 flex items-center justify-center font-[Bebas Neue] tracking-widest uppercase"
-          style={{ height: 'var(--ftr)', fontSize: 'clamp(12px, 1.8vh, 18px)' }}
+          style={{ height: 'var(--ftr)', fontSize: 'clamp(11px, 1.8vh, 18px)' }}
         >
           PHONY MOON CONTINUES TO SHINE IN NIGHT SKY!
         </footer>

--- a/src/index.css
+++ b/src/index.css
@@ -51,6 +51,12 @@ All colors MUST be HSL.
     --row-top: 58%;
     --row-bot: 42%;
 
+    /* Typography scaling tokens */
+    --h1: clamp(28px, 6vh, 64px);
+    --h2: clamp(18px, 3.2vh, 40px);
+    --btn: clamp(14px, 2.6vh, 28px);
+    --cap: clamp(10px, 1.6vh, 13px);
+
     /* Tabloid newspaper theme tokens */
     --paper: #f4f3f1;
     --ink: #111111;
@@ -124,6 +130,28 @@ All colors MUST be HSL.
     --pt-gap: 10px;
     --pt-radius: 14px;
   }
+  @media (max-height: 820px) {
+    :root {
+      --hdr: clamp(52px, 9.5dvh, 88px);
+      --ftr: clamp(30px, 5.5dvh, 56px);
+      --gut: clamp(6px, 0.9vw, 12px);
+
+      --row-top: 54%;
+      --row-bot: 46%;
+
+      --h1: clamp(24px, 5.2vh, 52px);
+      --h2: clamp(16px, 2.6vh, 34px);
+      --btn: clamp(12px, 2.2vh, 22px);
+      --cap: clamp(9px, 1.4vh, 12px);
+    }
+  }
+
+  @media (max-width: 1400px) {
+    :root {
+      --gut: clamp(6px, 0.8vw, 12px);
+    }
+  }
+
   .dark {
     --background: 222.2 84% 4.9%;
     --foreground: 210 40% 98%;


### PR DESCRIPTION
## Summary
- add responsive layout and typography CSS variables with laptop-specific overrides
- refactor the start screen grid to use height-controlled sections and responsive typography
- update faction and article cards so imagery covers containers and text scales with new variables

## Testing
- npm run lint *(fails: missing dependencies due to registry 403 while installing packages)*

------
https://chatgpt.com/codex/tasks/task_e_68cc20a8845c83209186c3ebd0fdfc1d