### PR TITLE
Adjust default master and music volumes

### DIFF
--- a/src/components/game/Options.tsx
+++ b/src/components/game/Options.tsx
@@ -289,8 +289,8 @@ const Options = ({ onClose, onBackToMainMenu, onSaveGame }: OptionsProps) => {
 
   const resetToDefaults = () => {
     const defaultSettings: GameSettings = {
-      masterVolume: 70,
-      musicVolume: 50,
+      masterVolume: 80,
+      musicVolume: 20,
       sfxVolume: 80,
       enableAnimations: true,
       autoEndTurn: false,

--- a/src/hooks/useAudio.ts
+++ b/src/hooks/useAudio.ts
@@ -29,13 +29,13 @@ export const useAudio = () => {
         console.log('🎵 useAudio: Loaded saved audio config');
         const rawMasterVolume = typeof parsed.masterVolume === 'number'
           ? parsed.masterVolume
-          : 15;
+          : 80;
         const rawSfxVolume = typeof parsed.sfxVolume === 'number'
           ? parsed.sfxVolume
           : 80;
         const rawMusicVolume = typeof parsed.musicVolume === 'number'
           ? parsed.musicVolume
-          : 50;
+          : 20;
 
         const normalizeVolume = (value: number) => {
           const clamped = Math.max(0, Math.min(100, value));
@@ -59,8 +59,8 @@ export const useAudio = () => {
     }
     console.log('🎵 useAudio: Using default audio config');
     return {
-      volume: 0.15, // Default to 15%
-      musicVolume: 0.5,
+      volume: 0.8, // Default to 80%
+      musicVolume: 0.2,
       sfxVolume: 0.8,
       muted: false,
       musicEnabled: true,


### PR DESCRIPTION
## Summary
- default the audio hook to an 80% master volume and 20% music mix when no saved settings exist
- update the options reset defaults to the same 80% master and 20% music mix

## Testing
- npm run lint *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68cea5632ef8832080f971f40e4a0040