### PR TITLE
Track combo achievements

### DIFF
--- a/src/components/game/AchievementPanel.tsx
+++ b/src/components/game/AchievementPanel.tsx
@@ -422,6 +422,47 @@ const AchievementPanel = ({ onClose }: AchievementPanelProps) => {
                   <div className="text-2xl font-bold text-orange-400">{Math.round(stats.total_play_time_minutes / 60)}h</div>
                   <div className="text-sm text-gray-400">Play Time</div>
                 </Card>
+                <Card className="p-4 bg-gray-800 border-gray-700 md:col-span-2">
+                  <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
+                    <div>
+                      <div className="text-2xl font-bold text-fuchsia-400">{stats.total_combos_executed}</div>
+                      <div className="text-sm text-gray-400">Combos Triggered</div>
+                    </div>
+                    <div>
+                      <div className="text-2xl font-bold text-sky-400">{stats.highest_combo_chain}</div>
+                      <div className="text-sm text-gray-400">Best Combo Chain</div>
+                    </div>
+                    <div>
+                      <div className="text-2xl font-bold text-amber-400">{stats.max_combos_in_single_game}</div>
+                      <div className="text-sm text-gray-400">Most Combos in a Game</div>
+                    </div>
+                  </div>
+                </Card>
+                <Card className="p-4 bg-gray-800 border-gray-700 md:col-span-2">
+                  <h4 className="text-sm font-semibold text-gray-200 mb-3">Combo Category Breakdown</h4>
+                  <div className="grid grid-cols-1 sm:grid-cols-2 gap-2 text-sm text-gray-300">
+                    <div className="flex items-center justify-between">
+                      <span>Sequence</span>
+                      <span className="font-semibold text-white">{stats.total_sequence_combos}</span>
+                    </div>
+                    <div className="flex items-center justify-between">
+                      <span>Count</span>
+                      <span className="font-semibold text-white">{stats.total_count_combos}</span>
+                    </div>
+                    <div className="flex items-center justify-between">
+                      <span>Threshold</span>
+                      <span className="font-semibold text-white">{stats.total_threshold_combos}</span>
+                    </div>
+                    <div className="flex items-center justify-between">
+                      <span>State Control</span>
+                      <span className="font-semibold text-white">{stats.total_state_combos}</span>
+                    </div>
+                    <div className="flex items-center justify-between">
+                      <span>Hybrid</span>
+                      <span className="font-semibold text-white">{stats.total_hybrid_combos}</span>
+                    </div>
+                  </div>
+                </Card>
               </div>
             </TabsContent>
 

--- a/src/contexts/AchievementContext.tsx
+++ b/src/contexts/AchievementContext.tsx
@@ -1,5 +1,6 @@
 import React, { createContext, useContext, useState, useEffect, useCallback, ReactNode } from 'react';
 import { AchievementManager, type Achievement, type PlayerStats } from '@/data/achievementSystem';
+import type { ComboEvaluation } from '@/game/combo.types';
 import { useToast } from '@/hooks/use-toast';
 
 interface AchievementContextType {
@@ -12,6 +13,7 @@ interface AchievementContextType {
   onGameStart: (faction: 'truth' | 'government', aiDifficulty: string) => void;
   onGameEnd: (won: boolean, victoryType: string, gameData: any) => void;
   onCardPlayed: (cardId: string, cardType: string, cardRarity?: string) => void;
+  onCombosResolved: (owner: 'human' | 'ai', evaluation: ComboEvaluation) => void;
   exportData: () => any;
   importData: (data: any) => boolean;
   resetProgress: () => void;
@@ -88,6 +90,12 @@ export const AchievementProvider: React.FC<AchievementProviderProps> = ({ childr
     refreshStats();
   }, [manager, refreshStats]);
 
+  const onCombosResolved = useCallback((owner: 'human' | 'ai', evaluation: ComboEvaluation) => {
+    console.log('Achievement: Combos resolved', { owner, comboCount: evaluation.results.length });
+    manager.onCombosResolved(owner, evaluation);
+    refreshStats();
+  }, [manager, refreshStats]);
+
   const exportData = useCallback(() => {
     return manager.exportData();
   }, [manager]);
@@ -151,6 +159,7 @@ export const AchievementProvider: React.FC<AchievementProviderProps> = ({ childr
     onGameStart,
     onGameEnd,
     onCardPlayed,
+    onCombosResolved,
     exportData,
     importData,
     resetProgress,

--- a/src/hooks/useGameState.ts
+++ b/src/hooks/useGameState.ts
@@ -519,6 +519,7 @@ export const useGameState = (aiDifficultyOverride?: AIDifficulty) => {
       
       const isHumanTurn = prev.currentPlayer === 'human';
       const comboResult = evaluateCombosForTurn(prev, isHumanTurn ? 'human' : 'ai');
+      achievements.onCombosResolved(isHumanTurn ? 'human' : 'ai', comboResult.evaluation);
       const fxEnabled = getComboSettings().fxEnabled;
 
       if (


### PR DESCRIPTION
## Summary
- extend the achievement stats model with combo tracking fields and persistence helpers
- add combo-focused achievement definitions and hook combo resolution into the game turn flow
- surface combo progress in the achievement statistics panel for quick monitoring

## Testing
- npm install *(fails: npm registry returned HTTP 403 responses for several packages, including ts-node)*

------
https://chatgpt.com/codex/tasks/task_e_68cd9591be288320a026007f77db572a