### PR TITLE
Allow opening edition to start without seeded events

### DIFF
--- a/src/hooks/__tests__/useGameState.events.test.ts
+++ b/src/hooks/__tests__/useGameState.events.test.ts
@@ -12,40 +12,45 @@ const makeEvent = (id: string): GameEvent => ({
 });
 
 describe('buildEditionEvents', () => {
-  it('returns seeded events on the first edition when no trigger occurs', () => {
-    const seededEvents = [makeEvent('seed-1'), makeEvent('seed-2')];
-
+  it('returns no events on the first edition when no trigger occurs', () => {
     const result = buildEditionEvents(
-      { turn: 1, round: 1, currentEvents: seededEvents },
+      { turn: 1, round: 1, currentEvents: [] },
       null,
     );
 
-    expect(result).toEqual(seededEvents);
-    expect(result).not.toBe(seededEvents);
+    expect(result).toEqual([]);
   });
 
-  it('appends triggered events to the seeded first edition', () => {
-    const seededEvents = [makeEvent('seed-1')];
+  it('returns only the triggered event on the first edition when a trigger occurs', () => {
     const triggered = makeEvent('triggered');
 
     const result = buildEditionEvents(
-      { turn: 1, round: 1, currentEvents: seededEvents },
+      { turn: 1, round: 1, currentEvents: [] },
       triggered,
     );
 
-    expect(result).toEqual([...seededEvents, triggered]);
+    expect(result).toEqual([triggered]);
   });
 
   it('returns no events when no trigger fires on later editions', () => {
-    const seededEvents = [makeEvent('seed-1')];
-
     const firstEdition = buildEditionEvents(
-      { turn: 1, round: 1, currentEvents: seededEvents },
-      null,
+      { turn: 1, round: 1, currentEvents: [] },
+      makeEvent('triggered'),
     );
 
     const result = buildEditionEvents(
       { turn: 2, round: 1, currentEvents: firstEdition },
+      null,
+    );
+
+    expect(result).toEqual([]);
+  });
+
+  it('ignores pre-seeded events on the first edition when no trigger occurs', () => {
+    const seededEvents = [makeEvent('seed-1'), makeEvent('seed-2')];
+
+    const result = buildEditionEvents(
+      { turn: 1, round: 1, currentEvents: seededEvents },
       null,
     );
 

--- a/src/hooks/eventEdition.ts
+++ b/src/hooks/eventEdition.ts
@@ -13,7 +13,7 @@ export const buildEditionEvents = (
   const events: GameEvent[] = [];
 
   const isFirstEdition = state.turn === 1 && state.round === 1;
-  if (isFirstEdition && state.currentEvents.length > 0) {
+  if (isFirstEdition && state.currentEvents.length > 0 && triggeredEvent) {
     events.push(...state.currentEvents);
   }
 

--- a/src/hooks/useGameState.ts
+++ b/src/hooks/useGameState.ts
@@ -7,7 +7,7 @@ import { getRandomAgenda, SecretAgenda } from '@/data/agendaDatabase';
 import { AIStrategist, type AIDifficulty, type CardPlay } from '@/data/aiStrategy';
 import { AIFactory } from '@/data/aiFactory';
 import { EnhancedAIStrategist } from '@/data/enhancedAIStrategy';
-import { EventManager, type GameEvent, EVENT_DATABASE } from '@/data/eventDatabase';
+import { EventManager, type GameEvent } from '@/data/eventDatabase';
 import { buildEditionEvents } from './eventEdition';
 import { getStartingHandSize, type DrawMode, type CardDrawState } from '@/data/cardDrawingSystem';
 import { useAchievements } from '@/contexts/AchievementContext';
@@ -90,15 +90,6 @@ interface GameState {
   drawMode: DrawMode;
   cardDrawState: CardDrawState;
 }
-
-const generateInitialEvents = (eventManager: EventManager): GameEvent[] => {
-  // Start with some common events for the first newspaper
-  const initialEvents = EVENT_DATABASE.filter(event =>
-    event.rarity === 'common' && !event.conditions
-  ).slice(0, 3);
-
-  return initialEvents;
-};
 
 const omitClashKey = (key: string, value: unknown) => (key === 'clash' ? undefined : value);
 
@@ -222,7 +213,7 @@ export const useGameState = (aiDifficultyOverride?: AIDifficulty) => {
         bonusValue: state.bonusValue
       };
     }),
-    currentEvents: generateInitialEvents(eventManager),
+    currentEvents: [],
     eventManager,
     showNewspaper: false,
     log: [


### PR DESCRIPTION
## Summary
- start the game state with an empty `currentEvents` array instead of seeding default newspaper entries
- update `buildEditionEvents` so turn-one editions stay blank when the random trigger misses
- refresh unit tests to reflect the new first-edition behavior and guard against accidental reseeding

## Testing
- bun test

------
https://chatgpt.com/codex/tasks/task_e_68cc49ea137c832080fc96fda5325494