### PR TITLE
Add global combo glitch screen effect

### DIFF
--- a/src/components/game/CardAnimationLayer.tsx
+++ b/src/components/game/CardAnimationLayer.tsx
@@ -299,6 +299,8 @@ const CardAnimationLayer: React.FC<CardAnimationLayerProps> = ({ children }) => 
         && window.matchMedia('(prefers-reduced-motion: reduce)').matches);
       const resolvedIntensity = intensity ?? 'minor';
 
+      const rootElement = typeof document !== 'undefined' ? document.documentElement : null;
+
       if (!prefersReducedMotion) {
         audio?.playSFX?.('radio-static');
         const sfxDelay = COMBO_GLITCH_SFX_DELAYS[resolvedIntensity];
@@ -307,6 +309,11 @@ const CardAnimationLayer: React.FC<CardAnimationLayerProps> = ({ children }) => 
             audio?.playSFX?.('radio-static');
           }, sfxDelay);
         }
+        rootElement?.classList.add('combo-glitching');
+        rootElement?.style.setProperty('--combo-glitch-duration', `${COMBO_GLITCH_DURATIONS[resolvedIntensity]}ms`);
+      } else {
+        rootElement?.classList.remove('combo-glitching');
+        rootElement?.style.removeProperty('--combo-glitch-duration');
       }
 
       const sanitizedMagnitude = typeof magnitude === 'number' && !Number.isNaN(magnitude)
@@ -566,6 +573,12 @@ const CardAnimationLayer: React.FC<CardAnimationLayerProps> = ({ children }) => 
     };
   }, [clearParanormalOverlays]);
 
+  useEffect(() => () => {
+    const rootElement = typeof document !== 'undefined' ? document.documentElement : null;
+    rootElement?.classList.remove('combo-glitching');
+    rootElement?.style.removeProperty('--combo-glitch-duration');
+  }, []);
+
   const handleParticleComplete = useCallback((id: number) => {
     setParticleEffects(prev => prev.filter(effect => effect.id !== id));
   }, []);
@@ -595,6 +608,9 @@ const CardAnimationLayer: React.FC<CardAnimationLayerProps> = ({ children }) => 
   }, []);
 
   const handleComboGlitchComplete = useCallback(() => {
+    const rootElement = typeof document !== 'undefined' ? document.documentElement : null;
+    rootElement?.classList.remove('combo-glitching');
+    rootElement?.style.removeProperty('--combo-glitch-duration');
     setComboGlitchOverlay(null);
   }, []);
 

--- a/src/index.css
+++ b/src/index.css
@@ -3237,3 +3237,104 @@ html, body, #root {
     @apply pointer-events-auto max-w-xs border border-slate-700 bg-slate-900/95 font-mono text-sm leading-snug text-slate-100 shadow-2xl;
   }
 }
+
+@keyframes combo-hit-stop {
+  0% {
+    transform: scale(1);
+  }
+  12% {
+    transform: scale(0.965);
+  }
+  32% {
+    transform: scale(0.982);
+  }
+  60% {
+    transform: scale(0.992);
+  }
+  100% {
+    transform: scale(1);
+  }
+}
+
+@keyframes combo-rgb-offset {
+  0% {
+    opacity: 0;
+    transform: translate3d(0, 0, 0);
+  }
+  18% {
+    opacity: 0.36;
+    transform: translate3d(-3px, 2px, 0);
+  }
+  42% {
+    opacity: 0.28;
+    transform: translate3d(3px, -2px, 0);
+  }
+  68% {
+    opacity: 0.22;
+    transform: translate3d(-2px, 1px, 0);
+  }
+  100% {
+    opacity: 0;
+    transform: translate3d(0, 0, 0);
+  }
+}
+
+@keyframes combo-rgb-flicker {
+  0%, 100% {
+    opacity: 0.05;
+  }
+  20% {
+    opacity: 0.25;
+  }
+  45% {
+    opacity: 0.18;
+  }
+  72% {
+    opacity: 0.14;
+  }
+}
+
+@media (prefers-reduced-motion: no-preference) {
+  html.combo-glitching {
+    --combo-glitch-duration: 900ms;
+    filter: contrast(1.12) saturate(1.28);
+  }
+
+  html.combo-glitching body::after {
+    content: '';
+    position: fixed;
+    inset: -6px;
+    pointer-events: none;
+    mix-blend-mode: screen;
+    z-index: 999;
+    background: linear-gradient(120deg,
+      rgba(59, 130, 246, 0.22) 10%,
+      rgba(236, 72, 153, 0.22) 50%,
+      rgba(34, 197, 94, 0.18) 90%
+    );
+    opacity: 0;
+    animation:
+      combo-rgb-offset var(--combo-glitch-duration, 900ms) cubic-bezier(0.3, 0, 0.2, 1) both,
+      combo-rgb-flicker 140ms steps(2, end) infinite;
+  }
+
+  html.combo-glitching #root {
+    will-change: transform;
+    animation: combo-hit-stop var(--combo-glitch-duration, 900ms) cubic-bezier(0.32, 0.72, 0.18, 1) both;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  html.combo-glitching {
+    filter: none;
+  }
+
+  html.combo-glitching body::after {
+    animation: none;
+    opacity: 0;
+  }
+
+  html.combo-glitching #root {
+    animation: none;
+  }
+}


### PR DESCRIPTION
## Summary
- toggle a combo-glitching class on the document root alongside the combo overlay lifecycle
- ensure the class is removed and timing metadata is cleared when the animation completes or the layer unmounts
- add CSS-driven screen filter, RGB offset overlay, and hit-stop animation that respect prefers-reduced-motion

## Testing
- npm run lint *(fails: missing @eslint/js because dependencies cannot be installed without access to ts-node package)*

------
https://chatgpt.com/codex/tasks/task_e_68d0359cd7448320b3600b057d59f342