### PR TITLE
Ensure getRandomCards draws without replacement

### DIFF
--- a/src/data/__tests__/cardDatabase.test.ts
+++ b/src/data/__tests__/cardDatabase.test.ts
@@ -1,0 +1,66 @@
+import { beforeAll, afterAll, describe, expect, it } from 'bun:test';
+
+type GetRandomCards = typeof import('@/data/cardDatabase').getRandomCards;
+
+let getRandomCards: GetRandomCards;
+let originalLocalStorage: Storage | undefined;
+
+function createMockLocalStorage(): Storage {
+  const store = new Map<string, string>();
+
+  return {
+    get length() {
+      return store.size;
+    },
+    clear() {
+      store.clear();
+    },
+    getItem(key: string) {
+      return store.has(key) ? store.get(key)! : null;
+    },
+    key(index: number) {
+      return Array.from(store.keys())[index] ?? null;
+    },
+    removeItem(key: string) {
+      store.delete(key);
+    },
+    setItem(key: string, value: string) {
+      store.set(key, value);
+    },
+  } as Storage;
+}
+
+describe('getRandomCards', () => {
+  beforeAll(async () => {
+    originalLocalStorage = globalThis.localStorage;
+    (globalThis as any).localStorage = createMockLocalStorage();
+
+    ({ getRandomCards } = await import('@/data/cardDatabase'));
+  });
+
+  afterAll(() => {
+    if (originalLocalStorage === undefined) {
+      delete (globalThis as any).localStorage;
+    } else {
+      globalThis.localStorage = originalLocalStorage;
+    }
+  });
+
+  it('returns unique cards until the pool is exhausted', () => {
+    const originalRandom = Math.random;
+    const sequence = [0, 0, 0, 0];
+    let callCount = 0;
+
+    Math.random = () => sequence[callCount++] ?? 0;
+
+    try {
+      const cards = getRandomCards(5, { faction: 'truth' });
+      expect(cards).toHaveLength(3);
+
+      const uniqueIds = new Set(cards.map(card => card.id));
+      expect(uniqueIds.size).toBe(cards.length);
+    } finally {
+      Math.random = originalRandom;
+    }
+  });
+});

--- a/src/data/cardDatabase.ts
+++ b/src/data/cardDatabase.ts
@@ -223,6 +223,11 @@ export function getRandomCards(
   for (let i = 0; i < count && poolCopy.length > 0; i++) {
     const randomIndex = Math.floor(Math.random() * poolCopy.length);
     selected.push(poolCopy[randomIndex]);
+    poolCopy.splice(randomIndex, 1);
+
+    if (poolCopy.length === 0) {
+      break;
+    }
   }
 
   return selected;


### PR DESCRIPTION
## Summary
- update `getRandomCards` to remove drawn entries so later draws remain unique and stop when the pool empties
- add a Bun test that seeds the fallback MVP pool and asserts `getRandomCards` delivers unique truth-faction cards until none remain

## Testing
- bun test src/data/__tests__/cardDatabase.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68cd3987a03483208e286f66055ff686