### PR TITLE
Prefer data-state-id for capture flashes

### DIFF
--- a/src/ui/UiOverlays.tsx
+++ b/src/ui/UiOverlays.tsx
@@ -62,6 +62,7 @@ export default function UiOverlays() {
 
     window.uiFlashState = (stateId: string, by: "P1" | "P2") => {
       const el =
+        document.querySelector(`[data-state-id="${stateId}"]`) ||
         document.querySelector(`[data-state="${stateId}"]`) ||
         document.getElementById(`state-${stateId}`) ||
         document.querySelector(`[data-usps="${stateId}"]`);


### PR DESCRIPTION
## Summary
- have uiFlashState first look for elements tagged with data-state-id before falling back to the older selectors

## Testing
- npm install *(fails: npm error 403 Forbidden - GET https://registry.npmjs.org/ts-node)*

------
https://chatgpt.com/codex/tasks/task_e_68cc5a5ea9488320a8fef04c0f262301