### PR TITLE
Use weighted deck generation in game state

### DIFF
--- a/src/hooks/useGameState.ts
+++ b/src/hooks/useGameState.ts
@@ -1,7 +1,7 @@
 import { useState, useCallback } from 'react';
 import type { GameCard } from '@/rules/mvp';
 import { CARD_DATABASE, getRandomCards } from '@/data/cardDatabase';
-import { generateMixedDeck } from '@/lib/decks/generator';
+import { generateWeightedDeck } from '@/data/weightedCardDistribution';
 import { USA_STATES, getInitialStateControl, getTotalIPFromStates, type StateData } from '@/data/usaStates';
 import { getRandomAgenda, SecretAgenda } from '@/data/agendaDatabase';
 import { type AIDifficulty } from '@/data/aiStrategy';
@@ -116,7 +116,7 @@ const drawCardsFromDeck = (
 
   while (drawn.length < count) {
     if (nextDeck.length === 0) {
-      const replenished = generateMixedDeck({ faction, deckSize: 40 }).deck;
+      const replenished = generateWeightedDeck(40, faction);
       if (replenished.length === 0) {
         break;
       }
@@ -155,8 +155,8 @@ export const useGameState = (aiDifficultyOverride?: AIDifficulty) => {
     hand: getRandomCards(3, { faction: 'truth' }),
     aiHand: getRandomCards(3, { faction: 'government' }),
     isGameOver: false,
-    deck: generateMixedDeck({ faction: 'truth', deckSize: 40 }).deck,
-    aiDeck: generateMixedDeck({ faction: 'government', deckSize: 40 }).deck,
+    deck: generateWeightedDeck(40, 'truth'),
+    aiDeck: generateWeightedDeck(40, 'government'),
     cardsPlayedThisTurn: 0,
     cardsPlayedThisRound: [],
     controlledStates: [],
@@ -236,7 +236,7 @@ export const useGameState = (aiDifficultyOverride?: AIDifficulty) => {
     
     const handSize = getStartingHandSize(drawMode, faction);
     // CRITICAL: Pass faction to deck generation
-    const newDeck = generateMixedDeck({ faction, deckSize: 40 }).deck;
+    const newDeck = generateWeightedDeck(40, faction);
     const startingHand = newDeck.slice(0, handSize);
     const initialControl = getInitialStateControl(faction);
 
@@ -254,10 +254,7 @@ export const useGameState = (aiDifficultyOverride?: AIDifficulty) => {
       deck: newDeck.slice(handSize),
       // AI gets opposite faction cards
       aiHand: getRandomCards(handSize, { faction: faction === 'government' ? 'truth' : 'government' }),
-      aiDeck: generateMixedDeck({
-        faction: faction === 'government' ? 'truth' : 'government',
-        deckSize: 40,
-      }).deck,
+      aiDeck: generateWeightedDeck(40, faction === 'government' ? 'truth' : 'government'),
       controlledStates: initialControl.player,
       aiControlledStates: initialControl.ai,
       isGameOver: false, // CRITICAL: Reset game over state


### PR DESCRIPTION
## Summary
- replace `useGameState` deck generation with the weighted deck generator for player and AI decks
- adjust draw replenishment to handle the direct array returned by the weighted generator

## Testing
- bun test
- bun run /tmp/checkDeck.ts

------
https://chatgpt.com/codex/tasks/task_e_68cd10eb81bc8320aeaafbf9152b7d51