### PR TITLE
Integrate combo tracking into frontend turn flow

### DIFF
--- a/src/hooks/__tests__/comboAdapter.test.ts
+++ b/src/hooks/__tests__/comboAdapter.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it } from 'bun:test';
+
+import type { GameState } from '@/hooks/gameStateTypes';
+import { evaluateCombosForTurn } from '@/hooks/comboAdapter';
+import type { TurnPlay } from '@/game/combo.types';
+import { getLastComboSummary } from '@/game/comboEngine';
+
+const makeTurnPlays = (): TurnPlay[] => {
+  const plays: TurnPlay[] = [];
+  for (let index = 0; index < 3; index += 1) {
+    const playSequence = index * 2;
+    const resolveSequence = playSequence + 1;
+    const base = {
+      owner: 'P1' as const,
+      cardId: `media-${index + 1}`,
+      cardName: `Media Play ${index + 1}`,
+      cardType: 'MEDIA' as const,
+      cardRarity: 'common' as const,
+      cost: 2,
+      targetStateId: undefined,
+    } satisfies Omit<TurnPlay, 'sequence' | 'stage' | 'metadata'>;
+
+    plays.push({ sequence: playSequence, stage: 'play', ...base });
+    plays.push({ sequence: resolveSequence, stage: 'resolve', ...base });
+  }
+  return plays;
+};
+
+const createState = (overrides: Partial<GameState> = {}): GameState => ({
+  faction: 'truth',
+  phase: 'action',
+  turn: 3,
+  round: 1,
+  currentPlayer: 'human',
+  aiDifficulty: 'medium',
+  aiPersonality: undefined,
+  truth: 50,
+  ip: 12,
+  aiIP: 10,
+  hand: [],
+  aiHand: [],
+  isGameOver: false,
+  deck: [],
+  aiDeck: [],
+  cardsPlayedThisTurn: 3,
+  cardsPlayedThisRound: [],
+  playHistory: [],
+  turnPlays: makeTurnPlays(),
+  controlledStates: [],
+  aiControlledStates: [],
+  states: [
+    {
+      id: 'CA',
+      name: 'California',
+      abbreviation: 'CA',
+      baseIP: 6,
+      defense: 4,
+      pressure: 0,
+      contested: false,
+      owner: 'neutral' as const,
+    },
+    {
+      id: 'NY',
+      name: 'New York',
+      abbreviation: 'NY',
+      baseIP: 5,
+      defense: 3,
+      pressure: 0,
+      contested: false,
+      owner: 'neutral' as const,
+    },
+  ],
+  currentEvents: [],
+  eventManager: undefined,
+  showNewspaper: false,
+  log: [],
+  agenda: undefined,
+  secretAgenda: undefined,
+  aiSecretAgenda: undefined,
+  animating: false,
+  aiTurnInProgress: false,
+  selectedCard: null,
+  targetState: null,
+  aiStrategist: undefined,
+  pendingCardDraw: 0,
+  newCards: [],
+  showNewCardsPresentation: false,
+  drawMode: 'standard',
+  cardDrawState: { cardsPlayedLastTurn: 0, lastTurnWithoutPlay: false },
+  ...overrides,
+});
+
+describe('evaluateCombosForTurn', () => {
+  it('applies combo rewards to the active player and updates the summary', () => {
+    const state = createState();
+    const result = evaluateCombosForTurn(state, 'human');
+
+    expect(result.evaluation.results.length).toBeGreaterThan(0);
+    expect(result.updatedTruth).toBeGreaterThan(state.truth);
+    expect(result.fxMessages.length).toBe(result.evaluation.results.length);
+    expect(result.logEntries[0]).toContain('Combos triggered');
+
+    const summary = getLastComboSummary();
+    expect(summary).not.toBeNull();
+    expect(summary?.player).toBe('P1');
+    expect(summary?.turn).toBe(state.turn);
+  });
+});

--- a/src/hooks/__tests__/processAiActions.test.ts
+++ b/src/hooks/__tests__/processAiActions.test.ts
@@ -24,6 +24,7 @@ const baseState = (overrides: Partial<GameState> = {}): GameState => ({
   cardsPlayedThisTurn: 0,
   cardsPlayedThisRound: [],
   playHistory: [],
+  turnPlays: [],
   controlledStates: [],
   aiControlledStates: [],
   states: [],

--- a/src/hooks/__tests__/useGameState.aiTurn.test.ts
+++ b/src/hooks/__tests__/useGameState.aiTurn.test.ts
@@ -37,6 +37,7 @@ const createBaseState = (overrides: Partial<GameState> = {}): GameState => ({
   cardsPlayedThisTurn: 0,
   cardsPlayedThisRound: [],
   playHistory: [],
+  turnPlays: [],
   controlledStates: [],
   aiControlledStates: [],
   states: [

--- a/src/hooks/comboAdapter.ts
+++ b/src/hooks/comboAdapter.ts
@@ -1,0 +1,122 @@
+import { applyComboRewards, evaluateCombos, formatComboReward } from '@/game/comboEngine';
+import type { ComboEvaluation } from '@/game/combo.types';
+import type { GameState as EngineGameState, PlayerId, PlayerState as EnginePlayerState } from '@/mvp/validator';
+
+import type { GameState } from './gameStateTypes';
+
+const HUMAN_PLAYER: PlayerId = 'P1';
+const AI_PLAYER: PlayerId = 'P2';
+
+const otherPlayer = (id: PlayerId): PlayerId => (id === HUMAN_PLAYER ? AI_PLAYER : HUMAN_PLAYER);
+
+const normalizeControlledStates = (state: GameState, abbreviations: string[]): string[] => {
+  const result: string[] = [];
+  const seen = new Set<string>();
+  for (const entry of abbreviations) {
+    const match = state.states.find(candidate =>
+      candidate.abbreviation === entry || candidate.id === entry || candidate.name === entry,
+    );
+    const resolved = match?.id ?? entry;
+    if (!seen.has(resolved)) {
+      seen.add(resolved);
+      result.push(resolved);
+    }
+  }
+  return result;
+};
+
+const buildPlayerState = (state: GameState, owner: 'human' | 'ai'): EnginePlayerState => {
+  const id = owner === 'human' ? HUMAN_PLAYER : AI_PLAYER;
+  const faction = owner === 'human'
+    ? state.faction
+    : state.faction === 'truth'
+      ? 'government'
+      : 'truth';
+  const ip = owner === 'human' ? state.ip : state.aiIP;
+  const controlled = owner === 'human' ? state.controlledStates : state.aiControlledStates;
+
+  return {
+    id,
+    faction,
+    deck: [],
+    hand: [],
+    discard: [],
+    ip,
+    states: normalizeControlledStates(state, controlled),
+  } satisfies EnginePlayerState;
+};
+
+const buildPressureByState = (state: GameState): EngineGameState['pressureByState'] => {
+  const map: EngineGameState['pressureByState'] = {};
+  for (const entry of state.states) {
+    map[entry.id] = { P1: 0, P2: 0 };
+  }
+  return map;
+};
+
+const buildStateDefense = (state: GameState): EngineGameState['stateDefense'] => {
+  const map: EngineGameState['stateDefense'] = {};
+  for (const entry of state.states) {
+    map[entry.id] = entry.defense;
+  }
+  return map;
+};
+
+export interface ComboAdapterResult {
+  evaluation: ComboEvaluation;
+  updatedTruth: number;
+  updatedPlayerIp: number;
+  updatedOpponentIp: number;
+  logEntries: string[];
+  fxMessages: string[];
+}
+
+export const evaluateCombosForTurn = (
+  state: GameState,
+  owner: 'human' | 'ai',
+): ComboAdapterResult => {
+  const playerId = owner === 'human' ? HUMAN_PLAYER : AI_PLAYER;
+  const opponentId = otherPlayer(playerId);
+
+  const engineState: EngineGameState = {
+    turn: state.turn,
+    currentPlayer: playerId,
+    truth: state.truth,
+    players: {
+      [HUMAN_PLAYER]: buildPlayerState(state, 'human'),
+      [AI_PLAYER]: buildPlayerState(state, 'ai'),
+    },
+    pressureByState: buildPressureByState(state),
+    stateDefense: buildStateDefense(state),
+    playsThisTurn: state.cardsPlayedThisTurn,
+    turnPlays: state.turnPlays.map(play => ({ ...play })),
+    log: [...state.log],
+  } satisfies EngineGameState;
+
+  const logStart = engineState.log.length;
+  const evaluation = evaluateCombos(engineState, playerId);
+  const rewardedState = applyComboRewards(engineState, playerId, evaluation);
+  const rewardLogs = rewardedState.log.slice(logStart);
+
+  const comboMessages = evaluation.results.map(result => {
+    const rewardText = formatComboReward(result.appliedReward);
+    return rewardText ? `${result.definition.name} ${rewardText}` : result.definition.name;
+  });
+
+  const summaryEntry = comboMessages.length > 0
+    ? `Combos triggered: ${comboMessages.join('; ')}`
+    : null;
+
+  const logEntries = summaryEntry
+    ? [summaryEntry, ...rewardLogs]
+    : rewardLogs;
+
+  return {
+    evaluation,
+    updatedTruth: rewardedState.truth,
+    updatedPlayerIp: rewardedState.players[playerId].ip,
+    updatedOpponentIp: rewardedState.players[opponentId].ip,
+    logEntries,
+    fxMessages: comboMessages,
+  };
+};

--- a/src/hooks/gameStateTypes.ts
+++ b/src/hooks/gameStateTypes.ts
@@ -4,6 +4,7 @@ import type { SecretAgenda } from '@/data/agendaDatabase';
 import type { EnhancedAIStrategist } from '@/data/enhancedAIStrategy';
 import type { DrawMode, CardDrawState } from '@/data/cardDrawingSystem';
 import type { AIDifficulty } from '@/data/aiStrategy';
+import type { TurnPlay } from '@/game/combo.types';
 
 export interface CardPlayRecord {
   card: GameCard;
@@ -40,6 +41,7 @@ export interface GameState {
   cardsPlayedThisTurn: number;
   cardsPlayedThisRound: CardPlayRecord[];
   playHistory: CardPlayRecord[];
+  turnPlays: TurnPlay[];
   controlledStates: string[];
   aiControlledStates: string[];
   states: Array<{


### PR DESCRIPTION
## Summary
- extend the frontend game state and helpers to capture combo-engine `TurnPlay` data for human and AI plays
- evaluate combos at the end of each turn to apply rewards, update logs, trigger FX, and reset the per-turn play buffer
- add combo adapter regression coverage to ensure recorded plays produce combo summaries

## Testing
- bun test

------
https://chatgpt.com/codex/tasks/task_e_68cd665a09748320acb5da5e96eaca49