### PR TITLE
Add focused card preview to collection

### DIFF
--- a/src/components/game/CardCollection.tsx
+++ b/src/components/game/CardCollection.tsx
@@ -9,6 +9,7 @@ import { useCardCollection } from '@/hooks/useCardCollection';
 import type { GameCard, MVPCardType } from '@/rules/mvp';
 import { CARD_DATABASE } from '@/data/cardDatabase';
 import { MVP_CARD_TYPES } from '@/rules/mvp';
+import BaseCard from '@/components/game/cards/BaseCard';
 
 interface CardCollectionProps {
   open: boolean;
@@ -20,6 +21,7 @@ const CardCollection = ({ open, onOpenChange }: CardCollectionProps) => {
   const [searchTerm, setSearchTerm] = useState('');
   const [filterType, setFilterType] = useState<string>('all');
   const [filterRarity, setFilterRarity] = useState<string>('all');
+  const [focusedCard, setFocusedCard] = useState<GameCard | null>(null);
   
   const stats = getCollectionStats();
   const discoveredCards = getDiscoveredCards();
@@ -38,35 +40,39 @@ const CardCollection = ({ open, onOpenChange }: CardCollectionProps) => {
     return matchesSearch && matchesType && matchesRarity;
   });
 
-  const CardItem = ({ card }: { card: GameCard }) => {
+  const CardItem = ({ card, onSelect }: { card: GameCard; onSelect: () => void }) => {
     const cardStats = getCardStats(card.id);
-    
+
     return (
-      <div className="bg-card border border-border rounded-lg p-4 hover:bg-accent/50 transition-colors">
+      <button
+        type="button"
+        onClick={onSelect}
+        className="w-full text-left bg-card border border-border rounded-lg p-4 hover:bg-accent/50 transition-colors focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 focus:ring-offset-background"
+      >
         <div className="flex items-start justify-between mb-2">
           <h3 className="font-bold text-lg text-foreground">{card.name}</h3>
           <div className="flex gap-2">
-            <Badge variant={card.rarity === 'legendary' ? 'destructive' : 
+            <Badge variant={card.rarity === 'legendary' ? 'destructive' :
                            card.rarity === 'rare' ? 'secondary' : 'outline'}>
               {card.rarity}
             </Badge>
             <Badge variant="outline">{normalizeCardType(card.type)}</Badge>
           </div>
         </div>
-        
+
         <p className="text-sm text-muted-foreground mb-3">{card.text}</p>
-        
+
         <div className="flex items-center justify-between text-xs text-muted-foreground">
           <span>Cost: {card.cost} IP</span>
           <span>Played: {cardStats.timesPlayed} times</span>
         </div>
-        
+
         {(card.flavor ?? card.flavorGov ?? card.flavorTruth) && (
           <div className="mt-2 p-2 bg-accent/30 rounded text-xs italic text-muted-foreground">
             "{card.flavor ?? card.flavorGov ?? card.flavorTruth}"
           </div>
         )}
-      </div>
+      </button>
     );
   };
 
@@ -156,11 +162,38 @@ const CardCollection = ({ open, onOpenChange }: CardCollectionProps) => {
           ) : (
             <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
               {filteredCards.map(card => (
-                <CardItem key={card.id} card={card} />
+                <CardItem
+                  key={card.id}
+                  card={card}
+                  onSelect={() => setFocusedCard(card)}
+                />
               ))}
             </div>
           )}
         </div>
+
+        {focusedCard && (
+          <div
+            className="fixed inset-0 z-50 flex items-center justify-center bg-black/70 backdrop-blur-sm p-4"
+            role="dialog"
+            aria-modal="true"
+            onClick={() => setFocusedCard(null)}
+          >
+            <div
+              className="relative flex w-full max-w-2xl flex-col items-center gap-4"
+              onClick={(event) => event.stopPropagation()}
+            >
+              <Button
+                variant="secondary"
+                className="self-end"
+                onClick={() => setFocusedCard(null)}
+              >
+                Close
+              </Button>
+              <BaseCard card={focusedCard} />
+            </div>
+          </div>
+        )}
       </DialogContent>
     </Dialog>
   );


### PR DESCRIPTION
## Summary
- track which card in the collection is focused for preview
- allow selecting a card in the grid to open a full-size preview overlay
- provide an overlay close action to return to the collection view

## Testing
- npm run lint *(fails: Cannot find package '@eslint/js' imported from eslint.config.js)*

------
https://chatgpt.com/codex/tasks/task_e_68cfe3921b388320a0a96f542eee4523