### PR TITLE
Add dedicated music volume controls

### DIFF
--- a/src/components/game/InGameOptions.tsx
+++ b/src/components/game/InGameOptions.tsx
@@ -184,12 +184,14 @@ const InGameOptions = ({
             
             <AudioControls
               volume={audio.config.volume}
+              musicVolume={audio.config.musicVolume}
               muted={audio.config.muted}
               musicEnabled={audio.config.musicEnabled}
               sfxEnabled={audio.config.sfxEnabled}
               isPlaying={audio.isPlaying}
               currentTrackName={audio.currentTrackName || 'None'}
               onVolumeChange={audio.setVolume}
+              onMusicVolumeChange={audio.setMusicVolume}
               onToggleMute={audio.toggleMute}
               onToggleMusic={audio.toggleMusic}
               onToggleSFX={audio.toggleSFX}

--- a/src/components/game/Options.tsx
+++ b/src/components/game/Options.tsx
@@ -117,7 +117,7 @@ const Options = ({ onClose, onBackToMainMenu, onSaveGame }: OptionsProps) => {
 
     const baseSettings: GameSettings = {
       masterVolume: Math.round(audio.config.volume * 100),
-      musicVolume: 50,
+      musicVolume: Math.round(audio.config.musicVolume * 100),
       sfxVolume: Math.round(audio.config.sfxVolume * 100),
       enableAnimations: true,
       autoEndTurn: false,
@@ -201,6 +201,14 @@ const Options = ({ onClose, onBackToMainMenu, onSaveGame }: OptionsProps) => {
     }
   }, [settings.sfxVolume, audio]);
 
+  useEffect(() => {
+    const currentMusicVolume = Math.round(audio.config.musicVolume * 100);
+    if (currentMusicVolume !== settings.musicVolume) {
+      console.log('🎵 Options: Syncing music volume from', currentMusicVolume, 'to', settings.musicVolume);
+      audio.setMusicVolume(settings.musicVolume / 100);
+    }
+  }, [settings.musicVolume, audio]);
+
   const persistSettings = (nextSettings: GameSettings, nextComboSettings: ComboSettings) => {
     if (typeof localStorage === 'undefined') {
       return;
@@ -266,6 +274,7 @@ const Options = ({ onClose, onBackToMainMenu, onSaveGame }: OptionsProps) => {
     setUiTheme('tabloid_bw');
     persistSettings(defaultSettings, defaultCombos);
     audio.setVolume(defaultSettings.masterVolume / 100);
+    audio.setMusicVolume(defaultSettings.musicVolume / 100);
     audio.setSfxVolume(defaultSettings.sfxVolume / 100);
   };
 
@@ -388,6 +397,22 @@ const Options = ({ onClose, onBackToMainMenu, onSaveGame }: OptionsProps) => {
 
               <div>
                 <label className="text-sm font-medium text-newspaper-text mb-2 block">
+                  Music Volume: {settings.musicVolume}%
+                </label>
+                <Slider
+                  value={[settings.musicVolume]}
+                  onValueChange={([value]) => {
+                    audio.setMusicVolume(value / 100);
+                    updateSettings({ musicVolume: value });
+                  }}
+                  max={100}
+                  step={1}
+                  className="w-full"
+                />
+              </div>
+
+              <div>
+                <label className="text-sm font-medium text-newspaper-text mb-2 block">
                   Sound Effects: {settings.sfxVolume}%
                 </label>
                 <Slider
@@ -407,6 +432,7 @@ const Options = ({ onClose, onBackToMainMenu, onSaveGame }: OptionsProps) => {
                   <label className="text-sm font-medium text-newspaper-text">Advanced Audio Controls</label>
                   <AudioControls
                     volume={audio.config.volume}
+                    musicVolume={audio.config.musicVolume}
                     muted={audio.config.muted}
                     musicEnabled={audio.config.musicEnabled}
                     sfxEnabled={audio.config.sfxEnabled}
@@ -416,6 +442,7 @@ const Options = ({ onClose, onBackToMainMenu, onSaveGame }: OptionsProps) => {
                     tracksLoaded={audio.tracksLoaded}
                     audioContextUnlocked={audio.audioContextUnlocked}
                     onVolumeChange={audio.setVolume}
+                    onMusicVolumeChange={audio.setMusicVolume}
                     onToggleMute={audio.toggleMute}
                     onToggleMusic={audio.toggleMusic}
                     onToggleSFX={audio.toggleSFX}

--- a/src/components/ui/audio-controls.tsx
+++ b/src/components/ui/audio-controls.tsx
@@ -25,6 +25,7 @@ import {
 
 interface AudioControlsProps {
   volume: number;
+  musicVolume: number;
   muted: boolean;
   musicEnabled: boolean;
   sfxEnabled: boolean;
@@ -34,6 +35,7 @@ interface AudioControlsProps {
   tracksLoaded?: boolean;
   audioContextUnlocked?: boolean;
   onVolumeChange: (volume: number) => void;
+  onMusicVolumeChange: (volume: number) => void;
   onToggleMute: () => void;
   onToggleMusic: () => void;
   onToggleSFX: () => void;
@@ -46,6 +48,7 @@ interface AudioControlsProps {
 
 export const AudioControls: React.FC<AudioControlsProps> = ({
   volume,
+  musicVolume,
   muted,
   musicEnabled,
   sfxEnabled,
@@ -55,6 +58,7 @@ export const AudioControls: React.FC<AudioControlsProps> = ({
   tracksLoaded = false,
   audioContextUnlocked = false,
   onVolumeChange,
+  onMusicVolumeChange,
   onToggleMute,
   onToggleMusic,
   onToggleSFX,
@@ -154,7 +158,19 @@ export const AudioControls: React.FC<AudioControlsProps> = ({
                 </Button>
               </div>
             </div>
-            
+
+            <div className="space-y-1">
+              <span className="text-xs text-muted-foreground">Music Volume ({Math.round(musicVolume * 100)}%)</span>
+              <Slider
+                value={[musicVolume * 100]}
+                onValueChange={values => onMusicVolumeChange(values[0] / 100)}
+                max={100}
+                step={1}
+                className="w-full"
+                disabled={!musicEnabled}
+              />
+            </div>
+
             {/* Playback Controls */}
             <div className="flex gap-1">
               <Button


### PR DESCRIPTION
## Summary
- add a dedicated musicVolume field to the audio configuration and ensure music playback honors it
- surface music volume controls in both options menus alongside the existing master and SFX sliders
- extend the shared audio controls popover with a music volume slider wired to the new setter

## Testing
- npm run lint *(fails: missing @eslint/js dependency due to install restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68ce8eae8ef88320a5e9c82ccc0e6e4f