### PR TITLE
Tighten truth victory thresholds to 95/5

### DIFF
--- a/src/components/game/ExtraEditionNewspaper.tsx
+++ b/src/components/game/ExtraEditionNewspaper.tsx
@@ -126,7 +126,7 @@ const ExtraEditionNewspaper = ({ report, onClose }: ExtraEditionNewspaperProps) 
     if (winner === "truth") {
       headlines.push(`SHEEPLE AWAKE! Truth Hits ${finalTruth}% — Government in Disarray!`);
       headlines.push(`Bat Boy Endorses New Regime; Ratings Soar!`);
-      if (finalTruth >= 90) headlines.push(`Elvira Declares Victory: 'Leaks Never Sleep!'`);
+      if (finalTruth >= 95) headlines.push(`Elvira Declares Victory: 'Leaks Never Sleep!'`);
       if (statesTruth >= 10) headlines.push(`Corn Empire Falls; Popcorn Prices Plunge!`);
     } else if (winner === "government") {
       headlines.push(`ORDER RESTORED! Narrative Lockdown at ${finalTruth}%`);

--- a/src/components/game/InteractiveOnboarding.tsx
+++ b/src/components/game/InteractiveOnboarding.tsx
@@ -69,7 +69,7 @@ const InteractiveOnboarding = ({ isActive, onComplete, onSkip, gameState }: Inte
     {
       id: 'victory',
       title: '🏆 Victory Conditions',
-      description: 'Win by controlling 10 states, reaching 300 IP, or achieving 90% truth level. Watch these in the header!',
+      description: 'Win by controlling 10 states, reaching 300 IP, or hitting your truth threshold (95% for Truth, 5% for Government). Watch these in the header!',
       target: '#victory-conditions'
     }
   ];

--- a/src/components/game/MechanicsTooltip.tsx
+++ b/src/components/game/MechanicsTooltip.tsx
@@ -31,7 +31,7 @@ const MechanicsTooltip = ({ children, mechanic, customContent }: MechanicsToolti
         title: '🔍 Truth Meter',
         icon: <TrendingUp size={16} />,
         description: 'Truth represents public awareness of the conspiracy. Higher truth makes cards more effective.',
-        example: 'At 90% truth, you win the game!',
+        example: 'At 95% truth, you win the game!',
         tips: ['Play truth-boosting cards', 'AI will try to suppress truth', 'Truth affects card costs']
       },
       ip: {

--- a/src/components/game/TruthMeter.tsx
+++ b/src/components/game/TruthMeter.tsx
@@ -7,13 +7,13 @@ interface TruthMeterProps {
 
 const TruthMeter = ({ value, faction = "Truth" }: TruthMeterProps) => {
   const getColor = () => {
-    if (value >= 90) return 'bg-truth-red';
-    if (value <= 10) return 'bg-government-blue';
+    if (value >= 95) return 'bg-truth-red';
+    if (value <= 5) return 'bg-government-blue';
     return 'bg-gradient-to-r from-government-blue to-truth-red';
   };
 
   const getGlowEffect = () => {
-    if (value >= 90 || value <= 10) {
+    if (value >= 95 || value <= 5) {
       return 'animate-truth-pulse';
     }
     return '';
@@ -47,11 +47,11 @@ const TruthMeter = ({ value, faction = "Truth" }: TruthMeterProps) => {
 
   const getStatusMessage = () => {
     if (faction === "Truth") {
-      if (value >= 90) return '👁️ THE VEIL IS LIFTED 👁️';
-      if (value <= 10) return '😴 THEY LIVE, WE SLEEP 😴';
+      if (value >= 95) return '👁️ THE VEIL IS LIFTED 👁️';
+      if (value <= 5) return '😴 THEY LIVE, WE SLEEP 😴';
     } else {
-      if (value >= 90) return '🚨 NARRATIVE COLLAPSE 🚨';
-      if (value <= 10) return '✅ OPERATION SUCCESS ✅';
+      if (value >= 95) return '🚨 NARRATIVE COLLAPSE 🚨';
+      if (value <= 5) return '✅ OPERATION SUCCESS ✅';
     }
     return null;
   };
@@ -62,10 +62,10 @@ const TruthMeter = ({ value, faction = "Truth" }: TruthMeterProps) => {
       
       <div className={`relative w-40 ${getGlowEffect()}`}>
         <div className="relative h-4 bg-black rounded border border-secret-red/50 overflow-hidden">
-          <div 
+          <div
             className={`absolute top-0 left-0 h-full transition-all duration-500 ${
-              value >= 90 ? 'bg-truth-red' : 
-              value <= 10 ? 'bg-government-blue' : 
+              value >= 95 ? 'bg-truth-red' :
+              value <= 5 ? 'bg-government-blue' :
               'bg-gradient-to-r from-government-blue via-yellow-500 to-truth-red'
             }`}
             style={{ width: `${value}%` }}
@@ -76,13 +76,13 @@ const TruthMeter = ({ value, faction = "Truth" }: TruthMeterProps) => {
         </div>
         
         {/* Critical thresholds with labels */}
-        <div className="absolute -bottom-2 left-[10%] transform -translate-x-1/2">
+        <div className="absolute -bottom-2 left-[5%] transform -translate-x-1/2">
           <div className="w-0.5 h-2 bg-government-blue"></div>
-          <div className="text-xs font-mono text-government-blue mt-1">10%</div>
+          <div className="text-xs font-mono text-government-blue mt-1">5%</div>
         </div>
-        <div className="absolute -bottom-2 left-[90%] transform -translate-x-1/2">
+        <div className="absolute -bottom-2 left-[95%] transform -translate-x-1/2">
           <div className="w-0.5 h-2 bg-truth-red"></div>
-          <div className="text-xs font-mono text-truth-red mt-1">90%</div>
+          <div className="text-xs font-mono text-truth-red mt-1">95%</div>
         </div>
       </div>
       
@@ -91,8 +91,8 @@ const TruthMeter = ({ value, faction = "Truth" }: TruthMeterProps) => {
           {value}%
         </div>
         <div className={`text-xs font-mono text-center ${
-          value >= 90 ? 'text-truth-red' :
-          value <= 10 ? 'text-government-blue' :
+          value >= 95 ? 'text-truth-red' :
+          value <= 5 ? 'text-government-blue' :
           'text-yellow-500'
         }`}>
           {getLabel()}
@@ -102,7 +102,7 @@ const TruthMeter = ({ value, faction = "Truth" }: TruthMeterProps) => {
       {/* Status indicators with glitch effects */}
       {getStatusMessage() && (
         <div className={`text-xs font-mono animate-glitch ${
-          value >= 90 ? 'text-truth-red' : 'text-government-blue'
+          value >= 95 ? 'text-truth-red' : 'text-government-blue'
         }`}>
           {getStatusMessage()}
         </div>

--- a/src/components/game/VictoryConditions.tsx
+++ b/src/components/game/VictoryConditions.tsx
@@ -40,7 +40,7 @@ export const VictoryConditions: React.FC<VictoryConditionsProps> = ({
             <div className="text-xs space-y-1 font-mono">
               <div>• Control 10 states</div>
               <div>• Reach 300 IP</div>
-              <div>• Truth ≥90%</div>
+              <div>• Truth ≥95% / ≤5%</div>
               <div className="border-t border-newspaper-bg/30 pt-1 mt-1">
                 <div className="text-center text-xs">States: {controlledStates}/10</div>
                 <div className="text-center text-xs">Truth: {truth}%</div>

--- a/src/content/mvpRules.ts
+++ b/src/content/mvpRules.ts
@@ -46,7 +46,7 @@ export const MVP_RULES_SECTIONS: MvpRulesSection[] = [
     title: 'Objective',
     bullets: [
       'Control 10 states to secure the map.',
-      'Truth faction wins at ≥ 90% Truth; Government faction wins at ≤ 10% Truth.',
+      'Truth faction wins at ≥ 95% Truth; Government faction wins at ≤ 5% Truth.',
       'Reach 300 Influence Points (IP) to overrun your rival’s resources.',
     ],
   },

--- a/src/data/achievementSystem.ts
+++ b/src/data/achievementSystem.ts
@@ -43,7 +43,7 @@ export const ACHIEVEMENTS: Achievement[] = [
   {
     id: 'truth_victory',
     name: 'Truth Revealed',
-    description: 'Win by achieving 90%+ Truth as Truth Seekers',
+    description: 'Win by achieving 95%+ Truth as Truth Seekers',
     category: 'victory',
     rarity: 'uncommon',
     icon: '💡',
@@ -59,7 +59,7 @@ export const ACHIEVEMENTS: Achievement[] = [
   {
     id: 'suppression_victory',
     name: 'Information Control',
-    description: 'Win by reducing Truth to 10% or below as Government',
+    description: 'Win by reducing Truth to 5% or below as Government',
     category: 'victory',
     rarity: 'uncommon',
     icon: '🔒',

--- a/src/data/enhancedAIStrategy.ts
+++ b/src/data/enhancedAIStrategy.ts
@@ -1250,8 +1250,8 @@ export class EnhancedAIStrategist implements AIStrategist {
     let playerTruthWin = false;
 
     if (aiFaction === 'government') {
-      aiTruthWin = truth <= 10;
-      playerTruthWin = truth >= 90;
+      aiTruthWin = truth <= 5;
+      playerTruthWin = truth >= 95;
       if (truth <= 0) {
         aiTruthWin = true;
       }
@@ -1259,8 +1259,8 @@ export class EnhancedAIStrategist implements AIStrategist {
         playerTruthWin = true;
       }
     } else {
-      aiTruthWin = truth >= 90;
-      playerTruthWin = truth <= 10;
+      aiTruthWin = truth >= 95;
+      playerTruthWin = truth <= 5;
       if (truth >= 100) {
         aiTruthWin = true;
       }

--- a/src/data/tutorialSystem.ts
+++ b/src/data/tutorialSystem.ts
@@ -137,7 +137,7 @@ export const TUTORIAL_SEQUENCES: TutorialSequence[] = [
       {
         id: 'victory_conditions',
         title: 'Path to Victory',
-        description: 'Win by: 1) Controlling 10+ states, 2) Accumulating 300+ IP, 3) Achieving extreme Truth levels (90%+ or 10%-), or 4) Completing your Secret Agenda.',
+        description: 'Win by: 1) Controlling 10+ states, 2) Accumulating 300+ IP, 3) Achieving extreme Truth levels (95%+ or 5%-), or 4) Completing your Secret Agenda.',
         position: 'center',
         delay: 4000
       }

--- a/src/data/victoryConditions.ts
+++ b/src/data/victoryConditions.ts
@@ -70,11 +70,11 @@ export const BASE_VICTORY_CONDITIONS: VictoryCondition[] = [
   {
     id: 'truth_high',
     name: 'Truth Awakening',
-    description: 'Truth ≥ 90% (Truth Seekers)',
+    description: 'Truth ≥ 95% (Truth Seekers)',
     priority: 2,
     faction: 'truth',
     checkCondition: (gameState: any) => {
-      return gameState.truth >= 90;
+      return gameState.truth >= 95;
     },
     getProgress: (gameState: any) => {
       return Math.max(0, Math.min(100, gameState.truth));
@@ -83,11 +83,11 @@ export const BASE_VICTORY_CONDITIONS: VictoryCondition[] = [
   {
     id: 'truth_low',
     name: 'Information Suppression',
-    description: 'Truth ≤ 10% (Government)',
+    description: 'Truth ≤ 5% (Government)',
     priority: 2,
     faction: 'government',
     checkCondition: (gameState: any) => {
-      return gameState.truth <= 10;
+      return gameState.truth <= 5;
     },
     getProgress: (gameState: any) => {
       // For government, progress goes up as truth goes down

--- a/src/hooks/useGameState.ts
+++ b/src/hooks/useGameState.ts
@@ -861,10 +861,10 @@ export const useGameState = (aiDifficultyOverride?: AIDifficulty) => {
     let playerWon = false;
 
     // Truth-based victories
-    if (state.truth >= 90 && state.faction === 'truth') {
+    if (state.truth >= 95 && state.faction === 'truth') {
       victoryType = 'truth_high';
       playerWon = true;
-    } else if (state.truth <= 10 && state.faction === 'government') {
+    } else if (state.truth <= 5 && state.faction === 'government') {
       victoryType = 'truth_low';
       playerWon = true;
     }

--- a/src/mvp/engine.ts
+++ b/src/mvp/engine.ts
@@ -373,12 +373,12 @@ export function winCheck(
     return { winner: 'P2', reason: 'states' };
   }
 
-  if (state.truth >= 90) {
+  if (state.truth >= 95) {
     const truthPlayer = players.P1.faction === 'truth' ? 'P1' : 'P2';
     return { winner: truthPlayer, reason: 'truth' };
   }
 
-  if (state.truth <= 10) {
+  if (state.truth <= 5) {
     const governmentPlayer = players.P1.faction === 'government' ? 'P1' : 'P2';
     return { winner: governmentPlayer, reason: 'truth' };
   }

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -389,11 +389,11 @@ const Index = () => {
       victoryType = 'agenda';
     }
     
-    // Priority 2: Truth thresholds (Truth ≥ 90% for Truth Seekers, Truth ≤ 10% for Government)
-    else if (gameState.truth >= 90 && gameState.faction === 'truth') {
+    // Priority 2: Truth thresholds (Truth ≥ 95% for Truth Seekers, Truth ≤ 5% for Government)
+    else if (gameState.truth >= 95 && gameState.faction === 'truth') {
       winner = 'truth';
       victoryType = 'truth';
-    } else if (gameState.truth <= 10 && gameState.faction === 'government') {
+    } else if (gameState.truth <= 5 && gameState.faction === 'government') {
       winner = 'government';
       victoryType = 'truth';
     }


### PR DESCRIPTION
## Summary
- raise the MVP engine and front-end truth victory requirement to 95% for Truth faction wins and 5% for Government wins
- synchronize AI planning, achievements, tutorials, onboarding copy, and victory UI/tooltips with the tighter truth thresholds

## Testing
- bun test

------
https://chatgpt.com/codex/tasks/task_e_68cdafde4b288320bdcc672e3f9ef800