### PR TITLE
Refine synergy cascade overlays and spotlight visuals

### DIFF
--- a/src/components/effects/ConspiracyCorkboard.tsx
+++ b/src/components/effects/ConspiracyCorkboard.tsx
@@ -1,0 +1,123 @@
+import React, { useEffect, useMemo, useState } from 'react';
+
+interface ConspiracyCorkboardProps {
+  x: number;
+  y: number;
+  comboName?: string;
+  bonusIP?: number;
+  onComplete?: () => void;
+}
+
+interface ThreadSegment {
+  id: string;
+  x1: number;
+  y1: number;
+  x2: number;
+  y2: number;
+  delay: number;
+}
+
+const CORKBOARD_DURATION = 2600;
+
+const ConspiracyCorkboard: React.FC<ConspiracyCorkboardProps> = ({
+  x,
+  y,
+  comboName,
+  bonusIP,
+  onComplete
+}) => {
+  const [prefersReducedMotion, setPrefersReducedMotion] = useState(() => {
+    if (typeof window === 'undefined') return false;
+    return window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+  });
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+
+    const mediaQuery = window.matchMedia('(prefers-reduced-motion: reduce)');
+    const handleChange = (event: MediaQueryListEvent) => {
+      setPrefersReducedMotion(event.matches);
+    };
+
+    setPrefersReducedMotion(mediaQuery.matches);
+    mediaQuery.addEventListener('change', handleChange);
+
+    return () => {
+      mediaQuery.removeEventListener('change', handleChange);
+    };
+  }, []);
+
+  useEffect(() => {
+    const duration = prefersReducedMotion ? CORKBOARD_DURATION * 0.6 : CORKBOARD_DURATION;
+
+    const timeout = window.setTimeout(() => {
+      onComplete?.();
+    }, duration);
+
+    return () => window.clearTimeout(timeout);
+  }, [prefersReducedMotion, onComplete]);
+
+  const overlayStyle = useMemo(() => ({
+    '--corkboard-x': `${x}px`,
+    '--corkboard-y': `${y}px`
+  }) as React.CSSProperties, [x, y]);
+
+  const threadSegments = useMemo<ThreadSegment[]>(() => (
+    Array.from({ length: 5 }, (_, index) => ({
+      id: `thread-${index}-${Math.random().toString(36).slice(2, 7)}`,
+      x1: 20 + Math.random() * 60,
+      y1: 18 + Math.random() * 64,
+      x2: 20 + Math.random() * 60,
+      y2: 18 + Math.random() * 64,
+      delay: 80 * index + Math.random() * 180
+    }))
+  ), []);
+
+  return (
+    <div
+      className={`conspiracy-corkboard-overlay${prefersReducedMotion ? ' conspiracy-corkboard-overlay--reduced' : ''}`}
+      style={overlayStyle}
+      aria-hidden="true"
+    >
+      <div className="conspiracy-corkboard-shadow" />
+      <div className="conspiracy-corkboard-panel">
+        <div className="conspiracy-corkboard-backdrop" />
+        <svg
+          className="conspiracy-threadmap"
+          viewBox="0 0 200 200"
+          role="presentation"
+        >
+          {threadSegments.map(segment => (
+            <line
+              key={segment.id}
+              x1={segment.x1}
+              y1={segment.y1}
+              x2={segment.x2}
+              y2={segment.y2}
+              className="conspiracy-thread"
+              style={{
+                '--thread-delay': `${segment.delay}ms`
+              } as React.CSSProperties}
+            />
+          ))}
+        </svg>
+
+        <div className="conspiracy-pin conspiracy-pin--north" />
+        <div className="conspiracy-pin conspiracy-pin--east" />
+        <div className="conspiracy-pin conspiracy-pin--south" />
+        <div className="conspiracy-pin conspiracy-pin--west" />
+
+        <div className="conspiracy-note">
+          <span className="conspiracy-note-label">SYNERGY CASCADE</span>
+          <span className="conspiracy-note-title">{comboName ?? 'UNKNOWN LEADS'}</span>
+          {typeof bonusIP === 'number' && (
+            <span className="conspiracy-note-metric">+{bonusIP} IP ROUTED</span>
+          )}
+          <span className="conspiracy-note-footer">CONNECTING RED STRINGS...</span>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default ConspiracyCorkboard;

--- a/src/components/game/TruthMeter.tsx
+++ b/src/components/game/TruthMeter.tsx
@@ -1,4 +1,4 @@
-import { Progress } from '@/components/ui/progress';
+import { useEffect, useState } from 'react';
 
 interface TruthMeterProps {
   value: number; // 0-100
@@ -6,6 +6,35 @@ interface TruthMeterProps {
 }
 
 const TruthMeter = ({ value, faction = "Truth" }: TruthMeterProps) => {
+  const [prefersReducedMotion, setPrefersReducedMotion] = useState(() => {
+    if (typeof window === 'undefined') return false;
+    return window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+  });
+  const [meltdownActive, setMeltdownActive] = useState(false);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+
+    const mediaQuery = window.matchMedia('(prefers-reduced-motion: reduce)');
+    const handleChange = (event: MediaQueryListEvent) => {
+      setPrefersReducedMotion(event.matches);
+    };
+
+    setPrefersReducedMotion(mediaQuery.matches);
+    mediaQuery.addEventListener('change', handleChange);
+
+    return () => mediaQuery.removeEventListener('change', handleChange);
+  }, []);
+
+  useEffect(() => {
+    if (prefersReducedMotion) {
+      setMeltdownActive(false);
+      return;
+    }
+
+    const isExtreme = value >= 95 || value <= 5;
+    setMeltdownActive(isExtreme);
+  }, [value, prefersReducedMotion]);
   const getColor = () => {
     if (value >= 95) return 'bg-truth-red';
     if (value <= 5) return 'bg-government-blue';
@@ -70,11 +99,23 @@ const TruthMeter = ({ value, faction = "Truth" }: TruthMeterProps) => {
             }`}
             style={{ width: `${value}%` }}
           />
-          
+
           {/* Animated scanlines */}
           <div className="absolute inset-0 bg-gradient-to-r from-transparent via-white/10 to-transparent animate-pulse"></div>
         </div>
-        
+
+        {meltdownActive && (
+          <div className="truth-meltdown-overlay" aria-hidden="true">
+            <div className="truth-meltdown-scanlines" />
+            <div className="truth-meltdown-stripes" />
+            <div className="truth-meltdown-sparks" />
+            <div className="truth-meltdown-warning">
+              <span>WE INTERRUPT THIS BROADCAST</span>
+              <strong>{`TRUTH LEVEL ${value}%`}</strong>
+            </div>
+          </div>
+        )}
+
         {/* Critical thresholds with labels */}
         <div className="absolute -bottom-2 left-[5%] transform -translate-x-1/2">
           <div className="w-0.5 h-2 bg-government-blue"></div>

--- a/src/hooks/useSynergyDetection.ts
+++ b/src/hooks/useSynergyDetection.ts
@@ -39,14 +39,14 @@ export const useSynergyDetection = () => {
           const centerX = window.innerWidth / 2 + (Math.random() - 0.5) * 200;
           const centerY = window.innerHeight / 2 + (Math.random() - 0.5) * 100;
           
+          // Notify parent component first so overlays can anchor
+          onSynergyActivated?.(combo, { x: centerX, y: centerY });
+
           // Trigger particle effects
           onParticleEffect?.('synergy', centerX, centerY);
-          
+
           // Show floating number for bonus IP
           onFloatingNumber?.(combo.bonusIP, 'synergy', centerX, centerY - 50);
-          
-          // Notify parent component
-          onSynergyActivated?.(combo, { x: centerX, y: centerY });
           
           // Trigger chain effects for multi-combo activations
           if (newCombinations.length > 1) {

--- a/src/index.css
+++ b/src/index.css
@@ -1382,3 +1382,432 @@ html, body, #root {
     display: none;
   }
 }
+
+/* === Conspiracy Corkboard Cascade === */
+.conspiracy-corkboard-overlay {
+  position: fixed;
+  inset: 0;
+  pointer-events: none;
+  z-index: 1200;
+  --corkboard-x: 50%;
+  --corkboard-y: 50%;
+}
+
+.conspiracy-corkboard-overlay--reduced .conspiracy-corkboard-panel {
+  transform: none;
+}
+
+.conspiracy-corkboard-shadow {
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(circle at var(--corkboard-x) var(--corkboard-y), rgba(17, 24, 39, 0.45), transparent 55%);
+  animation: corkboard-shadow-fade 0.6s ease-out forwards;
+}
+
+.conspiracy-corkboard-panel {
+  position: absolute;
+  left: calc(var(--corkboard-x) - 180px);
+  top: calc(var(--corkboard-y) - 170px);
+  width: 360px;
+  height: 260px;
+  background: linear-gradient(145deg, #3e3e3e, #2a2a2a);
+  border-radius: 18px;
+  border: 3px solid rgba(255, 255, 255, 0.08);
+  box-shadow: 0 20px 60px rgba(0, 0, 0, 0.45);
+  overflow: hidden;
+  transform-origin: top left;
+  animation: corkboard-pop 0.45s cubic-bezier(0.24, 0.82, 0.25, 1.1) forwards;
+}
+
+.conspiracy-corkboard-backdrop {
+  position: absolute;
+  inset: 0;
+  background: repeating-linear-gradient(45deg, rgba(148, 163, 184, 0.08) 0, rgba(148, 163, 184, 0.08) 12px, transparent 12px, transparent 24px);
+  filter: blur(0.5px);
+  opacity: 0;
+  animation: corkboard-backdrop-fade 0.6s ease-out 80ms forwards;
+}
+
+.conspiracy-threadmap {
+  position: absolute;
+  inset: 16px;
+  width: calc(100% - 32px);
+  height: calc(100% - 32px);
+  mix-blend-mode: screen;
+}
+
+.conspiracy-thread {
+  stroke: rgba(220, 38, 38, 0.85);
+  stroke-width: 2.5;
+  stroke-linecap: round;
+  stroke-dasharray: 6 6;
+  opacity: 0;
+  animation: corkboard-thread-draw 1.6s ease-out forwards;
+  animation-delay: var(--thread-delay, 120ms);
+}
+
+.conspiracy-pin {
+  position: absolute;
+  width: 26px;
+  height: 26px;
+  border-radius: 9999px;
+  background: radial-gradient(circle at 30% 30%, #f87171, #b91c1c 65%);
+  box-shadow: 0 0 0 2px rgba(15, 23, 42, 0.35), 0 0 18px rgba(248, 113, 113, 0.55);
+  animation: corkboard-pin-pulse 1.8s ease-in-out infinite;
+}
+
+.conspiracy-pin::after {
+  content: '';
+  position: absolute;
+  inset: 6px;
+  border-radius: inherit;
+  background: rgba(255, 255, 255, 0.55);
+  opacity: 0.8;
+}
+
+.conspiracy-pin--north {
+  top: 12px;
+  left: 50%;
+  transform: translateX(-50%);
+}
+
+.conspiracy-pin--south {
+  bottom: 16px;
+  left: 28%;
+}
+
+.conspiracy-pin--east {
+  top: 36%;
+  right: 18px;
+}
+
+.conspiracy-pin--west {
+  top: 44%;
+  left: 16px;
+}
+
+.conspiracy-note {
+  position: absolute;
+  right: 24px;
+  bottom: 28px;
+  min-width: 180px;
+  padding: 16px;
+  background: #fef9c3;
+  color: #1f2937;
+  font-family: 'IBM Plex Mono', ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace;
+  border-radius: 10px;
+  border: 2px solid rgba(59, 7, 7, 0.35);
+  box-shadow: 0 12px 30px rgba(124, 45, 18, 0.25), inset 0 0 0 1px rgba(148, 81, 0, 0.18);
+  transform: rotate(-2deg) translate3d(0, 0, 0);
+  animation: corkboard-note-drop 0.6s cubic-bezier(0.24, 0.82, 0.25, 1.1) 160ms forwards;
+  opacity: 0;
+}
+
+.conspiracy-note-label {
+  display: block;
+  font-size: 0.625rem;
+  letter-spacing: 0.25em;
+  margin-bottom: 6px;
+  color: rgba(120, 53, 15, 0.8);
+}
+
+.conspiracy-note-title {
+  display: block;
+  font-weight: 700;
+  font-size: 0.95rem;
+  margin-bottom: 6px;
+  text-transform: uppercase;
+  color: #7f1d1d;
+}
+
+.conspiracy-note-metric {
+  display: block;
+  font-weight: 600;
+  font-size: 0.85rem;
+  color: #b45309;
+}
+
+.conspiracy-note-footer {
+  display: block;
+  margin-top: 8px;
+  font-size: 0.7rem;
+  letter-spacing: 0.18em;
+  color: rgba(79, 70, 229, 0.6);
+}
+
+@keyframes corkboard-pop {
+  0% {
+    opacity: 0;
+    transform: translate3d(-18px, -18px, 0) scale(0.75) rotate(-6deg);
+  }
+  60% {
+    opacity: 1;
+    transform: translate3d(6px, 4px, 0) scale(1.03) rotate(1deg);
+  }
+  100% {
+    opacity: 1;
+    transform: translate3d(0, 0, 0) scale(1) rotate(0deg);
+  }
+}
+
+@keyframes corkboard-thread-draw {
+  0% {
+    opacity: 0;
+    stroke-dashoffset: 60;
+  }
+  35% {
+    opacity: 1;
+  }
+  100% {
+    opacity: 1;
+    stroke-dashoffset: 0;
+  }
+}
+
+@keyframes corkboard-pin-pulse {
+  0%, 100% {
+    transform: translateZ(0) scale(0.95);
+    box-shadow: 0 0 0 2px rgba(15, 23, 42, 0.35), 0 0 14px rgba(248, 113, 113, 0.38);
+  }
+  50% {
+    transform: translateZ(0) scale(1.05);
+    box-shadow: 0 0 0 3px rgba(15, 23, 42, 0.35), 0 0 24px rgba(248, 113, 113, 0.75);
+  }
+}
+
+@keyframes corkboard-note-drop {
+  0% {
+    transform: translate3d(0, -20px, 0) rotate(-6deg);
+    opacity: 0;
+  }
+  60% {
+    transform: translate3d(-4px, 6px, 0) rotate(-1.2deg);
+    opacity: 1;
+  }
+  100% {
+    transform: translate3d(0, 0, 0) rotate(-2deg);
+    opacity: 1;
+  }
+}
+
+@keyframes corkboard-backdrop-fade {
+  0% {
+    opacity: 0;
+  }
+  100% {
+    opacity: 1;
+  }
+}
+
+@keyframes corkboard-shadow-fade {
+  0% {
+    opacity: 0;
+  }
+  100% {
+    opacity: 1;
+  }
+}
+
+/* === Orbital Audit Spotlight === */
+.orbital-spotlight {
+  opacity: 0;
+  transition: opacity 180ms ease-out, filter 180ms ease-out;
+}
+
+.orbital-spotlight.active {
+  opacity: 0.55;
+}
+
+.orbital-spotlight.focused {
+  opacity: 1;
+  filter: drop-shadow(0 0 14px rgba(59, 130, 246, 0.6));
+}
+
+.orbital-spotlight.locked {
+  filter: drop-shadow(0 0 18px rgba(59, 130, 246, 0.75));
+}
+
+.orbital-ring {
+  fill: rgba(37, 99, 235, 0.08);
+  stroke: rgba(96, 165, 250, 0.75);
+  stroke-width: 2;
+  stroke-dasharray: 12 8;
+  animation: orbital-ring-spin 2.4s linear infinite;
+}
+
+.orbital-inner-ring {
+  fill: transparent;
+  stroke: rgba(147, 197, 253, 0.95);
+  stroke-width: 1.5;
+  stroke-dasharray: 6 6;
+  animation: orbital-ring-spin 1.6s linear infinite reverse;
+}
+
+.orbital-cross {
+  stroke: rgba(191, 219, 254, 0.85);
+  stroke-width: 2;
+  stroke-linecap: round;
+  animation: orbital-pulse 1.4s ease-in-out infinite;
+}
+
+.orbital-caption {
+  font-family: 'IBM Plex Mono', ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace;
+  font-size: 0.55rem;
+  letter-spacing: 0.35em;
+  fill: rgba(148, 163, 184, 0.8);
+  text-transform: uppercase;
+}
+
+@keyframes orbital-ring-spin {
+  0% {
+    stroke-dashoffset: 0;
+  }
+  100% {
+    stroke-dashoffset: -64;
+  }
+}
+
+@keyframes orbital-pulse {
+  0%, 100% {
+    opacity: 0.45;
+  }
+  50% {
+    opacity: 1;
+  }
+}
+
+/* === Truth-O-Meter Meltdown === */
+.truth-meltdown-overlay {
+  position: absolute;
+  inset: -6px -10px;
+  border: 1px solid rgba(220, 38, 38, 0.55);
+  background: linear-gradient(180deg, rgba(15, 15, 15, 0.85), rgba(8, 8, 8, 0.65));
+  mix-blend-mode: screen;
+  pointer-events: none;
+  overflow: hidden;
+  animation: crt-flicker 0.55s linear infinite;
+  border-radius: 10px;
+}
+
+.truth-meltdown-scanlines {
+  position: absolute;
+  inset: 0;
+  background: repeating-linear-gradient(0deg, rgba(248, 113, 113, 0.1) 0, rgba(248, 113, 113, 0.1) 2px, transparent 2px, transparent 4px);
+  animation: crt-scan 0.3s linear infinite;
+}
+
+.truth-meltdown-warning {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  gap: 4px;
+  text-align: center;
+  color: rgba(254, 226, 226, 0.92);
+  text-transform: uppercase;
+  font-family: 'IBM Plex Mono', ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace;
+  letter-spacing: 0.28em;
+  font-size: 0.6rem;
+  animation: truth-alert-pulse 1s ease-in-out infinite;
+}
+
+.truth-meltdown-warning strong {
+  font-size: 0.75rem;
+  letter-spacing: 0.45em;
+}
+
+.truth-meltdown-stripes {
+  position: absolute;
+  inset: 0;
+  background: repeating-linear-gradient(135deg, rgba(252, 211, 77, 0.22) 0, rgba(252, 211, 77, 0.22) 12px, transparent 12px, transparent 24px);
+  opacity: 0.75;
+  animation: truth-warning-stripe 1.8s linear infinite;
+}
+
+.truth-meltdown-sparks {
+  position: absolute;
+  inset: -20px;
+  background: radial-gradient(circle at 20% 20%, rgba(255, 255, 255, 0.25), transparent 45%),
+    radial-gradient(circle at 80% 60%, rgba(248, 113, 113, 0.35), transparent 55%);
+  animation: truth-spark 1.1s ease-in-out infinite;
+  mix-blend-mode: lighten;
+}
+
+@keyframes crt-flicker {
+  0%, 10%, 40%, 70% {
+    opacity: 0.85;
+  }
+  20%, 50%, 80% {
+    opacity: 0.65;
+  }
+  100% {
+    opacity: 0.9;
+  }
+}
+
+@keyframes crt-scan {
+  0% {
+    transform: translateY(-4px);
+  }
+  100% {
+    transform: translateY(4px);
+  }
+}
+
+@keyframes truth-warning-stripe {
+  0% {
+    background-position: 0 0;
+  }
+  100% {
+    background-position: 240px 120px;
+  }
+}
+
+@keyframes truth-alert-pulse {
+  0%, 100% {
+    opacity: 0.75;
+  }
+  50% {
+    opacity: 1;
+  }
+}
+
+@keyframes truth-spark {
+  0%, 100% {
+    opacity: 0.4;
+  }
+  50% {
+    opacity: 0.9;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .conspiracy-corkboard-shadow,
+  .conspiracy-corkboard-panel,
+  .conspiracy-thread,
+  .conspiracy-pin,
+  .conspiracy-note {
+    animation: none;
+  }
+
+  .orbital-ring,
+  .orbital-inner-ring,
+  .orbital-cross {
+    animation: none;
+  }
+
+  .truth-meltdown-overlay {
+    animation: none;
+    background: rgba(12, 12, 12, 0.75);
+  }
+
+  .truth-meltdown-scanlines,
+  .truth-meltdown-warning,
+  .truth-meltdown-stripes,
+  .truth-meltdown-sparks {
+    animation: none;
+    opacity: 0.6;
+  }
+}

--- a/src/utils/visualEffects.ts
+++ b/src/utils/visualEffects.ts
@@ -45,7 +45,8 @@ export class VisualEffectsCoordinator {
   static triggerSynergyActivation(
     bonusIP: number,
     position: EffectPosition,
-    effectType: 'synergy' | 'bigwin' | 'chain' = 'synergy'
+    effectType: 'synergy' | 'bigwin' | 'chain' = 'synergy',
+    comboName?: string
   ): void {
     window.dispatchEvent(new CustomEvent('synergyActivation', {
       detail: {
@@ -53,7 +54,8 @@ export class VisualEffectsCoordinator {
         x: position.x,
         y: position.y,
         effectType,
-        numberType: effectType
+        numberType: effectType,
+        comboName
       }
     }));
   }
@@ -108,6 +110,19 @@ export class VisualEffectsCoordinator {
         y: position.y
       }
     }));
+  }
+
+  // Signal Government ZONE targeting overlays
+  static triggerGovernmentZoneTarget(detail: {
+    active: boolean;
+    x?: number;
+    y?: number;
+    cardId?: string;
+    cardName?: string;
+    stateId?: string;
+    mode?: 'select' | 'lock' | 'complete';
+  }): void {
+    window.dispatchEvent(new CustomEvent('governmentZoneTarget', { detail }));
   }
 
   // Helper to get element center position


### PR DESCRIPTION
## Summary
- keep the Conspiracy Corkboard visible under reduced-motion preferences by shortening the dwell timer and adding a static variant class
- stop double-triggering synergy particle and floating number effects by letting the animation layer focus on the overlay while reordering the synergy detection callbacks
- make the orbital audit spotlight persist on eligible targets with new focused styling so the highlight remains visible during government zone targeting

## Testing
- npm run lint *(fails: cannot resolve @eslint/js in this environment)*
- npm run build *(fails: local vite binary is unavailable in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cdff0388908320b93d6310545010c7