### PR TITLE
Enhance AI deception tracking and adaptive logging

### DIFF
--- a/src/hooks/useGameState.ts
+++ b/src/hooks/useGameState.ts
@@ -651,6 +651,11 @@ export const useGameState = (aiDifficultyOverride?: AIDifficulty) => {
           if (threatResponse) {
             strategyDetails.push('Countering recent player action.');
           }
+
+          const adaptiveSummary = freshState.aiStrategist.getAdaptiveSummary();
+          if (adaptiveSummary.length) {
+            strategyDetails.push(...adaptiveSummary);
+          }
         }
       } else {
         bestPlay = freshState.aiStrategist.selectBestPlay(strategistView);
@@ -705,6 +710,15 @@ export const useGameState = (aiDifficultyOverride?: AIDifficulty) => {
 
       if (strategyDetails?.length) {
         logEntries.push(...strategyDetails);
+      }
+
+      if (prev.aiStrategist instanceof EnhancedAIStrategist) {
+        prev.aiStrategist.recordAiPlayOutcome({
+          card,
+          targetState,
+          resolution,
+          previousState: prev,
+        });
       }
 
       const playedCardRecord = createPlayedCardRecord({


### PR DESCRIPTION
## Summary
- add adaptive history tracking for AI deception targets, bluff outcomes, and threat trends to influence play selection
- expose aggregated deception and threat insights via the strategist so logs and heuristics can react to long-term patterns
- record resolved AI card outcomes and surface adaptive summaries in the turn log for verification

## Testing
- npm run lint *(fails: Cannot find package '@eslint/js' imported from eslint.config.js)*
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68ccc9ac676c83208b8ac8ae5e7d234b