### PR TITLE
Add combo engine modules, UI wiring, and tests

### DIFF
--- a/src/ai/policy.ts
+++ b/src/ai/policy.ts
@@ -364,7 +364,7 @@ function applyAction(state: GameState, action: Action): GameState {
     return playCard(state, action.cardId, action.targetStateId);
   }
   if (action.type === "end-turn") {
-    return endTurn(state, action.discards ?? []);
+    return endTurn(state, action.discards ?? []).state;
   }
   return state;
 }

--- a/src/components/dev/CardEffectValidator.tsx
+++ b/src/components/dev/CardEffectValidator.tsx
@@ -51,6 +51,7 @@ const CardEffectValidatorPanel: React.FC = () => {
       currentPlayer: 'P1',
       truth: testGameState.truth,
       playsThisTurn: 0,
+      turnPlays: [],
       log: engineLog,
       players: {
         P1: {

--- a/src/components/game/EffectTestPanel.tsx
+++ b/src/components/game/EffectTestPanel.tsx
@@ -36,6 +36,7 @@ const EffectTestPanel: React.FC = () => {
     currentPlayer: 'P1',
     truth: gameState.truth,
     playsThisTurn: 0,
+    turnPlays: [],
     log: engineLog,
     players: {
       P1: {

--- a/src/components/game/HowToPlay.tsx
+++ b/src/components/game/HowToPlay.tsx
@@ -4,6 +4,7 @@ import { Button } from '@/components/ui/button';
 import { ScrollArea } from '@/components/ui/scroll-area';
 import { ChevronDown, ChevronUp } from 'lucide-react';
 import {
+  MVP_COMBO_OVERVIEW,
   MVP_COST_TABLE_ROWS,
   MVP_RULES_SECTIONS,
   MVP_RULES_TITLE,
@@ -180,6 +181,58 @@ const HowToPlay = ({ onClose }: HowToPlayProps) => {
                       ))}
                     </tbody>
                   </table>
+                </div>
+              </section>
+
+              <section className="space-y-3">
+                <h2 className="text-2xl font-bold text-newspaper-text font-mono">
+                  Combo Catalogue
+                </h2>
+                <p className="text-newspaper-text/80 leading-relaxed">
+                  Combos award extra resources when you meet their turn-based requirements. Each entry below shows the reward payload and any caps that limit repeated payouts. Mix and match to build the turn that fits your strategy.
+                </p>
+                <div className="grid gap-4 md:grid-cols-2">
+                  {MVP_COMBO_OVERVIEW.map(group => (
+                    <div
+                      key={group.category}
+                      className="border border-newspaper-text/30 bg-newspaper-text/5 p-3 rounded"
+                    >
+                      <div className="flex items-center justify-between mb-2">
+                        <h3 className="text-xl font-semibold text-newspaper-text font-mono uppercase">
+                          {group.category} Combos
+                        </h3>
+                        <span className="text-xs font-semibold text-newspaper-text/70">
+                          {group.combos.length} listed
+                        </span>
+                      </div>
+                      <div className="space-y-3 text-sm">
+                        {group.combos.map(combo => {
+                          const rewardText = combo.reward.replace(/[()]/g, '').trim();
+                          return (
+                            <div key={combo.id} className="border-t border-dashed border-newspaper-text/30 pt-2 first:border-t-0 first:pt-0">
+                              <div className="flex flex-wrap items-baseline justify-between gap-2">
+                                <span className="font-semibold text-newspaper-text">{combo.name}</span>
+                                {rewardText && (
+                                  <span className="text-xs font-mono text-newspaper-text/70">
+                                    Reward: {rewardText}
+                                  </span>
+                                )}
+                              </div>
+                              <p className="text-newspaper-text/80 text-xs leading-relaxed mt-1">
+                                {combo.description}
+                              </p>
+                              {(combo.cap || combo.fxText) && (
+                                <div className="mt-1 flex flex-wrap gap-2 text-[11px] text-newspaper-text/60">
+                                  {combo.cap ? <span>Cap: {combo.cap}</span> : null}
+                                  {combo.fxText ? <span className="italic">FX: {combo.fxText}</span> : null}
+                                </div>
+                              )}
+                            </div>
+                          );
+                        })}
+                      </div>
+                    </div>
+                  ))}
                 </div>
               </section>
             </div>

--- a/src/components/game/HowToPlayTabloid.tsx
+++ b/src/components/game/HowToPlayTabloid.tsx
@@ -3,6 +3,7 @@ import { Button } from '@/components/ui/button';
 import { ScrollArea } from '@/components/ui/scroll-area';
 import { ChevronDown, ChevronUp } from 'lucide-react';
 import {
+  MVP_COMBO_OVERVIEW,
   MVP_COST_TABLE_ROWS,
   MVP_RULES_SECTIONS,
   MVP_RULES_TITLE,
@@ -174,6 +175,60 @@ const HowToPlayTabloid = ({ onClose }: HowToPlayTabloidProps) => {
                       ))}
                     </tbody>
                   </table>
+                </div>
+              </section>
+
+              <section className="border-2 border-black bg-white p-3 shadow-[2px_2px_0_#000] space-y-3">
+                <div className="flex items-center justify-between">
+                  <h2 className="text-xl font-black uppercase tracking-tight font-[Oswald,Impact,Arial-Black,system-ui,sans-serif]">
+                    COMBO CATALOGUE
+                  </h2>
+                  <div className="bg-red-500 text-white px-1 py-0.5 text-[8px] font-black uppercase border border-black">
+                    TOP SECRET
+                  </div>
+                </div>
+                <p className="text-sm leading-relaxed">
+                  Trigger these patterns within a single turn to earn additional IP or Truth. Manage the system, FX channel, and individual combos from the Options menu.
+                </p>
+                <div className="grid gap-3 md:grid-cols-2">
+                  {MVP_COMBO_OVERVIEW.map(group => (
+                    <div key={group.category} className="border-2 border-dashed border-black bg-white p-2 shadow-[2px_2px_0_#000]">
+                      <div className="flex items-center justify-between">
+                        <h3 className="text-lg font-black uppercase tracking-tight">
+                          {group.category} Combos
+                        </h3>
+                        <span className="text-[9px] font-black text-black/70 uppercase">
+                          {group.combos.length} listed
+                        </span>
+                      </div>
+                      <div className="mt-2 space-y-2 text-xs leading-relaxed">
+                        {group.combos.map(combo => {
+                          const rewardText = combo.reward.replace(/[()]/g, '').trim();
+                          return (
+                            <div key={combo.id} className="border-t border-dotted border-black/30 pt-1 first:border-t-0 first:pt-0">
+                              <div className="flex flex-wrap items-baseline justify-between gap-1">
+                                <span className="font-semibold text-black">{combo.name}</span>
+                                {rewardText && (
+                                  <span className="text-[10px] font-mono text-black/70 uppercase">
+                                    Reward: {rewardText}
+                                  </span>
+                                )}
+                              </div>
+                              <p className="text-black/80">
+                                {combo.description}
+                              </p>
+                              {(combo.cap || combo.fxText) && (
+                                <div className="mt-1 flex flex-wrap gap-2 text-[10px] text-black/60 uppercase">
+                                  {combo.cap ? <span>Cap {combo.cap}</span> : null}
+                                  {combo.fxText ? <span className="italic normal-case">FX: {combo.fxText}</span> : null}
+                                </div>
+                              )}
+                            </div>
+                          );
+                        })}
+                      </div>
+                    </div>
+                  ))}
                 </div>
               </section>
             </div>

--- a/src/game/combo.config.ts
+++ b/src/game/combo.config.ts
@@ -1,0 +1,473 @@
+import type { ComboDefinition, ComboSettings } from './combo.types';
+
+const sequenceCombos: ComboDefinition[] = [
+  {
+    id: 'sequence_attack_blitz',
+    name: 'Attack Blitz',
+    description: 'Play three ATTACK cards in a row to overwhelm the opposition.',
+    category: 'sequence',
+    priority: 100,
+    cap: 4,
+    trigger: { kind: 'sequence', sequence: ['ATTACK', 'ATTACK', 'ATTACK'] },
+    reward: { ip: 5, log: '+IP from attack blitz' },
+    fxText: 'Chain of strikes detonated!'
+  },
+  {
+    id: 'sequence_media_wave',
+    name: 'Media Wave',
+    description: 'Flood the airwaves with three back-to-back MEDIA plays.',
+    category: 'sequence',
+    priority: 100,
+    trigger: { kind: 'sequence', sequence: ['MEDIA', 'MEDIA', 'MEDIA'] },
+    reward: { truth: 4, log: '+Truth from media wave' },
+    fxText: 'Broadcast control achieved.'
+  },
+  {
+    id: 'sequence_zone_lock',
+    name: 'Zone Lock',
+    description: 'Deploy three ZONE cards consecutively to lock the map.',
+    category: 'sequence',
+    priority: 95,
+    trigger: { kind: 'sequence', sequence: ['ZONE', 'ZONE', 'ZONE'] },
+    reward: { ip: 3, log: '+IP from zone lock' },
+    fxText: 'Territories fortified.'
+  },
+  {
+    id: 'sequence_shock_and_awe',
+    name: 'Shock & Awe',
+    description: 'Strike with ATTACK then follow with double MEDIA spin.',
+    category: 'sequence',
+    priority: 96,
+    trigger: { kind: 'sequence', sequence: ['ATTACK', 'MEDIA', 'MEDIA'] },
+    reward: { truth: 3, log: '+Truth from shock & awe' },
+    fxText: 'Narrative blitz hits hard.'
+  },
+  {
+    id: 'sequence_crossfire',
+    name: 'Crossfire',
+    description: 'MEDIA exposes the target before a pair of ATTACK plays.',
+    category: 'sequence',
+    priority: 92,
+    trigger: { kind: 'sequence', sequence: ['MEDIA', 'ATTACK', 'ATTACK'] },
+    reward: { ip: 3, log: '+IP from crossfire' },
+    fxText: 'Crossfire barrage complete.'
+  },
+  {
+    id: 'sequence_signal_jam',
+    name: 'Signal Jam',
+    description: 'MEDIA-ZONE-MEDIA triangle to scramble responses.',
+    category: 'sequence',
+    priority: 90,
+    trigger: { kind: 'sequence', sequence: ['MEDIA', 'ZONE', 'MEDIA'] },
+    reward: { truth: 2, log: 'Truth swing from signal jam' },
+    fxText: 'Signals disrupted.'
+  },
+  {
+    id: 'sequence_territorial_push',
+    name: 'Territorial Push',
+    description: 'ZONE-ATTACK-ZONE to lock down contested regions.',
+    category: 'sequence',
+    priority: 94,
+    trigger: { kind: 'sequence', sequence: ['ZONE', 'ATTACK', 'ZONE'] },
+    reward: { ip: 3, log: 'IP surge from territorial push' },
+    fxText: 'Zones reinforced.'
+  },
+  {
+    id: 'sequence_full_spectrum',
+    name: 'Full Spectrum',
+    description: 'Play ATTACK, MEDIA and ZONE in sequence for total coverage.',
+    category: 'sequence',
+    priority: 98,
+    trigger: { kind: 'sequence', sequence: ['ATTACK', 'MEDIA', 'ZONE'] },
+    reward: { ip: 2, truth: 1, log: 'Full spectrum pressure applied' },
+    fxText: 'Full spectrum dominance!'
+  },
+  {
+    id: 'sequence_closed_circuit',
+    name: 'Closed Circuit',
+    description: 'ZONE-MEDIA-ATTACK loops intelligence to offense.',
+    category: 'sequence',
+    priority: 91,
+    trigger: { kind: 'sequence', sequence: ['ZONE', 'MEDIA', 'ATTACK'] },
+    reward: { ip: 2, log: 'Closed circuit advantage' },
+    fxText: 'Circuit complete.'
+  },
+  {
+    id: 'sequence_firestorm',
+    name: 'Firestorm',
+    description: 'Two ATTACK cards followed by MEDIA exploitation.',
+    category: 'sequence',
+    priority: 93,
+    trigger: { kind: 'sequence', sequence: ['ATTACK', 'ATTACK', 'MEDIA'] },
+    reward: { truth: 2, log: 'Media fans the flames' },
+    fxText: 'Firestorm breaks containment.'
+  }
+];
+
+const countCombos: ComboDefinition[] = [
+  {
+    id: 'count_attack_barrage',
+    name: 'Attack Barrage',
+    description: 'Play at least three ATTACK cards during the turn.',
+    category: 'count',
+    priority: 89,
+    cap: 4,
+    trigger: { kind: 'count', type: 'ATTACK', count: 3 },
+    reward: { ip: 6, log: 'Barrage drains their reserves' },
+    fxText: 'Barrage executed.'
+  },
+  {
+    id: 'count_media_campaign',
+    name: 'Media Campaign',
+    description: 'Publish three MEDIA pieces to sway opinion.',
+    category: 'count',
+    priority: 88,
+    trigger: { kind: 'count', type: 'MEDIA', count: 3 },
+    reward: { truth: 3, log: 'Campaign shifts public sentiment' },
+    fxText: 'Campaign reaches critical mass.'
+  },
+  {
+    id: 'count_zone_network',
+    name: 'Zone Network',
+    description: 'Deploy two or more ZONE cards to secure control.',
+    category: 'count',
+    priority: 87,
+    trigger: { kind: 'count', type: 'ZONE', count: 2 },
+    reward: { ip: 2, log: 'Network strengthens position' },
+    fxText: 'Network anchors the field.'
+  },
+  {
+    id: 'count_full_press',
+    name: 'Full Press',
+    description: 'Play four or more cards of any type in a turn.',
+    category: 'count',
+    priority: 85,
+    trigger: { kind: 'count', type: 'ANY', count: 4 },
+    reward: { ip: 2, log: 'Full press exhausts the opposition' },
+    fxText: 'Full press accomplished.'
+  },
+  {
+    id: 'count_relentless',
+    name: 'Relentless Pressure',
+    description: 'Play five or more cards regardless of type.',
+    category: 'count',
+    priority: 84,
+    trigger: { kind: 'count', type: 'ANY', count: 5 },
+    reward: { ip: 3, log: 'Relentless drive yields dividends' },
+    fxText: 'Relentless momentum maintained.'
+  },
+  {
+    id: 'count_rare_circle',
+    name: 'Rare Circle',
+    description: 'Play two or more cards of rare or legendary rarity.',
+    category: 'count',
+    priority: 83,
+    trigger: { kind: 'count', type: 'ANY', count: 2, rarity: 'rare' },
+    reward: { ip: 3, log: 'Elites mobilised' },
+    fxText: 'Rare assets deployed.'
+  },
+  {
+    id: 'count_legendary_gambit',
+    name: 'Legendary Gambit',
+    description: 'Play a legendary card to swing the narrative.',
+    category: 'count',
+    priority: 90,
+    trigger: { kind: 'count', type: 'ANY', count: 1, rarity: 'legendary' },
+    reward: { ip: 4, log: 'Legendary gambit pays off' },
+    fxText: 'Legendary gambit ignites.'
+  },
+  {
+    id: 'count_media_pair',
+    name: 'Media Pair',
+    description: 'Play two MEDIA cards to maintain coverage.',
+    category: 'count',
+    priority: 82,
+    trigger: { kind: 'count', type: 'MEDIA', count: 2 },
+    reward: { truth: 2, log: 'Media pairing sustains attention' },
+    fxText: 'Media pair resonates.'
+  },
+  {
+    id: 'count_balanced_arsenal',
+    name: 'Balanced Arsenal',
+    description: 'Play at least one card of each type in a single turn.',
+    category: 'count',
+    priority: 88,
+    trigger: { kind: 'hybrid', triggers: [
+      { kind: 'count', type: 'ATTACK', count: 1 },
+      { kind: 'count', type: 'MEDIA', count: 1 },
+      { kind: 'count', type: 'ZONE', count: 1 }
+    ] },
+    reward: { ip: 2, truth: 1, log: 'Balanced arsenal unlocks flexibility' },
+    fxText: 'Balanced arsenal achieved.'
+  },
+  {
+    id: 'count_budget_masters',
+    name: 'Budget Masters',
+    description: 'Play three low-cost cards (cost ≤ 2) in one turn.',
+    category: 'count',
+    priority: 81,
+    trigger: { kind: 'threshold', metric: 'lowCostCount', value: 3 },
+    reward: { truth: 2, log: 'Budget plays resonate locally' },
+    fxText: 'Budget mastery applauded.'
+  }
+];
+
+const thresholdCombos: ComboDefinition[] = [
+  {
+    id: 'threshold_total_spend_12',
+    name: 'Strategic Budget',
+    description: 'Spend at least 12 IP on cards this turn.',
+    category: 'threshold',
+    priority: 80,
+    trigger: { kind: 'threshold', metric: 'ipSpent', value: 12 },
+    reward: { ip: 4, log: 'Budget converts to momentum' },
+    fxText: 'Strategic funds deployed.'
+  },
+  {
+    id: 'threshold_attack_spend_9',
+    name: 'Ordnance Allocation',
+    description: 'Invest 9 or more IP into ATTACK cards in one turn.',
+    category: 'threshold',
+    priority: 86,
+    trigger: { kind: 'threshold', metric: 'attackSpent', value: 9 },
+    reward: { ip: 3, log: 'Heavy strike investment returns' },
+    fxText: 'Ordnance allocated with precision.'
+  },
+  {
+    id: 'threshold_media_spend_8',
+    name: 'Broadcast Budget',
+    description: 'Invest eight or more IP into MEDIA plays.',
+    category: 'threshold',
+    priority: 85,
+    trigger: { kind: 'threshold', metric: 'mediaSpent', value: 8 },
+    reward: { truth: 4, log: 'Media saturation achieved' },
+    fxText: 'Broadcast network saturates feeds.'
+  },
+  {
+    id: 'threshold_zone_spend_6',
+    name: 'Logistics Surge',
+    description: 'Spend at least six IP on ZONE cards this turn.',
+    category: 'threshold',
+    priority: 84,
+    trigger: { kind: 'threshold', metric: 'zoneSpent', value: 6 },
+    reward: { ip: 2, log: 'Logistics surge expands reach' },
+    fxText: 'Logistics surge enacted.'
+  },
+  {
+    id: 'threshold_total_spend_18',
+    name: 'Grand Offensive',
+    description: 'Spend eighteen or more IP during a single turn.',
+    category: 'threshold',
+    priority: 88,
+    trigger: { kind: 'threshold', metric: 'ipSpent', value: 18 },
+    reward: { ip: 5, log: 'Grand offensive reshapes the board' },
+    fxText: 'Grand offensive underway.'
+  },
+  {
+    id: 'threshold_low_cost_4',
+    name: 'Grassroots Push',
+    description: 'Deploy four low-cost cards (cost ≤ 2).',
+    category: 'threshold',
+    priority: 79,
+    trigger: { kind: 'threshold', metric: 'lowCostCount', value: 4 },
+    reward: { truth: 2, log: 'Grassroots push builds trust' },
+    fxText: 'Grassroots surge mobilised.'
+  },
+  {
+    id: 'threshold_high_cost_2',
+    name: 'High Roller',
+    description: 'Play two cards costing six IP or more.',
+    category: 'threshold',
+    priority: 83,
+    trigger: { kind: 'threshold', metric: 'highCostCount', value: 2 },
+    reward: { ip: 3, log: 'High-cost cards swing the tide' },
+    fxText: 'High rollers crash the market.'
+  },
+  {
+    id: 'threshold_unique_states_3',
+    name: 'Multi-State Operation',
+    description: 'Target three different states with ZONE cards.',
+    category: 'threshold',
+    priority: 82,
+    trigger: { kind: 'threshold', metric: 'uniqueStatesTargeted', value: 3 },
+    reward: { ip: 3, log: 'Multi-state operation widens influence' },
+    fxText: 'Operation spans multiple fronts.'
+  }
+];
+
+const stateCombos: ComboDefinition[] = [
+  {
+    id: 'state_double_down',
+    name: 'Double Down',
+    description: 'Target the same state twice with ZONE plays in a turn.',
+    category: 'state',
+    priority: 78,
+    trigger: { kind: 'state', cardType: 'ZONE', sameStateCount: 2 },
+    reward: { ip: 2, log: 'Double targeting overwhelms defences' },
+    fxText: 'Double down intensifies pressure.'
+  },
+  {
+    id: 'state_lockdown',
+    name: 'Lockdown',
+    description: 'Hit the same state three times with ZONE cards.',
+    category: 'state',
+    priority: 90,
+    trigger: { kind: 'state', cardType: 'ZONE', sameStateCount: 3 },
+    reward: { ip: 4, log: 'Lockdown secures the region' },
+    fxText: 'State locked down tight.'
+  },
+  {
+    id: 'state_coastal_pressure',
+    name: 'Coastal Pressure',
+    description: 'Target two coastal states (CA, OR, WA, FL, NY).',
+    category: 'state',
+    priority: 76,
+    trigger: { kind: 'state', cardType: 'ZONE', targetList: ['CA', 'OR', 'WA', 'FL', 'NY'], uniqueStatesCount: 2 },
+    reward: { ip: 2, log: 'Coastal pressure strains supply lines' },
+    fxText: 'Coasts feel the squeeze.'
+  },
+  {
+    id: 'state_border_push',
+    name: 'Border Push',
+    description: 'Apply ZONE pressure to two southern border states.',
+    category: 'state',
+    priority: 77,
+    trigger: { kind: 'state', cardType: 'ZONE', targetList: ['CA', 'AZ', 'NM', 'TX'], uniqueStatesCount: 2 },
+    reward: { ip: 2, log: 'Border operations escalate' },
+    fxText: 'Border push surges forward.'
+  },
+  {
+    id: 'state_capital_strike',
+    name: 'Capital Strike',
+    description: 'Target DC with any ZONE card.',
+    category: 'state',
+    priority: 85,
+    trigger: { kind: 'state', cardType: 'ZONE', targetList: ['DC'], sameStateCount: 1 },
+    reward: { truth: 3, log: 'Capital strike rattles leadership' },
+    fxText: 'Capital strike executed.'
+  },
+  {
+    id: 'state_heartland_drive',
+    name: 'Heartland Drive',
+    description: 'Target two heartland states (IA, KS, MO, NE, OK).',
+    category: 'state',
+    priority: 75,
+    trigger: { kind: 'state', cardType: 'ZONE', targetList: ['IA', 'KS', 'MO', 'NE', 'OK'], uniqueStatesCount: 2 },
+    reward: { ip: 2, log: 'Heartland drive captures logistics' },
+    fxText: 'Heartland drive advances.'
+  }
+];
+
+const hybridCombos: ComboDefinition[] = [
+  {
+    id: 'hybrid_precision_strike',
+    name: 'Precision Strike',
+    description: 'Chain ATTACK into ZONE while spending six IP on ATTACK plays.',
+    category: 'hybrid',
+    priority: 92,
+    trigger: {
+      kind: 'hybrid',
+      triggers: [
+        { kind: 'sequence', sequence: ['ATTACK', 'ZONE'] },
+        { kind: 'threshold', metric: 'attackSpent', value: 6 }
+      ]
+    },
+    reward: { ip: 3, log: 'Precision strike breaks resistance' },
+    fxText: 'Precision strike lands.'
+  },
+  {
+    id: 'hybrid_signal_lock',
+    name: 'Signal Lock',
+    description: 'Play MEDIA twice and spend at least three IP on ZONE.',
+    category: 'hybrid',
+    priority: 86,
+    trigger: {
+      kind: 'hybrid',
+      triggers: [
+        { kind: 'sequence', sequence: ['MEDIA', 'MEDIA'] },
+        { kind: 'threshold', metric: 'zoneSpent', value: 3 }
+      ]
+    },
+    reward: { truth: 2, log: 'Signal lock cements the story' },
+    fxText: 'Signal lock jams dissent.'
+  },
+  {
+    id: 'hybrid_momentum',
+    name: 'Momentum Engine',
+    description: 'Play three cards and spend at least ten IP in total.',
+    category: 'hybrid',
+    priority: 88,
+    trigger: {
+      kind: 'hybrid',
+      triggers: [
+        { kind: 'count', type: 'ANY', count: 3 },
+        { kind: 'threshold', metric: 'ipSpent', value: 10 }
+      ]
+    },
+    reward: { ip: 3, log: 'Momentum engine fuels dominance' },
+    fxText: 'Momentum engine roaring.'
+  },
+  {
+    id: 'hybrid_rally',
+    name: 'Public Rally',
+    description: 'Two MEDIA plays and two unique targeted states in one turn.',
+    category: 'hybrid',
+    priority: 87,
+    trigger: {
+      kind: 'hybrid',
+      triggers: [
+        { kind: 'count', type: 'MEDIA', count: 2 },
+        { kind: 'threshold', metric: 'uniqueStatesTargeted', value: 2 }
+      ]
+    },
+    reward: { truth: 3, log: 'Public rally energises supporters' },
+    fxText: 'Crowds rally behind the message.'
+  },
+  {
+    id: 'hybrid_last_resort',
+    name: 'Last Resort',
+    description: 'Play two cards including at least one high-cost option.',
+    category: 'hybrid',
+    priority: 74,
+    trigger: {
+      kind: 'hybrid',
+      triggers: [
+        { kind: 'count', type: 'ANY', count: 2 },
+        { kind: 'threshold', metric: 'highCostCount', value: 1 }
+      ]
+    },
+    reward: { ip: 2, log: 'Last resort squeezes hidden reserves' },
+    fxText: 'Last resort deployed.'
+  },
+  {
+    id: 'hybrid_chain_reaction',
+    name: 'Chain Reaction',
+    description: 'Execute a three-card sequence while targeting two states.',
+    category: 'hybrid',
+    priority: 93,
+    trigger: {
+      kind: 'hybrid',
+      triggers: [
+        { kind: 'count', type: 'ANY', count: 3 },
+        { kind: 'threshold', metric: 'uniqueStatesTargeted', value: 2 }
+      ]
+    },
+    reward: { ip: 3, truth: 1, log: 'Chain reaction cascades advantages' },
+    fxText: 'Chain reaction ignites across the map.'
+  }
+];
+
+export const COMBO_DEFINITIONS: ComboDefinition[] = [
+  ...sequenceCombos,
+  ...countCombos,
+  ...thresholdCombos,
+  ...stateCombos,
+  ...hybridCombos,
+];
+
+export const DEFAULT_COMBO_SETTINGS: ComboSettings = {
+  enabled: true,
+  fxEnabled: true,
+  maxCombosPerTurn: 3,
+  comboToggles: Object.fromEntries(COMBO_DEFINITIONS.map(def => [def.id, def.enabledByDefault ?? true])),
+};

--- a/src/game/combo.types.ts
+++ b/src/game/combo.types.ts
@@ -1,0 +1,122 @@
+import type { MVPCardType, Rarity } from '@/rules/mvp';
+import type { PlayerId } from '@/mvp/validator';
+
+export type TurnPlayStage = 'play' | 'resolve';
+
+export interface TurnPlay {
+  sequence: number;
+  stage: TurnPlayStage;
+  owner: PlayerId;
+  cardId: string;
+  cardName: string;
+  cardType: MVPCardType;
+  cardRarity: Rarity;
+  cost: number;
+  targetStateId?: string;
+  metadata?: Record<string, number | string | undefined>;
+}
+
+export type ComboCategory = 'sequence' | 'count' | 'threshold' | 'state' | 'hybrid';
+
+export interface SequenceTrigger {
+  kind: 'sequence';
+  sequence: MVPCardType[];
+  allowGaps?: boolean;
+}
+
+export interface CountTrigger {
+  kind: 'count';
+  type: MVPCardType | 'ANY';
+  count: number;
+  rarity?: Rarity | 'ANY';
+  operator?: '>=' | '<=' | '==';
+}
+
+export type ThresholdMetric =
+  | 'ipSpent'
+  | 'attackSpent'
+  | 'mediaSpent'
+  | 'zoneSpent'
+  | 'uniqueStatesTargeted'
+  | 'plays'
+  | 'lowCostCount'
+  | 'highCostCount';
+
+export interface ThresholdTrigger {
+  kind: 'threshold';
+  metric: ThresholdMetric;
+  value: number;
+}
+
+export interface StateTrigger {
+  kind: 'state';
+  sameStateCount?: number;
+  uniqueStatesCount?: number;
+  targetList?: string[];
+  cardType?: MVPCardType | 'ANY';
+}
+
+export interface HybridTrigger {
+  kind: 'hybrid';
+  triggers: ComboTrigger[];
+  mode?: 'all' | 'any';
+}
+
+export type ComboTrigger = SequenceTrigger | CountTrigger | ThresholdTrigger | StateTrigger | HybridTrigger;
+
+export interface ComboReward {
+  ip?: number;
+  truth?: number;
+  log?: string;
+}
+
+export interface ComboDefinition {
+  id: string;
+  name: string;
+  description: string;
+  category: ComboCategory;
+  priority: number;
+  cap?: number;
+  enabledByDefault?: boolean;
+  trigger: ComboTrigger;
+  reward: ComboReward;
+  fxText?: string;
+}
+
+export interface ComboResult {
+  definition: ComboDefinition;
+  reward: ComboReward;
+  appliedReward: ComboReward;
+  details: {
+    matchedPlays: TurnPlay[];
+    extra?: Record<string, number | string>;
+  };
+}
+
+export interface ComboEvaluation {
+  results: ComboResult[];
+  totalReward: ComboReward;
+  logs: string[];
+}
+
+export interface ComboSettings {
+  enabled: boolean;
+  fxEnabled: boolean;
+  comboToggles: Record<string, boolean>;
+  maxCombosPerTurn: number;
+}
+
+export interface ComboFXCallbacks {
+  onComboTriggered?: (result: ComboResult) => void;
+  onComboFx?: (result: ComboResult) => void;
+}
+
+export interface ComboOptions extends Partial<ComboSettings> {
+  fxCallbacks?: ComboFXCallbacks;
+  disabledCombos?: string[];
+}
+
+export interface ComboSummary extends ComboEvaluation {
+  player: PlayerId;
+  turn: number;
+}

--- a/src/game/comboEngine.test.ts
+++ b/src/game/comboEngine.test.ts
@@ -1,0 +1,190 @@
+import { beforeEach, describe, expect, it } from 'bun:test';
+import type { GameState, PlayerId, PlayerState } from '@/mvp/validator';
+import type { TurnPlay } from './combo.types';
+import { applyComboRewards, evaluateCombos, setComboSettings } from './comboEngine';
+import { COMBO_DEFINITIONS, DEFAULT_COMBO_SETTINGS } from './combo.config';
+
+type MutableGameState = GameState & { players: Record<PlayerId, PlayerState> };
+
+const basePlayer = (id: PlayerId): PlayerState => ({
+  id,
+  faction: id === 'P1' ? 'truth' : 'government',
+  deck: [],
+  hand: [],
+  discard: [],
+  ip: 10,
+  states: [],
+});
+
+const createState = (
+  plays: TurnPlay[],
+  overrides: Partial<GameState> = {},
+  playerOverrides: Partial<Record<PlayerId, Partial<PlayerState>>> = {},
+): MutableGameState => {
+  const players: Record<PlayerId, PlayerState> = {
+    P1: { ...basePlayer('P1'), ...(playerOverrides.P1 ?? {}) },
+    P2: { ...basePlayer('P2'), ...(playerOverrides.P2 ?? {}) },
+  } as Record<PlayerId, PlayerState>;
+
+  return {
+    turn: 3,
+    currentPlayer: 'P1',
+    truth: 50,
+    players,
+    pressureByState: {},
+    stateDefense: {},
+    playsThisTurn: plays.length,
+    turnPlays: plays,
+    log: [],
+    ...overrides,
+    players: {
+      P1: players.P1,
+      P2: players.P2,
+      ...((overrides.players as Record<PlayerId, PlayerState> | undefined) ?? {}),
+    },
+  } as MutableGameState;
+};
+
+let sequence = 0;
+const makePlay = (partial: Partial<TurnPlay> & { cardType: TurnPlay['cardType']; cost: number }): TurnPlay => {
+  sequence += 1;
+  return {
+    sequence,
+    stage: 'resolve',
+    owner: 'P1',
+    cardId: `card-${sequence}`,
+    cardName: partial.cardType,
+    cardType: partial.cardType,
+    cardRarity: partial.cardRarity ?? 'common',
+    cost: partial.cost,
+    targetStateId: partial.targetStateId,
+    metadata: partial.metadata,
+  } satisfies TurnPlay;
+};
+
+const enableOnly = (ids: string[], extra?: Parameters<typeof evaluateCombos>[2]): Parameters<typeof evaluateCombos>[2] => {
+  const toggles = Object.fromEntries(COMBO_DEFINITIONS.map(def => [def.id, ids.includes(def.id)]));
+  return {
+    enabled: true,
+    fxEnabled: false,
+    maxCombosPerTurn: DEFAULT_COMBO_SETTINGS.maxCombosPerTurn,
+    comboToggles: toggles,
+    ...extra,
+  };
+};
+
+beforeEach(() => {
+  sequence = 0;
+  setComboSettings({
+    ...DEFAULT_COMBO_SETTINGS,
+    comboToggles: { ...DEFAULT_COMBO_SETTINGS.comboToggles },
+  });
+});
+
+describe('comboEngine.evaluateCombos', () => {
+  it('identifies sequence combos using resolved plays order', () => {
+    const plays: TurnPlay[] = [
+      makePlay({ cardType: 'MEDIA', cost: 2 }),
+      makePlay({ cardType: 'MEDIA', cost: 3 }),
+      makePlay({ cardType: 'MEDIA', cost: 1 }),
+    ];
+    const state = createState(plays);
+
+    const evaluation = evaluateCombos(state, 'P1', enableOnly(['sequence_media_wave']));
+
+    expect(evaluation.results).toHaveLength(1);
+    expect(evaluation.results[0].definition.id).toBe('sequence_media_wave');
+    expect(evaluation.results[0].details.matchedPlays.map(play => play.cardType)).toEqual([
+      'MEDIA',
+      'MEDIA',
+      'MEDIA',
+    ]);
+    expect(evaluation.totalReward.truth).toBe(4);
+    expect(evaluation.logs).toEqual(['Media Wave (+4 Truth)']);
+  });
+
+  it('triggers count combos based on total plays regardless of type', () => {
+    const plays: TurnPlay[] = [
+      makePlay({ cardType: 'ATTACK', cost: 3 }),
+      makePlay({ cardType: 'MEDIA', cost: 2 }),
+      makePlay({ cardType: 'ZONE', cost: 3, targetStateId: 'CA' }),
+      makePlay({ cardType: 'ATTACK', cost: 2 }),
+      makePlay({ cardType: 'MEDIA', cost: 1 }),
+    ];
+    const state = createState(plays);
+
+    const evaluation = evaluateCombos(state, 'P1', enableOnly(['count_relentless']));
+
+    expect(evaluation.results).toHaveLength(1);
+    expect(evaluation.results[0].definition.id).toBe('count_relentless');
+    expect(evaluation.totalReward.ip).toBe(3);
+  });
+
+  it('detects state-targeted combos when the same state is hit repeatedly', () => {
+    const plays: TurnPlay[] = [
+      makePlay({ cardType: 'ZONE', cost: 3, targetStateId: 'CA' }),
+      makePlay({ cardType: 'ZONE', cost: 2, targetStateId: 'CA' }),
+    ];
+    const state = createState(plays);
+
+    const evaluation = evaluateCombos(state, 'P1', enableOnly(['state_double_down']));
+
+    expect(evaluation.results).toHaveLength(1);
+    expect(evaluation.results[0].definition.id).toBe('state_double_down');
+    expect(evaluation.results[0].details.matchedPlays).toHaveLength(2);
+    expect(evaluation.results[0].details.extra).toEqual({ state: 'CA' });
+  });
+
+  it('measures threshold metrics such as total IP spent', () => {
+    const plays: TurnPlay[] = [
+      makePlay({ cardType: 'ATTACK', cost: 5 }),
+      makePlay({ cardType: 'MEDIA', cost: 4 }),
+      makePlay({ cardType: 'ZONE', cost: 3, targetStateId: 'NY' }),
+    ];
+    const state = createState(plays);
+
+    const evaluation = evaluateCombos(state, 'P1', enableOnly(['threshold_total_spend_12']));
+
+    expect(evaluation.results).toHaveLength(1);
+    expect(evaluation.results[0].definition.id).toBe('threshold_total_spend_12');
+    expect(evaluation.results[0].details.extra).toEqual({ value: 12 });
+    expect(evaluation.totalReward.ip).toBe(4);
+  });
+
+  it('respects priority and caps rewards when max combos per turn is limited', () => {
+    const plays: TurnPlay[] = [
+      makePlay({ cardType: 'ATTACK', cost: 4 }),
+      makePlay({ cardType: 'ATTACK', cost: 4 }),
+      makePlay({ cardType: 'ATTACK', cost: 4 }),
+    ];
+    const state = createState(plays, {}, { P1: { ip: 10 } });
+
+    const evaluation = evaluateCombos(
+      state,
+      'P1',
+      enableOnly(['sequence_attack_blitz', 'count_attack_barrage'], { maxCombosPerTurn: 1 }),
+    );
+
+    expect(evaluation.results).toHaveLength(1);
+    expect(evaluation.results[0].definition.id).toBe('sequence_attack_blitz');
+    expect(evaluation.totalReward.ip).toBe(4);
+    expect(evaluation.logs).toEqual(['Attack Blitz (+4 IP)']);
+
+    const updated = applyComboRewards(state, 'P1', evaluation);
+    expect(updated.players.P1.ip).toBe(14);
+    expect(updated.log).toContain('+IP from attack blitz');
+  });
+
+  it('does not trigger state combos when zone plays lack targets', () => {
+    const plays: TurnPlay[] = [
+      makePlay({ cardType: 'ZONE', cost: 3 }),
+      makePlay({ cardType: 'ZONE', cost: 4 }),
+    ];
+    const state = createState(plays);
+
+    const evaluation = evaluateCombos(state, 'P1', enableOnly(['state_capital_strike', 'state_double_down']));
+
+    expect(evaluation.results).toHaveLength(0);
+    expect(evaluation.totalReward).toEqual({});
+  });
+});

--- a/src/game/comboEngine.ts
+++ b/src/game/comboEngine.ts
@@ -1,0 +1,527 @@
+import { clampIP } from '@/engine/applyEffects-mvp';
+import { applyTruthDelta } from '@/utils/truth';
+import type { GameState, PlayerId } from '@/mvp/validator';
+import { COMBO_DEFINITIONS, DEFAULT_COMBO_SETTINGS } from './combo.config';
+import {
+  type ComboDefinition,
+  type ComboEvaluation,
+  type ComboOptions,
+  type ComboResult,
+  type ComboSettings,
+  type ComboSummary,
+  type ComboTrigger,
+  type ComboReward,
+  type TurnPlay,
+} from './combo.types';
+
+interface ComboMetrics {
+  ipSpent: number;
+  attackSpent: number;
+  mediaSpent: number;
+  zoneSpent: number;
+  plays: number;
+  lowCostCount: number;
+  highCostCount: number;
+  uniqueStatesTargeted: number;
+  stateCounts: Map<string, number>;
+  lowCostPlays: TurnPlay[];
+  highCostPlays: TurnPlay[];
+  attackPlays: TurnPlay[];
+  mediaPlays: TurnPlay[];
+  zonePlays: TurnPlay[];
+  targetedPlays: TurnPlay[];
+}
+
+let comboSettings: ComboSettings = {
+  ...DEFAULT_COMBO_SETTINGS,
+  comboToggles: { ...DEFAULT_COMBO_SETTINGS.comboToggles },
+};
+
+let lastComboSummary: ComboSummary | null = null;
+
+function ensureToggleCoverage(settings: ComboSettings): ComboSettings {
+  const toggles = { ...settings.comboToggles };
+  for (const def of COMBO_DEFINITIONS) {
+    if (typeof toggles[def.id] === 'undefined') {
+      toggles[def.id] = def.enabledByDefault ?? true;
+    }
+  }
+  return { ...settings, comboToggles: toggles };
+}
+
+export function getComboSettings(): ComboSettings {
+  return ensureToggleCoverage(comboSettings);
+}
+
+export function setComboSettings(update: Partial<ComboSettings>): ComboSettings {
+  const base = ensureToggleCoverage(comboSettings);
+  const next: ComboSettings = {
+    ...base,
+    ...update,
+    comboToggles: { ...base.comboToggles },
+  };
+
+  if (update.comboToggles) {
+    for (const [key, value] of Object.entries(update.comboToggles)) {
+      next.comboToggles[key] = value;
+    }
+  }
+
+  next.maxCombosPerTurn = Number.isFinite(next.maxCombosPerTurn)
+    ? Math.max(0, Math.floor(next.maxCombosPerTurn))
+    : base.maxCombosPerTurn;
+
+  comboSettings = ensureToggleCoverage(next);
+  return comboSettings;
+}
+
+function resolveSettings(overrides?: ComboOptions): ComboSettings {
+  const base = ensureToggleCoverage(comboSettings);
+  if (!overrides) {
+    return base;
+  }
+
+  const merged: ComboSettings = {
+    ...base,
+    ...overrides,
+    comboToggles: { ...base.comboToggles },
+  } satisfies ComboSettings;
+
+  if (overrides.comboToggles) {
+    for (const [key, value] of Object.entries(overrides.comboToggles)) {
+      merged.comboToggles[key] = value;
+    }
+  }
+
+  if (overrides.disabledCombos) {
+    for (const id of overrides.disabledCombos) {
+      merged.comboToggles[id] = false;
+    }
+  }
+
+  if (overrides.maxCombosPerTurn !== undefined) {
+    merged.maxCombosPerTurn = Math.max(0, Math.floor(overrides.maxCombosPerTurn));
+  }
+
+  return ensureToggleCoverage(merged);
+}
+
+function computeMetrics(plays: TurnPlay[]): ComboMetrics {
+  const attackPlays = plays.filter(play => play.cardType === 'ATTACK');
+  const mediaPlays = plays.filter(play => play.cardType === 'MEDIA');
+  const zonePlays = plays.filter(play => play.cardType === 'ZONE');
+  const targetedPlays = zonePlays.filter(play => typeof play.targetStateId === 'string' && play.targetStateId.length > 0);
+
+  const stateCounts = new Map<string, number>();
+  for (const play of targetedPlays) {
+    const key = play.targetStateId!;
+    stateCounts.set(key, (stateCounts.get(key) ?? 0) + 1);
+  }
+
+  const lowCostPlays = plays.filter(play => play.cost <= 2);
+  const highCostPlays = plays.filter(play => play.cost >= 6);
+
+  return {
+    ipSpent: plays.reduce((acc, play) => acc + play.cost, 0),
+    attackSpent: attackPlays.reduce((acc, play) => acc + play.cost, 0),
+    mediaSpent: mediaPlays.reduce((acc, play) => acc + play.cost, 0),
+    zoneSpent: zonePlays.reduce((acc, play) => acc + play.cost, 0),
+    plays: plays.length,
+    lowCostCount: lowCostPlays.length,
+    highCostCount: highCostPlays.length,
+    uniqueStatesTargeted: new Set(targetedPlays.map(play => play.targetStateId)).size,
+    stateCounts,
+    lowCostPlays,
+    highCostPlays,
+    attackPlays,
+    mediaPlays,
+    zonePlays,
+    targetedPlays,
+  } satisfies ComboMetrics;
+}
+
+function matchesRarity(actual: string, required?: string | null): boolean {
+  if (!required || required === 'ANY') {
+    return true;
+  }
+
+  if (required === 'rare') {
+    return actual === 'rare' || actual === 'legendary';
+  }
+
+  return actual === required;
+}
+
+interface TriggerMatchResult {
+  success: boolean;
+  matchedPlays: TurnPlay[];
+  extra?: Record<string, number | string>;
+}
+
+function mergeMatchResults(results: TriggerMatchResult[]): TriggerMatchResult {
+  const matched = new Map<number, TurnPlay>();
+  for (const result of results) {
+    for (const play of result.matchedPlays) {
+      matched.set(play.sequence, play);
+    }
+  }
+  const extra: Record<string, number | string> = {};
+  for (const result of results) {
+    if (result.extra) {
+      Object.assign(extra, result.extra);
+    }
+  }
+  return {
+    success: true,
+    matchedPlays: Array.from(matched.values()).sort((a, b) => a.sequence - b.sequence),
+    extra: Object.keys(extra).length > 0 ? extra : undefined,
+  };
+}
+
+function matchSequence(
+  trigger: Extract<ComboTrigger, { kind: 'sequence' }>,
+  plays: TurnPlay[],
+): TriggerMatchResult {
+  const { sequence, allowGaps } = trigger;
+  if (sequence.length === 0) {
+    return { success: true, matchedPlays: [] };
+  }
+
+  if (allowGaps) {
+    const matched: TurnPlay[] = [];
+    let index = 0;
+    for (const play of plays) {
+      if (play.cardType === sequence[index]) {
+        matched.push(play);
+        index += 1;
+        if (index >= sequence.length) {
+          return { success: true, matchedPlays: matched };
+        }
+      }
+    }
+    return { success: false, matchedPlays: [] };
+  }
+
+  for (let i = 0; i <= plays.length - sequence.length; i++) {
+    const window = plays.slice(i, i + sequence.length);
+    if (window.every((play, idx) => play.cardType === sequence[idx])) {
+      return { success: true, matchedPlays: window };
+    }
+  }
+
+  return { success: false, matchedPlays: [] };
+}
+
+function matchCount(
+  trigger: Extract<ComboTrigger, { kind: 'count' }>,
+  plays: TurnPlay[],
+): TriggerMatchResult {
+  const filtered = plays.filter(play => (trigger.type === 'ANY' || play.cardType === trigger.type) && matchesRarity(play.cardRarity, trigger.rarity));
+  const count = filtered.length;
+  const operator = trigger.operator ?? '>=';
+  let success = false;
+  if (operator === '>=' && count >= trigger.count) {
+    success = true;
+  } else if (operator === '<=' && count <= trigger.count) {
+    success = true;
+  } else if (operator === '==' && count === trigger.count) {
+    success = true;
+  }
+
+  return {
+    success,
+    matchedPlays: success ? filtered.slice(0, trigger.count) : [],
+    extra: success ? { count } : undefined,
+  };
+}
+
+function matchThreshold(
+  trigger: Extract<ComboTrigger, { kind: 'threshold' }>,
+  metrics: ComboMetrics,
+): TriggerMatchResult {
+  let success = false;
+  let matched: TurnPlay[] = [];
+  let actual = 0;
+
+  switch (trigger.metric) {
+    case 'ipSpent':
+      actual = metrics.ipSpent;
+      matched = metrics.attackPlays.concat(metrics.mediaPlays, metrics.zonePlays);
+      success = actual >= trigger.value;
+      break;
+    case 'attackSpent':
+      actual = metrics.attackSpent;
+      matched = metrics.attackPlays;
+      success = actual >= trigger.value;
+      break;
+    case 'mediaSpent':
+      actual = metrics.mediaSpent;
+      matched = metrics.mediaPlays;
+      success = actual >= trigger.value;
+      break;
+    case 'zoneSpent':
+      actual = metrics.zoneSpent;
+      matched = metrics.zonePlays;
+      success = actual >= trigger.value;
+      break;
+    case 'uniqueStatesTargeted':
+      actual = metrics.uniqueStatesTargeted;
+      matched = metrics.targetedPlays;
+      success = actual >= trigger.value;
+      break;
+    case 'plays':
+      actual = metrics.plays;
+      matched = metrics.attackPlays.concat(metrics.mediaPlays, metrics.zonePlays);
+      success = actual >= trigger.value;
+      break;
+    case 'lowCostCount':
+      actual = metrics.lowCostCount;
+      matched = metrics.lowCostPlays;
+      success = actual >= trigger.value;
+      break;
+    case 'highCostCount':
+      actual = metrics.highCostCount;
+      matched = metrics.highCostPlays;
+      success = actual >= trigger.value;
+      break;
+  }
+
+  return {
+    success,
+    matchedPlays: success ? matched : [],
+    extra: success ? { value: actual } : undefined,
+  };
+}
+
+function matchState(
+  trigger: Extract<ComboTrigger, { kind: 'state' }>,
+  metrics: ComboMetrics,
+): TriggerMatchResult {
+  const { cardType, targetList, sameStateCount, uniqueStatesCount } = trigger;
+
+  let candidates = metrics.targetedPlays;
+  if (cardType && cardType !== 'ANY') {
+    candidates = candidates.filter(play => play.cardType === cardType);
+  }
+
+  if (targetList && targetList.length > 0) {
+    const set = new Set(targetList);
+    candidates = candidates.filter(play => play.targetStateId && set.has(play.targetStateId));
+  }
+
+  const counts = new Map<string, number>();
+  for (const play of candidates) {
+    const key = play.targetStateId!;
+    counts.set(key, (counts.get(key) ?? 0) + 1);
+  }
+
+  if (sameStateCount && sameStateCount > 0) {
+    for (const [state, value] of counts.entries()) {
+      if (value >= sameStateCount) {
+        const matched = candidates.filter(play => play.targetStateId === state).slice(0, sameStateCount);
+        return {
+          success: true,
+          matchedPlays: matched,
+          extra: { state },
+        };
+      }
+    }
+    return { success: false, matchedPlays: [] };
+  }
+
+  if (uniqueStatesCount && uniqueStatesCount > 0) {
+    const unique = new Set(candidates.map(play => play.targetStateId));
+    if (unique.size >= uniqueStatesCount) {
+      const matched: TurnPlay[] = [];
+      const taken = new Set<string>();
+      for (const play of candidates) {
+        if (!play.targetStateId) continue;
+        if (taken.has(play.targetStateId)) continue;
+        matched.push(play);
+        taken.add(play.targetStateId);
+        if (taken.size >= uniqueStatesCount) {
+          break;
+        }
+      }
+      return {
+        success: true,
+        matchedPlays: matched,
+        extra: { unique: unique.size },
+      };
+    }
+    return { success: false, matchedPlays: [] };
+  }
+
+  return { success: candidates.length > 0, matchedPlays: candidates };
+}
+
+function evaluateTrigger(
+  trigger: ComboTrigger,
+  plays: TurnPlay[],
+  metrics: ComboMetrics,
+): TriggerMatchResult {
+  switch (trigger.kind) {
+    case 'sequence':
+      return matchSequence(trigger, plays);
+    case 'count':
+      return matchCount(trigger, plays);
+    case 'threshold':
+      return matchThreshold(trigger, metrics);
+    case 'state':
+      return matchState(trigger, metrics);
+    case 'hybrid': {
+      const { triggers, mode = 'all' } = trigger;
+      const results: TriggerMatchResult[] = [];
+      let anySuccess = false;
+      for (const inner of triggers) {
+        const res = evaluateTrigger(inner, plays, metrics);
+        results.push(res);
+        if (res.success) {
+          anySuccess = true;
+        } else if (mode === 'all') {
+          return { success: false, matchedPlays: [] };
+        }
+      }
+
+      if (mode === 'any') {
+        const winners = results.filter(result => result.success);
+        if (winners.length === 0) {
+          return { success: false, matchedPlays: [] };
+        }
+        return mergeMatchResults(winners);
+      }
+
+      if (!anySuccess) {
+        return { success: false, matchedPlays: [] };
+      }
+
+      return mergeMatchResults(results.filter(result => result.success));
+    }
+    default:
+      return { success: false, matchedPlays: [] };
+  }
+}
+
+function formatReward(reward: ComboReward): string {
+  const parts: string[] = [];
+  if (reward.ip && reward.ip !== 0) {
+    parts.push(`${reward.ip > 0 ? '+' : ''}${reward.ip} IP`);
+  }
+  if (reward.truth && reward.truth !== 0) {
+    parts.push(`${reward.truth > 0 ? '+' : ''}${reward.truth} Truth`);
+  }
+  return parts.length > 0 ? `(${parts.join(', ')})` : '';
+}
+
+function clampReward(def: ComboDefinition, reward: ComboReward): ComboReward {
+  if (!def.cap) {
+    return { ...reward };
+  }
+
+  const capped: ComboReward = { ...reward };
+  if (typeof reward.ip === 'number' && reward.ip > 0) {
+    capped.ip = Math.min(reward.ip, def.cap);
+  }
+  if (typeof reward.truth === 'number' && reward.truth > 0) {
+    capped.truth = Math.min(reward.truth, def.cap);
+  }
+  return capped;
+}
+
+export function evaluateCombos(
+  state: GameState,
+  player: PlayerId,
+  options?: ComboOptions,
+): ComboEvaluation {
+  const settings = resolveSettings(options);
+  const plays = state.turnPlays
+    .filter(play => play.stage === 'resolve' && play.owner === player)
+    .sort((a, b) => a.sequence - b.sequence);
+
+  if (!settings.enabled || plays.length === 0) {
+    const empty: ComboEvaluation = { results: [], totalReward: {}, logs: [] };
+    lastComboSummary = { ...empty, player, turn: state.turn };
+    return empty;
+  }
+
+  const metrics = computeMetrics(plays);
+  const sortedDefs = [...COMBO_DEFINITIONS].sort((a, b) => b.priority - a.priority);
+  const results: ComboResult[] = [];
+  const logs: string[] = [];
+  const totalReward: ComboReward = {};
+
+  for (const def of sortedDefs) {
+    if (!settings.comboToggles[def.id]) {
+      continue;
+    }
+    if (results.length >= settings.maxCombosPerTurn) {
+      break;
+    }
+
+    const match = evaluateTrigger(def.trigger, plays, metrics);
+    if (!match.success) {
+      continue;
+    }
+
+    const applied = clampReward(def, def.reward);
+    if (typeof applied.ip === 'number') {
+      totalReward.ip = (totalReward.ip ?? 0) + applied.ip;
+    }
+    if (typeof applied.truth === 'number') {
+      totalReward.truth = (totalReward.truth ?? 0) + applied.truth;
+    }
+
+    results.push({
+      definition: def,
+      reward: def.reward,
+      appliedReward: applied,
+      details: { matchedPlays: match.matchedPlays, extra: match.extra },
+    });
+
+    const text = formatReward(applied);
+    logs.push(text ? `${def.name} ${text}` : def.name);
+  }
+
+  const summary: ComboEvaluation = { results, totalReward, logs };
+  lastComboSummary = { ...summary, player, turn: state.turn };
+  return summary;
+}
+
+export function applyComboRewards(
+  state: GameState,
+  player: PlayerId,
+  evaluation: ComboEvaluation,
+): GameState {
+  if (evaluation.results.length === 0) {
+    return state;
+  }
+
+  const updated = state;
+  if (evaluation.totalReward.ip && evaluation.totalReward.ip !== 0) {
+    const playerState = updated.players[player];
+    updated.players[player] = {
+      ...playerState,
+      ip: clampIP(playerState.ip + evaluation.totalReward.ip),
+    };
+  }
+
+  if (evaluation.totalReward.truth && evaluation.totalReward.truth !== 0) {
+    applyTruthDelta(updated, evaluation.totalReward.truth, player);
+  }
+
+  for (const result of evaluation.results) {
+    if (result.reward.log) {
+      updated.log.push(result.reward.log);
+    }
+  }
+
+  return updated;
+}
+
+export function getLastComboSummary(): ComboSummary | null {
+  return lastComboSummary;
+}
+
+export function formatComboReward(reward: ComboReward): string {
+  return formatReward(reward);
+}

--- a/src/game/hooks/useRules.ts
+++ b/src/game/hooks/useRules.ts
@@ -7,6 +7,8 @@ import {
   startTurn as startTurnMvp,
   winCheck as winCheckMvp,
   type Card,
+  type EndTurnOptions,
+  type EndTurnResult,
 } from '@/mvp';
 import type { UIGameState } from '@/state/gameState';
 
@@ -15,7 +17,7 @@ type RulesAdapter = {
   canPlay: (state: UIGameState, card: Card, targetStateId?: string) => { ok: boolean; reason?: string };
   playCard: (state: UIGameState, cardId: string, targetStateId?: string) => UIGameState;
   resolve: (state: UIGameState, owner: 'P1' | 'P2', card: Card, targetStateId?: string) => UIGameState;
-  endTurn: (state: UIGameState, discards: string[]) => UIGameState;
+  endTurn: (state: UIGameState, discards: string[], options?: EndTurnOptions) => EndTurnResult;
   winCheck: (state: UIGameState) => ReturnType<typeof winCheckMvp>;
 };
 
@@ -24,7 +26,7 @@ const MVP_RULES: RulesAdapter = {
   canPlay: (state, card, targetStateId) => canPlayMvp(state, card, targetStateId),
   playCard: (state, cardId, targetStateId) => playCardMvp(state, cardId, targetStateId),
   resolve: (state, owner, card, targetStateId) => resolveMvp(state, owner, card, targetStateId),
-  endTurn: (state, discards) => endTurnMvp(state, discards),
+  endTurn: (state, discards, options) => endTurnMvp(state, discards, options),
   winCheck: state => winCheckMvp(state),
 };
 

--- a/src/mvp/validator.ts
+++ b/src/mvp/validator.ts
@@ -1,4 +1,5 @@
 import type { Faction, GameCard, MVPCardType, Rarity } from '@/rules/mvp';
+import type { TurnPlay } from '@/game/combo.types';
 import { expectedCost, MVP_CARD_TYPES } from '@/rules/mvp';
 
 export type EffectsATTACK = {
@@ -42,6 +43,7 @@ export type GameState = {
   pressureByState: Record<string, { P1: number; P2: number }>;
   stateDefense: Record<string, number>;
   playsThisTurn: number;
+  turnPlays: TurnPlay[];
   log: string[];
 };
 
@@ -469,6 +471,10 @@ export function cloneGameState(state: GameState): GameState {
   return {
     ...state,
     log: [...state.log],
+    turnPlays: state.turnPlays.map(play => ({
+      ...play,
+      metadata: play.metadata ? { ...play.metadata } : undefined,
+    })),
     players: {
       P1: clonePlayer(state.players.P1),
       P2: clonePlayer(state.players.P2),

--- a/src/systems/cardResolution.ts
+++ b/src/systems/cardResolution.ts
@@ -164,6 +164,7 @@ const toEngineState = (
     pressureByState,
     stateDefense,
     playsThisTurn: 0,
+    turnPlays: [],
     log,
   };
 };

--- a/src/systems/turns/takeAiTurn.ts
+++ b/src/systems/turns/takeAiTurn.ts
@@ -20,7 +20,7 @@ function applyAction(state: GameState, action: Action): GameState {
     return playCard(state, action.cardId, action.targetStateId);
   }
   if (action.type === 'end-turn') {
-    return endTurn(state, action.discards ?? []);
+    return endTurn(state, action.discards ?? []).state;
   }
   return state;
 }

--- a/src/test/effectSystemValidation.ts
+++ b/src/test/effectSystemValidation.ts
@@ -29,6 +29,7 @@ export function validateFixedEffectSystem() {
       currentPlayer: 'P1',
       truth: 50,
       playsThisTurn: 0,
+      turnPlays: [],
       log,
       players: {
         P1: {

--- a/src/ui/UiOverlays.tsx
+++ b/src/ui/UiOverlays.tsx
@@ -11,7 +11,7 @@ type AnyCard = {
   effects?: any;
 };
 
-type Toast = { id: number; text: string; slot: "truth" | "ip-left" | "ip-right" };
+type Toast = { id: number; text: string; slot: "truth" | "ip-left" | "ip-right" | "combo" };
 
 declare global {
   interface Window {
@@ -19,6 +19,7 @@ declare global {
     uiToastTruth?: (delta: number) => void;
     uiToastIp?: (playerId: "P1" | "P2", delta: number) => void;
     uiFlashState?: (stateId: string, by: "P1" | "P2") => void; // placeholder for future prompts
+    uiComboToast?: (message: string) => void;
   }
 }
 
@@ -60,6 +61,12 @@ export default function UiOverlays() {
       window.setTimeout(() => setToasts((t) => t.filter((x) => x.id !== id)), 900);
     };
 
+    window.uiComboToast = (message: string) => {
+      const id = Date.now() + Math.random();
+      setToasts((t) => [...t, { id, text: message, slot: "combo" }]);
+      window.setTimeout(() => setToasts((t) => t.filter((x) => x.id !== id)), 1400);
+    };
+
     window.uiFlashState = (stateId: string, by: "P1" | "P2") => {
       const el =
         document.querySelector(`[data-state-id="${stateId}"]`) ||
@@ -83,6 +90,7 @@ export default function UiOverlays() {
       delete window.uiToastTruth;
       delete window.uiToastIp;
       delete window.uiFlashState;
+      delete window.uiComboToast;
     };
   }, []);
 
@@ -148,6 +156,16 @@ export default function UiOverlays() {
           .filter((t) => t.slot === "ip-right")
           .map((t) => (
             <div key={t.id} className="px-3 py-1 bg-black text-white text-sm shadow">
+              {t.text}
+            </div>
+          ))}
+      </div>
+      {/* Combo notifications */}
+      <div className="fixed bottom-10 left-1/2 -translate-x-1/2 z-[998] space-y-2">
+        {toasts
+          .filter((t) => t.slot === "combo")
+          .map((t) => (
+            <div key={t.id} className="px-4 py-2 bg-black text-yellow-300 text-sm shadow-lg">
               {t.text}
             </div>
           ))}


### PR DESCRIPTION
## Summary
- introduce combo engine types, configuration, runtime evaluation helpers, and expose per-turn summaries from the MVP engine
- surface combo information and settings throughout the MVP UI, including options, how-to-play docs, and newspaper overlays with FX toasts
- add dedicated combo engine unit tests covering sequence/count/state/threshold/cap scenarios and no-target handling

## Testing
- bun test
- bun run lint *(fails: missing @eslint/js / dependency install blocked by 403 responses when running `bun install`)*

------
https://chatgpt.com/codex/tasks/task_e_68cc5d321fc08320b1ead1211f9bd076