### PR TITLE
Adjust starting truth baseline to 50

### DIFF
--- a/src/hooks/useGameState.ts
+++ b/src/hooks/useGameState.ts
@@ -166,7 +166,7 @@ export const useGameState = (aiDifficultyOverride?: AIDifficulty) => {
     round: 1,
     currentPlayer: 'human',
     aiDifficulty,
-    truth: 60,
+    truth: 50,
     ip: 15,
     aiIP: 15,
     // Use all available cards to ensure proper deck building
@@ -201,7 +201,7 @@ export const useGameState = (aiDifficultyOverride?: AIDifficulty) => {
     showNewspaper: false,
     log: [
       'Game started - Truth Seekers faction selected',
-      'Starting Truth: 60%',
+      'Starting Truth: 50%',
       'Cards drawn: 3',
       `AI Difficulty: ${aiDifficulty}`
     ],
@@ -247,7 +247,7 @@ export const useGameState = (aiDifficultyOverride?: AIDifficulty) => {
   );
 
   const initGame = useCallback((faction: 'government' | 'truth') => {
-    const startingTruth = faction === 'government' ? 40 : 60;
+    const startingTruth = 50;
     const startingIP = faction === 'government' ? 20 : 10; // Player IP
     const aiStartingIP = faction === 'government' ? 10 : 20; // AI starts as the opposite faction
     

--- a/src/systems/__tests__/cardResolution.test.ts
+++ b/src/systems/__tests__/cardResolution.test.ts
@@ -10,7 +10,7 @@ import {
 } from '../cardResolution';
 
 const createBaseSnapshot = (overrides: Partial<GameSnapshot> = {}): GameSnapshot => ({
-  truth: 60,
+  truth: 50,
   ip: 12,
   aiIP: 20,
   hand: [],
@@ -44,8 +44,8 @@ const createTracker = (initial?: Partial<PlayerStats>): AchievementTracker & { u
       total_states_controlled: 0,
       max_states_controlled_single_game: 0,
       max_ip_reached: 0,
-      max_truth_reached: 60,
-      min_truth_reached: 60,
+      max_truth_reached: 50,
+      min_truth_reached: 50,
       ...initial,
     },
     updateStats: update => {
@@ -80,8 +80,8 @@ describe('resolveCardMVP', () => {
     expect(tracker.updates).toHaveLength(1);
     expect(tracker.updates[0]).toMatchObject({
       max_ip_reached: 10,
-      max_truth_reached: 60,
-      min_truth_reached: 60,
+      max_truth_reached: 50,
+      min_truth_reached: 50,
     });
   });
 


### PR DESCRIPTION
## Summary
- set the initial game state and reset logic to start at a 50% truth baseline for both factions
- update card resolution test fixtures and expectations to reflect the new 50% truth starting point

## Testing
- bun test

------
https://chatgpt.com/codex/tasks/task_e_68cdabf170008320999a450ae1297ae8