### PR TITLE
Use local card art assets with placeholder fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,12 @@ This project is built with:
 - shadcn-ui
 - Tailwind CSS
 
+## Card art assets
+
+Custom artwork for cards should be stored in `public/card-art/` with filenames that match the card ID. The game first looks for a
+`<cardId>.jpg` image and then for `<cardId>.png`. If neither file is present the UI will automatically fall back to the existing
+placeholder illustrations.
+
 ## How can I deploy this project?
 
 Simply open [Lovable](https://lovable.dev/projects/fa2f38e2-5939-4c65-a945-2c0f8029da84) and click on Share -> Publish.

--- a/src/components/game/CardImage.tsx
+++ b/src/components/game/CardImage.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { isExtensionCard, getCardExtensionInfo } from '@/data/extensionIntegration';
 
 interface CardImageProps {
@@ -9,9 +9,10 @@ interface CardImageProps {
 const CardImage: React.FC<CardImageProps> = ({ cardId, className = '' }) => {
   const [imageError, setImageError] = useState(false);
   const [imageLoaded, setImageLoaded] = useState(false);
+  const [imageExtension, setImageExtension] = useState<'jpg' | 'png'>('jpg');
 
   // Check if this is an extension card with temp image
-  const getImagePath = () => {
+  const getFallbackImagePath = () => {
     // Primary: extension metadata
     if (isExtensionCard(cardId)) {
       const extensionInfo = getCardExtensionInfo(cardId);
@@ -47,10 +48,28 @@ const CardImage: React.FC<CardImageProps> = ({ cardId, className = '' }) => {
     return '/lovable-uploads/e7c952a9-333a-4f6b-b1b5-f5aeb6c3d9c1.png';
   };
 
-  const imagePath = getImagePath();
+  const fallbackImagePath = getFallbackImagePath();
+  const imagePath = imageError
+    ? fallbackImagePath
+    : `/card-art/${cardId}.${imageExtension}`;
+
+  useEffect(() => {
+    setImageError(false);
+    setImageLoaded(false);
+    setImageExtension('jpg');
+  }, [cardId]);
 
   const handleImageError = () => {
-    setImageError(true);
+    setImageLoaded(false);
+
+    if (!imageError && imageExtension === 'jpg') {
+      setImageExtension('png');
+      return;
+    }
+
+    if (!imageError) {
+      setImageError(true);
+    }
   };
 
   const handleImageLoad = () => {


### PR DESCRIPTION
## Summary
- attempt to load card art from public/card-art using the card id before falling back to placeholder images
- add jpg to png retry logic and reset handlers when the card id changes
- document the expected location and naming convention for card artwork assets in the README

## Testing
- npm run lint *(fails: missing dev dependency due to private registry restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68cdb2c51cf4832092ad3db9ede98203