### PR TITLE
Respect paranormal overlay toggle

### DIFF
--- a/src/components/game/CardAnimationLayer.tsx
+++ b/src/components/game/CardAnimationLayer.tsx
@@ -185,6 +185,10 @@ const CardAnimationLayer: React.FC<CardAnimationLayerProps> = ({ children }) => 
       reducedMotion?: boolean;
     }>) => {
       if (!event?.detail) return;
+      if (!areParanormalEffectsEnabled()) {
+        setBroadcastOverlay(null);
+        return;
+      }
       const { position, intensity, setList, truthValue, reducedMotion } = event.detail;
       if (position && !reducedMotion) {
         spawnParticleEffect('broadcast', position.x, position.y);
@@ -209,8 +213,12 @@ const CardAnimationLayer: React.FC<CardAnimationLayerProps> = ({ children }) => 
       stateName?: string;
       footageQuality: string;
       reducedMotion?: boolean;
-    }>) => {
+      }>) => {
       if (!event?.detail) return;
+      if (!areParanormalEffectsEnabled()) {
+        setCryptidOverlay(null);
+        return;
+      }
       const { position, stateId, stateName, footageQuality, reducedMotion } = event.detail;
       if (position && !reducedMotion) {
         spawnParticleEffect('cryptid', position.x, position.y);
@@ -236,6 +244,10 @@ const CardAnimationLayer: React.FC<CardAnimationLayerProps> = ({ children }) => 
       y: number;
     }>) => {
       if (!event?.detail) return;
+      if (!areParanormalEffectsEnabled()) {
+        setBreakingNewsOverlay(null);
+        return;
+      }
       const { newsText, x, y } = event.detail;
       setBreakingNewsOverlay({
         id: Date.now(),
@@ -254,6 +266,10 @@ const CardAnimationLayer: React.FC<CardAnimationLayerProps> = ({ children }) => 
       y: number;
     }>) => {
       if (!event?.detail) return;
+      if (!areParanormalEffectsEnabled()) {
+        setSurveillanceOverlay(null);
+        return;
+      }
       const { targetName, threatLevel, x, y } = event.detail;
       setSurveillanceOverlay({
         id: Date.now(),
@@ -274,6 +290,10 @@ const CardAnimationLayer: React.FC<CardAnimationLayerProps> = ({ children }) => 
       y: number;
     }>) => {
       if (!event?.detail) return;
+      if (!areParanormalEffectsEnabled()) {
+        setTypewriterOverlay(null);
+        return;
+      }
       const { documentTitle, documentContent, classificationLevel, x, y } = event.detail;
       setTypewriterOverlay({
         id: Date.now(),
@@ -293,6 +313,10 @@ const CardAnimationLayer: React.FC<CardAnimationLayerProps> = ({ children }) => 
       y: number;
     }>) => {
       if (!event?.detail) return;
+      if (!areParanormalEffectsEnabled()) {
+        setStaticOverlay(null);
+        return;
+      }
       const { intensity, message, x, y } = event.detail;
       setStaticOverlay({
         id: Date.now(),
@@ -318,6 +342,10 @@ const CardAnimationLayer: React.FC<CardAnimationLayerProps> = ({ children }) => 
       y: number;
     }>) => {
       if (!event?.detail) return;
+      if (!areParanormalEffectsEnabled()) {
+        setEvidenceOverlay(null);
+        return;
+      }
       const { caseTitle, photos, x, y } = event.detail;
       setEvidenceOverlay({
         id: Date.now(),
@@ -404,6 +432,43 @@ const CardAnimationLayer: React.FC<CardAnimationLayerProps> = ({ children }) => 
       window.removeEventListener('evidenceGallery', handleEvidenceGallery as EventListener);
     };
   }, [spawnParticleEffect, audio]);
+
+  const clearParanormalOverlays = useCallback(() => {
+    setBreakingNewsOverlay(null);
+    setSurveillanceOverlay(null);
+    setTypewriterOverlay(null);
+    setStaticOverlay(null);
+    setEvidenceOverlay(null);
+    setBroadcastOverlay(null);
+    setCryptidOverlay(null);
+  }, []);
+
+  useEffect(() => {
+    const handleParanormalToggle = (event: Event) => {
+      const detail = (event as CustomEvent<{ enabled?: boolean }>).detail;
+      if (!detail?.enabled) {
+        clearParanormalOverlays();
+      }
+    };
+
+    const handleStorageSync = () => {
+      if (!areParanormalEffectsEnabled()) {
+        clearParanormalOverlays();
+      }
+    };
+
+    if (!areParanormalEffectsEnabled()) {
+      clearParanormalOverlays();
+    }
+
+    window.addEventListener('shadowgov:paranormal-effects-toggled', handleParanormalToggle);
+    window.addEventListener('storage', handleStorageSync);
+
+    return () => {
+      window.removeEventListener('shadowgov:paranormal-effects-toggled', handleParanormalToggle);
+      window.removeEventListener('storage', handleStorageSync);
+    };
+  }, [clearParanormalOverlays]);
 
   const handleParticleComplete = useCallback((id: number) => {
     setParticleEffects(prev => prev.filter(effect => effect.id !== id));

--- a/src/components/game/Options.tsx
+++ b/src/components/game/Options.tsx
@@ -243,6 +243,11 @@ const Options = ({ onClose, onBackToMainMenu, onSaveGame }: OptionsProps) => {
         setDifficultyFromLabel(newSettings.difficulty);
       }
       persistSettings(updated, comboSettingsState);
+      if (typeof window !== 'undefined' && prev.paranormalEffectsEnabled !== updated.paranormalEffectsEnabled) {
+        window.dispatchEvent(new CustomEvent('shadowgov:paranormal-effects-toggled', {
+          detail: { enabled: updated.paranormalEffectsEnabled }
+        }));
+      }
       return updated;
     });
   };

--- a/src/utils/visualEffects.ts
+++ b/src/utils/visualEffects.ts
@@ -1,3 +1,5 @@
+import { areParanormalEffectsEnabled } from '@/state/settings';
+
 // Visual Effects Integration Utilities
 // Centralized system for triggering coordinated visual effects
 
@@ -133,6 +135,10 @@ export class VisualEffectsCoordinator {
     reducedMotion?: boolean;
     source?: 'truth' | 'government';
   }): void {
+    if (!areParanormalEffectsEnabled()) {
+      return;
+    }
+
     window.dispatchEvent(new CustomEvent('truthMeltdownBroadcast', {
       detail: {
         ...detail,
@@ -148,6 +154,10 @@ export class VisualEffectsCoordinator {
     footageQuality: string;
     reducedMotion?: boolean;
   }): void {
+    if (!areParanormalEffectsEnabled()) {
+      return;
+    }
+
     window.dispatchEvent(new CustomEvent('cryptidSighting', {
       detail: {
         ...detail,
@@ -186,6 +196,10 @@ export class VisualEffectsCoordinator {
 
   // Trigger breaking news ticker overlay
   static triggerBreakingNews(newsText: string, position: EffectPosition): void {
+    if (!areParanormalEffectsEnabled()) {
+      return;
+    }
+
     window.dispatchEvent(new CustomEvent('breakingNews', {
       detail: {
         newsText,
@@ -201,6 +215,10 @@ export class VisualEffectsCoordinator {
     threatLevel: 'LOW' | 'MEDIUM' | 'HIGH' | 'CLASSIFIED',
     position: EffectPosition
   ): void {
+    if (!areParanormalEffectsEnabled()) {
+      return;
+    }
+
     window.dispatchEvent(new CustomEvent('governmentSurveillance', {
       detail: {
         targetName,
@@ -218,6 +236,10 @@ export class VisualEffectsCoordinator {
     classificationLevel: 'UNCLASSIFIED' | 'CONFIDENTIAL' | 'SECRET' | 'TOP SECRET',
     position: EffectPosition
   ): void {
+    if (!areParanormalEffectsEnabled()) {
+      return;
+    }
+
     window.dispatchEvent(new CustomEvent('typewriterReveal', {
       detail: {
         documentTitle,
@@ -235,6 +257,10 @@ export class VisualEffectsCoordinator {
     message: string,
     position: EffectPosition
   ): void {
+    if (!areParanormalEffectsEnabled()) {
+      return;
+    }
+
     window.dispatchEvent(new CustomEvent('staticInterference', {
       detail: {
         intensity,
@@ -257,6 +283,10 @@ export class VisualEffectsCoordinator {
     }> | undefined,
     position: EffectPosition
   ): void {
+    if (!areParanormalEffectsEnabled()) {
+      return;
+    }
+
     window.dispatchEvent(new CustomEvent('evidenceGallery', {
       detail: {
         caseTitle,
@@ -273,6 +303,10 @@ export class VisualEffectsCoordinator {
     cardName: string,
     position: EffectPosition
   ): void {
+    if (!areParanormalEffectsEnabled()) {
+      return;
+    }
+
     switch (eventType) {
       case 'media_blast':
         this.triggerBreakingNews(


### PR DESCRIPTION
## Summary
- short-circuit contextual visual effect dispatchers when paranormal overlays are disabled
- guard card animation overlay handlers, centralize clearing, and react to paranormal toggle events so overlays are removed immediately
- broadcast a paranormal toggle event from the options screen so other layers can sync with the user preference

## Testing
- npm run lint *(fails: missing @eslint/js in workspace)*

------
https://chatgpt.com/codex/tasks/task_e_68cfc42afeac8320a4862c549815541b