### PR TITLE
Scale card overlays with card size

### DIFF
--- a/src/components/game/ExtensionCardBadge.tsx
+++ b/src/components/game/ExtensionCardBadge.tsx
@@ -127,8 +127,10 @@ export const ExtensionCardBadge = ({ cardId, card, variant = 'inline' }: Extensi
     : `${badgeLabel} Card`;
 
   if (variant === 'overlay') {
+    const scaledInset = 'calc(0.25rem * var(--card-scale, 1))';
+
     return (
-      <div className="absolute top-1 right-1 z-10">
+      <div className="absolute z-10" style={{ top: scaledInset, right: scaledInset }}>
         <Badge className={`${faction === 'truth' ? 'bg-truth-blue/90 border-truth-blue' : 'bg-government-blue/90 border-government-blue'} text-white text-xs px-1 py-0.5 animate-fade-in`}>
           {symbol}
         </Badge>

--- a/src/index.css
+++ b/src/index.css
@@ -959,6 +959,8 @@ All colors MUST be HSL.
   position: absolute;
   inset: 0;
   pointer-events: none;
+  transform-origin: top left;
+  transform: scale(var(--card-scale, 1));
 }
 
 /* Polaroid frame */


### PR DESCRIPTION
## Summary
- scale card frame overlays with the card size token so overlay decorations shrink with mini cards
- anchor overlay badge offsets to the card scale variable to keep the emoji badge snug against the frame edge

## Testing
- npm run lint *(fails: missing @eslint/js dependency in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cfafdcda6c832087d0921b70bc4e1e