### PR TITLE
Add combo glitch gating before newspaper overlay

### DIFF
--- a/src/components/game/Options.tsx
+++ b/src/components/game/Options.tsx
@@ -297,10 +297,15 @@ const Options = ({ onClose, onBackToMainMenu, onSaveGame }: OptionsProps) => {
     if (update.comboToggles) {
       normalized.comboToggles = { ...update.comboToggles };
     }
+    if (update.glitchMode && !['off', 'minimal', 'full'].includes(update.glitchMode)) {
+      delete normalized.glitchMode;
+    }
     const merged = setComboSettings(normalized);
     setComboSettingsState(merged);
     persistSettings(settings, merged);
   };
+
+  const comboGlitchMode = comboSettingsState.glitchMode ?? 'full';
 
   const resetToDefaults = () => {
     const defaultSettings: GameSettings = {
@@ -692,6 +697,23 @@ const Options = ({ onClose, onBackToMainMenu, onSaveGame }: OptionsProps) => {
                   FX notifications ({comboSettingsState.fxEnabled ? 'on' : 'off'})
                 </span>
               </div>
+            </div>
+
+            <div className="mt-4 grid gap-2 sm:grid-cols-[auto,1fr] sm:items-center">
+              <label className="text-sm font-medium text-newspaper-text" htmlFor="combo-glitch-mode">
+                Show combo glitches
+              </label>
+              <select
+                id="combo-glitch-mode"
+                value={comboGlitchMode}
+                onChange={event => applyComboSettings({ glitchMode: event.target.value as typeof comboGlitchMode })}
+                className="w-full rounded border border-newspaper-text bg-newspaper-bg p-2 text-newspaper-text"
+                disabled={!comboSettingsState.enabled || !comboSettingsState.fxEnabled}
+              >
+                <option value="full">Full</option>
+                <option value="minimal">Minimal</option>
+                <option value="off">Off</option>
+              </select>
             </div>
 
             <div className="mt-4">

--- a/src/components/game/TabloidNewspaper.tsx
+++ b/src/components/game/TabloidNewspaper.tsx
@@ -2,8 +2,13 @@ import type { TabloidNewspaperProps, TabloidPlayedCard } from './TabloidNewspape
 import LegacyTabloidNewspaper from './TabloidNewspaperLegacy';
 import TabloidNewspaperV2 from './TabloidNewspaperV2';
 import { featureFlags } from '@/state/featureFlags';
+import { isNewspaperBlocked } from './newspaperGate';
 
 const TabloidNewspaper = (props: TabloidNewspaperProps) => {
+  if (isNewspaperBlocked()) {
+    return null;
+  }
+
   if (featureFlags.newspaperV2) {
     return <TabloidNewspaperV2 {...props} />;
   }

--- a/src/components/game/TabloidNewspaperLegacy.tsx
+++ b/src/components/game/TabloidNewspaperLegacy.tsx
@@ -342,7 +342,7 @@ const LegacyTabloidNewspaper = ({ events, playedCards, faction, truth, onClose }
   const truthStatus = getTruthMeterStatus();
 
   return (
-    <div className="fixed inset-0 bg-black/90 flex items-center justify-center z-[100] p-2">
+    <div className="newspaper-layer flex items-center justify-center bg-black/90 p-2">
       <Card className={`max-w-6xl w-full max-h-[90vh] overflow-y-auto bg-white border-8 border-black shadow-2xl ${
         glitching ? 'animate-pulse' : ''
       }`} style={{ fontFamily: 'serif' }}>

--- a/src/components/game/TabloidNewspaperV2.tsx
+++ b/src/components/game/TabloidNewspaperV2.tsx
@@ -543,7 +543,7 @@ const TabloidNewspaperV2 = ({
   const truthDeltaLabel = formatTruthDelta(roundContext.truthDeltaTotal);
 
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 p-4">
+    <div className="newspaper-layer flex items-center justify-center bg-black/40 p-4">
       <UICard className="ink-smudge relative flex h-full max-h-[90vh] w-full max-w-6xl flex-col overflow-hidden border-4 border-newspaper-border bg-newspaper-bg text-newspaper-text shadow-2xl">
         <header className="relative border-b-4 border-double border-newspaper-border bg-newspaper-header/90 px-6 py-5">
           {breakingStamp ? (

--- a/src/components/game/newspaperGate.ts
+++ b/src/components/game/newspaperGate.ts
@@ -1,0 +1,3 @@
+import { FXState } from '@/utils/visualEffects';
+
+export const isNewspaperBlocked = (): boolean => FXState.isGlitchActive();

--- a/src/game/combo.config.ts
+++ b/src/game/combo.config.ts
@@ -471,4 +471,5 @@ export const DEFAULT_COMBO_SETTINGS: ComboSettings = {
   maxCombosPerTurn: 2,
   comboToggles: Object.fromEntries(COMBO_DEFINITIONS.map(def => [def.id, def.enabledByDefault ?? true])),
   rng: Math.random,
+  glitchMode: 'full',
 };

--- a/src/game/combo.types.ts
+++ b/src/game/combo.types.ts
@@ -105,6 +105,7 @@ export interface ComboSettings {
   comboToggles: Record<string, boolean>;
   maxCombosPerTurn: number;
   rng?: () => number;
+  glitchMode?: 'off' | 'minimal' | 'full';
 }
 
 export interface ComboFXCallbacks {

--- a/src/game/comboEngine.ts
+++ b/src/game/comboEngine.ts
@@ -49,7 +49,8 @@ function ensureToggleCoverage(settings: ComboSettings): ComboSettings {
     }
   }
   const rng = settings.rng ?? DEFAULT_COMBO_SETTINGS.rng ?? Math.random;
-  return { ...settings, comboToggles: toggles, rng };
+  const glitchMode = settings.glitchMode ?? DEFAULT_COMBO_SETTINGS.glitchMode ?? 'full';
+  return { ...settings, comboToggles: toggles, rng, glitchMode };
 }
 
 export function getComboSettings(): ComboSettings {
@@ -66,6 +67,7 @@ export function setComboSettings(update: Partial<ComboSettings>): ComboSettings 
     ...base,
     ...update,
     comboToggles: { ...base.comboToggles },
+    glitchMode: update.glitchMode ?? base.glitchMode ?? 'full',
   };
 
   if (update.comboToggles) {
@@ -99,6 +101,10 @@ function resolveSettings(overrides?: ComboOptions): ComboSettings {
     for (const [key, value] of Object.entries(overrides.comboToggles)) {
       merged.comboToggles[key] = value;
     }
+  }
+
+  if (overrides.glitchMode) {
+    merged.glitchMode = overrides.glitchMode;
   }
 
   if (overrides.disabledCombos) {

--- a/src/index.css
+++ b/src/index.css
@@ -637,6 +637,19 @@ All colors MUST be HSL.
     }
   }
 
+  .combo-glitch-layer {
+    position: fixed;
+    inset: 0;
+    z-index: 60;
+    pointer-events: none;
+  }
+
+  .newspaper-layer {
+    position: fixed;
+    inset: 0;
+    z-index: 40;
+  }
+
   .combo-glitch-container {
     animation: combo-glitch-jitter 0.28s steps(2, end) infinite;
   }
@@ -3294,10 +3307,19 @@ html, body, #root {
   }
 }
 
+  html.combo-glitching {
+    filter: grayscale(1) contrast(1.05);
+  }
+
+  html.combo-glitching #root * {
+    transition-duration: 0.75s !important;
+    animation-play-state: paused !important;
+  }
+
 @media (prefers-reduced-motion: no-preference) {
   html.combo-glitching {
     --combo-glitch-duration: 900ms;
-    filter: contrast(1.12) saturate(1.28);
+    filter: grayscale(1) contrast(1.05);
   }
 
   html.combo-glitching body::after {
@@ -3326,7 +3348,7 @@ html, body, #root {
 
 @media (prefers-reduced-motion: reduce) {
   html.combo-glitching {
-    filter: none;
+    filter: grayscale(1) contrast(1.05);
   }
 
   html.combo-glitching body::after {

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -1248,7 +1248,7 @@ const Index = () => {
   };
 
   const handleEndTurn = () => {
-    endTurn();
+    void endTurn();
     audio.playSFX('turnEnd');
     // Play card draw sound after a short delay
     setTimeout(() => {

--- a/src/utils/__tests__/visualEffects.test.ts
+++ b/src/utils/__tests__/visualEffects.test.ts
@@ -1,0 +1,100 @@
+import { beforeEach, afterEach, describe, expect, it } from 'bun:test';
+import { isNewspaperBlocked } from '@/components/game/newspaperGate';
+import { FXState, playComboGlitchIfAny } from '@/utils/visualEffects';
+
+class MockWindow extends EventTarget {
+  innerWidth = 1024;
+  innerHeight = 768;
+
+  matchMedia(): MediaQueryList {
+    return {
+      matches: false,
+      media: '',
+      onchange: null,
+      addListener: () => {},
+      removeListener: () => {},
+      addEventListener: () => {},
+      removeEventListener: () => {},
+      dispatchEvent: () => false,
+    };
+  }
+
+  setTimeout(handler: (...args: unknown[]) => void, timeout?: number): number {
+    return globalThis.setTimeout(handler, timeout) as unknown as number;
+  }
+
+  clearTimeout(handle?: number): void {
+    globalThis.clearTimeout(handle);
+  }
+}
+
+const ensureCustomEvent = () => {
+  if (typeof globalThis.CustomEvent === 'function') {
+    return;
+  }
+
+  class CustomEventPolyfill<T> extends Event {
+    detail: T;
+
+    constructor(event: string, params?: CustomEventInit<T>) {
+      super(event, params);
+      this.detail = params?.detail as T;
+    }
+  }
+
+  (globalThis as any).CustomEvent = CustomEventPolyfill;
+};
+
+describe('playComboGlitchIfAny', () => {
+  beforeEach(() => {
+    ensureCustomEvent();
+    const mockWindow = new MockWindow();
+    (globalThis as any).window = mockWindow;
+    (globalThis as any).document = undefined;
+    FXState.__internalSetActive?.(false);
+  });
+
+  afterEach(() => {
+    delete (globalThis as any).window;
+    delete (globalThis as any).document;
+    FXState.__internalSetActive?.(false);
+  });
+
+  it('resolves immediately when no combos are present', async () => {
+    const windowMock = globalThis.window as unknown as EventTarget;
+    let glitchEventFired = false;
+    windowMock.addEventListener('comboGlitch', () => {
+      glitchEventFired = true;
+    });
+
+    await playComboGlitchIfAny({ combos: [], magnitude: 0, messages: [] });
+
+    expect(glitchEventFired).toBe(false);
+  });
+
+  it('waits for comboGlitchComplete before resolving', async () => {
+    const windowMock = globalThis.window as unknown as EventTarget;
+    let resolved = false;
+
+    const promise = playComboGlitchIfAny({ combos: ['Chain'], magnitude: 3, messages: [] });
+    void promise.then(() => {
+      resolved = true;
+    });
+
+    await Promise.resolve();
+    expect(resolved).toBe(false);
+
+    windowMock.dispatchEvent(new Event('comboGlitchComplete'));
+    await promise;
+
+    expect(resolved).toBe(true);
+  });
+});
+
+describe('Tabloid newspaper gate', () => {
+  it('reports blocked status when a glitch is active', () => {
+    FXState.__internalSetActive?.(true);
+    expect(isNewspaperBlocked()).toBe(true);
+    FXState.__internalSetActive?.(false);
+  });
+});


### PR DESCRIPTION
## Summary
- add an awaitable `playComboGlitchIfAny` barrier with shared FX state tracking and portal-based glitch overlay handling
- gate the round recap via a reusable newspaper guard, update CSS layering, and expose combo glitch intensity options
- extend settings to support glitch modes and add regression tests for the FX barrier and newspaper lock

## Testing
- bun test
- npm run lint *(fails: missing @eslint/js dependency in offline environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d04ce79c5c832093ad5e8919be56b5