### PR TITLE
Fix AI card resolution to use fresh hand state

### DIFF
--- a/src/hooks/__tests__/useGameState.aiTurn.test.ts
+++ b/src/hooks/__tests__/useGameState.aiTurn.test.ts
@@ -1,0 +1,135 @@
+import { describe, expect, it } from 'bun:test';
+
+import type { GameCard } from '@/rules/mvp';
+import { applyAiCardPlay, type AiCardPlayParams } from '@/hooks/aiHelpers';
+import type { GameState } from '@/hooks/gameStateTypes';
+import type { AchievementTracker } from '@/systems/cardResolution';
+
+const achievementsStub: AchievementTracker = {
+  stats: {
+    total_states_controlled: 0,
+    max_states_controlled_single_game: 0,
+    max_ip_reached: 0,
+    max_truth_reached: 0,
+    min_truth_reached: 100,
+  },
+  updateStats: () => {
+    /* no-op for tests */
+  },
+};
+
+const createBaseState = (overrides: Partial<GameState> = {}): GameState => ({
+  faction: 'truth',
+  phase: 'ai_turn',
+  turn: 3,
+  round: 1,
+  currentPlayer: 'ai',
+  aiDifficulty: 'medium',
+  aiPersonality: undefined,
+  truth: 50,
+  ip: 12,
+  aiIP: 10,
+  hand: [],
+  aiHand: [],
+  isGameOver: false,
+  deck: [],
+  aiDeck: [],
+  cardsPlayedThisTurn: 0,
+  cardsPlayedThisRound: [],
+  controlledStates: [],
+  aiControlledStates: [],
+  states: [
+    {
+      id: 'CA',
+      name: 'California',
+      abbreviation: 'CA',
+      baseIP: 6,
+      defense: 4,
+      pressure: 0,
+      owner: 'player',
+    },
+    {
+      id: 'NV',
+      name: 'Nevada',
+      abbreviation: 'NV',
+      baseIP: 3,
+      defense: 3,
+      pressure: 0,
+      owner: 'neutral',
+    },
+  ],
+  currentEvents: [],
+  eventManager: undefined,
+  showNewspaper: false,
+  log: [],
+  agenda: undefined,
+  secretAgenda: undefined,
+  aiSecretAgenda: undefined,
+  animating: false,
+  aiTurnInProgress: true,
+  selectedCard: null,
+  targetState: null,
+  aiStrategist: undefined,
+  pendingCardDraw: 0,
+  newCards: [],
+  showNewCardsPresentation: false,
+  drawMode: 'standard',
+  cardDrawState: { cardsPlayedLastTurn: 0, lastTurnWithoutPlay: false },
+  ...overrides,
+});
+
+describe('applyAiCardPlay', () => {
+  it('executes a planned card that was drawn during the income step', () => {
+    const drawnCard: GameCard = {
+      id: 'ai-income-card',
+      name: 'Crisis Broadcast',
+      type: 'MEDIA',
+      faction: 'government',
+      rarity: 'common',
+      cost: 2,
+      effects: { truthDelta: -6 },
+    };
+
+    const initialState = createBaseState({
+      aiHand: [drawnCard],
+      log: ['AI income step completed.'],
+    });
+
+    const plan: AiCardPlayParams = {
+      cardId: drawnCard.id,
+      card: drawnCard,
+      targetState: 'CA',
+      reasoning: 'Exploit freshly drawn propaganda piece.',
+      strategyDetails: ['AI Synergy Bonus: Momentum from new draws'],
+    };
+
+    const result = applyAiCardPlay(initialState, plan, achievementsStub);
+
+    expect(result.failed).toBeUndefined();
+    expect(result.card).toBe(drawnCard);
+    expect(result.nextState.aiHand).toHaveLength(0);
+    expect(result.nextState.cardsPlayedThisRound).toHaveLength(1);
+    expect(result.nextState.cardsPlayedThisRound[0].card.id).toBe(drawnCard.id);
+    expect(result.nextState.log.length).toBeGreaterThan(initialState.log.length);
+    expect(result.nextState.log.some(entry => entry.includes(drawnCard.name))).toBe(true);
+    expect(result.nextState.log.some(entry => entry.includes('AI focus'))).toBe(true);
+  });
+
+  it('logs a failure without strategy metadata when the planned card is missing', () => {
+    const initialState = createBaseState();
+
+    const plan: AiCardPlayParams = {
+      cardId: 'missing-card',
+      reasoning: 'Should not appear if the card vanished.',
+      strategyDetails: ['AI focus: would have played the missing card'],
+    };
+
+    const result = applyAiCardPlay(initialState, plan, achievementsStub);
+
+    expect(result.failed).toBe(true);
+    expect(result.nextState.aiHand).toEqual(initialState.aiHand);
+    expect(result.nextState.cardsPlayedThisRound).toEqual(initialState.cardsPlayedThisRound);
+    expect(result.nextState.log.some(entry => entry.includes('missing-card'))).toBe(true);
+    expect(result.nextState.log.some(entry => entry.includes('AI focus'))).toBe(false);
+  });
+});

--- a/src/hooks/aiHelpers.ts
+++ b/src/hooks/aiHelpers.ts
@@ -1,0 +1,144 @@
+import type { GameCard } from '@/rules/mvp';
+import { featureFlags } from '@/state/featureFlags';
+import { resolveCardMVP, type AchievementTracker, type CardPlayResolution } from '@/systems/cardResolution';
+
+import type { GameState } from './gameStateTypes';
+
+const CAPTURE_REGEX = /(captured|seized)\s+([^!]+)!/i;
+
+export const extractCapturedStates = (logEntries: string[]): string[] => {
+  const states: string[] = [];
+  for (const entry of logEntries) {
+    const match = entry.match(CAPTURE_REGEX);
+    if (match) {
+      states.push(match[2]);
+    }
+  }
+  return states;
+};
+
+export const createPlayedCardRecord = (params: {
+  card: GameCard;
+  player: 'human' | 'ai';
+  targetState?: string | null;
+  resolution: CardPlayResolution;
+  previousTruth: number;
+}) => ({
+  card: params.card,
+  player: params.player,
+  targetState: params.targetState ?? null,
+  truthDelta: params.resolution.truth - params.previousTruth,
+  capturedStates: extractCapturedStates(params.resolution.logEntries),
+});
+
+const summarizeStrategy = (reasoning?: string, strategyDetails?: string[]): string | undefined => {
+  const source = reasoning ?? strategyDetails?.[0];
+  if (!source) {
+    return undefined;
+  }
+
+  const cleaned = source.replace(/^AI Strategy:\s*/i, '').replace(/^AI Synergy Bonus:\s*/i, '').trim();
+  const normalized = cleaned.replace(/\s+/g, ' ');
+
+  if (!normalized.length) {
+    return 'AI executed a strategic play.';
+  }
+
+  const firstSentenceMatch = normalized.match(/^[^.?!]*(?:[.?!]|$)/);
+  const firstSentence = (firstSentenceMatch ? firstSentenceMatch[0] : normalized).trim();
+  if (!firstSentence.length) {
+    return 'AI executed a strategic play.';
+  }
+
+  return firstSentence.length > 100 ? `${firstSentence.slice(0, 97).trimEnd()}…` : firstSentence;
+};
+
+export const buildStrategyLogEntries = (reasoning?: string, strategyDetails?: string[]): string[] => {
+  if (featureFlags.aiVerboseStrategyLog) {
+    const verboseEntries: string[] = [];
+    if (reasoning) {
+      verboseEntries.push(`AI Strategy: ${reasoning}`);
+    }
+    if (strategyDetails?.length) {
+      verboseEntries.push(...strategyDetails);
+    }
+    return verboseEntries;
+  }
+
+  const summary = summarizeStrategy(reasoning, strategyDetails);
+  return summary ? [`AI focus: ${summary}`] : [];
+};
+
+export interface AiCardPlayParams {
+  cardId: string;
+  card?: GameCard;
+  targetState?: string;
+  reasoning?: string;
+  strategyDetails?: string[];
+}
+
+export interface AiCardPlayResult {
+  nextState: GameState;
+  card?: GameCard;
+  resolution?: CardPlayResolution;
+  failed?: boolean;
+}
+
+export const applyAiCardPlay = (
+  prev: GameState,
+  params: AiCardPlayParams,
+  achievements: AchievementTracker,
+): AiCardPlayResult => {
+  const { cardId, card: providedCard, targetState, reasoning, strategyDetails } = params;
+  const resolvedCard = prev.aiHand.find(handCard => handCard.id === (providedCard?.id ?? cardId));
+
+  if (!resolvedCard) {
+    const missingName = providedCard?.name ?? cardId;
+    return {
+      nextState: {
+        ...prev,
+        log: [
+          ...prev.log,
+          `AI attempted to execute planned card "${missingName}" but it was no longer available.`,
+        ],
+      },
+      failed: true,
+    };
+  }
+
+  const resolution = resolveCardMVP(prev, resolvedCard, targetState ?? null, 'ai', achievements);
+  const logEntries = [...prev.log, ...resolution.logEntries];
+  const strategyLogEntries = buildStrategyLogEntries(reasoning, strategyDetails);
+
+  if (strategyLogEntries.length) {
+    logEntries.push(...strategyLogEntries);
+  }
+
+  const playedCardRecord = createPlayedCardRecord({
+    card: resolvedCard,
+    player: 'ai',
+    targetState,
+    resolution,
+    previousTruth: prev.truth,
+  });
+
+  const nextState: GameState = {
+    ...prev,
+    ip: resolution.ip,
+    aiIP: resolution.aiIP,
+    truth: resolution.truth,
+    states: resolution.states,
+    controlledStates: resolution.controlledStates,
+    aiControlledStates: resolution.aiControlledStates,
+    targetState: resolution.targetState,
+    aiHand: prev.aiHand.filter(c => c.id !== resolvedCard.id),
+    cardsPlayedThisRound: [...prev.cardsPlayedThisRound, playedCardRecord],
+    log: logEntries,
+  };
+
+  return {
+    nextState,
+    card: resolvedCard,
+    resolution,
+  };
+};

--- a/src/hooks/gameStateTypes.ts
+++ b/src/hooks/gameStateTypes.ts
@@ -1,0 +1,79 @@
+import type { GameCard } from '@/rules/mvp';
+import type { EventManager, GameEvent } from '@/data/eventDatabase';
+import type { SecretAgenda } from '@/data/agendaDatabase';
+import type { EnhancedAIStrategist } from '@/data/enhancedAIStrategy';
+import type { DrawMode, CardDrawState } from '@/data/cardDrawingSystem';
+import type { AIDifficulty } from '@/data/aiStrategy';
+
+export interface GameState {
+  faction: 'government' | 'truth';
+  phase: 'income' | 'action' | 'capture' | 'event' | 'newspaper' | 'victory' | 'ai_turn' | 'card_presentation';
+  turn: number;
+  round: number;
+  currentPlayer: 'human' | 'ai';
+  aiDifficulty: AIDifficulty;
+  aiPersonality?: string;
+  truth: number;
+  ip: number;
+  aiIP: number;
+  hand: GameCard[];
+  aiHand: GameCard[];
+  isGameOver: boolean;
+  deck: GameCard[];
+  aiDeck: GameCard[];
+  cardsPlayedThisTurn: number;
+  cardsPlayedThisRound: Array<{
+    card: GameCard;
+    player: 'human' | 'ai';
+    targetState?: string | null;
+    truthDelta?: number;
+    capturedStates?: string[];
+  }>;
+  controlledStates: string[];
+  aiControlledStates: string[];
+  states: Array<{
+    id: string;
+    name: string;
+    abbreviation: string;
+    baseIP: number;
+    defense: number;
+    pressure: number;
+    owner: 'player' | 'ai' | 'neutral';
+    specialBonus?: string;
+    bonusValue?: number;
+    occupierCardId?: string | null;
+    occupierCardName?: string | null;
+    occupierLabel?: string | null;
+    occupierIcon?: string | null;
+    occupierUpdatedAt?: number;
+  }>;
+  currentEvents: GameEvent[];
+  eventManager?: EventManager;
+  showNewspaper: boolean;
+  log: string[];
+  agenda?: SecretAgenda & {
+    progress?: number;
+    complete?: boolean;
+    revealed?: boolean;
+  };
+  secretAgenda?: SecretAgenda & {
+    progress: number;
+    completed: boolean;
+    revealed: boolean;
+  };
+  aiSecretAgenda?: SecretAgenda & {
+    progress: number;
+    completed: boolean;
+    revealed: boolean;
+  };
+  animating: boolean;
+  aiTurnInProgress: boolean;
+  selectedCard: string | null;
+  targetState: string | null;
+  aiStrategist?: EnhancedAIStrategist;
+  pendingCardDraw?: number;
+  newCards?: GameCard[];
+  showNewCardsPresentation?: boolean;
+  drawMode: DrawMode;
+  cardDrawState: CardDrawState;
+}


### PR DESCRIPTION
## Summary
- move AI card resolution utilities into dedicated helpers and share the game state type
- refactor useGameState AI play flow to resolve cards from the updater and accept planned card metadata
- add a regression test ensuring the AI can play a card drawn during the income step and handles missing cards gracefully

## Testing
- bun test

------
https://chatgpt.com/codex/tasks/task_e_68ccf826edb48320ac9a5b12e1a653ea