### PR TITLE
Remove duplicate selectBestPlay override

### DIFF
--- a/src/data/enhancedAIStrategy.ts
+++ b/src/data/enhancedAIStrategy.ts
@@ -251,10 +251,6 @@ export class EnhancedAIStrategist implements AIStrategist {
     return this.selectBestPlayWithSynergies(gameState, evaluation);
   }
 
-  public override selectBestPlay(gameState: any): CardPlay | null {
-    return this.selectOptimalPlay(gameState);
-  }
-
   private runMCTS(
     gameState: any,
     iterations: number,


### PR DESCRIPTION
## Summary
- remove the duplicate `selectBestPlay` override from `EnhancedAIStrategist` so the class no longer declares an override without a base implementation

## Testing
- `npm run build` *(fails: vite command missing because dependencies are not installed in the execution environment; npm install blocked by 403 fetching ts-node)*

------
https://chatgpt.com/codex/tasks/task_e_68ce61fadb7c83209e590263f506987d