### PR TITLE
Enhance combo glitch overlay messaging and animations

### DIFF
--- a/src/components/game/CardAnimationLayer.tsx
+++ b/src/components/game/CardAnimationLayer.tsx
@@ -81,6 +81,7 @@ const CardAnimationLayer: React.FC<CardAnimationLayerProps> = ({ children }) => 
     magnitude: number;
     duration: number;
     reducedMotion?: boolean;
+    fxMessages: string[];
   } | null>(null);
   const [broadcastOverlay, setBroadcastOverlay] = useState<{
     id: number;
@@ -279,6 +280,7 @@ const CardAnimationLayer: React.FC<CardAnimationLayerProps> = ({ children }) => 
       intensity?: 'minor' | 'major' | 'mega';
       magnitude?: number;
       reducedMotion?: boolean;
+      fxMessages?: string[];
     }>) => {
       if (!event?.detail) return;
 
@@ -289,6 +291,7 @@ const CardAnimationLayer: React.FC<CardAnimationLayerProps> = ({ children }) => 
         intensity,
         magnitude,
         reducedMotion,
+        fxMessages,
       } = event.detail;
 
       const prefersReducedMotion = reducedMotion ?? (typeof window !== 'undefined'
@@ -319,6 +322,12 @@ const CardAnimationLayer: React.FC<CardAnimationLayerProps> = ({ children }) => 
         magnitude: sanitizedMagnitude,
         duration: COMBO_GLITCH_DURATIONS[resolvedIntensity],
         reducedMotion: prefersReducedMotion,
+        fxMessages: Array.isArray(fxMessages)
+          ? fxMessages
+            .filter((message): message is string => typeof message === 'string')
+            .map(message => message.trim())
+            .filter(message => message.length > 0)
+          : [],
       });
     };
 
@@ -642,6 +651,7 @@ const CardAnimationLayer: React.FC<CardAnimationLayerProps> = ({ children }) => 
             magnitude={comboGlitchOverlay.magnitude}
             duration={comboGlitchOverlay.duration}
             reducedMotion={comboGlitchOverlay.reducedMotion}
+            fxMessages={comboGlitchOverlay.fxMessages}
             onComplete={handleComboGlitchComplete}
           />
         )}

--- a/src/hooks/useGameState.ts
+++ b/src/hooks/useGameState.ts
@@ -618,6 +618,7 @@ export const useGameState = (aiDifficultyOverride?: AIDifficulty) => {
           position: effectPosition,
           comboNames,
           magnitude,
+          fxMessages: comboResult.fxMessages,
         });
       }
 

--- a/src/index.css
+++ b/src/index.css
@@ -668,6 +668,29 @@ All colors MUST be HSL.
     animation: combo-glitch-shard 0.6s ease-in-out infinite alternate;
   }
 
+  .combo-glitch-text-scramble {
+    animation: combo-glitch-text-scramble 0.78s cubic-bezier(0.22, 0.61, 0.36, 1);
+    will-change: transform, filter, opacity;
+  }
+
+  .combo-glitch-text-scanline {
+    position: relative;
+    overflow: hidden;
+    animation: combo-glitch-text-scanline 0.88s cubic-bezier(0.19, 1, 0.22, 1);
+    will-change: clip-path, opacity;
+  }
+
+  .combo-glitch-text-scanline::after {
+    content: '';
+    position: absolute;
+    inset: 0;
+    background: linear-gradient(180deg, transparent 0%, rgba(255, 255, 255, 0.4) 50%, transparent 100%);
+    mix-blend-mode: screen;
+    transform: translateY(-120%);
+    animation: combo-glitch-text-sheen 0.88s cubic-bezier(0.19, 1, 0.22, 1);
+    pointer-events: none;
+  }
+
   @keyframes combo-glitch-jitter {
     0% {
       transform: translate(-50%, -50%) scale(1) skewX(0deg);
@@ -716,11 +739,70 @@ All colors MUST be HSL.
     }
   }
 
+  @keyframes combo-glitch-text-scramble {
+    0% {
+      opacity: 0;
+      transform: translateY(-8px);
+      filter: blur(6px) saturate(160%);
+    }
+    35% {
+      opacity: 0.6;
+      transform: translateY(3px);
+      filter: blur(3px) saturate(180%);
+    }
+    70% {
+      opacity: 0.95;
+      transform: translateY(-2px);
+      filter: blur(1.2px) saturate(120%);
+    }
+    100% {
+      opacity: 1;
+      transform: translateY(0);
+      filter: blur(0) saturate(100%);
+    }
+  }
+
+  @keyframes combo-glitch-text-scanline {
+    0% {
+      opacity: 0;
+      clip-path: inset(0 0 100% 0);
+    }
+    40% {
+      opacity: 0.85;
+      clip-path: inset(0 0 40% 0);
+    }
+    70% {
+      opacity: 0.95;
+      clip-path: inset(0 0 12% 0);
+    }
+    100% {
+      opacity: 1;
+      clip-path: inset(0 0 0 0);
+    }
+  }
+
+  @keyframes combo-glitch-text-sheen {
+    0% {
+      opacity: 0;
+      transform: translateY(-120%);
+    }
+    30% {
+      opacity: 0.9;
+    }
+    100% {
+      opacity: 0;
+      transform: translateY(120%);
+    }
+  }
+
   @media (prefers-reduced-motion: reduce) {
     .combo-glitch-container,
     .combo-glitch-core,
     .combo-glitch-lines,
-    .combo-glitch-shard {
+    .combo-glitch-shard,
+    .combo-glitch-text-scramble,
+    .combo-glitch-text-scanline,
+    .combo-glitch-text-scanline::after {
       animation-duration: 0.001ms !important;
       animation-iteration-count: 1 !important;
     }

--- a/src/utils/visualEffects.ts
+++ b/src/utils/visualEffects.ts
@@ -35,12 +35,19 @@ export class VisualEffectsCoordinator {
     comboNames: string[];
     intensity?: 'minor' | 'major' | 'mega';
     magnitude?: number;
+    fxMessages?: string[];
   }): void {
     if (typeof window === 'undefined') {
       return;
     }
 
     const comboNames = detail.comboNames ?? [];
+    const fxMessages = Array.isArray(detail.fxMessages)
+      ? detail.fxMessages
+        .filter((message): message is string => typeof message === 'string')
+        .map(message => message.trim())
+        .filter(message => message.length > 0)
+      : [];
     const magnitude = typeof detail.magnitude === 'number' && !Number.isNaN(detail.magnitude)
       ? Math.max(0, detail.magnitude)
       : undefined;
@@ -88,6 +95,7 @@ export class VisualEffectsCoordinator {
         intensity: resolvedIntensity,
         magnitude: magnitude ?? 0,
         reducedMotion,
+        fxMessages,
       }
     }));
   }


### PR DESCRIPTION
## Summary
- generate combo glitch taglines and reward callouts using combo names and FX messages with reduced-motion fallbacks
- thread combo FX messaging through the visual effects coordinator and animation layer to power the overlay copy
- add text scramble and scanline reveal animations for glitch text with CSS keyframes and reduced-motion handling

## Testing
- npm run lint *(fails: missing @eslint/js because npm install is blocked by registry access restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68d033bc8f408320b47e985ae95423cd