### PR TITLE
Use neutral truth formatting in combo rewards

### DIFF
--- a/src/game/comboEngine.ts
+++ b/src/game/comboEngine.ts
@@ -414,11 +414,14 @@ function evaluateTrigger(
 
 function formatReward(reward: ComboReward): string {
   const parts: string[] = [];
-  if (reward.ip && reward.ip !== 0) {
-    parts.push(`${reward.ip > 0 ? '+' : ''}${reward.ip} IP`);
+  const ip = reward.ip;
+  if (typeof ip === 'number' && ip !== 0) {
+    parts.push(`${ip > 0 ? '+' : ''}${ip} IP`);
   }
-  if (reward.truth && reward.truth !== 0) {
-    parts.push(`${reward.truth > 0 ? '+' : ''}${reward.truth} Truth`);
+
+  const truth = reward.truth;
+  if (typeof truth === 'number' && truth !== 0) {
+    parts.push(`${truth > 0 ? `±${truth}` : truth} Truth`);
   }
   return parts.length > 0 ? `(${parts.join(', ')})` : '';
 }


### PR DESCRIPTION
## Summary
- update combo reward formatting so Truth payouts show a neutral ± prefix instead of forcing a positive sign

## Testing
- npm run lint *(fails: missing @eslint/js dependency)*

------
https://chatgpt.com/codex/tasks/task_e_68cc756adbe8832093389bba2db9d9df