### PR TITLE
Raise IP victory threshold to 300

### DIFF
--- a/DESIGN_DOC_MVP.md
+++ b/DESIGN_DOC_MVP.md
@@ -4,7 +4,7 @@ Paranoid Times — Design \& Regelbok (MVP)
 
 
 
-Paranoid Times er et satirisk kartspill om å vinne narrativet, plystre bort motstanderens ressurser og “punsje” politisk press inn i delstater. Kortene er “nyheter” og aksjoner som skaper målbare effekter i spillets verden: IP (Influence Points), Truth (0–100%), og Pressure per stat. Førstemann til 10 stater, Truth-terskel, eller 200 IP vinner.
+Paranoid Times er et satirisk kartspill om å vinne narrativet, plystre bort motstanderens ressurser og “punsje” politisk press inn i delstater. Kortene er “nyheter” og aksjoner som skaper målbare effekter i spillets verden: IP (Influence Points), Truth (0–100%), og Pressure per stat. Førstemann til 10 stater, Truth-terskel, eller 300 IP vinner.
 
 
 
@@ -60,7 +60,7 @@ Truth ≥ 90% (Truth-spilleren) / Truth ≤ 10% (Government-spilleren), eller
 
 
 
-Du har 200 IP.
+Du har 300 IP.
 
 
 
@@ -530,7 +530,7 @@ Bytt currentPlayer, turn++.
 
 
 
-winCheck(s): kall etter endTurn: 10 stater / Truth-terskel / 200 IP.
+winCheck(s): kall etter endTurn: 10 stater / Truth-terskel / 300 IP.
 
 
 

--- a/docs/_archive/ShadowGov-Rules-v2.1.md
+++ b/docs/_archive/ShadowGov-Rules-v2.1.md
@@ -13,7 +13,7 @@ Win immediately if ANY of the following is true:
 - Truth ≥ 90% (Truth Seekers win)  
 - Truth ≤ 10% (Government wins)  
 - Control 10 states  
-- Reach 200 IP (Influence Points)  
+- Reach 300 IP (Influence Points)
 - Complete your Secret Agenda  
 
 ---
@@ -158,7 +158,7 @@ Humor: 10% chance to make a “stupid” move with a funny log.
 - Truth ≥90% (Truth Seekers win).  
 - Truth ≤10% (Government wins).  
 - Control 10 states.  
-- Reach 200 IP.  
+- Reach 300 IP.
 - Complete Secret Agenda.  
 
 ---

--- a/src/components/game/InteractiveOnboarding.tsx
+++ b/src/components/game/InteractiveOnboarding.tsx
@@ -30,7 +30,7 @@ const InteractiveOnboarding = ({ isActive, onComplete, onSkip, gameState }: Inte
     {
       id: 'welcome',
       title: '🎯 Welcome to Shadow Government!',
-      description: 'You are a player choosing between Government or Truth Seekers. Win by controlling 10 states, reaching 200 IP, or achieving your faction\'s truth threshold.',
+      description: 'You are a player choosing between Government or Truth Seekers. Win by controlling 10 states, reaching 300 IP, or achieving your faction\'s truth threshold.',
       target: '#game-header',
       skipable: true
     },
@@ -69,7 +69,7 @@ const InteractiveOnboarding = ({ isActive, onComplete, onSkip, gameState }: Inte
     {
       id: 'victory',
       title: '🏆 Victory Conditions',
-      description: 'Win by controlling 10 states, reaching 200 IP, or achieving 90% truth level. Watch these in the header!',
+      description: 'Win by controlling 10 states, reaching 300 IP, or achieving 90% truth level. Watch these in the header!',
       target: '#victory-conditions'
     }
   ];

--- a/src/components/game/VictoryConditions.tsx
+++ b/src/components/game/VictoryConditions.tsx
@@ -34,17 +34,17 @@ export const VictoryConditions: React.FC<VictoryConditionsProps> = ({
         <div className="mt-2">
           {isMobile ? (
             <div className="text-xs font-mono">
-              States: {controlledStates}/10 | Truth: {truth}% | IP: {ip}/200
+              States: {controlledStates}/10 | Truth: {truth}% | IP: {ip}/300
             </div>
           ) : (
             <div className="text-xs space-y-1 font-mono">
               <div>• Control 10 states</div>
-              <div>• Reach 200 IP</div>
+              <div>• Reach 300 IP</div>
               <div>• Truth ≥90%</div>
               <div className="border-t border-newspaper-bg/30 pt-1 mt-1">
                 <div className="text-center text-xs">States: {controlledStates}/10</div>
                 <div className="text-center text-xs">Truth: {truth}%</div>
-                <div className="text-center text-xs">IP: {ip}/200</div>
+                <div className="text-center text-xs">IP: {ip}/300</div>
               </div>
             </div>
           )}

--- a/src/content/mvpRules.ts
+++ b/src/content/mvpRules.ts
@@ -47,7 +47,7 @@ export const MVP_RULES_SECTIONS: MvpRulesSection[] = [
     bullets: [
       'Control 10 states to secure the map.',
       'Truth faction wins at ≥ 90% Truth; Government faction wins at ≤ 10% Truth.',
-      'Reach 200 Influence Points (IP) to overrun your rival’s resources.',
+      'Reach 300 Influence Points (IP) to overrun your rival’s resources.',
     ],
   },
   {

--- a/src/data/achievementSystem.ts
+++ b/src/data/achievementSystem.ts
@@ -88,7 +88,7 @@ export const ACHIEVEMENTS: Achievement[] = [
   {
     id: 'economic_supremacy',
     name: 'Resource Emperor',
-    description: 'Win by accumulating 200+ IP',
+    description: 'Win by accumulating 300+ IP',
     category: 'victory',
     rarity: 'uncommon',
     icon: '💰',

--- a/src/data/agendaDatabase.ts
+++ b/src/data/agendaDatabase.ts
@@ -200,8 +200,8 @@ export const AGENDA_DATABASE: SecretAgenda[] = [
     faction: 'government',
     category: 'resource',
     title: 'Resource Monopoly',
-    description: 'Accumulate 200 IP through systematic exploitation',
-    target: 200,
+    description: 'Accumulate 300 IP through systematic exploitation',
+    target: 300,
     difficulty: 'hard',
     checkProgress: (gameState) => {
       return gameState.ip;

--- a/src/data/enhancedAIStrategy.ts
+++ b/src/data/enhancedAIStrategy.ts
@@ -1243,8 +1243,8 @@ export class EnhancedAIStrategist implements AIStrategist {
 
     const aiTerritorialWin = aiStates >= 10;
     const playerTerritorialWin = playerStates >= 10;
-    const aiEconomicWin = aiIp >= 200;
-    const playerEconomicWin = playerIp >= 200;
+    const aiEconomicWin = aiIp >= 300;
+    const playerEconomicWin = playerIp >= 300;
 
     let aiTruthWin = false;
     let playerTruthWin = false;
@@ -1292,7 +1292,7 @@ export class EnhancedAIStrategist implements AIStrategist {
 
     const aiIp = gameState.aiIP ?? 0;
     const playerIp = this.getPlayerIp(gameState);
-    const ipScore = Math.max(-1, Math.min(1, (aiIp - playerIp) / 200));
+    const ipScore = Math.max(-1, Math.min(1, (aiIp - playerIp) / 300));
 
     const aiFaction = this.getAiFaction(gameState);
     const truthValue = gameState.truth ?? 50;

--- a/src/data/tutorialSystem.ts
+++ b/src/data/tutorialSystem.ts
@@ -60,7 +60,7 @@ export const TUTORIAL_SEQUENCES: TutorialSequence[] = [
       {
         id: 'ip_display',
         title: 'Influence Points (IP)',
-        description: 'IP is your operational currency. Gain IP from controlled states and use it to play powerful cards. Accumulating 200+ IP can secure victory through resource dominance.',
+        description: 'IP is your operational currency. Gain IP from controlled states and use it to play powerful cards. Accumulating 300+ IP can secure victory through resource dominance.',
         targetElement: '.ip-display',
         position: 'left',
         delay: 3000
@@ -137,7 +137,7 @@ export const TUTORIAL_SEQUENCES: TutorialSequence[] = [
       {
         id: 'victory_conditions',
         title: 'Path to Victory',
-        description: 'Win by: 1) Controlling 10+ states, 2) Accumulating 200+ IP, 3) Achieving extreme Truth levels (90%+ or 10%-), or 4) Completing your Secret Agenda.',
+        description: 'Win by: 1) Controlling 10+ states, 2) Accumulating 300+ IP, 3) Achieving extreme Truth levels (90%+ or 10%-), or 4) Completing your Secret Agenda.',
         position: 'center',
         delay: 4000
       }

--- a/src/data/victoryConditions.ts
+++ b/src/data/victoryConditions.ts
@@ -99,14 +99,14 @@ export const BASE_VICTORY_CONDITIONS: VictoryCondition[] = [
   {
     id: 'ip_victory',
     name: 'Resource Dominance',
-    description: 'Accumulate 200 IP',
+    description: 'Accumulate 300 IP',
     priority: 3,
     faction: 'both',
     checkCondition: (gameState: any) => {
-      return gameState.ip >= 200;
+      return gameState.ip >= 300;
     },
     getProgress: (gameState: any) => {
-      return Math.max(0, Math.min(100, (gameState.ip / 200) * 100));
+      return Math.max(0, Math.min(100, (gameState.ip / 300) * 100));
     }
   },
 

--- a/src/hooks/useGameState.ts
+++ b/src/hooks/useGameState.ts
@@ -873,8 +873,8 @@ export const useGameState = (aiDifficultyOverride?: AIDifficulty) => {
       victoryType = 'territorial';
       playerWon = true;
     }
-    // Economic victory (200+ IP)
-    else if (state.ip >= 200) {
+    // Economic victory (300+ IP)
+    else if (state.ip >= 300) {
       victoryType = 'economic';
       playerWon = true;
     }
@@ -884,7 +884,7 @@ export const useGameState = (aiDifficultyOverride?: AIDifficulty) => {
       playerWon = true;
     }
     // AI victory conditions (similar checks for AI)
-    else if (state.aiIP >= 200 || state.controlledStates.filter(s => state.states.find(st => st.abbreviation === s)?.owner === 'ai').length >= 10) {
+    else if (state.aiIP >= 300 || state.controlledStates.filter(s => state.states.find(st => st.abbreviation === s)?.owner === 'ai').length >= 10) {
       playerWon = false;
     }
 
@@ -896,7 +896,7 @@ export const useGameState = (aiDifficultyOverride?: AIDifficulty) => {
         finalTruth: state.truth,
         statesControlled: state.controlledStates.length
       });
-    } else if (!playerWon && (state.aiIP >= 200 || state.truth <= 0 || state.truth >= 100)) {
+    } else if (!playerWon && (state.aiIP >= 300 || state.truth <= 0 || state.truth >= 100)) {
       achievements.onGameEnd(false, 'defeat', {
         turns: state.turn,
         finalIP: state.ip,

--- a/src/mvp/engine.ts
+++ b/src/mvp/engine.ts
@@ -383,10 +383,10 @@ export function winCheck(
     return { winner: governmentPlayer, reason: 'truth' };
   }
 
-  if (players.P1.ip >= 200) {
+  if (players.P1.ip >= 300) {
     return { winner: 'P1', reason: 'ip' };
   }
-  if (players.P2.ip >= 200) {
+  if (players.P2.ip >= 300) {
     return { winner: 'P2', reason: 'ip' };
   }
 

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -398,11 +398,11 @@ const Index = () => {
       victoryType = 'truth';
     }
     
-    // Priority 3: IP victory (200 IP)
-    else if (gameState.ip >= 200) {
+    // Priority 3: IP victory (300 IP)
+    else if (gameState.ip >= 300) {
       winner = gameState.faction;
       victoryType = 'ip';
-    } else if (gameState.aiIP >= 200) {
+    } else if (gameState.aiIP >= 300) {
       winner = gameState.faction === 'government' ? 'truth' : 'government';
       victoryType = 'ip';
     }


### PR DESCRIPTION
## Summary
- raise the IP victory condition threshold to 300 across the core victory manager, game state checks, UI, and AI helpers
- refresh onboarding, tutorial, rule, achievement, and documentation text to match the new 300 IP objective

## Testing
- npm run lint *(fails: missing @eslint/js dependency because dependencies cannot be installed due to 403 fetching ts-node)*

------
https://chatgpt.com/codex/tasks/task_e_68cda1c8404483209f05eb95b0657863