### PR TITLE
Fix evidence gallery fallback handling

### DIFF
--- a/src/components/effects/EvidencePhotoGallery.tsx
+++ b/src/components/effects/EvidencePhotoGallery.tsx
@@ -54,7 +54,7 @@ const EvidencePhotoGallery: React.FC<EvidencePhotoGalleryProps> = ({
     }
   ], []);
 
-  const displayPhotos = photos || defaultPhotos;
+  const displayPhotos = photos?.length ? photos : defaultPhotos;
 
   useEffect(() => {
     if (reducedMotion) {
@@ -86,19 +86,21 @@ const EvidencePhotoGallery: React.FC<EvidencePhotoGalleryProps> = ({
 
   const currentPhoto = displayPhotos[currentPhotoIndex];
 
-  if (reducedMotion) {
-    return (
-      <div
-        className="evidence-gallery-simple"
-        style={galleryStyle}
-        role="dialog"
-        aria-label={`Evidence gallery: ${caseTitle}`}
-      >
-        <div className="simple-evidence">
-          📸 Evidence Review: {caseTitle}
-        </div>
+  const simpleOverlay = (
+    <div
+      className="evidence-gallery-simple"
+      style={galleryStyle}
+      role="dialog"
+      aria-label={`Evidence gallery: ${caseTitle}`}
+    >
+      <div className="simple-evidence">
+        📸 Evidence Review: {caseTitle}
       </div>
-    );
+    </div>
+  );
+
+  if (reducedMotion || !currentPhoto) {
+    return simpleOverlay;
   }
 
   return (

--- a/src/utils/visualEffects.ts
+++ b/src/utils/visualEffects.ts
@@ -254,7 +254,7 @@ export class VisualEffectsCoordinator {
       caption: string;
       timestamp: string;
       caseNumber: string;
-    }>,
+    }> | undefined,
     position: EffectPosition
   ): void {
     window.dispatchEvent(new CustomEvent('evidenceGallery', {
@@ -306,7 +306,7 @@ export class VisualEffectsCoordinator {
       case 'evidence_leaked':
         this.triggerEvidenceGallery(
           `LEAKED: ${cardName} FILES`,
-          [], // Use default photos
+          undefined, // Use default photos
           position
         );
         break;


### PR DESCRIPTION
## Summary
- ensure the evidence gallery falls back to default imagery when the custom list is missing or empty
- guard the gallery renderer by reusing the simple overlay whenever no current photo is available
- update the visual effects coordinator to avoid passing empty photo arrays when triggering the gallery

## Testing
- npm run build *(fails: vite command missing because dependencies could not be installed; npm install blocked by 403 fetching ts-node)*

------
https://chatgpt.com/codex/tasks/task_e_68cea87bf77483209a2e27e7e38b1e91