### PR TITLE
Align expansion mix modes with deck generation

### DIFF
--- a/src/components/game/__tests__/ManageExpansions.test.ts
+++ b/src/components/game/__tests__/ManageExpansions.test.ts
@@ -105,4 +105,51 @@ describe('summarizeExpansionCards', () => {
     expect(deck.length).toBeGreaterThan(0);
     expect(deck.every(card => card.extId === 'cryptids')).toBe(true);
   });
+
+  it('aligns balanced mix weights with the deck builder core floor', async () => {
+    const cryptidsCards: GameCard[] = [
+      {
+        id: 'cryptid-alpha',
+        name: 'Mothman',
+        type: 'ATTACK',
+        faction: 'truth',
+        rarity: 'common',
+        cost: 2,
+        extId: 'cryptids',
+      },
+      {
+        id: 'cryptid-beta',
+        name: 'Jersey Devil',
+        type: 'MEDIA',
+        faction: 'truth',
+        rarity: 'uncommon',
+        cost: 3,
+        extId: 'cryptids',
+      },
+    ];
+
+    EXPANSION_MANIFEST.push({
+      id: 'cryptids',
+      title: 'Cryptids',
+      fileName: 'cryptids.json',
+      cardCount: cryptidsCards.length,
+      cards: cryptidsCards,
+      metadata: { name: 'Cryptids' },
+    });
+
+    await updateEnabledExpansions(['cryptids']);
+
+    weightedDistribution.updateSettings({
+      ...DEFAULT_DISTRIBUTION_SETTINGS,
+      mode: 'balanced',
+      duplicateLimit: 10,
+      setWeights: { core: 1, cryptids: 1 },
+    });
+
+    const weights = weightedDistribution.getCurrentSetWeights();
+
+    expect(weights.core).toBeGreaterThan(0);
+    expect(weights.cryptids).toBeGreaterThan(0);
+    expect(weights.core).toBeCloseTo(weights.cryptids, 5);
+  });
 });

--- a/src/data/weightedCardDistribution.ts
+++ b/src/data/weightedCardDistribution.ts
@@ -1,4 +1,5 @@
 import type { GameCard } from '@/rules/mvp';
+import { CORE_FLOOR } from '@/lib/decks/expansions';
 import { ensureMvpCosts, getCoreCards, isMvpCard } from './cardDatabase';
 import { EXPANSION_MANIFEST } from './expansions';
 import {
@@ -222,37 +223,85 @@ class WeightedCardDistribution {
   private getEffectiveWeights(): SetWeights {
     const weights: SetWeights = { core: 0 };
     const availableSets = this.getAvailableCardSets();
+    const coreSet = availableSets.find(set => set.isCore && set.cards.length > 0);
+    const activeExpansions = availableSets.filter(set => !set.isCore && set.cards.length > 0);
+
+    const setWeight = (setId: string, weight: number) => {
+      if (setId === 'core') {
+        weights.core = Math.max(0, weight);
+        return;
+      }
+
+      if (weight > 0) {
+        weights[setId] = weight;
+      }
+    };
 
     switch (this.settings.mode) {
-      case 'core-only':
-        weights.core = 1.0;
-        availableSets.forEach(set => {
-          if (!set.isCore && set.id in weights) {
-            delete weights[set.id];
+      case 'core-only': {
+        if (coreSet) {
+          setWeight('core', 1);
+        }
+        break;
+      }
+
+      case 'expansion-only': {
+        if (activeExpansions.length === 0) {
+          if (coreSet) {
+            setWeight('core', 1);
+          }
+          break;
+        }
+
+        setWeight('core', 0);
+        activeExpansions.forEach(set => setWeight(set.id, 1));
+        break;
+      }
+
+      case 'balanced': {
+        if (coreSet) {
+          setWeight('core', 1);
+        }
+
+        activeExpansions.forEach(set => setWeight(set.id, 1));
+
+        if (coreSet && activeExpansions.length > 0) {
+          const expansionSum = activeExpansions.reduce(
+            (sum, set) => sum + (weights[set.id] ?? 0),
+            0,
+          );
+          const requiredCoreWeight = (CORE_FLOOR * expansionSum) / (1 - CORE_FLOOR);
+          setWeight('core', Math.max(weights.core ?? 0, requiredCoreWeight));
+        } else if (coreSet) {
+          setWeight('core', Math.max(weights.core ?? 0, 1));
+        }
+
+        break;
+      }
+
+      case 'custom': {
+        const normalize = (value?: number) =>
+          typeof value === 'number' && Number.isFinite(value) ? Math.max(0, value) : 0;
+
+        setWeight('core', normalize(this.settings.setWeights.core));
+
+        activeExpansions.forEach(set => {
+          const weight = normalize(this.settings.setWeights[set.id]);
+          if (weight > 0) {
+            setWeight(set.id, weight);
           }
         });
+
         break;
-      
-      case 'expansion-only':
-        availableSets.forEach(set => {
-          if (!set.isCore && set.cards.length > 0) {
-            weights[set.id] = 1.0;
-          }
-        });
-        break;
-      
-      case 'balanced':
-        weights.core = 2.0;
-        availableSets.forEach(set => {
-          if (!set.isCore && set.cards.length > 0) {
-            weights[set.id] = 1.0;
-          }
-        });
-        break;
-      
-      case 'custom':
-        Object.assign(weights, this.settings.setWeights);
-        break;
+      }
+    }
+
+    const totalActiveWeight = Object.entries(weights)
+      .filter(([setId]) => setId === 'core' || activeExpansions.some(set => set.id === setId))
+      .reduce((sum, [, value]) => sum + (Number.isFinite(value) ? value : 0), 0);
+
+    if (totalActiveWeight <= 0 && coreSet) {
+      setWeight('core', 1);
     }
 
     return weights;
@@ -488,6 +537,10 @@ class WeightedCardDistribution {
 
   getSettings(): DistributionSettings {
     return { ...this.settings };
+  }
+
+  getCurrentSetWeights(): SetWeights {
+    return { ...this.getEffectiveWeights() };
   }
 
   setMode(mode: DistributionMode): void {

--- a/src/lib/decks/expansions.ts
+++ b/src/lib/decks/expansions.ts
@@ -27,7 +27,7 @@ export type MixMode =
 
 const CORE_SET_ID = 'core';
 const CORE_SET_NAME = 'Core Deck';
-const CORE_FLOOR = 0.5; // TODO: expose via settings if playtesting demands a different baseline.
+export const CORE_FLOOR = 0.5; // TODO: expose via settings if playtesting demands a different baseline.
 
 type WeightMap = Record<string, number>;
 


### PR DESCRIPTION
## Summary
- export the deck builder core floor constant for reuse by the weighted distribution engine
- synchronize weighted deck generation mix-mode weights with the UI builder logic and expose current weights for verification
- expand expansion management tests to ensure the balanced mix honors the core floor expectations

## Testing
- bun test src/components/game/__tests__/ManageExpansions.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68cfb773a7b08320a9b119abded0bd5b