### PR TITLE
Add truth flash overlay and media card trigger

### DIFF
--- a/src/components/effects/ParticleSystem.tsx
+++ b/src/components/effects/ParticleSystem.tsx
@@ -13,11 +13,24 @@ interface Particle {
   opacity: number;
 }
 
+export type ParticleEffectType =
+  | 'deploy'
+  | 'capture'
+  | 'counter'
+  | 'victory'
+  | 'synergy'
+  | 'bigwin'
+  | 'stateloss'
+  | 'chain'
+  | 'flash'
+  | 'stateevent'
+  | 'contested';
+
 interface ParticleSystemProps {
   active: boolean;
   x: number;
   y: number;
-  type: 'deploy' | 'capture' | 'counter' | 'victory' | 'synergy' | 'bigwin' | 'stateloss' | 'chain';
+  type: ParticleEffectType;
   onComplete?: () => void;
 }
 
@@ -87,21 +100,33 @@ export const ParticleSystem: React.FC<ParticleSystemProps> = ({
     };
   }, [active, x, y, type, onComplete]);
 
-  const getParticleCount = (type: string): number => {
+  const getParticleCount = (type: ParticleEffectType): number => {
     switch (type) {
-      case 'victory': case 'bigwin': return 60;
-      case 'synergy': return 40;
-      case 'chain': return 35;
-      case 'deploy': case 'stateloss': return 30;
-      case 'capture': case 'counter': return 20;
+      case 'victory':
+      case 'bigwin':
+        return 60;
+      case 'flash':
+        return 48;
+      case 'synergy':
+      case 'stateevent':
+        return 40;
+      case 'chain':
+      case 'contested':
+        return 35;
+      case 'deploy':
+      case 'stateloss':
+        return 30;
+      case 'capture':
+      case 'counter':
+        return 20;
       default: return 20;
     }
   };
 
-  const createParticle = (id: number, centerX: number, centerY: number, effectType: string): Particle => {
+  const createParticle = (id: number, centerX: number, centerY: number, effectType: ParticleEffectType): Particle => {
     const angle = (Math.PI * 2 * id) / 20 + Math.random() * 0.5;
     const speed = getParticleSpeed(effectType);
-    
+
     const color = getParticleColor(effectType);
 
     const spread = getParticleSpread(effectType);
@@ -121,17 +146,27 @@ export const ParticleSystem: React.FC<ParticleSystemProps> = ({
     };
   };
 
-  const getParticleSpeed = (type: string): number => {
+  const getParticleSpeed = (type: ParticleEffectType): number => {
     switch (type) {
-      case 'victory': case 'bigwin': return 4 + Math.random() * 5;
-      case 'synergy': return 3 + Math.random() * 4;
-      case 'chain': return 2.5 + Math.random() * 3;
-      case 'stateloss': return 1.5 + Math.random() * 2;
-      default: return 2 + Math.random() * 3;
+      case 'victory':
+      case 'bigwin':
+        return 4 + Math.random() * 5;
+      case 'flash':
+        return 3.5 + Math.random() * 4;
+      case 'synergy':
+      case 'stateevent':
+        return 3 + Math.random() * 4;
+      case 'chain':
+      case 'contested':
+        return 2.5 + Math.random() * 3;
+      case 'stateloss':
+        return 1.5 + Math.random() * 2;
+      default:
+        return 2 + Math.random() * 3;
     }
   };
 
-  const getParticleColor = (type: string): string => {
+  const getParticleColor = (type: ParticleEffectType): string => {
     switch (type) {
       case 'deploy':
         return `hsl(${142 + Math.random() * 20}, 76%, ${36 + Math.random() * 20}%)`;
@@ -147,38 +182,73 @@ export const ParticleSystem: React.FC<ParticleSystemProps> = ({
         return `hsl(${180 + Math.random() * 40}, 90%, ${50 + Math.random() * 20}%)`;
       case 'stateloss':
         return `hsl(${0 + Math.random() * 20}, 95%, ${40 + Math.random() * 15}%)`;
+      case 'flash':
+        return `hsla(${50 + Math.random() * 10}, 95%, ${85 + Math.random() * 10}%, ${0.85 - Math.random() * 0.2})`;
+      case 'stateevent':
+        return `hsl(${305 + Math.random() * 20}, 88%, ${62 + Math.random() * 12}%)`;
+      case 'contested':
+        return `hsl(${200 + Math.random() * 20}, 72%, ${58 + Math.random() * 10}%)`;
       default:
         return `hsl(${Math.random() * 360}, 70%, 60%)`;
     }
   };
 
-  const getParticleSpread = (type: string): number => {
+  const getParticleSpread = (type: ParticleEffectType): number => {
     switch (type) {
-      case 'victory': case 'bigwin': return 80;
-      case 'synergy': return 70;
-      case 'chain': return 60;
-      default: return 50;
+      case 'victory':
+      case 'bigwin':
+        return 80;
+      case 'flash':
+        return 90;
+      case 'synergy':
+      case 'stateevent':
+        return 70;
+      case 'chain':
+      case 'contested':
+        return 60;
+      default:
+        return 50;
     }
   };
 
-  const getParticleLifespan = (type: string): number => {
+  const getParticleLifespan = (type: ParticleEffectType): number => {
     const base = 120 + Math.random() * 60;
     switch (type) {
-      case 'victory': case 'bigwin': return base * 1.5;
-      case 'synergy': return base * 1.3;
-      case 'chain': return base * 1.1;
-      case 'stateloss': return base * 0.8;
-      default: return base;
+      case 'victory':
+      case 'bigwin':
+        return base * 1.5;
+      case 'flash':
+        return base * 1.2;
+      case 'synergy':
+      case 'stateevent':
+        return base * 1.3;
+      case 'chain':
+      case 'contested':
+        return base * 1.1;
+      case 'stateloss':
+        return base * 0.8;
+      default:
+        return base;
     }
   };
 
-  const getParticleSize = (type: string): number => {
+  const getParticleSize = (type: ParticleEffectType): number => {
     switch (type) {
-      case 'victory': case 'bigwin': return 5 + Math.random() * 5;
-      case 'synergy': return 4 + Math.random() * 4;
-      case 'chain': return 3 + Math.random() * 3;
-      case 'stateloss': return 2 + Math.random() * 2;
-      default: return 2 + Math.random() * 3;
+      case 'victory':
+      case 'bigwin':
+        return 5 + Math.random() * 5;
+      case 'flash':
+        return 3 + Math.random() * 3;
+      case 'synergy':
+      case 'stateevent':
+        return 4 + Math.random() * 4;
+      case 'chain':
+      case 'contested':
+        return 3 + Math.random() * 3;
+      case 'stateloss':
+        return 2 + Math.random() * 2;
+      default:
+        return 2 + Math.random() * 3;
     }
   };
 

--- a/src/components/effects/TabloidFlashOverlay.tsx
+++ b/src/components/effects/TabloidFlashOverlay.tsx
@@ -1,0 +1,197 @@
+import React, { useEffect, useMemo, useState } from 'react';
+
+interface TabloidFlashOverlayProps {
+  x: number;
+  y: number;
+  onComplete?: () => void;
+}
+
+interface RadialBurst {
+  id: string;
+  rotation: string;
+  delay: string;
+  scale: string;
+}
+
+interface StarBurst {
+  id: string;
+  delay: string;
+  offsetX: string;
+  offsetY: string;
+  scale: string;
+}
+
+interface PolaroidFragment {
+  id: string;
+  src: string;
+  delay: string;
+  offsetX: string;
+  startY: string;
+  midY: string;
+  finalY: string;
+  rotationStart: string;
+  rotationMid: string;
+  rotationEnd: string;
+  scale: string;
+}
+
+const FLASH_DURATION = 1600;
+const polaroidSources = [
+  '/placeholder-event.png',
+  '/card-art/GOV-006.jpg',
+  '/card-art/GOV-011.jpg'
+];
+
+const TabloidFlashOverlay: React.FC<TabloidFlashOverlayProps> = ({ x, y, onComplete }) => {
+  const [prefersReducedMotion, setPrefersReducedMotion] = useState(() => {
+    if (typeof window === 'undefined') return false;
+    return window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+  });
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+
+    const mediaQuery = window.matchMedia('(prefers-reduced-motion: reduce)');
+    const handleChange = (event: MediaQueryListEvent) => {
+      setPrefersReducedMotion(event.matches);
+    };
+
+    setPrefersReducedMotion(mediaQuery.matches);
+    mediaQuery.addEventListener('change', handleChange);
+
+    return () => {
+      mediaQuery.removeEventListener('change', handleChange);
+    };
+  }, []);
+
+  useEffect(() => {
+    if (prefersReducedMotion) {
+      onComplete?.();
+      return;
+    }
+
+    const timeout = window.setTimeout(() => {
+      onComplete?.();
+    }, FLASH_DURATION);
+
+    return () => window.clearTimeout(timeout);
+  }, [prefersReducedMotion, onComplete]);
+
+  const overlayStyle = useMemo(() => ({
+    '--flash-x': `${x}px`,
+    '--flash-y': `${y}px`
+  }) as React.CSSProperties, [x, y]);
+
+  const radials: RadialBurst[] = useMemo(() => (
+    Array.from({ length: 8 }, (_, index) => ({
+      id: `radial-${index}`,
+      rotation: `${Math.random() * 360}deg`,
+      delay: `${index * 35 + Math.random() * 80}ms`,
+      scale: (0.85 + Math.random() * 0.7).toFixed(2)
+    }))
+  ), []);
+
+  const stars: StarBurst[] = useMemo(() => (
+    Array.from({ length: 6 }, (_, index) => ({
+      id: `star-${index}`,
+      delay: `${180 + index * 60 + Math.random() * 110}ms`,
+      offsetX: `${(Math.random() - 0.5) * 220}px`,
+      offsetY: `${(Math.random() - 0.35) * 200}px`,
+      scale: (0.75 + Math.random() * 0.9).toFixed(2)
+    }))
+  ), []);
+
+  const polaroids: PolaroidFragment[] = useMemo(() => {
+    if (Math.random() < 0.45) {
+      return [];
+    }
+
+    const count = 1 + Math.floor(Math.random() * 2);
+    const sources = [...polaroidSources].sort(() => Math.random() - 0.5).slice(0, count);
+
+    return sources.map((src, index) => {
+      const finalY = 36 + Math.random() * 32;
+      const midY = finalY - (50 + Math.random() * 20);
+      const startY = finalY - (110 + Math.random() * 40);
+      const baseRotation = (Math.random() - 0.5) * 18;
+
+      return {
+        id: `polaroid-${index}`,
+        src,
+        delay: `${260 + index * 140 + Math.random() * 120}ms`,
+        offsetX: `${(Math.random() - 0.5) * 260}px`,
+        startY: `${startY}px`,
+        midY: `${midY}px`,
+        finalY: `${finalY}px`,
+        rotationStart: `${baseRotation - 12}deg`,
+        rotationMid: `${baseRotation + 6}deg`,
+        rotationEnd: `${baseRotation}deg`,
+        scale: (0.85 + Math.random() * 0.2).toFixed(2)
+      };
+    });
+  }, []);
+
+  if (prefersReducedMotion) {
+    return null;
+  }
+
+  return (
+    <div
+      className="tabloid-flash-overlay"
+      style={overlayStyle}
+      aria-hidden="true"
+    >
+      <div className="tabloid-flash-ambient" />
+      <div
+        className="tabloid-flash-center"
+        style={{ left: x, top: y }}
+      >
+        <div className="tabloid-flash-core" />
+        <div className="tabloid-flash-ring" />
+        {radials.map(radial => (
+          <span
+            key={radial.id}
+            className="tabloid-flash-radial"
+            style={{
+              '--flash-delay': radial.delay,
+              '--flash-burst-rotation': radial.rotation,
+              '--flash-burst-scale': radial.scale
+            } as React.CSSProperties}
+          />
+        ))}
+        {stars.map(star => (
+          <span
+            key={star.id}
+            className="tabloid-flash-star"
+            style={{
+              '--flash-delay': star.delay,
+              '--flash-star-x': star.offsetX,
+              '--flash-star-y': star.offsetY,
+              '--flash-star-scale': star.scale
+            } as React.CSSProperties}
+          />
+        ))}
+        {polaroids.map(polaroid => (
+          <span
+            key={polaroid.id}
+            className="tabloid-flash-polaroid"
+            style={{
+              '--flash-delay': polaroid.delay,
+              '--flash-polaroid-x': polaroid.offsetX,
+              '--flash-polaroid-start-y': polaroid.startY,
+              '--flash-polaroid-mid-y': polaroid.midY,
+              '--flash-polaroid-y': polaroid.finalY,
+              '--flash-polaroid-rotation-start': polaroid.rotationStart,
+              '--flash-polaroid-rotation-mid': polaroid.rotationMid,
+              '--flash-polaroid-rotation-end': polaroid.rotationEnd,
+              '--flash-polaroid-scale': polaroid.scale,
+              '--polaroid-image': `url(${polaroid.src})`
+            } as React.CSSProperties}
+          />
+        ))}
+      </div>
+    </div>
+  );
+};
+
+export default TabloidFlashOverlay;

--- a/src/hooks/useAudio.ts
+++ b/src/hooks/useAudio.ts
@@ -225,6 +225,7 @@ export const useAudio = () => {
     // Create sound effects with fallback handling - only load existing files
     const existingSfxFiles = {
       cardPlay: '/audio/card-play.mp3',
+      flash: '/audio/card-play.mp3',
       cardDraw: '/audio/card-draw.mp3',
       stateCapture: '/audio/state-capture.mp3',
       turnEnd: '/audio/turn-end.mp3',

--- a/src/index.css
+++ b/src/index.css
@@ -1098,3 +1098,287 @@ html, body, #root {
   box-shadow: 0 0 0 4px rgba(255, 255, 255, 0.85), 0 0 12px rgba(0, 0, 0, 0.8);
   transition: outline 0.2s ease, box-shadow 0.2s ease;
 }
+
+/* === Tabloid Flash Overlay === */
+.tabloid-flash-overlay {
+  position: fixed;
+  inset: 0;
+  pointer-events: none;
+  z-index: 1100;
+  overflow: hidden;
+  --flash-x: 50%;
+  --flash-y: 50%;
+}
+
+.tabloid-flash-ambient {
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(
+    circle at var(--flash-x) var(--flash-y),
+    rgba(255, 255, 255, 0.92) 0%,
+    rgba(255, 170, 210, 0.65) 18%,
+    rgba(255, 140, 200, 0.32) 34%,
+    rgba(255, 140, 200, 0.18) 50%,
+    transparent 70%
+  );
+  animation: tabloid-flash-fade 1.25s ease-out forwards;
+  mix-blend-mode: screen;
+}
+
+.tabloid-flash-center {
+  position: absolute;
+  width: 0;
+  height: 0;
+  transform: translate(-50%, -50%);
+}
+
+.tabloid-flash-core {
+  position: absolute;
+  width: 240px;
+  height: 240px;
+  margin-left: -120px;
+  margin-top: -120px;
+  border-radius: 999px;
+  background: radial-gradient(
+    circle,
+    rgba(255, 255, 255, 0.98) 0%,
+    rgba(255, 206, 227, 0.88) 48%,
+    rgba(255, 173, 214, 0.24) 78%,
+    rgba(255, 160, 210, 0.05) 100%
+  );
+  animation: tabloid-flash-core 1s ease-out forwards;
+  filter: blur(0.2px);
+  mix-blend-mode: screen;
+}
+
+.tabloid-flash-ring {
+  position: absolute;
+  width: 320px;
+  height: 320px;
+  margin-left: -160px;
+  margin-top: -160px;
+  border-radius: 999px;
+  border: 2px solid rgba(255, 255, 255, 0.85);
+  box-shadow: 0 0 36px rgba(255, 200, 230, 0.5);
+  animation: tabloid-flash-ring 1.2s ease-out forwards;
+  mix-blend-mode: screen;
+}
+
+.tabloid-flash-radial {
+  position: absolute;
+  width: 220px;
+  height: 4px;
+  border-radius: 999px;
+  background: linear-gradient(
+    90deg,
+    rgba(255, 255, 255, 0.92) 0%,
+    rgba(255, 186, 213, 0.95) 45%,
+    rgba(255, 168, 209, 0.35) 75%,
+    transparent 100%
+  );
+  transform-origin: left center;
+  transform: rotate(var(--flash-burst-rotation, 0deg)) scaleX(0.1);
+  animation: tabloid-flash-burst 0.95s cubic-bezier(0.22, 0.61, 0.36, 1) forwards;
+  animation-delay: var(--flash-delay, 0ms);
+  filter: drop-shadow(0 0 12px rgba(255, 255, 255, 0.6));
+  opacity: 0;
+  mix-blend-mode: screen;
+}
+
+.tabloid-flash-star {
+  position: absolute;
+  width: 26px;
+  height: 26px;
+  left: 0;
+  top: 0;
+  background: radial-gradient(circle, rgba(255, 255, 255, 0.95) 0%, rgba(255, 255, 255, 0.18) 72%, transparent 100%);
+  transform: translate(var(--flash-star-x, 0), var(--flash-star-y, 0)) scale(0.2);
+  animation: tabloid-flash-star 1s ease-out forwards;
+  animation-delay: var(--flash-delay, 0ms);
+  opacity: 0;
+  mix-blend-mode: screen;
+}
+
+.tabloid-flash-star::before,
+.tabloid-flash-star::after {
+  content: '';
+  position: absolute;
+  inset: 5px;
+  background: linear-gradient(90deg, transparent, rgba(255, 255, 255, 0.95), transparent);
+  border-radius: 999px;
+}
+
+.tabloid-flash-star::after {
+  transform: rotate(90deg);
+}
+
+.tabloid-flash-polaroid {
+  position: absolute;
+  width: 96px;
+  height: 108px;
+  border-radius: 8px;
+  background: #ffffff;
+  border: 2px solid rgba(255, 255, 255, 0.85);
+  box-shadow: 0 18px 32px rgba(0, 0, 0, 0.35);
+  overflow: hidden;
+  transform-origin: center;
+  transform: translate(var(--flash-polaroid-x, 0), var(--flash-polaroid-start-y, -120px))
+    rotate(var(--flash-polaroid-rotation-start, -8deg))
+    scale(0.7);
+  animation: tabloid-flash-polaroid 1.4s cubic-bezier(0.24, 0.82, 0.25, 1) forwards;
+  animation-delay: var(--flash-delay, 0ms);
+  opacity: 0;
+}
+
+.tabloid-flash-polaroid::before {
+  content: '';
+  position: absolute;
+  inset: 10px 10px 28px;
+  background-image: var(--polaroid-image);
+  background-size: cover;
+  background-position: center;
+  filter: saturate(1.05) contrast(1.05);
+}
+
+.tabloid-flash-polaroid::after {
+  content: '';
+  position: absolute;
+  bottom: 8px;
+  left: 12px;
+  right: 12px;
+  height: 14px;
+  background: rgba(255, 255, 255, 0.88);
+  border-radius: 2px;
+  box-shadow: inset 0 0 10px rgba(0, 0, 0, 0.08);
+}
+
+@keyframes tabloid-flash-core {
+  0% {
+    opacity: 0;
+    transform: scale(0.4);
+  }
+  25% {
+    opacity: 1;
+    transform: scale(1);
+  }
+  100% {
+    opacity: 0;
+    transform: scale(1.4);
+  }
+}
+
+@keyframes tabloid-flash-ring {
+  0% {
+    opacity: 0.6;
+    transform: scale(0.75);
+  }
+  35% {
+    opacity: 1;
+    transform: scale(1);
+  }
+  100% {
+    opacity: 0;
+    transform: scale(1.35);
+  }
+}
+
+@keyframes tabloid-flash-burst {
+  0% {
+    opacity: 0;
+    transform: rotate(var(--flash-burst-rotation, 0deg)) scaleX(0.1);
+  }
+  30% {
+    opacity: 1;
+    transform: rotate(var(--flash-burst-rotation, 0deg)) scaleX(var(--flash-burst-scale, 1.1));
+  }
+  100% {
+    opacity: 0;
+    transform: rotate(var(--flash-burst-rotation, 0deg)) scaleX(var(--flash-burst-scale, 1.1));
+  }
+}
+
+@keyframes tabloid-flash-star {
+  0% {
+    opacity: 0;
+    transform: translate(var(--flash-star-x, 0), var(--flash-star-y, 0)) scale(0.2);
+  }
+  40% {
+    opacity: 1;
+    transform: translate(var(--flash-star-x, 0), var(--flash-star-y, 0)) scale(var(--flash-star-scale, 1));
+  }
+  100% {
+    opacity: 0;
+    transform: translate(var(--flash-star-x, 0), var(--flash-star-y, 0)) scale(0);
+  }
+}
+
+@keyframes tabloid-flash-polaroid {
+  0% {
+    opacity: 0;
+    transform: translate(var(--flash-polaroid-x, 0), var(--flash-polaroid-start-y, -140px))
+      rotate(var(--flash-polaroid-rotation-start, -10deg))
+      scale(0.7);
+  }
+  35% {
+    opacity: 1;
+    transform: translate(var(--flash-polaroid-x, 0), var(--flash-polaroid-mid-y, -40px))
+      rotate(var(--flash-polaroid-rotation-mid, 6deg))
+      scale(var(--flash-polaroid-scale, 1));
+  }
+  70% {
+    opacity: 0.95;
+    transform: translate(var(--flash-polaroid-x, 0), var(--flash-polaroid-y, 24px))
+      rotate(var(--flash-polaroid-rotation-end, 0deg))
+      scale(var(--flash-polaroid-scale, 1));
+  }
+  100% {
+    opacity: 0;
+    transform: translate(var(--flash-polaroid-x, 0), var(--flash-polaroid-y, 24px))
+      rotate(var(--flash-polaroid-rotation-end, 0deg))
+      scale(var(--flash-polaroid-scale, 1));
+  }
+}
+
+@keyframes tabloid-flash-fade {
+  0% {
+    opacity: 0;
+  }
+  15% {
+    opacity: 1;
+  }
+  100% {
+    opacity: 0;
+  }
+}
+
+@keyframes tabloid-flash-glow {
+  0% {
+    opacity: 0;
+  }
+  100% {
+    opacity: 0.75;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .tabloid-flash-overlay .tabloid-flash-ambient {
+    animation: tabloid-flash-glow 0.35s ease-out forwards;
+    background: radial-gradient(
+      circle at var(--flash-x) var(--flash-y),
+      rgba(255, 255, 255, 0.75) 0%,
+      rgba(255, 180, 210, 0.45) 32%,
+      transparent 70%
+    );
+  }
+
+  .tabloid-flash-overlay .tabloid-flash-core {
+    animation: tabloid-flash-glow 0.35s ease-out forwards;
+  }
+
+  .tabloid-flash-overlay .tabloid-flash-ring,
+  .tabloid-flash-overlay .tabloid-flash-radial,
+  .tabloid-flash-overlay .tabloid-flash-star,
+  .tabloid-flash-overlay .tabloid-flash-polaroid {
+    display: none;
+  }
+}

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -747,24 +747,30 @@ const Index = () => {
       recordCardPlay(cardId);
       
       // Enhanced visual effects for successful card play
+      let effectPosition = VisualEffectsCoordinator.getScreenCenter();
       const cardElement = document.querySelector(`[data-card-id="${cardId}"]`);
       if (cardElement) {
-        const position = VisualEffectsCoordinator.getElementCenter(cardElement);
+        effectPosition = VisualEffectsCoordinator.getElementCenter(cardElement);
 
         // Trigger deploy particle effect
-        VisualEffectsCoordinator.triggerParticleEffect('deploy', position);
+        VisualEffectsCoordinator.triggerParticleEffect('deploy', effectPosition);
 
         if (card.faction === 'government' && card.type === 'ATTACK') {
-          VisualEffectsCoordinator.triggerGovernmentRedaction(position);
+          VisualEffectsCoordinator.triggerGovernmentRedaction(effectPosition);
         }
 
         // Show floating number for IP cost
         if (card.cost > 0) {
           VisualEffectsCoordinator.showFloatingNumber(-card.cost, 'ip', {
-            x: position.x - 30,
-            y: position.y - 20
+            x: effectPosition.x - 30,
+            y: effectPosition.y - 20
           });
         }
+      }
+
+      if (card.faction === 'truth' && card.type === 'MEDIA') {
+        VisualEffectsCoordinator.triggerTruthFlash(effectPosition);
+        audio.playSFX('flash');
       }
       
       toast.success(`✅ ${card.name} deployed successfully!`, {

--- a/src/utils/visualEffects.ts
+++ b/src/utils/visualEffects.ts
@@ -9,12 +9,12 @@ export interface EffectPosition {
 export class VisualEffectsCoordinator {
   // Trigger particle effect at specific position
   static triggerParticleEffect(
-    type: 'deploy' | 'capture' | 'counter' | 'victory' | 'synergy' | 'bigwin' | 'stateloss' | 'chain' | 'stateevent' | 'contested',
+    type: 'deploy' | 'capture' | 'counter' | 'victory' | 'synergy' | 'bigwin' | 'stateloss' | 'chain' | 'stateevent' | 'contested' | 'flash',
     position: EffectPosition
   ): void {
     window.dispatchEvent(new CustomEvent('cardDeployed', {
-      detail: { 
-        type, 
+      detail: {
+        type,
         x: position.x, 
         y: position.y 
       }
@@ -24,6 +24,16 @@ export class VisualEffectsCoordinator {
   // Trigger full-screen government redaction sweep
   static triggerGovernmentRedaction(position: EffectPosition): void {
     window.dispatchEvent(new CustomEvent('governmentRedaction', {
+      detail: {
+        x: position.x,
+        y: position.y
+      }
+    }));
+  }
+
+  // Trigger a tabloid flash burst
+  static triggerTruthFlash(position: EffectPosition): void {
+    window.dispatchEvent(new CustomEvent('truthFlash', {
       detail: {
         x: position.x,
         y: position.y


### PR DESCRIPTION
## Summary
- add a TabloidFlashOverlay effect with randomized bursts, stars, and polaroid drops that respects reduced motion
- allow CardAnimationLayer to queue multiple particle systems, listen for truth flash events, and render the overlay while ParticleSystem supports a new flash variant
- trigger the new truth flash for Truth MEDIA cards, play a matching SFX, and wire supporting CSS plus audio asset loading

## Testing
- npm run lint *(fails: cannot resolve @eslint/js before dependencies install; npm install blocked by 403 fetching ts-node)*

------
https://chatgpt.com/codex/tasks/task_e_68cdca618c2883209b4ef7f1ac240c16