### PR TITLE
Fix expansion card summaries and restore expansion distribution

### DIFF
--- a/src/components/game/ManageExpansions.tsx
+++ b/src/components/game/ManageExpansions.tsx
@@ -23,6 +23,7 @@ import { useDistributionSettings } from '@/hooks/useDistributionSettings';
 import type { DistributionMode } from '@/data/weightedCardDistribution';
 import { ChevronDown } from 'lucide-react';
 import { cn } from '@/lib/utils';
+import { summarizeExpansionCards } from './manageExpansions.helpers';
 
 interface ManageExpansionsProps {
   onClose: () => void;
@@ -70,20 +71,6 @@ const computeStats = (cards: GameCard[]): StatBlock => {
     factions,
     rarities: Array.from(rarityCounts.entries()),
   };
-};
-
-const EXPANSION_ID_SET = new Set(EXPANSION_MANIFEST.map(pack => pack.id));
-
-const summarizeExpansionCards = (cards: GameCard[]): Record<string, number> => {
-  const counts: Record<string, number> = {};
-  cards.forEach(card => {
-    const extId = card.extId;
-    if (!extId || !EXPANSION_ID_SET.has(extId)) {
-      return;
-    }
-    counts[extId] = (counts[extId] ?? 0) + 1;
-  });
-  return counts;
 };
 
 interface ExpansionDetail {
@@ -272,7 +259,7 @@ const ManageExpansions = ({ onClose }: ManageExpansionsProps) => {
     ];
 
     expansionDetails
-      .filter(detail => detail.enabled && detail.loadedCount > 0)
+      .filter(detail => detail.enabled)
       .forEach(detail => {
         sets.push({
           id: detail.pack.id,
@@ -313,7 +300,7 @@ const ManageExpansions = ({ onClose }: ManageExpansionsProps) => {
   );
 
   const activeExpansionNames = expansionDetails
-    .filter(detail => detail.enabled && detail.loadedCount > 0)
+    .filter(detail => detail.enabled)
     .map(detail => detail.pack.title)
     .join(', ');
 

--- a/src/components/game/__tests__/ManageExpansions.test.ts
+++ b/src/components/game/__tests__/ManageExpansions.test.ts
@@ -1,0 +1,108 @@
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
+import type { GameCard } from '@/rules/mvp';
+import { summarizeExpansionCards } from '@/components/game/manageExpansions.helpers';
+import { EXPANSION_MANIFEST } from '@/data/expansions';
+import { updateEnabledExpansions } from '@/data/expansions/state';
+import { DEFAULT_DISTRIBUTION_SETTINGS, weightedDistribution } from '@/data/weightedCardDistribution';
+
+type ExpansionPackSnapshot = (typeof EXPANSION_MANIFEST)[number];
+
+const cloneManifest = (manifest: ExpansionPackSnapshot[]): ExpansionPackSnapshot[] =>
+  manifest.map(pack => ({
+    ...pack,
+    cards: pack.cards.map(card => ({ ...card })),
+    metadata: pack.metadata ? { ...pack.metadata } : undefined,
+  }));
+
+describe('summarizeExpansionCards', () => {
+  const originalManifest = cloneManifest(EXPANSION_MANIFEST);
+
+  beforeEach(async () => {
+    EXPANSION_MANIFEST.splice(0, EXPANSION_MANIFEST.length);
+    await updateEnabledExpansions([]);
+    weightedDistribution.updateSettings({
+      ...DEFAULT_DISTRIBUTION_SETTINGS,
+      setWeights: { ...DEFAULT_DISTRIBUTION_SETTINGS.setWeights },
+    });
+  });
+
+  afterEach(async () => {
+    EXPANSION_MANIFEST.splice(0, EXPANSION_MANIFEST.length, ...cloneManifest(originalManifest));
+    await updateEnabledExpansions([]);
+    weightedDistribution.updateSettings({
+      ...DEFAULT_DISTRIBUTION_SETTINGS,
+      setWeights: { ...DEFAULT_DISTRIBUTION_SETTINGS.setWeights },
+    });
+  });
+
+  it('counts cards for expansions added after initial manifest load', () => {
+    const cryptidsCard: GameCard = {
+      id: 'cryptid-test',
+      name: 'Mothman',
+      type: 'ATTACK',
+      faction: 'truth',
+      rarity: 'common',
+      cost: 2,
+      extId: 'cryptids',
+    };
+
+    // Without a manifest entry the card should be ignored
+    expect(summarizeExpansionCards([cryptidsCard])).toEqual({});
+
+    EXPANSION_MANIFEST.push({
+      id: 'cryptids',
+      title: 'Cryptids',
+      fileName: 'cryptids.json',
+      cardCount: 1,
+      cards: [cryptidsCard],
+      metadata: { name: 'Cryptids' },
+    });
+
+    expect(summarizeExpansionCards([cryptidsCard])).toEqual({ cryptids: 1 });
+  });
+
+  it('allows weighted distribution to draw from enabled expansion packs', async () => {
+    const cryptidsCards: GameCard[] = [
+      {
+        id: 'cryptid-alpha',
+        name: 'Mothman',
+        type: 'ATTACK',
+        faction: 'truth',
+        rarity: 'common',
+        cost: 2,
+        extId: 'cryptids',
+      },
+      {
+        id: 'cryptid-beta',
+        name: 'Jersey Devil',
+        type: 'MEDIA',
+        faction: 'truth',
+        rarity: 'uncommon',
+        cost: 3,
+        extId: 'cryptids',
+      },
+    ];
+
+    EXPANSION_MANIFEST.push({
+      id: 'cryptids',
+      title: 'Cryptids',
+      fileName: 'cryptids.json',
+      cardCount: cryptidsCards.length,
+      cards: cryptidsCards,
+      metadata: { name: 'Cryptids' },
+    });
+
+    await updateEnabledExpansions(['cryptids']);
+
+    weightedDistribution.updateSettings({
+      mode: 'expansion-only',
+      duplicateLimit: 10,
+      setWeights: { core: 0, cryptids: 1 },
+    });
+
+    const deck = weightedDistribution.generateWeightedDeck(6, 'truth');
+
+    expect(deck.length).toBeGreaterThan(0);
+    expect(deck.every(card => card.extId === 'cryptids')).toBe(true);
+  });
+});

--- a/src/components/game/manageExpansions.helpers.ts
+++ b/src/components/game/manageExpansions.helpers.ts
@@ -1,0 +1,17 @@
+import { EXPANSION_MANIFEST } from '@/data/expansions';
+import type { GameCard } from '@/rules/mvp';
+
+export const summarizeExpansionCards = (cards: GameCard[]): Record<string, number> => {
+  const counts: Record<string, number> = {};
+  const validIds = new Set(EXPANSION_MANIFEST.map(pack => pack.id));
+
+  cards.forEach(card => {
+    const extId = card.extId;
+    if (!extId || !validIds.has(extId)) {
+      return;
+    }
+    counts[extId] = (counts[extId] ?? 0) + 1;
+  });
+
+  return counts;
+};


### PR DESCRIPTION
## Summary
- Recompute expansion card counts against the current manifest so newly loaded packs contribute to the deck pool
- Treat enabled expansions as active sets to re-enable balanced and expansion-only distribution options in the control panel
- Add helper utilities and regression tests to verify expansion cards are counted and the weighted generator can draw from enabled packs

## Testing
- bun test


------
https://chatgpt.com/codex/tasks/task_e_68cfb209652c8320934699b90fdc602b