### PR TITLE
Normalize cryptids manifest ID

### DIFF
--- a/public/extensions/cryptids.json
+++ b/public/extensions/cryptids.json
@@ -1,5 +1,5 @@
 {
-  "id": "exp-cryptids",
+  "id": "cryptids",
   "name": "Cryptids",
   "version": "2.0.0",
   "schemaVersion": 2,


### PR DESCRIPTION
## Summary
- switch the shipped cryptids manifest to use the canonical `cryptids` identifier

## Testing
- `npm install` *(fails: npm cannot download dependencies such as ts-node due to 403 responses from the registry in this environment)*
- `npm run build` *(fails: vite command missing because dependencies cannot be installed without registry access)*

------
https://chatgpt.com/codex/tasks/task_e_68ceabd16a34832081121f1ea49b8511