### PR TITLE
Start both factions with 5 IP and disable paranormal effects by default

### DIFF
--- a/src/components/game/InteractiveOnboarding.tsx
+++ b/src/components/game/InteractiveOnboarding.tsx
@@ -44,7 +44,7 @@ const InteractiveOnboarding = ({ isActive, onComplete, onSkip, gameState }: Inte
     {
       id: 'ip',
       title: '💰 Influence Points (IP)',
-      description: 'IP starts at 0 for both factions. End turns to collect 5 + controlled states, then spend it to deploy cards.',
+      description: 'IP starts at 5 for both factions. End turns to collect 5 + controlled states, then spend it to deploy cards.',
       target: '#ip-display'
     },
     {

--- a/src/components/game/Options.tsx
+++ b/src/components/game/Options.tsx
@@ -130,7 +130,7 @@ const Options = ({ onClose, onBackToMainMenu, onSaveGame }: OptionsProps) => {
       confirmActions: true,
       drawMode: 'standard',
       uiTheme,
-      paranormalEffectsEnabled: true,
+      paranormalEffectsEnabled: false,
     };
 
     const stored = typeof localStorage !== 'undefined'
@@ -302,7 +302,7 @@ const Options = ({ onClose, onBackToMainMenu, onSaveGame }: OptionsProps) => {
       confirmActions: true,
       drawMode: 'standard',
       uiTheme: 'tabloid_bw',
-      paranormalEffectsEnabled: true,
+      paranormalEffectsEnabled: false,
     };
 
     const defaultCombos = setComboSettings({

--- a/src/content/mvpRules.ts
+++ b/src/content/mvpRules.ts
@@ -54,8 +54,9 @@ export const MVP_RULES_SECTIONS: MvpRulesSection[] = [
     title: 'Setup',
     bullets: [
       'Each player draws 5 cards after shuffling their deck.',
-      'Set national Truth to 50% and both Influence Point tracks to 0.',
+      'Set national Truth to 50% and give both factions 5 starting IP.',
       'Every state begins with 0 Pressure for both factions.',
+      'Paranormal overlays & sightings are disabled by default—enable them from Options if desired.',
     ],
   },
   {

--- a/src/hooks/useGameState.ts
+++ b/src/hooks/useGameState.ts
@@ -47,7 +47,7 @@ const sanitizeCardDrawState = (value: Partial<CardDrawState> | undefined | null)
   lastTurnWithoutPlay: Boolean(value?.lastTurnWithoutPlay),
 });
 
-const MIGRATION_LOG_ENTRY = 'Save migrated to v1.1 baseline (0 IP start, five-card opener).';
+const MIGRATION_LOG_ENTRY = 'Save migrated to v1.1 baseline (5 IP start, five-card opener).';
 
 type RawSaveData = Partial<GameState> & {
   version?: string;
@@ -69,11 +69,11 @@ const migrateSaveData = (raw: RawSaveData): RawSaveData & { version: string; dra
   };
 
   if (!Number.isFinite(migrated.ip as number)) {
-    migrated.ip = 0;
+    migrated.ip = 5;
   }
 
   if (!Number.isFinite(migrated.aiIP as number)) {
-    migrated.aiIP = 0;
+    migrated.aiIP = 5;
   }
 
   if (!Array.isArray(migrated.log)) {
@@ -228,8 +228,8 @@ export const useGameState = (aiDifficultyOverride?: AIDifficulty) => {
     currentPlayer: 'human',
     aiDifficulty,
     truth: 50,
-    ip: 0,
-    aiIP: 0,
+    ip: 5,
+    aiIP: 5,
     // Use all available cards to ensure proper deck building
     hand: getRandomCards(HAND_LIMIT, { faction: 'truth' }),
     aiHand: getRandomCards(HAND_LIMIT, { faction: 'government' }),
@@ -306,8 +306,8 @@ export const useGameState = (aiDifficultyOverride?: AIDifficulty) => {
 
   const initGame = useCallback((faction: 'government' | 'truth') => {
     const startingTruth = 50;
-    const startingIP = 0;
-    const aiStartingIP = 0;
+    const startingIP = 5;
+    const aiStartingIP = 5;
     
     // Get draw mode from localStorage
     const savedSettings = localStorage.getItem('gameSettings');

--- a/src/state/settings.ts
+++ b/src/state/settings.ts
@@ -30,13 +30,13 @@ export function setDifficultyFromLabel(label: string) {
 
 export function areParanormalEffectsEnabled(): boolean {
   if (typeof localStorage === "undefined") {
-    return true;
+    return false;
   }
 
   try {
     const stored = localStorage.getItem(OPTIONS_STORAGE_KEY);
     if (!stored) {
-      return true;
+      return false;
     }
 
     const parsed = JSON.parse(stored) as { paranormalEffectsEnabled?: unknown } | null;
@@ -47,5 +47,5 @@ export function areParanormalEffectsEnabled(): boolean {
     console.warn("Failed to read paranormal effects setting: ", error);
   }
 
-  return true;
+  return false;
 }


### PR DESCRIPTION
## Summary
- start new games with 5 IP for both the player and AI, including save migrations
- update onboarding copy and MVP rules to describe the higher starting IP and note paranormal overlays default off
- default paranormal overlays & sightings setting to off in both runtime logic and the options UI

## Testing
- `npm run lint` *(fails: missing @eslint/js before dependencies can be installed)*
- `npm install` *(fails: peer dependency resolution conflict for react-day-picker/date-fns)*
- `npm install --legacy-peer-deps` *(fails: 403 fetching @jridgewell/trace-mapping from npm registry)*

------
https://chatgpt.com/codex/tasks/task_e_68cfa400213c8320984a44a2a902c760