### PR TITLE
Adjust AI to skip unaffordable plays

### DIFF
--- a/src/data/__tests__/aiAffordability.test.ts
+++ b/src/data/__tests__/aiAffordability.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from 'bun:test';
+import { AIStrategist, type CardPlay } from '@/data/aiStrategy';
+import { EnhancedAIStrategist } from '@/data/enhancedAIStrategy';
+import type { GameCard } from '@/rules/mvp';
+
+class TestStrategist extends AIStrategist {
+  protected override generateCardPlays(card: GameCard): CardPlay[] {
+    const priority = card.id === 'expensive-card' ? 1 : 0.6;
+    return [{ cardId: card.id, priority, reasoning: 'test priority' }];
+  }
+}
+
+class TestEnhancedStrategist extends EnhancedAIStrategist {
+  protected override generateCardPlays(card: GameCard): CardPlay[] {
+    const priority = card.id === 'expensive-card' ? 1 : 0.6;
+    return [{ cardId: card.id, priority, reasoning: 'test priority' }];
+  }
+}
+
+describe('AI affordability heuristics', () => {
+  const expensiveCard: GameCard = {
+    id: 'expensive-card',
+    name: 'Expensive Card',
+    type: 'ATTACK',
+    faction: 'truth',
+    cost: 5,
+  };
+
+  const cheapCard: GameCard = {
+    id: 'cheap-card',
+    name: 'Cheap Card',
+    type: 'ATTACK',
+    faction: 'truth',
+    cost: 2,
+  };
+
+  const createGameState = () => ({
+    aiIP: 3,
+    ip: 0,
+    truth: 50,
+    faction: 'government' as const,
+    hand: [expensiveCard, cheapCard],
+    aiHand: [expensiveCard, cheapCard],
+    states: [],
+    cardsPlayedThisRound: [],
+    turn: 1,
+    round: 1,
+  });
+
+  it('prefers an affordable card in the basic strategist', () => {
+    const strategist = new TestStrategist('medium');
+    const play = strategist.selectBestPlay(createGameState());
+
+    expect(play?.cardId).toBe('cheap-card');
+  });
+
+  it('prefers an affordable card in the enhanced strategist', () => {
+    const strategist = new TestEnhancedStrategist('easy');
+    const originalRandom = Math.random;
+    Math.random = () => 0;
+
+    try {
+      const play = strategist.selectOptimalPlay(createGameState());
+      expect(play?.cardId).toBe('cheap-card');
+    } finally {
+      Math.random = originalRandom;
+    }
+  });
+});

--- a/src/data/aiStrategy.ts
+++ b/src/data/aiStrategy.ts
@@ -518,9 +518,19 @@ export class AIStrategist {
 
     const evaluation = this.evaluateGameState(gameState);
     const possiblePlays: CardPlay[] = [];
+    const availableIp = typeof gameState.aiIP === 'number' ? gameState.aiIP : 0;
 
     // Evaluate each card in hand
     for (const card of gameState.hand) {
+      const cardCost =
+        typeof card.cost === 'number'
+          ? card.cost
+          : this.getCardMetadata(card.id)?.cost ?? 0;
+
+      if (cardCost > availableIp) {
+        continue;
+      }
+
       const plays = this.generateCardPlays(card, gameState, evaluation);
       possiblePlays.push(...plays);
     }

--- a/src/data/enhancedAIStrategy.ts
+++ b/src/data/enhancedAIStrategy.ts
@@ -870,12 +870,22 @@ export class EnhancedAIStrategist extends AIStrategist {
   private generateAllPossiblePlays(gameState: any): CardPlay[] {
     const plays: CardPlay[] = [];
     const evaluation = this.evaluateGameState(gameState);
-    
+    const availableIp = typeof gameState.aiIP === 'number' ? gameState.aiIP : 0;
+
     for (const card of gameState.hand || []) {
+      const cardCost =
+        typeof card.cost === 'number'
+          ? card.cost
+          : this.getCardMetadata(card.id)?.cost ?? 0;
+
+      if (cardCost > availableIp) {
+        continue;
+      }
+
       const cardPlays = this.generateCardPlays(card, gameState, evaluation);
       plays.push(...cardPlays);
     }
-    
+
     return plays;
   }
 


### PR DESCRIPTION
## Summary
- skip generating card plays the AI cannot currently afford in both the base and enhanced strategists
- allow the AI turn executor to immediately try alternative cards when the top choice is unaffordable while preserving enhanced strategy details
- add an affordability regression test to ensure the AI selects a cheaper card when high-priority options exceed its IP

## Testing
- bun test

------
https://chatgpt.com/codex/tasks/task_e_68ccd91317ac8320bb51579a1b11db02