### PR TITLE
Track combo truth deltas for newspaper context

### DIFF
--- a/src/components/game/TabloidNewspaperLegacy.tsx
+++ b/src/components/game/TabloidNewspaperLegacy.tsx
@@ -21,6 +21,7 @@ export interface TabloidNewspaperProps {
   playedCards: TabloidPlayedCard[];
   faction: 'government' | 'truth';
   truth: number;
+  comboTruthDelta?: number;
   onClose: () => void;
 }
 

--- a/src/components/game/TabloidNewspaperV2.test.tsx
+++ b/src/components/game/TabloidNewspaperV2.test.tsx
@@ -40,4 +40,17 @@ describe('TabloidNewspaperV2 truth delta summary', () => {
     expect(context.truthDeltaTotal).toBe(expectedNet);
     expect(formatTruthDelta(context.truthDeltaTotal)).toBe('+4%');
   });
+
+  it('accounts for combo truth swings separately from card plays and events', () => {
+    const playerCards = [makeCard('player-small', 'human', 2)];
+    const opponentCards = [makeCard('opponent-boost', 'ai', -1)];
+    const eventTruth = 0;
+    const comboTruth = 5;
+
+    const context = buildRoundContext(playerCards, opponentCards, eventTruth, comboTruth);
+    const expectedNet = 2 - 1 + 0 + comboTruth;
+
+    expect(context.truthDeltaTotal).toBe(expectedNet);
+    expect(formatTruthDelta(context.truthDeltaTotal)).toBe('+6%');
+  });
 });

--- a/src/components/game/TabloidNewspaperV2.tsx
+++ b/src/components/game/TabloidNewspaperV2.tsx
@@ -160,7 +160,14 @@ type SecondaryStory = SecondaryCardStory | ReturnType<typeof createEventStory>;
 
 const isCardStory = (story: SecondaryStory): story is SecondaryCardStory => 'player' in story;
 
-const TabloidNewspaperV2 = ({ events, playedCards, faction, truth, onClose }: TabloidNewspaperProps) => {
+const TabloidNewspaperV2 = ({
+  events,
+  playedCards,
+  faction,
+  truth,
+  comboTruthDelta = 0,
+  onClose,
+}: TabloidNewspaperProps) => {
   const [data, setData] = useState<NewspaperData | null>(null);
   const [masthead, setMasthead] = useState('THE PARANOID TIMES');
   const [glitchText, setGlitchText] = useState<string | null>(null);
@@ -270,8 +277,8 @@ const TabloidNewspaperV2 = ({ events, playedCards, faction, truth, onClose }: Ta
 
   const eventsTruthDelta = useMemo(() => computeEventTruthDelta(events), [events]);
   const roundContext = useMemo(
-    () => buildRoundContext(playerCards, opponentCards, eventsTruthDelta),
-    [playerCards, opponentCards, eventsTruthDelta],
+    () => buildRoundContext(playerCards, opponentCards, eventsTruthDelta, comboTruthDelta),
+    [playerCards, opponentCards, eventsTruthDelta, comboTruthDelta],
   );
 
   const heroEvent = heroCardEntry ? null : events[0];

--- a/src/components/game/tabloidRoundUtils.ts
+++ b/src/components/game/tabloidRoundUtils.ts
@@ -15,13 +15,14 @@ export const buildRoundContext = (
   playerCards: TabloidPlayedCard[],
   opponentCards: TabloidPlayedCard[],
   eventsTruthDelta: number,
+  comboTruthDelta = 0,
 ): RoundContext => {
   const truthFromPlayer = playerCards.reduce((sum, entry) => sum + (entry.truthDelta ?? 0), 0);
   const truthFromOpponent = opponentCards.reduce((sum, entry) => sum + (entry.truthDelta ?? 0), 0);
   const capturedStates = playerCards.flatMap(entry => entry.capturedStates ?? []);
 
   return {
-    truthDeltaTotal: truthFromPlayer + truthFromOpponent + eventsTruthDelta,
+    truthDeltaTotal: truthFromPlayer + truthFromOpponent + eventsTruthDelta + comboTruthDelta,
     capturedStates,
     cardsPlayedByYou: playerCards.map(entry => entry.card as Card),
     cardsPlayedByOpp: opponentCards.map(entry => entry.card as Card),

--- a/src/hooks/__tests__/comboAdapter.test.ts
+++ b/src/hooks/__tests__/comboAdapter.test.ts
@@ -44,6 +44,7 @@ const createState = (overrides: Partial<GameState> = {}): GameState => ({
   aiDeck: [],
   cardsPlayedThisTurn: 3,
   cardsPlayedThisRound: [],
+  comboTruthDeltaThisRound: 0,
   playHistory: [],
   turnPlays: makeTurnPlays(),
   controlledStates: [],
@@ -97,6 +98,7 @@ describe('evaluateCombosForTurn', () => {
 
     expect(result.evaluation.results.length).toBeGreaterThan(0);
     expect(result.updatedTruth).toBeGreaterThan(state.truth);
+    expect(result.truthDelta).toBe(result.updatedTruth - state.truth);
     expect(result.fxMessages.length).toBe(result.evaluation.results.length);
     expect(result.logEntries[0]).toContain('Combos triggered');
 

--- a/src/hooks/__tests__/processAiActions.test.ts
+++ b/src/hooks/__tests__/processAiActions.test.ts
@@ -23,6 +23,7 @@ const baseState = (overrides: Partial<GameState> = {}): GameState => ({
   aiDeck: [],
   cardsPlayedThisTurn: 0,
   cardsPlayedThisRound: [],
+  comboTruthDeltaThisRound: 0,
   playHistory: [],
   turnPlays: [],
   controlledStates: [],

--- a/src/hooks/__tests__/useGameState.aiTurn.test.ts
+++ b/src/hooks/__tests__/useGameState.aiTurn.test.ts
@@ -36,6 +36,7 @@ const createBaseState = (overrides: Partial<GameState> = {}): GameState => ({
   aiDeck: [],
   cardsPlayedThisTurn: 0,
   cardsPlayedThisRound: [],
+  comboTruthDeltaThisRound: 0,
   playHistory: [],
   turnPlays: [],
   controlledStates: [],

--- a/src/hooks/comboAdapter.ts
+++ b/src/hooks/comboAdapter.ts
@@ -65,6 +65,7 @@ const buildStateDefense = (state: GameState): EngineGameState['stateDefense'] =>
 export interface ComboAdapterResult {
   evaluation: ComboEvaluation;
   updatedTruth: number;
+  truthDelta: number;
   updatedPlayerIp: number;
   updatedOpponentIp: number;
   logEntries: string[];
@@ -97,6 +98,7 @@ export const evaluateCombosForTurn = (
   const evaluation = evaluateCombos(engineState, playerId);
   const rewardedState = applyComboRewards(engineState, playerId, evaluation);
   const rewardLogs = rewardedState.log.slice(logStart);
+  const truthDelta = rewardedState.truth - state.truth;
 
   const comboMessages = evaluation.results.map(result => {
     const rewardText = formatComboReward(result.appliedReward);
@@ -114,6 +116,7 @@ export const evaluateCombosForTurn = (
   return {
     evaluation,
     updatedTruth: rewardedState.truth,
+    truthDelta,
     updatedPlayerIp: rewardedState.players[playerId].ip,
     updatedOpponentIp: rewardedState.players[opponentId].ip,
     logEntries,

--- a/src/hooks/gameStateTypes.ts
+++ b/src/hooks/gameStateTypes.ts
@@ -42,6 +42,7 @@ export interface GameState {
   cardsPlayedThisRound: CardPlayRecord[];
   playHistory: CardPlayRecord[];
   turnPlays: TurnPlay[];
+  comboTruthDeltaThisRound: number;
   controlledStates: string[];
   aiControlledStates: string[];
   states: Array<{

--- a/src/hooks/useGameState.ts
+++ b/src/hooks/useGameState.ts
@@ -177,6 +177,7 @@ export const useGameState = (aiDifficultyOverride?: AIDifficulty) => {
     aiDeck: generateWeightedDeck(40, 'government'),
     cardsPlayedThisTurn: 0,
     cardsPlayedThisRound: [],
+    comboTruthDeltaThisRound: 0,
     playHistory: [],
     turnPlays: [],
     controlledStates: [],
@@ -582,6 +583,7 @@ export const useGameState = (aiDifficultyOverride?: AIDifficulty) => {
         const humanIpAfterCombos = comboResult.updatedPlayerIp;
         const aiIpAfterCombos = comboResult.updatedOpponentIp;
         const truthAfterCombos = comboResult.updatedTruth;
+        const comboTruthDelta = comboResult.truthDelta;
 
         const logEntries = [
           ...comboLog,
@@ -604,6 +606,7 @@ export const useGameState = (aiDifficultyOverride?: AIDifficulty) => {
           aiIP: aiIpAfterCombos,
           pendingCardDraw,
           currentEvents: newEvents,
+          comboTruthDeltaThisRound: prev.comboTruthDeltaThisRound + comboTruthDelta,
           cardDrawState: {
             cardsPlayedLastTurn: prev.cardsPlayedThisTurn,
             lastTurnWithoutPlay: prev.cardsPlayedThisTurn === 0
@@ -632,6 +635,7 @@ export const useGameState = (aiDifficultyOverride?: AIDifficulty) => {
         aiIP: comboResult.updatedPlayerIp,
         cardsPlayedThisTurn: 0,
         turnPlays: [],
+        comboTruthDeltaThisRound: prev.comboTruthDeltaThisRound + comboResult.truthDelta,
         log: [...comboLog, 'AI turn completed']
       };
     });
@@ -824,6 +828,7 @@ export const useGameState = (aiDifficultyOverride?: AIDifficulty) => {
         deck: remainingDeck,
         showNewspaper: false,
         cardsPlayedThisRound: [],
+        comboTruthDeltaThisRound: 0,
         phase: 'action',
         currentPlayer: 'human',
         showNewCardsPresentation: false,
@@ -950,6 +955,8 @@ export const useGameState = (aiDifficultyOverride?: AIDifficulty) => {
         turnPlays: Array.isArray(saveData.turnPlays)
           ? saveData.turnPlays
           : [],
+        comboTruthDeltaThisRound:
+          typeof saveData.comboTruthDeltaThisRound === 'number' ? saveData.comboTruthDeltaThisRound : 0,
         // Ensure objects are properly reconstructed
         eventManager: prev.eventManager, // Keep the current event manager
         aiStrategist: prev.aiStrategist || AIFactory.createStrategist(saveData.aiDifficulty || 'medium')

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -1290,6 +1290,7 @@ const Index = () => {
           playedCards={gameState.cardsPlayedThisRound}
           faction={gameState.faction}
           truth={gameState.truth}
+          comboTruthDelta={gameState.comboTruthDeltaThisRound}
           onClose={handleCloseNewspaper}
         />
       )}


### PR DESCRIPTION
## Summary
- expose combo truth deltas from the adapter and accumulate them in game state for each round
- feed the aggregated combo truth swing into the newspaper round context so truth summaries include combo rewards
- update related types and unit tests to cover the new truth delta tracking

## Testing
- bun test

------
https://chatgpt.com/codex/tasks/task_e_68cd9b45caf4832082de5666e3507cbb