### PR TITLE
Show expansion badges for manifest-backed cards

### DIFF
--- a/src/components/game/ExtensionCardBadge.tsx
+++ b/src/components/game/ExtensionCardBadge.tsx
@@ -1,5 +1,6 @@
 import { Badge } from '@/components/ui/badge';
 import { isExtensionCard, getCardExtensionInfo } from '@/data/extensionIntegration';
+import { getExpansionManifest, EXPANSION_MANIFEST } from '@/data/expansions';
 import type { GameCard } from '@/rules/mvp';
 
 interface ExtensionCardBadgeProps {
@@ -7,6 +8,17 @@ interface ExtensionCardBadgeProps {
   card?: GameCard;
   variant?: 'inline' | 'overlay';
 }
+
+type ExtendedGameCard = GameCard & {
+  _setId?: string;
+  _setName?: string;
+};
+
+type BadgeExtensionInfo = {
+  id: string;
+  name: string;
+  version?: string;
+};
 
 // Determine faction from card properties
 const getCardFaction = (card?: GameCard): 'government' | 'truth' => {
@@ -27,20 +39,79 @@ const getCardFaction = (card?: GameCard): 'government' | 'truth' => {
 };
 
 export const ExtensionCardBadge = ({ cardId, card, variant = 'inline' }: ExtensionCardBadgeProps) => {
-  if (!isExtensionCard(cardId)) {
+  const extendedCard = card as ExtendedGameCard | undefined;
+  const hasExpansionMeta = Boolean(extendedCard?.extId || extendedCard?._setId);
+
+  if (!isExtensionCard(cardId) && !hasExpansionMeta) {
     return null;
   }
 
   const extensionInfo = getCardExtensionInfo(cardId);
+  const manifest = getExpansionManifest();
+  const expansions = manifest.length ? manifest : EXPANSION_MANIFEST;
+
+  const lookupExpansionInfo = (): BadgeExtensionInfo | null => {
+    if (!expansions.length) {
+      return null;
+    }
+
+    const candidateIds = [extendedCard?.extId, extendedCard?._setId]
+      .filter((value): value is string => typeof value === 'string' && value.trim().length > 0)
+      .map(value => value.toLowerCase());
+
+    const candidateNames = [extendedCard?._setName]
+      .filter((value): value is string => typeof value === 'string' && value.trim().length > 0)
+      .map(value => value.toLowerCase());
+
+    const matchExpansionById = () =>
+      expansions.find(pack => {
+        const packId = pack.id?.toLowerCase();
+        const packTitle = pack.title?.toLowerCase();
+        return candidateIds.some(id => id === packId || id === packTitle);
+      });
+
+    const matchExpansionByName = () =>
+      expansions.find(pack => {
+        const metadataName = pack.metadata?.name?.toLowerCase();
+        const packTitle = pack.title?.toLowerCase();
+        return candidateNames.some(name => name === metadataName || name === packTitle);
+      });
+
+    const matchExpansionByCardId = () =>
+      expansions.find(pack => pack.cards?.some(expansionCard => expansionCard.id === cardId));
+
+    const expansion = matchExpansionById() ?? matchExpansionByName() ?? matchExpansionByCardId();
+
+    if (!expansion) {
+      return null;
+    }
+
+    const displayName = expansion.metadata?.name || expansion.title || expansion.id;
+    return {
+      id: expansion.id,
+      name: displayName,
+      version: expansion.metadata?.version,
+    };
+  };
+
+  const expansionInfo = extensionInfo ?? lookupExpansionInfo();
   const faction = getCardFaction(card);
 
-  const extensionId = extensionInfo?.id?.toLowerCase();
-  const isCryptidsExtension = extensionId?.includes('cryptid');
-  const isHalloweenExtension = extensionId?.includes('halloween');
+  const normalizedSetId =
+    extendedCard?.extId?.toLowerCase() || extendedCard?._setId?.toLowerCase() || expansionInfo?.id?.toLowerCase();
+  const normalizedName = expansionInfo?.name?.toLowerCase();
+  const isCryptidsExtension = Boolean(
+    normalizedSetId?.includes('cryptid') || normalizedName?.includes('cryptid'),
+  );
+  const isHalloweenExtension = Boolean(
+    normalizedSetId?.includes('halloween') || normalizedName?.includes('halloween') || normalizedName?.includes('spook'),
+  );
 
   // Base faction styling + fallback labels
   const factionLabel = faction === 'truth' ? 'Truth Ext' : 'Gov Ext';
   const factionSymbol = faction === 'truth' ? '👁️' : '🦎';
+
+  const badgeLabel = expansionInfo?.name || extendedCard?._setName || extendedCard?.extId || extendedCard?._setId || factionLabel;
 
   // Extension specific overrides
   const symbol = isCryptidsExtension
@@ -49,16 +120,12 @@ export const ExtensionCardBadge = ({ cardId, card, variant = 'inline' }: Extensi
       ? '🎃'
       : factionSymbol;
 
-  const badgeText = isCryptidsExtension
-    ? 'CRYPTIDS'
-    : isHalloweenExtension
-      ? 'HALLOWEEN'
-      : factionLabel.split(' ')[0].toUpperCase();
+  const badgeText = badgeLabel.toUpperCase();
 
-  const badgeTitle = extensionInfo
-    ? `${extensionInfo.name} Extension v${extensionInfo.version}`
-    : `${factionLabel} Card`;
-  
+  const badgeTitle = expansionInfo
+    ? `${expansionInfo.name} Expansion${expansionInfo.version ? ` v${expansionInfo.version}` : ''}`
+    : `${badgeLabel} Card`;
+
   if (variant === 'overlay') {
     return (
       <div className="absolute top-1 right-1 z-10">


### PR DESCRIPTION
## Summary
- ensure expansion badges render when cards include extId/_setId metadata
- read expansion manifest data to derive names and themed emojis for Cryptids and Halloween sets
- retain faction-based styling while supporting overlay/inline variants for manifest-backed cards

## Testing
- npm run lint *(fails: missing @eslint/js because npm install could not fetch ts-node due to registry 403)*

------
https://chatgpt.com/codex/tasks/task_e_68cfa6ef66b88320912255464829b425