### PR TITLE
Guard AI turn when game ends

### DIFF
--- a/src/hooks/__tests__/processAiActions.test.ts
+++ b/src/hooks/__tests__/processAiActions.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it } from 'bun:test';
+
+import type { GameCard } from '@/rules/mvp';
+import type { GameState } from '@/hooks/gameStateTypes';
+import { processAiActions, type ProcessAiActionsOptions } from '@/hooks/aiTurnActions';
+import type { AiCardPlayParams } from '@/hooks/aiHelpers';
+
+const baseState = (overrides: Partial<GameState> = {}): GameState => ({
+  faction: 'truth',
+  phase: 'ai_turn',
+  turn: 4,
+  round: 1,
+  currentPlayer: 'ai',
+  aiDifficulty: 'medium',
+  aiPersonality: undefined,
+  truth: 42,
+  ip: 15,
+  aiIP: 18,
+  hand: [],
+  aiHand: [],
+  isGameOver: false,
+  deck: [],
+  aiDeck: [],
+  cardsPlayedThisTurn: 0,
+  cardsPlayedThisRound: [],
+  controlledStates: [],
+  aiControlledStates: [],
+  states: [],
+  currentEvents: [],
+  eventManager: undefined,
+  showNewspaper: false,
+  log: [],
+  agenda: undefined,
+  secretAgenda: undefined,
+  aiSecretAgenda: undefined,
+  animating: false,
+  aiTurnInProgress: true,
+  selectedCard: null,
+  targetState: null,
+  aiStrategist: undefined,
+  pendingCardDraw: 0,
+  newCards: [],
+  showNewCardsPresentation: false,
+  drawMode: 'standard',
+  cardDrawState: { cardsPlayedLastTurn: 0, lastTurnWithoutPlay: false },
+  ...overrides,
+});
+
+describe('processAiActions', () => {
+  it('stops further plays when a card ends the game mid-turn', async () => {
+    const finisher: GameCard = {
+      id: 'finisher-card',
+      name: 'Sudden Shutdown',
+      type: 'MEDIA',
+      faction: 'government',
+      rarity: 'common',
+      cost: 2,
+      effects: { truthDelta: -12 },
+    };
+
+    const followUp: GameCard = {
+      id: 'followup-card',
+      name: 'Extra Spin',
+      type: 'MEDIA',
+      faction: 'government',
+      rarity: 'common',
+      cost: 1,
+      effects: { truthDelta: -3 },
+    };
+
+    const playedParams: AiCardPlayParams[] = [];
+    const readSnapshots: GameState[] = [baseState(), baseState({ isGameOver: false })];
+    let waits = 0;
+
+    const options: ProcessAiActionsOptions = {
+      actions: [
+        { cardId: finisher.id, card: finisher },
+        { cardId: followUp.id, card: followUp },
+      ],
+      sequenceDetails: ['Initial strategic plan'],
+      readLatestState: async () => {
+        if (readSnapshots.length > 1) {
+          return readSnapshots.shift()!;
+        }
+        return readSnapshots[0];
+      },
+      playCard: async params => {
+        playedParams.push(params);
+        return baseState({ isGameOver: true });
+      },
+      waitBetweenActions: async () => {
+        waits += 1;
+      },
+    };
+
+    const result = await processAiActions(options);
+
+    expect(result.gameOver).toBe(true);
+    expect(playedParams).toHaveLength(1);
+    expect(playedParams[0].cardId).toBe(finisher.id);
+    expect(playedParams[0].strategyDetails).toEqual(['Initial strategic plan']);
+    expect(waits).toBe(0);
+  });
+});

--- a/src/hooks/aiTurnActions.ts
+++ b/src/hooks/aiTurnActions.ts
@@ -1,0 +1,61 @@
+import type { GameCard } from '@/rules/mvp';
+import type { GameState } from './gameStateTypes';
+import type { AiCardPlayParams } from './aiHelpers';
+
+export interface ProcessAiActionsOptions {
+  actions: Array<{
+    cardId: string;
+    card?: GameCard;
+    targetState?: string;
+    reasoning?: string;
+    strategyDetails?: string[];
+  }>;
+  sequenceDetails: string[];
+  readLatestState: () => Promise<GameState>;
+  playCard: (params: AiCardPlayParams) => Promise<GameState>;
+  waitBetweenActions: () => Promise<void>;
+}
+
+export const processAiActions = async ({
+  actions,
+  sequenceDetails,
+  readLatestState,
+  playCard,
+  waitBetweenActions,
+}: ProcessAiActionsOptions): Promise<{ gameOver: boolean }> => {
+  for (let index = 0; index < actions.length; index++) {
+    const latestBeforeAction = await readLatestState();
+    if (latestBeforeAction.isGameOver) {
+      return { gameOver: true };
+    }
+
+    const action = actions[index];
+    const detailEntries = [
+      ...(index === 0 ? sequenceDetails : []),
+      ...(action.strategyDetails ?? []),
+    ];
+
+    const stateAfterPlay = await playCard({
+      cardId: action.cardId,
+      card: action.card,
+      targetState: action.targetState,
+      reasoning: action.reasoning,
+      strategyDetails: detailEntries.length ? detailEntries : undefined,
+    });
+
+    if (stateAfterPlay.isGameOver) {
+      return { gameOver: true };
+    }
+
+    const latestAfterAction = await readLatestState();
+    if (latestAfterAction.isGameOver) {
+      return { gameOver: true };
+    }
+
+    if (index < actions.length - 1) {
+      await waitBetweenActions();
+    }
+  }
+
+  return { gameOver: false };
+};


### PR DESCRIPTION
## Summary
- add explicit game-over checks to the AI turn routine so it aborts planned work and pending cleanup when the match ends
- extract AI action sequencing into a helper with a unit test that verifies mid-turn victories stop further plays

## Testing
- bun test

------
https://chatgpt.com/codex/tasks/task_e_68cd40e6b6b0832090c223a320e3ba1d