### PR TITLE
Fix combo truth reward sign handling

### DIFF
--- a/src/game/comboEngine.ts
+++ b/src/game/comboEngine.ts
@@ -519,11 +519,11 @@ export function applyComboRewards(
     };
   }
 
-  const truthMagnitude = Math.abs(evaluation.totalReward.truth ?? 0);
-  if (truthMagnitude !== 0) {
+  const truthReward = evaluation.totalReward.truth ?? 0;
+  if (truthReward !== 0) {
     const playerState = updated.players[player];
     const faction = playerState?.faction ?? 'truth';
-    const signedTruthDelta = faction === 'truth' ? truthMagnitude : -truthMagnitude;
+    const signedTruthDelta = faction === 'government' ? -truthReward : truthReward;
     applyTruthDelta(updated, signedTruthDelta, player);
   }
 


### PR DESCRIPTION
## Summary
- propagate signed truth rewards through combo application while inverting for government factions
- add negative-truth combo coverage for truth and government players

## Testing
- bun test src/game/comboEngine.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68cd371218e48320accb5ab333a1de24