### PR TITLE
Add government redaction sweep visual effect

### DIFF
--- a/src/components/effects/RedactionSweep.tsx
+++ b/src/components/effects/RedactionSweep.tsx
@@ -1,0 +1,103 @@
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+
+interface RedactionSweepProps {
+  onComplete?: () => void;
+}
+
+interface RedactionBarDescriptor {
+  delay: number;
+  tilt: number;
+  width: number;
+}
+
+const BAR_COUNT = 7;
+const STATIC_DURATION_MS = 1000;
+
+const RedactionSweep: React.FC<RedactionSweepProps> = ({ onComplete }) => {
+  const [prefersReducedMotion, setPrefersReducedMotion] = useState(false);
+
+  useEffect(() => {
+    if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') {
+      return;
+    }
+
+    const mediaQuery = window.matchMedia('(prefers-reduced-motion: reduce)');
+    setPrefersReducedMotion(mediaQuery.matches);
+
+    const handleChange = (event: MediaQueryListEvent) => {
+      setPrefersReducedMotion(event.matches);
+    };
+
+    if ('addEventListener' in mediaQuery) {
+      mediaQuery.addEventListener('change', handleChange);
+      return () => mediaQuery.removeEventListener('change', handleChange);
+    }
+
+    mediaQuery.addListener(handleChange);
+    return () => mediaQuery.removeListener(handleChange);
+  }, []);
+
+  useEffect(() => {
+    if (!prefersReducedMotion) {
+      return;
+    }
+
+    const timeout = window.setTimeout(() => {
+      onComplete?.();
+    }, STATIC_DURATION_MS);
+
+    return () => window.clearTimeout(timeout);
+  }, [prefersReducedMotion, onComplete]);
+
+  const handleAnimationEnd = useCallback(
+    (event: React.AnimationEvent<HTMLDivElement>) => {
+      if (event.target === event.currentTarget && !prefersReducedMotion) {
+        onComplete?.();
+      }
+    },
+    [onComplete, prefersReducedMotion]
+  );
+
+  const bars = useMemo<RedactionBarDescriptor[]>(() => {
+    const midpoint = (BAR_COUNT - 1) / 2;
+
+    return Array.from({ length: BAR_COUNT }, (_, index) => {
+      const distanceFromCenter = Math.abs(index - midpoint);
+      const tilt = (index % 2 === 0 ? -1 : 1) * (1.2 + distanceFromCenter * 0.35);
+      const width = 82 - distanceFromCenter * 8;
+      const delay = index * 0.08;
+
+      return { delay, tilt, width };
+    });
+  }, []);
+
+  return (
+    <div
+      className="redaction-overlay"
+      aria-hidden="true"
+      role="presentation"
+      data-reduced-motion={prefersReducedMotion ? 'true' : 'false'}
+      onAnimationEnd={handleAnimationEnd}
+    >
+      <div className="redaction-overlay__content">
+        {bars.map((bar, index) => (
+          <div
+            key={index}
+            className="redaction-bar"
+            style={
+              {
+                '--bar-delay': `${bar.delay}s`,
+                '--bar-tilt': `${bar.tilt}deg`,
+                '--bar-width': `${bar.width}%`
+              } as React.CSSProperties
+            }
+          >
+            <span className="redaction-bar__label">REDACTED</span>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+};
+
+export default RedactionSweep;

--- a/src/components/game/CardAnimationLayer.tsx
+++ b/src/components/game/CardAnimationLayer.tsx
@@ -1,6 +1,7 @@
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { ParticleSystem } from '@/components/effects/ParticleSystem';
 import FloatingNumbers from '@/components/effects/FloatingNumbers';
+import RedactionSweep from '@/components/effects/RedactionSweep';
 
 interface CardAnimationLayerProps {
   children?: React.ReactNode;
@@ -24,6 +25,11 @@ const CardAnimationLayer: React.FC<CardAnimationLayerProps> = ({ children }) => 
     type: 'ip' | 'truth' | 'damage' | 'synergy' | 'combo' | 'chain';
     x?: number;
     y?: number;
+  } | null>(null);
+
+  const [redactionSweep, setRedactionSweep] = useState<{
+    active: boolean;
+    key: number;
   } | null>(null);
 
   useEffect(() => {
@@ -80,12 +86,20 @@ const CardAnimationLayer: React.FC<CardAnimationLayerProps> = ({ children }) => 
       });
     };
 
+    const handleGovernmentRedaction = () => {
+      setRedactionSweep({
+        active: true,
+        key: Date.now()
+      });
+    };
+
     // Register event listeners
     window.addEventListener('cardDeployed', handleCardDeployed as EventListener);
     window.addEventListener('stateCapture', handleStateCapture as EventListener);
     window.addEventListener('stateLoss', handleStateLoss as EventListener);
     window.addEventListener('synergyActivation', handleSynergyActivation as EventListener);
     window.addEventListener('showFloatingNumber', handleFloatingNumber as EventListener);
+    window.addEventListener('governmentRedaction', handleGovernmentRedaction as EventListener);
 
     return () => {
       window.removeEventListener('cardDeployed', handleCardDeployed as EventListener);
@@ -93,6 +107,7 @@ const CardAnimationLayer: React.FC<CardAnimationLayerProps> = ({ children }) => 
       window.removeEventListener('stateLoss', handleStateLoss as EventListener);
       window.removeEventListener('synergyActivation', handleSynergyActivation as EventListener);
       window.removeEventListener('showFloatingNumber', handleFloatingNumber as EventListener);
+      window.removeEventListener('governmentRedaction', handleGovernmentRedaction as EventListener);
     };
   }, []);
 
@@ -104,17 +119,23 @@ const CardAnimationLayer: React.FC<CardAnimationLayerProps> = ({ children }) => 
     setFloatingNumber(null);
   };
 
+  const handleRedactionComplete = () => {
+    setRedactionSweep(null);
+  };
+
   return (
     <>
       {/* Full-screen overlay for card animations */}
-      <div 
-        id="card-play-layer" 
+      <div
+        id="card-play-layer"
         className="fixed inset-0 pointer-events-none z-[40]"
         aria-hidden="true"
       >
         {children}
+        {redactionSweep?.active && (
+          <RedactionSweep key={redactionSweep.key} onComplete={handleRedactionComplete} />
+        )}
       </div>
-      
 
       {/* Particle Effects */}
       <ParticleSystem

--- a/src/index.css
+++ b/src/index.css
@@ -228,6 +228,182 @@ All colors MUST be HSL.
 }
 
 @layer components {
+  /* Government redaction sweep overlay */
+  .redaction-overlay {
+    position: absolute;
+    inset: 0;
+    pointer-events: none;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    overflow: hidden;
+    background: rgba(8, 9, 13, 0);
+    animation: redaction-overlay-fade 1.8s ease-in-out forwards;
+    z-index: 60;
+  }
+
+  .redaction-overlay::before {
+    content: "";
+    position: absolute;
+    inset: 0;
+    background: radial-gradient(circle at 50% 50%, rgba(255, 255, 255, 0.15), transparent 55%);
+    opacity: 0;
+    animation: redaction-overlay-highlight 1.6s ease-out forwards;
+  }
+
+  .redaction-overlay__content {
+    position: relative;
+    width: 100%;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: clamp(12px, 3vh, 28px);
+    padding: clamp(16px, 5vh, 48px) clamp(16px, 6vw, 64px);
+  }
+
+  .redaction-bar {
+    position: relative;
+    width: min(720px, var(--bar-width, 80%));
+    height: clamp(38px, 8vh, 72px);
+    background: rgba(0, 0, 0, 0.92);
+    color: #f9fafb;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    overflow: hidden;
+    border-radius: 6px;
+    box-shadow: 0 14px 32px rgba(0, 0, 0, 0.5), 0 0 0 2px rgba(255, 255, 255, 0.08);
+    transform: translateX(-125%) rotate(var(--bar-tilt, 0deg));
+    opacity: 0;
+    animation: redaction-bar-sweep 1.2s cubic-bezier(0.42, 0, 0.2, 1) forwards;
+    animation-delay: var(--bar-delay, 0s);
+  }
+
+  .redaction-bar::before {
+    content: "";
+    position: absolute;
+    inset: 0;
+    background-image: repeating-linear-gradient(
+      -45deg,
+      rgba(255, 255, 255, 0.1) 0px,
+      rgba(255, 255, 255, 0.1) 6px,
+      transparent 6px,
+      transparent 12px
+    );
+    opacity: 0.18;
+    mix-blend-mode: screen;
+    animation: redaction-bar-stripes 0.8s linear infinite;
+  }
+
+  .redaction-bar::after {
+    content: "";
+    position: absolute;
+    inset: 0;
+    border: 1px solid rgba(255, 255, 255, 0.18);
+    opacity: 0.4;
+    pointer-events: none;
+  }
+
+  .redaction-bar__label {
+    position: relative;
+    z-index: 1;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    padding: 0 clamp(24px, 4vw, 48px);
+    font-family: "Bebas Neue", "Anton", system-ui, sans-serif;
+    font-size: clamp(1.5rem, 4vw, 3.25rem);
+    letter-spacing: 0.45em;
+    text-indent: 0.45em;
+    text-transform: uppercase;
+    color: rgba(248, 250, 252, 0.95);
+    line-height: 1;
+    text-shadow: 0 2px 12px rgba(0, 0, 0, 0.65);
+    white-space: nowrap;
+    animation: redaction-text-flicker 0.6s steps(2, end) 3 forwards;
+  }
+
+  .redaction-bar__label::after {
+    content: "REDACTED";
+    position: absolute;
+    inset: 0;
+    transform: translate(2px, 1px);
+    color: rgba(248, 250, 252, 0.12);
+    pointer-events: none;
+  }
+
+  @keyframes redaction-overlay-fade {
+    0% { background: rgba(8, 9, 13, 0); }
+    20% { background: rgba(8, 9, 13, 0.55); }
+    65% { background: rgba(8, 9, 13, 0.6); }
+    100% { background: rgba(8, 9, 13, 0); }
+  }
+
+  @keyframes redaction-overlay-highlight {
+    0% { opacity: 0; }
+    30% { opacity: 0.4; }
+    80% { opacity: 0.15; }
+    100% { opacity: 0; }
+  }
+
+  @keyframes redaction-bar-sweep {
+    0% {
+      transform: translateX(-135%) rotate(var(--bar-tilt, 0deg));
+      opacity: 0;
+    }
+    25% {
+      opacity: 1;
+    }
+    45% {
+      transform: translateX(0%) rotate(var(--bar-tilt, 0deg));
+      opacity: 1;
+    }
+    80% {
+      transform: translateX(0%) rotate(var(--bar-tilt, 0deg));
+      opacity: 1;
+    }
+    100% {
+      transform: translateX(135%) rotate(var(--bar-tilt, 0deg));
+      opacity: 0;
+    }
+  }
+
+  @keyframes redaction-bar-stripes {
+    0% { background-position: 0 0; }
+    100% { background-position: 120px 0; }
+  }
+
+  @keyframes redaction-text-flicker {
+    0%, 100% { opacity: 0.9; }
+    50% { opacity: 1; }
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .redaction-overlay {
+      animation: none;
+      background: rgba(8, 9, 13, 0.82);
+    }
+
+    .redaction-overlay::before {
+      animation: none;
+      opacity: 0.2;
+    }
+
+    .redaction-bar {
+      animation: none;
+      transform: none;
+      opacity: 1;
+    }
+
+    .redaction-bar::before {
+      animation: none;
+    }
+
+    .redaction-bar__label {
+      animation: none;
+    }
+  }
+
   /* Enhanced Card Animation System */
   .play-card-clone {
     position: absolute;

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -750,10 +750,14 @@ const Index = () => {
       const cardElement = document.querySelector(`[data-card-id="${cardId}"]`);
       if (cardElement) {
         const position = VisualEffectsCoordinator.getElementCenter(cardElement);
-        
+
         // Trigger deploy particle effect
         VisualEffectsCoordinator.triggerParticleEffect('deploy', position);
-        
+
+        if (card.faction === 'government' && card.type === 'ATTACK') {
+          VisualEffectsCoordinator.triggerGovernmentRedaction(position);
+        }
+
         // Show floating number for IP cost
         if (card.cost > 0) {
           VisualEffectsCoordinator.showFloatingNumber(-card.cost, 'ip', {

--- a/src/utils/visualEffects.ts
+++ b/src/utils/visualEffects.ts
@@ -21,6 +21,16 @@ export class VisualEffectsCoordinator {
     }));
   }
 
+  // Trigger full-screen government redaction sweep
+  static triggerGovernmentRedaction(position: EffectPosition): void {
+    window.dispatchEvent(new CustomEvent('governmentRedaction', {
+      detail: {
+        x: position.x,
+        y: position.y
+      }
+    }));
+  }
+
   // Trigger synergy activation effects
   static triggerSynergyActivation(
     bonusIP: number,


### PR DESCRIPTION
## Summary
- add a full-screen RedactionSweep overlay component with reduced-motion support
- extend the card animation layer and global styles to play the redaction sweep on demand
- expose a triggerGovernmentRedaction helper and invoke it for government attack card plays

## Testing
- npm run lint *(fails: missing @eslint/js because dependencies could not be installed; `npm install` returns 403 for ts-node)*

------
https://chatgpt.com/codex/tasks/task_e_68cdc70db9088320bb6dd4bf79b6dde1