### PR TITLE
Adjust truth combo rewards by faction

### DIFF
--- a/src/game/comboEngine.ts
+++ b/src/game/comboEngine.ts
@@ -519,8 +519,12 @@ export function applyComboRewards(
     };
   }
 
-  if (evaluation.totalReward.truth && evaluation.totalReward.truth !== 0) {
-    applyTruthDelta(updated, evaluation.totalReward.truth, player);
+  const truthMagnitude = Math.abs(evaluation.totalReward.truth ?? 0);
+  if (truthMagnitude !== 0) {
+    const playerState = updated.players[player];
+    const faction = playerState?.faction ?? 'truth';
+    const signedTruthDelta = faction === 'truth' ? truthMagnitude : -truthMagnitude;
+    applyTruthDelta(updated, signedTruthDelta, player);
   }
 
   for (const result of evaluation.results) {


### PR DESCRIPTION
## Summary
- treat combo truth rewards as faction-signed deltas when applying them while keeping existing IP handling intact
- extend combo engine tests to allow specifying play owners and cover government truth combo behavior

## Testing
- bun test src/game/comboEngine.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68cc7927f9788320b7942af69ea03e80