### PR TITLE
Add paranormal effects toggle and respect setting

### DIFF
--- a/src/components/game/CardAnimationLayer.tsx
+++ b/src/components/game/CardAnimationLayer.tsx
@@ -7,6 +7,7 @@ import ConspiracyCorkboard from '@/components/effects/ConspiracyCorkboard';
 import UFOElvisBroadcast from '@/components/effects/UFOElvisBroadcast';
 import BigfootTrailCam from '@/components/effects/BigfootTrailCam';
 import { useAudioContext } from '@/contexts/AudioContext';
+import { areParanormalEffectsEnabled } from '@/state/settings';
 
 interface CardAnimationLayerProps {
   children?: React.ReactNode;
@@ -145,7 +146,9 @@ const CardAnimationLayer: React.FC<CardAnimationLayerProps> = ({ children }) => 
         truthValue,
         reducedMotion,
       });
-      audio?.playSFX?.('ufo-elvis');
+      if (areParanormalEffectsEnabled()) {
+        audio?.playSFX?.('ufo-elvis');
+      }
     };
 
     const handleCryptidSighting = (event: CustomEvent<{
@@ -169,7 +172,9 @@ const CardAnimationLayer: React.FC<CardAnimationLayerProps> = ({ children }) => 
         footageQuality,
         reducedMotion,
       });
-      audio?.playSFX?.('cryptid-rumble');
+      if (areParanormalEffectsEnabled()) {
+        audio?.playSFX?.('cryptid-rumble');
+      }
     };
 
     const handleFloatingNumber = (event: CustomEvent<{ value: number; type: 'ip' | 'truth' | 'damage' | 'synergy' | 'combo' | 'chain'; x: number; y: number }>) => {

--- a/src/components/game/EnhancedUSAMap.tsx
+++ b/src/components/game/EnhancedUSAMap.tsx
@@ -7,6 +7,7 @@ import * as topojson from 'topojson-client';
 import { geoAlbersUsa, geoPath } from 'd3-geo';
 import { AlertTriangle, Target, Shield } from 'lucide-react';
 import { VisualEffectsCoordinator } from '@/utils/visualEffects';
+import { areParanormalEffectsEnabled } from '@/state/settings';
 
 
 interface EnhancedState {
@@ -418,16 +419,19 @@ const EnhancedUSAMap: React.FC<EnhancedUSAMapProps> = ({
                   y: svgRect.top + centroid[1]
                 });
               }
-              VisualEffectsCoordinator.triggerCryptidSighting({
-                position: {
-                  x: svgRect.left + centroid[0],
-                  y: svgRect.top + centroid[1]
-                },
-                stateId: stateKey,
-                stateName,
-                footageQuality: prefersReducedMotion ? 'still' : Math.random() > 0.6 ? 'thermal' : 'grainy',
-                reducedMotion: prefersReducedMotion,
-              });
+
+              if (areParanormalEffectsEnabled()) {
+                VisualEffectsCoordinator.triggerCryptidSighting({
+                  position: {
+                    x: svgRect.left + centroid[0],
+                    y: svgRect.top + centroid[1]
+                  },
+                  stateId: stateKey,
+                  stateName,
+                  footageQuality: prefersReducedMotion ? 'still' : Math.random() > 0.6 ? 'thermal' : 'grainy',
+                  reducedMotion: prefersReducedMotion,
+                });
+              }
             }
           }
         }

--- a/src/components/game/Options.tsx
+++ b/src/components/game/Options.tsx
@@ -99,6 +99,7 @@ interface GameSettings {
   confirmActions: boolean;
   drawMode: 'standard' | 'classic' | 'momentum' | 'catchup' | 'fast';
   uiTheme: 'tabloid_bw' | 'government_classic';
+  paranormalEffectsEnabled: boolean;
 }
 
 const Options = ({ onClose, onBackToMainMenu, onSaveGame }: OptionsProps) => {
@@ -128,6 +129,7 @@ const Options = ({ onClose, onBackToMainMenu, onSaveGame }: OptionsProps) => {
       confirmActions: true,
       drawMode: 'standard',
       uiTheme,
+      paranormalEffectsEnabled: true,
     };
 
     const stored = typeof localStorage !== 'undefined'
@@ -242,6 +244,7 @@ const Options = ({ onClose, onBackToMainMenu, onSaveGame }: OptionsProps) => {
       confirmActions: true,
       drawMode: 'standard',
       uiTheme: 'tabloid_bw',
+      paranormalEffectsEnabled: true,
     };
 
     const defaultCombos = setComboSettings({
@@ -475,6 +478,14 @@ const Options = ({ onClose, onBackToMainMenu, onSaveGame }: OptionsProps) => {
                 <Switch
                   checked={settings.screenShake}
                   onCheckedChange={checked => updateSettings({ screenShake: checked })}
+                />
+              </div>
+
+              <div className="flex items-center justify-between">
+                <label className="text-sm font-medium text-newspaper-text">Paranormal Overlays &amp; Sightings</label>
+                <Switch
+                  checked={settings.paranormalEffectsEnabled}
+                  onCheckedChange={checked => updateSettings({ paranormalEffectsEnabled: checked })}
                 />
               </div>
 

--- a/src/components/game/TruthMeter.tsx
+++ b/src/components/game/TruthMeter.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useRef, useState } from 'react';
 import { VisualEffectsCoordinator } from '@/utils/visualEffects';
+import { areParanormalEffectsEnabled } from '@/state/settings';
 
 interface TruthMeterProps {
   value: number; // 0-100
@@ -69,6 +70,10 @@ const TruthMeter = ({ value, faction = "Truth" }: TruthMeterProps) => {
         'Return to Sender (Government Edit)',
         'Can\'t Help Falling in Static',
       ];
+
+    if (!areParanormalEffectsEnabled()) {
+      return;
+    }
 
     VisualEffectsCoordinator.triggerTruthMeltdownBroadcast({
       position,

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -41,6 +41,7 @@ import toast, { Toaster } from 'react-hot-toast';
 import type { CardPlayRecord } from '@/hooks/gameStateTypes';
 import { getStateByAbbreviation, getStateById } from '@/data/usaStates';
 import type { ParanormalSighting } from '@/types/paranormal';
+import { areParanormalEffectsEnabled } from '@/state/settings';
 
 type ImpactType = 'capture' | 'truth' | 'ip' | 'damage' | 'support';
 
@@ -596,6 +597,10 @@ const Index = () => {
       }>).detail;
       if (!detail) return;
 
+      if (!areParanormalEffectsEnabled()) {
+        return;
+      }
+
       const timestamp = Date.now();
       const track = detail.setList?.[0] ?? 'Suspicious Minds?';
       const template = pickTemplate(BROADCAST_SIGHTING_TAGLINES);
@@ -633,6 +638,10 @@ const Index = () => {
         footageQuality: string;
       }>).detail;
       if (!detail) return;
+
+      if (!areParanormalEffectsEnabled()) {
+        return;
+      }
 
       const timestamp = Date.now();
       const stateName = detail.stateName ?? resolveStateName(detail.stateId);

--- a/src/state/settings.ts
+++ b/src/state/settings.ts
@@ -1,5 +1,7 @@
 import type { Difficulty } from "../ai";
 
+const OPTIONS_STORAGE_KEY = "gameSettings";
+
 export function getDifficulty(): Difficulty {
   const storage = typeof localStorage !== "undefined" ? localStorage : null;
   const raw = storage?.getItem("shadowgov:difficulty") ?? "NORMAL";
@@ -24,4 +26,26 @@ export function setDifficultyFromLabel(label: string) {
   if (typeof localStorage !== "undefined") {
     localStorage.setItem("shadowgov:difficulty", map[label] ?? "NORMAL");
   }
+}
+
+export function areParanormalEffectsEnabled(): boolean {
+  if (typeof localStorage === "undefined") {
+    return true;
+  }
+
+  try {
+    const stored = localStorage.getItem(OPTIONS_STORAGE_KEY);
+    if (!stored) {
+      return true;
+    }
+
+    const parsed = JSON.parse(stored) as { paranormalEffectsEnabled?: unknown } | null;
+    if (parsed && typeof parsed.paranormalEffectsEnabled === "boolean") {
+      return parsed.paranormalEffectsEnabled;
+    }
+  } catch (error) {
+    console.warn("Failed to read paranormal effects setting: ", error);
+  }
+
+  return true;
 }


### PR DESCRIPTION
## Summary
- add a paranormal effects toggle to the options menu and persist it with game settings
- expose a helper that reads the saved paranormal effects flag and guard cryptid/broadcast event dispatchers and feed listeners
- prevent related SFX from playing when paranormal overlays are disabled

## Testing
- npm run lint *(fails: missing local eslint dependency because packages could not be installed in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68ce5565acc88320ac25d4f44c1bcff4