### PR TITLE
Reset event editions after trigger rolls

### DIFF
--- a/src/hooks/__tests__/useGameState.events.test.ts
+++ b/src/hooks/__tests__/useGameState.events.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from 'bun:test';
+import { buildEditionEvents } from '@/hooks/eventEdition';
+import type { GameEvent } from '@/data/eventDatabase';
+
+const makeEvent = (id: string): GameEvent => ({
+  id,
+  title: `Event ${id}`,
+  content: 'Placeholder content',
+  type: 'random',
+  rarity: 'common',
+  weight: 1,
+});
+
+describe('buildEditionEvents', () => {
+  it('returns seeded events on the first edition when no trigger occurs', () => {
+    const seededEvents = [makeEvent('seed-1'), makeEvent('seed-2')];
+
+    const result = buildEditionEvents(
+      { turn: 1, round: 1, currentEvents: seededEvents },
+      null,
+    );
+
+    expect(result).toEqual(seededEvents);
+    expect(result).not.toBe(seededEvents);
+  });
+
+  it('appends triggered events to the seeded first edition', () => {
+    const seededEvents = [makeEvent('seed-1')];
+    const triggered = makeEvent('triggered');
+
+    const result = buildEditionEvents(
+      { turn: 1, round: 1, currentEvents: seededEvents },
+      triggered,
+    );
+
+    expect(result).toEqual([...seededEvents, triggered]);
+  });
+
+  it('returns no events when no trigger fires on later editions', () => {
+    const seededEvents = [makeEvent('seed-1')];
+
+    const firstEdition = buildEditionEvents(
+      { turn: 1, round: 1, currentEvents: seededEvents },
+      null,
+    );
+
+    const result = buildEditionEvents(
+      { turn: 2, round: 1, currentEvents: firstEdition },
+      null,
+    );
+
+    expect(result).toEqual([]);
+  });
+
+  it('returns only the triggered event on later editions', () => {
+    const triggered = makeEvent('triggered');
+
+    const result = buildEditionEvents(
+      { turn: 3, round: 1, currentEvents: [] },
+      triggered,
+    );
+
+    expect(result).toEqual([triggered]);
+  });
+});

--- a/src/hooks/eventEdition.ts
+++ b/src/hooks/eventEdition.ts
@@ -1,0 +1,25 @@
+import type { GameEvent } from '@/data/eventDatabase';
+
+export interface EditionEventSnapshot {
+  turn: number;
+  round: number;
+  currentEvents: GameEvent[];
+}
+
+export const buildEditionEvents = (
+  state: EditionEventSnapshot,
+  triggeredEvent: GameEvent | null,
+): GameEvent[] => {
+  const events: GameEvent[] = [];
+
+  const isFirstEdition = state.turn === 1 && state.round === 1;
+  if (isFirstEdition && state.currentEvents.length > 0) {
+    events.push(...state.currentEvents);
+  }
+
+  if (triggeredEvent) {
+    events.push(triggeredEvent);
+  }
+
+  return events;
+};

--- a/src/hooks/useGameState.ts
+++ b/src/hooks/useGameState.ts
@@ -8,6 +8,7 @@ import { AIStrategist, type AIDifficulty, type CardPlay } from '@/data/aiStrateg
 import { AIFactory } from '@/data/aiFactory';
 import { EnhancedAIStrategist } from '@/data/enhancedAIStrategy';
 import { EventManager, type GameEvent, EVENT_DATABASE } from '@/data/eventDatabase';
+import { buildEditionEvents } from './eventEdition';
 import { getStartingHandSize, type DrawMode, type CardDrawState } from '@/data/cardDrawingSystem';
 import { useAchievements } from '@/contexts/AchievementContext';
 import { resolveCardMVP, type CardPlayResolution } from '@/systems/cardResolution';
@@ -495,16 +496,15 @@ export const useGameState = (aiDifficultyOverride?: AIDifficulty) => {
         prev.eventManager?.updateTurn(prev.turn);
 
         // Trigger random event using event manager gating
-        let newEvents = [...prev.currentEvents];
         let eventEffectLog: string[] = [];
         let truthModifier = 0;
         let ipModifier = 0;
         let bonusCardDraw = 0;
+        let triggeredEvent: GameEvent | null = null;
 
         if (prev.eventManager) {
-          const triggeredEvent = prev.eventManager.maybeSelectRandomEvent(prev);
+          triggeredEvent = prev.eventManager.maybeSelectRandomEvent(prev);
           if (triggeredEvent) {
-            newEvents = [triggeredEvent];
 
             // Apply event effects
             if (triggeredEvent.effects) {
@@ -520,6 +520,8 @@ export const useGameState = (aiDifficultyOverride?: AIDifficulty) => {
             }
           }
         }
+
+        const newEvents = buildEditionEvents(prev, triggeredEvent);
 
         // Store pending card draw for after newspaper
         const pendingCardDraw = bonusCardDraw;


### PR DESCRIPTION
## Summary
- ensure end-of-turn event generation starts from an empty slate and only appends the triggered event
- preserve the initial newspaper's seeded flavor events via a shared helper
- cover the new helper with tests that simulate consecutive editions without and with triggered events

## Testing
- bun test

------
https://chatgpt.com/codex/tasks/task_e_68cc3fb9a8a0832085de8de800429fcf