### PR TITLE
Lower default combo cap to two per turn

### DIFF
--- a/src/content/mvpRules.ts
+++ b/src/content/mvpRules.ts
@@ -76,7 +76,7 @@ export const MVP_RULES_SECTIONS: MvpRulesSection[] = [
       'Count combos reward playing several cards of a type, rarity, or overall volume.',
       'Threshold combos measure total IP spent, high/low cost usage, and unique targets.',
       'State combos focus on hitting the same location repeatedly or spreading across regions.',
-      'Hybrid combos mix multiple triggers. All rewards respect each combo’s cap and your per-turn limit (default 3).',
+      'Hybrid combos mix multiple triggers. All rewards respect each combo’s cap and your per-turn limit (default 2).',
     ],
   },
   {

--- a/src/game/combo.config.ts
+++ b/src/game/combo.config.ts
@@ -468,7 +468,7 @@ export const COMBO_DEFINITIONS: ComboDefinition[] = [
 export const DEFAULT_COMBO_SETTINGS: ComboSettings = {
   enabled: true,
   fxEnabled: true,
-  maxCombosPerTurn: 3,
+  maxCombosPerTurn: 2,
   comboToggles: Object.fromEntries(COMBO_DEFINITIONS.map(def => [def.id, def.enabledByDefault ?? true])),
   rng: Math.random,
 };


### PR DESCRIPTION
## Summary
- reduce the default combo settings to cap turns at two triggers
- refresh the MVP rules copy to match the new combo limit

## Testing
- bun test src/game/comboEngine.test.ts
- bun test src/hooks/__tests__/comboAdapter.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68cdae96bdb48320ae62df148b359970