### PR TITLE
Align starter economy with MVP baseline

### DIFF
--- a/src/components/game/InteractiveOnboarding.tsx
+++ b/src/components/game/InteractiveOnboarding.tsx
@@ -37,14 +37,14 @@ const InteractiveOnboarding = ({ isActive, onComplete, onSkip, gameState }: Inte
     {
       id: 'hand',
       title: '🎴 Your Hand',
-      description: 'These are your cards. Each has a cost (circle) and type. Click cards to examine them closely.',
+      description: 'Every op opens with five cards. Each shows its cost (circle) and type — click a card to inspect the details.',
       target: '#enhanced-hand',
       action: 'Click on a card to examine it'
     },
     {
       id: 'ip',
       title: '💰 Influence Points (IP)',
-      description: 'IP is your currency. You gain IP each turn based on controlled states. Spend it to play cards.',
+      description: 'IP starts at 0 for both factions. End turns to collect 5 + controlled states, then spend it to deploy cards.',
       target: '#ip-display'
     },
     {

--- a/src/data/cardDrawingSystem.ts
+++ b/src/data/cardDrawingSystem.ts
@@ -14,14 +14,15 @@ export interface DrawModeConfig {
 export const DRAW_MODE_CONFIGS: Record<DrawMode, DrawModeConfig> = {
   standard: {
     name: 'Standard',
-    description: 'Balanced draw system with safety nets',
-    startingHandSize: 4,
+    description: 'MVP baseline: five-card opener with steady draw-up',
+    startingHandSize: 5,
     baseDrawPerTurn: 1,
-    minHandGuarantee: 3,
+    minHandGuarantee: 5,
     midgameRampTurn: 8,
     midgameExtraDraw: 1,
     specialRules: [
-      'Draw up to 3 cards if hand < 3 at turn start',
+      'Both factions start with five cards',
+      'Top of turn: draw back up to five cards',
       'From turn 8: +1 extra draw per turn'
     ]
   },
@@ -132,12 +133,15 @@ export function calculateCardDraw(
 
 export function getStartingHandSize(mode: DrawMode, faction?: 'government' | 'truth'): number {
   const config = DRAW_MODE_CONFIGS[mode];
-  
+
   // Keep faction-based variance for balance
   if (faction === 'government') {
+    if (mode === 'standard') {
+      return config.startingHandSize;
+    }
     return Math.max(3, config.startingHandSize - 1);
   }
-  
+
   return config.startingHandSize;
 }
 


### PR DESCRIPTION
## Summary
- reset new-game setup to the MVP baseline with 0 IP, five-card openers, and mirrored AI hands
- document the five-card opener in the Standard draw-mode config and tighten saved-game migration with schema validation
- refresh onboarding copy so new players learn about the 0 IP start and income pacing

## Testing
- `npm run lint` *(fails: missing @eslint/js because registry access for ts-node/@eslint/js is blocked in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cec4d867c08320bddacf6249459d89