### PR TITLE
Add feature flag for concise AI strategy logging

### DIFF
--- a/src/state/featureFlags.ts
+++ b/src/state/featureFlags.ts
@@ -1,9 +1,11 @@
 export type FeatureFlags = {
   newspaperV2: boolean;
+  aiVerboseStrategyLog: boolean;
 };
 
 const DEFAULT_FLAGS: FeatureFlags = {
   newspaperV2: true,
+  aiVerboseStrategyLog: false,
 };
 
 const readBoolean = (key: string, fallback: boolean): boolean => {
@@ -35,4 +37,6 @@ const overrides: Partial<FeatureFlags> =
 
 export const featureFlags: FeatureFlags = {
   newspaperV2: overrides.newspaperV2 ?? readBoolean('shadowgov:flag:newspaperV2', DEFAULT_FLAGS.newspaperV2),
+  aiVerboseStrategyLog:
+    overrides.aiVerboseStrategyLog ?? readBoolean('shadowgov:flag:aiVerboseStrategyLog', DEFAULT_FLAGS.aiVerboseStrategyLog),
 };


### PR DESCRIPTION
## Summary
- add an `aiVerboseStrategyLog` feature flag that can be toggled via local storage or window overrides
- condense AI strategy log entries when the verbose flag is disabled while still allowing debug console output
- keep verbose behaviour intact when the flag is enabled

## Testing
- npm run lint *(fails: Cannot find package '@eslint/js' before dependencies can be installed due to 403 when fetching ts-node)*

------
https://chatgpt.com/codex/tasks/task_e_68ccd7d7e6e48320b28f2ec085fff57c