### PR TITLE
Auto-enable balanced mix when activating expansions

### DIFF
--- a/src/components/game/ManageExpansions.tsx
+++ b/src/components/game/ManageExpansions.tsx
@@ -367,9 +367,12 @@ const ManageExpansions = ({ onClose }: ManageExpansionsProps) => {
 
   const handleExpansionToggle = async (expansionId: string) => {
     setUpdateError(null);
-    const nextIds = enabledExpansions.includes(expansionId)
+    const isCurrentlyEnabled = enabledExpansions.includes(expansionId);
+    const wasEmpty = enabledExpansions.length === 0;
+    const nextIds = isCurrentlyEnabled
       ? enabledExpansions.filter(id => id !== expansionId)
       : [...enabledExpansions, expansionId];
+    const willBeEmpty = nextIds.length === 0;
 
     setEnabledExpansions(nextIds);
     setPendingUpdates(prev => ({ ...prev, [expansionId]: true }));
@@ -378,6 +381,12 @@ const ManageExpansions = ({ onClose }: ManageExpansionsProps) => {
       const cards = await updateEnabledExpansions(nextIds);
       setExpansionCards(cards);
       setExpansionCounts(summarizeExpansionCards(cards));
+
+      if (!isCurrentlyEnabled && wasEmpty && settings.mode === 'core-only') {
+        setMode('balanced');
+      } else if (isCurrentlyEnabled && willBeEmpty && settings.mode !== 'core-only') {
+        setMode('core-only');
+      }
     } catch (error) {
       console.error('Failed to update expansions:', error);
       setUpdateError('Failed to update expansion selection. Restoring previous state.');


### PR DESCRIPTION
## Summary
- automatically flip the distribution mode to the balanced mix whenever the first expansion pack is enabled so the new cards flow into decks
- restore the core-only mode when the last expansion is disabled to keep the distribution settings aligned with the available card pool

## Testing
- npm run lint *(fails: missing dependencies due to npm 403 fetching ts-node)*

------
https://chatgpt.com/codex/tasks/task_e_68ce94c06c588320a49755eefb2e36cd