### PR TITLE
Pass card rarity to achievement tracking

### DIFF
--- a/src/contexts/AchievementContext.tsx
+++ b/src/contexts/AchievementContext.tsx
@@ -11,7 +11,7 @@ interface AchievementContextType {
   updateStats: (updates: Partial<PlayerStats>) => void;
   onGameStart: (faction: 'truth' | 'government', aiDifficulty: string) => void;
   onGameEnd: (won: boolean, victoryType: string, gameData: any) => void;
-  onCardPlayed: (cardId: string, cardType: string) => void;
+  onCardPlayed: (cardId: string, cardType: string, cardRarity?: string) => void;
   exportData: () => any;
   importData: (data: any) => boolean;
   resetProgress: () => void;
@@ -82,9 +82,9 @@ export const AchievementProvider: React.FC<AchievementProviderProps> = ({ childr
     refreshStats();
   }, [manager, refreshStats]);
 
-  const onCardPlayed = useCallback((cardId: string, cardType: string) => {
-    console.log('Achievement: Card played', { cardId, cardType });
-    manager.onCardPlayed(cardId, cardType);
+  const onCardPlayed = useCallback((cardId: string, cardType: string, cardRarity?: string) => {
+    console.log('Achievement: Card played', { cardId, cardType, cardRarity });
+    manager.onCardPlayed(cardType, cardRarity);
     refreshStats();
   }, [manager, refreshStats]);
 

--- a/src/data/achievementSystem.ts
+++ b/src/data/achievementSystem.ts
@@ -846,12 +846,12 @@ export class AchievementManager {
     this.updateStats(updates);
   }
 
-  onCardPlayed(cardType: string, cardRarity: string) {
+  onCardPlayed(cardType: string, cardRarity?: string) {
     this.incrementStat('total_cards_played');
-    
+
     // Reset per-game counters at start of new game
     // (This would be called when a new game starts)
-    
+
     switch (cardType.toLowerCase()) {
       case 'media':
         this.incrementStat('media_cards_played');
@@ -871,7 +871,7 @@ export class AchievementManager {
         break;
     }
 
-    if (cardRarity === 'legendary') {
+    if (cardRarity?.toLowerCase() === 'legendary') {
       this.incrementStat('legendary_cards_played');
     }
   }

--- a/src/hooks/useGameState.ts
+++ b/src/hooks/useGameState.ts
@@ -331,7 +331,7 @@ export const useGameState = (aiDifficultyOverride?: AIDifficulty) => {
         return prev;
       }
 
-      achievements.onCardPlayed(cardId, card.type);
+      achievements.onCardPlayed(cardId, card.type, card.rarity);
 
       const targetState = targetOverride ?? prev.targetState ?? null;
       const resolution = resolveCardEffects(prev, card, targetState);
@@ -386,7 +386,7 @@ export const useGameState = (aiDifficultyOverride?: AIDifficulty) => {
       return;
     }
 
-    achievements.onCardPlayed(cardId, card.type);
+    achievements.onCardPlayed(cardId, card.type, card.rarity);
 
     const targetState = explicitTargetState ?? gameState.targetState ?? null;
     let pendingRecord: ReturnType<typeof createPlayedCardRecord> | null = null;


### PR DESCRIPTION
## Summary
- allow the achievement context to capture and forward card rarity when cards are played
- ensure the achievement manager counts legendary plays defensively even when rarity is missing
- update game state hooks to pass both type and rarity for each play

## Testing
- npm run lint *(fails: Cannot find package '@eslint/js' during eslint config load)*

------
https://chatgpt.com/codex/tasks/task_e_68cd92bf059083209719803c756f4d64