### PR TITLE
refactor(ai): re-export enhanced planner

### DIFF
--- a/src/ai/enhancedController.ts
+++ b/src/ai/enhancedController.ts
@@ -26,7 +26,7 @@ interface TurnSequencePlan {
   evaluationScore: number;
 }
 
-interface ChooseTurnActionsParams {
+export interface ChooseTurnActionsParams {
   strategist: EnhancedAIStrategist;
   gameState: AIPlanningState;
   maxActions?: number;

--- a/src/ai/index.ts
+++ b/src/ai/index.ts
@@ -1,2 +1,8 @@
-export { chooseTurnActions, evaluate } from "./policy";
+export {
+  chooseTurnActions,
+  type ChooseTurnActionsParams,
+  type PlannedCardAction,
+  type TurnSequencePlan,
+} from "./enhancedController";
+export { evaluate } from "./policy";
 export { AI_PRESETS, type Difficulty, type AiConfig } from "./difficulty";

--- a/src/ai/policy.ts
+++ b/src/ai/policy.ts
@@ -212,7 +212,10 @@ function biasedSort(s: GameState, cfg: AiConfig) {
   };
 }
 
-export function chooseTurnActions(state: GameState, level: Difficulty): Action[] {
+/**
+ * @deprecated Use chooseTurnActions from enhancedController instead.
+ */
+export function legacyChooseTurnActions(state: GameState, level: Difficulty): Action[] {
   const cfg = AI_PRESETS[level];
   // Try a direct goal burst first (Truth ≥90 for truth / ≤10 for government)
   const legalNow = legalActionsFor(state);


### PR DESCRIPTION
## Summary
- re-export the enhanced controller turn planner and types through the AI entrypoint
- expose ChooseTurnActionsParams for callers that need the typed signature
- rename the legacy policy export to discourage new usage of the deprecated planner

## Testing
- bun test src/ai

------
https://chatgpt.com/codex/tasks/task_e_68ccebb49e088320a1e80cb1307263cb