### PR TITLE
Fix tabloid truth delta calculations

### DIFF
--- a/src/components/game/TabloidNewspaperV2.test.tsx
+++ b/src/components/game/TabloidNewspaperV2.test.tsx
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'bun:test';
+import { buildRoundContext, formatTruthDelta } from './tabloidRoundUtils';
+import type { TabloidPlayedCard } from './TabloidNewspaperLegacy';
+
+type PlayerType = TabloidPlayedCard['player'];
+
+const makeCard = (id: string, player: PlayerType, truthDelta: number): TabloidPlayedCard => ({
+  card: {
+    id,
+    name: id,
+    type: 'MEDIA',
+    faction: player === 'human' ? 'truth' : 'government',
+    cost: 1,
+  },
+  player,
+  truthDelta,
+});
+
+describe('TabloidNewspaperV2 truth delta summary', () => {
+  it('returns a negative swing when the opposition suppresses truth', () => {
+    const playerCards = [makeCard('player-boost', 'human', 4)];
+    const opponentCards = [makeCard('opponent-suppress', 'ai', -6)];
+    const eventTruth = 1;
+
+    const context = buildRoundContext(playerCards, opponentCards, eventTruth);
+    const expectedNet = 4 + -6 + 1;
+
+    expect(context.truthDeltaTotal).toBe(expectedNet);
+    expect(formatTruthDelta(context.truthDeltaTotal)).toBe('−1%');
+  });
+
+  it('returns a positive swing when the opposition boosts truth', () => {
+    const playerCards = [makeCard('player-small', 'human', 2)];
+    const opponentCards = [makeCard('opponent-boost', 'ai', 3)];
+    const eventTruth = -1;
+
+    const context = buildRoundContext(playerCards, opponentCards, eventTruth);
+    const expectedNet = 2 + 3 - 1;
+
+    expect(context.truthDeltaTotal).toBe(expectedNet);
+    expect(formatTruthDelta(context.truthDeltaTotal)).toBe('+4%');
+  });
+});

--- a/src/components/game/TabloidNewspaperV2.tsx
+++ b/src/components/game/TabloidNewspaperV2.tsx
@@ -10,6 +10,7 @@ import type { TabloidNewspaperProps, TabloidPlayedCard } from './TabloidNewspape
 import type { Card } from '@/types';
 import { getStateByAbbreviation, getStateById } from '@/data/usaStates';
 import { formatComboReward, getLastComboSummary } from '@/game/comboEngine';
+import { buildRoundContext, formatTruthDelta } from './tabloidRoundUtils';
 
 const GLITCH_OPTIONS = ['PAGE NOT FOUND', '░░░ERROR░░░', '▓▓▓SIGNAL LOST▓▓▓', '404 TRUTH NOT FOUND'];
 
@@ -27,15 +28,6 @@ const FALLBACK_DATA: NewspaperData = {
   stamps: { breaking: ['BREAKING'], classified: ['CLASSIFIED'] },
 };
 
-const formatTruthDelta = (value?: number) => {
-  if (value === undefined || Number.isNaN(value) || value === 0) {
-    return null;
-  }
-  const rounded = Math.abs(value) < 1 ? Math.round(value * 10) / 10 : Math.round(value);
-  const sign = value > 0 ? '+' : value < 0 ? '−' : '';
-  return `${sign}${Math.abs(rounded)}%`;
-};
-
 const formatTarget = (entry: TabloidPlayedCard): string | null => {
   if (entry.card.type !== 'ZONE') {
     return null;
@@ -50,23 +42,6 @@ const formatTarget = (entry: TabloidPlayedCard): string | null => {
   const stateByAbbr = getStateByAbbreviation(target.toUpperCase());
   const name = stateById?.name ?? stateByAbbr?.name ?? target;
   return `Target: ${name}`;
-};
-
-const buildRoundContext = (
-  playerCards: TabloidPlayedCard[],
-  opponentCards: TabloidPlayedCard[],
-  eventsTruthDelta: number,
-): RoundContext => {
-  const truthFromPlayer = playerCards.reduce((sum, entry) => sum + (entry.truthDelta ?? 0), 0);
-  const truthFromOpponent = opponentCards.reduce((sum, entry) => sum + (entry.truthDelta ?? 0), 0);
-  const capturedStates = playerCards.flatMap(entry => entry.capturedStates ?? []);
-
-  return {
-    truthDeltaTotal: truthFromPlayer - truthFromOpponent + eventsTruthDelta,
-    capturedStates,
-    cardsPlayedByYou: playerCards.map(entry => entry.card as Card),
-    cardsPlayedByOpp: opponentCards.map(entry => entry.card as Card),
-  };
 };
 
 const computeEventTruthDelta = (events: TabloidNewspaperProps['events']): number => {

--- a/src/components/game/tabloidRoundUtils.ts
+++ b/src/components/game/tabloidRoundUtils.ts
@@ -1,0 +1,29 @@
+import type { RoundContext } from '@/features/newspaper/generate';
+import type { Card } from '@/types';
+import type { TabloidPlayedCard } from './TabloidNewspaperLegacy';
+
+export const formatTruthDelta = (value?: number) => {
+  if (value === undefined || Number.isNaN(value) || value === 0) {
+    return null;
+  }
+  const rounded = Math.abs(value) < 1 ? Math.round(value * 10) / 10 : Math.round(value);
+  const sign = value > 0 ? '+' : value < 0 ? '−' : '';
+  return `${sign}${Math.abs(rounded)}%`;
+};
+
+export const buildRoundContext = (
+  playerCards: TabloidPlayedCard[],
+  opponentCards: TabloidPlayedCard[],
+  eventsTruthDelta: number,
+): RoundContext => {
+  const truthFromPlayer = playerCards.reduce((sum, entry) => sum + (entry.truthDelta ?? 0), 0);
+  const truthFromOpponent = opponentCards.reduce((sum, entry) => sum + (entry.truthDelta ?? 0), 0);
+  const capturedStates = playerCards.flatMap(entry => entry.capturedStates ?? []);
+
+  return {
+    truthDeltaTotal: truthFromPlayer + truthFromOpponent + eventsTruthDelta,
+    capturedStates,
+    cardsPlayedByYou: playerCards.map(entry => entry.card as Card),
+    cardsPlayedByOpp: opponentCards.map(entry => entry.card as Card),
+  };
+};


### PR DESCRIPTION
## Summary
- ensure the tabloid round context adds the opponent's signed truth swing instead of subtracting it
- extract reusable helpers for truth formatting/aggregation and cover them with regression tests

## Testing
- bun test

------
https://chatgpt.com/codex/tasks/task_e_68cd8c44cfb0832097818efcc2da6467