### PR TITLE
Move zone card active toaster above map

### DIFF
--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -1577,25 +1577,23 @@ const Index = () => {
           </div>
         </div>
         <div className="flex min-h-0 flex-1 flex-col gap-4">
-          <div className="relative flex min-h-[320px] flex-1 flex-col overflow-hidden rounded border-2 border-newspaper-border bg-white/80">
-            {gameState.selectedCard && gameState.hand.find(c => c.id === gameState.selectedCard)?.type === 'ZONE' && !gameState.targetState && (
-              <div className="pointer-events-none absolute top-4 right-4 z-20">
-                <div className="max-w-sm animate-pulse border-2 border-newspaper-border bg-newspaper-text p-4 font-mono text-newspaper-bg shadow-2xl">
-                  <div className="mb-2 flex items-center gap-2 text-lg">
-                    🎯 <span className="font-bold">ZONE CARD ACTIVE</span>
-                  </div>
-                  <div className="mb-3 text-sm">
-                    Click any <span className="font-bold text-yellow-400">NEUTRAL</span> or <span className="font-bold text-red-500">ENEMY</span> state to target
-                  </div>
-                  <div className="mb-2 rounded bg-black/20 p-2 text-xs">
-                    Card will deploy automatically when target is selected
-                  </div>
-                  <div className="flex items-center gap-1 text-xs text-yellow-400">
-                    ⚠️ Cannot target your own states
-                  </div>
-                </div>
+          {gameState.selectedCard && gameState.hand.find(c => c.id === gameState.selectedCard)?.type === 'ZONE' && !gameState.targetState && (
+            <div className="rounded border-2 border-newspaper-border bg-newspaper-text p-4 font-mono text-newspaper-bg shadow-2xl">
+              <div className="mb-2 flex items-center gap-2 text-lg">
+                🎯 <span className="font-bold">ZONE CARD ACTIVE</span>
               </div>
-            )}
+              <div className="mb-3 text-sm">
+                Click any <span className="font-bold text-yellow-400">NEUTRAL</span> or <span className="font-bold text-red-500">ENEMY</span> state to target
+              </div>
+              <div className="mb-2 rounded bg-black/20 p-2 text-xs">
+                Card will deploy automatically when target is selected
+              </div>
+              <div className="flex items-center gap-1 text-xs text-yellow-400">
+                ⚠️ Cannot target your own states
+              </div>
+            </div>
+          )}
+          <div className="relative flex min-h-[320px] flex-1 flex-col overflow-hidden rounded border-2 border-newspaper-border bg-white/80">
             <div className="relative flex-1">
               <EnhancedUSAMap
                 states={gameState.states}


### PR DESCRIPTION
## Summary
- relocate the zone card active notice from the map overlay to a dedicated banner above the map so it no longer blocks the view

## Testing
- npm run lint *(fails: missing @eslint/js dependency in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d0384770908320832f1fe8402cfd1c