### PR TITLE
Refine enhanced AI play selection and logging

### DIFF
--- a/src/data/enhancedAIStrategy.ts
+++ b/src/data/enhancedAIStrategy.ts
@@ -30,15 +30,11 @@ interface DeceptionState {
 }
 
 // Enhanced Card Play with synergy info
-interface EnhancedCardPlay {
-  cardId: string;
-  targetState?: string;
-  priority: number;
-  reasoning: string;
+export type EnhancedCardPlay = CardPlay & {
   synergies: CardSynergy[];
   deceptionValue: number;
   threatResponse: boolean;
-}
+};
 
 export class EnhancedAIStrategist extends AIStrategist {
   private cardSynergies: CardSynergy[] = [];
@@ -68,6 +64,10 @@ export class EnhancedAIStrategist extends AIStrategist {
 
     // Fallback to enhanced heuristic search
     return this.selectBestPlayWithSynergies(gameState);
+  }
+
+  public override selectBestPlay(gameState: any): CardPlay | null {
+    return this.selectOptimalPlay(gameState);
   }
 
   private runMCTS(gameState: any, iterations: number): EnhancedCardPlay | null {


### PR DESCRIPTION
## Summary
- export an `EnhancedCardPlay` type and override `selectBestPlay` to delegate to `selectOptimalPlay`
- enhance the AI turn loop to surface enhanced strategist insights and pass them through card-play logging
- confirm the existing difficulty mapping continues to instantiate the enhanced strategist for hard and legendary AI, keeping UI indicators aligned

## Testing
- npm run lint *(fails: missing npm dependencies due to registry permissions for ts-node)*

------
https://chatgpt.com/codex/tasks/task_e_68cc3317364083209fb2a2a1237a59fb