### PR TITLE
Handle empty MCTS roots and unaffordable plans

### DIFF
--- a/src/ai/__tests__/unifiedAiPlanning.test.ts
+++ b/src/ai/__tests__/unifiedAiPlanning.test.ts
@@ -130,4 +130,35 @@ describe('Unified AI planning', () => {
       });
     });
   }
+
+  it('returns an empty plan when no affordable cards are available', () => {
+    for (const difficulty of DIFFICULTIES) {
+      const strategist = AIFactory.createStrategist(DIFFICULTY_TO_AI[difficulty]);
+      const baseState = createPlanningState();
+      const expensiveHand = baseState.aiHand.map(card => ({
+        ...card,
+        cost: (card.cost ?? 0) + 10,
+      }));
+
+      const planningState = {
+        ...baseState,
+        aiIP: 0,
+        aiHand: expensiveHand,
+      };
+
+      let plan: ReturnType<typeof chooseTurnActions> | null = null;
+      expect(() => {
+        plan = chooseTurnActions({
+          strategist,
+          gameState: planningState,
+          maxActions: 3,
+          priorityThreshold: 0.2,
+        });
+      }).not.toThrow();
+
+      expect(plan).not.toBeNull();
+      expect(plan!.actions.length).toBe(0);
+      expect(plan!.sequenceDetails.length).toBeGreaterThan(0);
+    }
+  });
 });

--- a/src/data/enhancedAIStrategy.ts
+++ b/src/data/enhancedAIStrategy.ts
@@ -257,25 +257,37 @@ export class EnhancedAIStrategist implements AIStrategist {
 
   private runMCTS(gameState: any, iterations: number): EnhancedCardPlay | null {
     const root = this.createMCTSNode(gameState, null);
-    
+
+    if (root.unexploredMoves.length === 0) {
+      return this.selectBestPlayWithSynergies(gameState);
+    }
+
     for (let i = 0; i < iterations; i++) {
       // Selection
       let node = this.selectNode(root);
-      
+
+      if (node.unexploredMoves.length === 0) {
+        break;
+      }
+
       // Expansion
       if (node.unexploredMoves.length > 0 && node.visits > 0) {
         node = this.expandNode(node);
       }
-      
+
       // Simulation
       const reward = this.simulateGame(node.gameState);
-      
+
       // Backpropagation
       this.backpropagate(node, reward);
     }
 
     // Return best move
-    const bestChild = root.children.reduce((best, child) => 
+    if (root.children.length === 0) {
+      return this.selectBestPlayWithSynergies(gameState);
+    }
+
+    const bestChild = root.children.reduce((best, child) =>
       child.visits > best.visits ? child : best
     );
 
@@ -311,6 +323,10 @@ export class EnhancedAIStrategist implements AIStrategist {
   }
 
   private expandNode(node: MCTSNode): MCTSNode {
+    if (node.unexploredMoves.length === 0) {
+      return node;
+    }
+
     const move = node.unexploredMoves.pop()!;
     const newGameState = this.simulateMove(node.gameState, move);
     


### PR DESCRIPTION
## Summary
- fall back to heuristic planning when MCTS cannot expand any children
- stop the search loop once no unexplored moves remain and guard expansion popping
- add a regression test covering turns where every card is unaffordable

## Testing
- bun test src/ai/__tests__/unifiedAiPlanning.test.ts


------
https://chatgpt.com/codex/tasks/task_e_68cd086385548320bbec1106a185c974