### PR TITLE
Enhance MVP reporting with match history

### DIFF
--- a/src/components/game/PlayedCardsDock.tsx
+++ b/src/components/game/PlayedCardsDock.tsx
@@ -1,18 +1,11 @@
 import React from 'react';
 import { cn } from '@/lib/utils';
+import type { CardPlayRecord } from '@/hooks/gameStateTypes';
 import type { GameCard } from '@/rules/mvp';
 import BaseCard from '@/components/game/cards/BaseCard';
 
-interface PlayedCard {
-  card: GameCard;
-  player: 'human' | 'ai';
-  targetState?: string | null;
-  truthDelta?: number;
-  capturedStates?: string[];
-}
-
 interface PlayedCardsDockProps {
-  playedCards: PlayedCard[];
+  playedCards: CardPlayRecord[];
 }
 
 const CardsInPlayCard = ({ card }: { card: GameCard }) => (
@@ -28,7 +21,7 @@ const CardsInPlayCard = ({ card }: { card: GameCard }) => (
 interface SectionProps {
   title: string;
   toneClass: string;
-  cards: PlayedCard[];
+  cards: CardPlayRecord[];
   emptyMessage: string;
   ariaLabel: string;
 }

--- a/src/data/__tests__/aiAffordability.test.ts
+++ b/src/data/__tests__/aiAffordability.test.ts
@@ -45,6 +45,7 @@ describe('AI affordability heuristics', () => {
     aiHand: [expensiveCard, cheapCard],
     states: [],
     cardsPlayedThisRound: [],
+    playHistory: [],
     turn: 1,
     round: 1,
   });

--- a/src/data/__tests__/enhancedAIStrategy.mcts.test.ts
+++ b/src/data/__tests__/enhancedAIStrategy.mcts.test.ts
@@ -25,6 +25,7 @@ describe('EnhancedAIStrategist MCTS simulation cloning', () => {
     hand: [captureCard],
     aiHand: [captureCard],
     cardsPlayedThisRound: [],
+    playHistory: [],
     states: [
       {
         id: 'ca',

--- a/src/hooks/__tests__/processAiActions.test.ts
+++ b/src/hooks/__tests__/processAiActions.test.ts
@@ -23,6 +23,7 @@ const baseState = (overrides: Partial<GameState> = {}): GameState => ({
   aiDeck: [],
   cardsPlayedThisTurn: 0,
   cardsPlayedThisRound: [],
+  playHistory: [],
   controlledStates: [],
   aiControlledStates: [],
   states: [],

--- a/src/hooks/__tests__/useGameState.aiTurn.test.ts
+++ b/src/hooks/__tests__/useGameState.aiTurn.test.ts
@@ -36,6 +36,7 @@ const createBaseState = (overrides: Partial<GameState> = {}): GameState => ({
   aiDeck: [],
   cardsPlayedThisTurn: 0,
   cardsPlayedThisRound: [],
+  playHistory: [],
   controlledStates: [],
   aiControlledStates: [],
   states: [

--- a/src/hooks/gameStateTypes.ts
+++ b/src/hooks/gameStateTypes.ts
@@ -5,6 +5,22 @@ import type { EnhancedAIStrategist } from '@/data/enhancedAIStrategy';
 import type { DrawMode, CardDrawState } from '@/data/cardDrawingSystem';
 import type { AIDifficulty } from '@/data/aiStrategy';
 
+export interface CardPlayRecord {
+  card: GameCard;
+  player: 'human' | 'ai';
+  faction: 'government' | 'truth';
+  targetState: string | null;
+  truthDelta: number;
+  ipDelta: number;
+  aiIpDelta: number;
+  capturedStates: string[];
+  damageDealt: number;
+  round: number;
+  turn: number;
+  timestamp: number;
+  logEntries: string[];
+}
+
 export interface GameState {
   faction: 'government' | 'truth';
   phase: 'income' | 'action' | 'capture' | 'event' | 'newspaper' | 'victory' | 'ai_turn' | 'card_presentation';
@@ -22,13 +38,8 @@ export interface GameState {
   deck: GameCard[];
   aiDeck: GameCard[];
   cardsPlayedThisTurn: number;
-  cardsPlayedThisRound: Array<{
-    card: GameCard;
-    player: 'human' | 'ai';
-    targetState?: string | null;
-    truthDelta?: number;
-    capturedStates?: string[];
-  }>;
+  cardsPlayedThisRound: CardPlayRecord[];
+  playHistory: CardPlayRecord[];
   controlledStates: string[];
   aiControlledStates: string[];
   states: Array<{


### PR DESCRIPTION
## Summary
- add a persistent card play history and richer metrics to the game state so each turn is recorded beyond the active round
- analyze full-match history at game over to surface an MVP card with capture, truth, and IP impact data for the report
- update the Tabloid victory and extra edition screens to present the MVP story and supporting details based on the new report

## Testing
- bun test

------
https://chatgpt.com/codex/tasks/task_e_68cd4cd0ba7c8320b7b4cf30e35c5b4d