### PR TITLE
Reposition toast notifications away from map

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -3050,3 +3050,19 @@ html, body, #root {
   0%, 100% { opacity: 0.8; }
   50% { opacity: 1; }
 }
+
+@layer components {
+  .game-toast-container {
+    @apply pointer-events-none pr-6 pb-6;
+    padding-right: calc(env(safe-area-inset-right) + 1.5rem);
+    padding-bottom: calc(env(safe-area-inset-bottom) + 1.5rem);
+  }
+
+  .game-toast-container > * {
+    @apply pointer-events-auto;
+  }
+
+  .game-toast {
+    @apply pointer-events-auto max-w-xs border border-slate-700 bg-slate-900/95 font-mono text-sm leading-snug text-slate-100 shadow-2xl;
+  }
+}

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -1658,15 +1658,12 @@ const Index = () => {
 
       {uiNotificationsEnabled && (
         <Toaster
-          position="top-right"
+          position="bottom-right"
+          gutter={12}
+          containerClassName="game-toast-container"
           toastOptions={{
             duration: 3000,
-            style: {
-              background: '#1f2937',
-              color: '#f3f4f6',
-              border: '1px solid #374151',
-              fontFamily: 'monospace'
-            }
+            className: 'game-toast',
           }}
         />
       )}


### PR DESCRIPTION
## Summary
- reposition the global toaster so zone guidance notifications sit in the lower corner instead of covering the map
- add scoped utility classes to control toast container spacing, safe-area padding, and readable styling

## Testing
- npm run lint *(fails: Cannot find package '@eslint/js' imported from eslint.config.js)*

------
https://chatgpt.com/codex/tasks/task_e_68cfe45945648320a9cafb6eba746172