### PR TITLE
Move toast notifications to bottom-left corner

### DIFF
--- a/src/components/ui/toast.tsx
+++ b/src/components/ui/toast.tsx
@@ -14,7 +14,7 @@ const ToastViewport = React.forwardRef<
   <ToastPrimitives.Viewport
     ref={ref}
     className={cn(
-      "fixed top-0 z-[100] flex max-h-screen w-full flex-col-reverse p-4 sm:bottom-0 sm:right-0 sm:top-auto sm:flex-col md:max-w-[420px]",
+      "fixed bottom-0 left-0 z-[100] flex max-h-screen w-full flex-col-reverse p-4 sm:flex-col md:max-w-[420px]",
       className,
     )}
     {...props}

--- a/src/components/ui/toaster.tsx
+++ b/src/components/ui/toaster.tsx
@@ -18,7 +18,7 @@ export function Toaster() {
           </Toast>
         );
       })}
-      <ToastViewport className="fixed top-4 left-4 flex flex-col p-4 gap-2" />
+      <ToastViewport className="fixed bottom-4 left-4 top-auto flex flex-col gap-2 p-4" />
     </ToastProvider>
   );
 }


### PR DESCRIPTION
## Summary
- update the shared toast viewport defaults to anchor notifications to the lower-left corner
- adjust the app-level toaster instance to use bottom-left positioning for stacked toasts

## Testing
- npm run lint *(fails: missing @eslint/js dependency)*

------
https://chatgpt.com/codex/tasks/task_e_68d0d7e00afc8320b676665edf0d0380