### PR TITLE
Adjust combo thresholds and expose configurable turn limit

### DIFF
--- a/src/ai/enhancedController.ts
+++ b/src/ai/enhancedController.ts
@@ -1,4 +1,5 @@
 import { EnhancedAIStrategist, type EnhancedCardPlay } from '@/data/enhancedAIStrategy';
+import { DEFAULT_MAX_CARDS_PER_TURN, normalizeMaxCardsPerTurn } from '@/config/turnLimits';
 import type { GameCard } from '@/rules/mvp';
 
 interface AIPlanningState {
@@ -34,7 +35,7 @@ export interface ChooseTurnActionsParams {
 }
 
 const DEFAULT_PRIORITY_THRESHOLD = 0.3;
-const DEFAULT_MAX_ACTIONS = 3;
+const DEFAULT_MAX_ACTIONS = DEFAULT_MAX_CARDS_PER_TURN;
 const ABSOLUTE_PRIORITY_FLOOR = 0.18;
 
 const DIFFICULTY_PRIORITY_FLOORS: Record<EnhancedAIStrategist['difficulty'], number> = {
@@ -113,6 +114,7 @@ export const chooseTurnActions = ({
     sequenceDetails.push(...adaptiveSummary);
   }
 
+  const actionLimit = normalizeMaxCardsPerTurn(maxActions);
   const actions: PlannedCardAction[] = [];
   const synergyHighlights = new Set<string>();
   const chosenIds = new Set<string>();
@@ -159,7 +161,7 @@ export const chooseTurnActions = ({
     };
   };
 
-  while (actions.length < maxActions) {
+  while (actions.length < actionLimit) {
     const remainingHand = initialHand.filter(
       card => !chosenIds.has(card.id) && !attemptedIds.has(card.id),
     );

--- a/src/components/dev/CardEffectValidator.tsx
+++ b/src/components/dev/CardEffectValidator.tsx
@@ -13,6 +13,7 @@ import { CheckCircle, XCircle, AlertTriangle, Bug, Zap } from 'lucide-react';
 import { CARD_DATABASE } from '@/data/cardDatabase';
 import { CardEffectValidator, CardTextGenerator } from '@/systems/CardTextGenerator';
 import { applyEffectsMvp } from '@/engine/applyEffects-mvp';
+import { DEFAULT_MAX_CARDS_PER_TURN } from '@/config/turnLimits';
 import { cloneGameState, type Card as EngineCard, type GameState as EngineGameState } from '@/mvp';
 import type { GameCard } from '@/rules/mvp';
 
@@ -50,6 +51,7 @@ const CardEffectValidatorPanel: React.FC = () => {
       turn: testGameState.turn,
       currentPlayer: 'P1',
       truth: testGameState.truth,
+      maxPlaysPerTurn: DEFAULT_MAX_CARDS_PER_TURN,
       playsThisTurn: 0,
       turnPlays: [],
       log: engineLog,

--- a/src/components/game/EffectTestPanel.tsx
+++ b/src/components/game/EffectTestPanel.tsx
@@ -6,6 +6,7 @@ import { Badge } from '@/components/ui/badge';
 import { Input } from '@/components/ui/input';
 import { CardEffectValidator, CardTextGenerator } from '@/systems/CardTextGenerator';
 import { applyEffectsMvp } from '@/engine/applyEffects-mvp';
+import { DEFAULT_MAX_CARDS_PER_TURN } from '@/config/turnLimits';
 import { cloneGameState, type Card as EngineCard, type GameState as EngineGameState } from '@/mvp';
 import { CARD_DATABASE } from '@/data/cardDatabase';
 import type { Card as CardType } from '@/types/cardEffects';
@@ -35,6 +36,7 @@ const EffectTestPanel: React.FC = () => {
     turn: gameState.turn,
     currentPlayer: 'P1',
     truth: gameState.truth,
+    maxPlaysPerTurn: DEFAULT_MAX_CARDS_PER_TURN,
     playsThisTurn: 0,
     turnPlays: [],
     log: engineLog,

--- a/src/components/game/InteractiveOnboarding.tsx
+++ b/src/components/game/InteractiveOnboarding.tsx
@@ -4,6 +4,7 @@ import { Button } from '@/components/ui/button';
 import { Progress } from '@/components/ui/progress';
 import { Badge } from '@/components/ui/badge';
 import { ArrowRight, ArrowLeft, X, CheckCircle2, Play } from 'lucide-react';
+import { normalizeMaxCardsPerTurn } from '@/config/turnLimits';
 
 interface OnboardingStep {
   id: string;
@@ -25,6 +26,7 @@ interface InteractiveOnboardingProps {
 const InteractiveOnboarding = ({ isActive, onComplete, onSkip, gameState }: InteractiveOnboardingProps) => {
   const [currentStep, setCurrentStep] = useState(0);
   const [completedSteps, setCompletedSteps] = useState<string[]>([]);
+  const maxCardsPerTurn = normalizeMaxCardsPerTurn(gameState?.maxCardsPerTurn);
 
   const onboardingSteps: OnboardingStep[] = [
     {
@@ -63,7 +65,7 @@ const InteractiveOnboarding = ({ isActive, onComplete, onSkip, gameState }: Inte
     {
       id: 'turn-end',
       title: '⏭️ End Turn',
-      description: 'When you\'re done playing cards, click "End Turn". You can play up to 3 cards per turn.',
+      description: `When you're done playing cards, click "End Turn". You can play up to ${maxCardsPerTurn} cards per turn.`,
       target: '#end-turn-button'
     },
     {

--- a/src/config/turnLimits.ts
+++ b/src/config/turnLimits.ts
@@ -1,0 +1,8 @@
+export const DEFAULT_MAX_CARDS_PER_TURN = 3;
+
+export function normalizeMaxCardsPerTurn(value: number | undefined | null): number {
+  if (typeof value !== 'number' || !Number.isFinite(value)) {
+    return DEFAULT_MAX_CARDS_PER_TURN;
+  }
+  return Math.max(1, Math.floor(value));
+}

--- a/src/data/enhancedAIStrategy.ts
+++ b/src/data/enhancedAIStrategy.ts
@@ -1,5 +1,6 @@
 import type { GameCard } from '@/rules/mvp';
 import { resolveCardMVP, type CardPlayResolution, type GameSnapshot } from '@/systems/cardResolution';
+import { DEFAULT_MAX_CARDS_PER_TURN, normalizeMaxCardsPerTurn } from '@/config/turnLimits';
 import { CARD_DATABASE } from './cardDatabase';
 import { getAiTuningConfig, type AiTuningConfig } from './aiTuning';
 import {
@@ -1215,6 +1216,11 @@ export class EnhancedAIStrategist implements AIStrategist {
       aiIP: gameState.aiIP ?? 0,
       hand: playerHand,
       aiHand,
+      maxCardsPerTurn: normalizeMaxCardsPerTurn(
+        typeof gameState.maxCardsPerTurn === 'number'
+          ? gameState.maxCardsPerTurn
+          : (gameState.maxPlaysPerTurn ?? DEFAULT_MAX_CARDS_PER_TURN),
+      ),
       controlledStates: playerControlledStates,
       aiControlledStates,
       round: gameState.round ?? 0,

--- a/src/data/tutorialSystem.ts
+++ b/src/data/tutorialSystem.ts
@@ -1,3 +1,5 @@
+import { DEFAULT_MAX_CARDS_PER_TURN } from '@/config/turnLimits';
+
 export interface TutorialStep {
   id: string;
   title: string;
@@ -84,7 +86,7 @@ export const TUTORIAL_SEQUENCES: TutorialSequence[] = [
       {
         id: 'first_card_play',
         title: 'Play Your First Card',
-        description: 'Click on a card in your hand to select it. Cards show their IP cost and effects. You can play up to 3 cards per turn.',
+        description: `Click on a card in your hand to select it. Cards show their IP cost and effects. You can play up to ${DEFAULT_MAX_CARDS_PER_TURN} cards per turn.`,
         targetElement: '.game-hand .card:first-child',
         position: 'top',
         action: 'click',

--- a/src/game/combo.config.ts
+++ b/src/game/combo.config.ts
@@ -139,22 +139,22 @@ const countCombos: ComboDefinition[] = [
   {
     id: 'count_full_press',
     name: 'Full Press',
-    description: 'Play four or more cards of any type in a turn.',
+    description: 'Play three cards of any type in a turn to keep pressure high.',
     category: 'count',
     priority: 85,
-    trigger: { kind: 'count', type: 'ANY', count: 4 },
+    trigger: { kind: 'threshold', metric: 'plays', value: 3 },
     reward: { ip: 2, log: 'Full press exhausts the opposition' },
-    fxText: 'Full press accomplished.'
+    fxText: 'Full press sustained across the front.'
   },
   {
     id: 'count_relentless',
     name: 'Relentless Pressure',
-    description: 'Play five or more cards regardless of type.',
+    description: 'Invest at least nine IP into plays regardless of type.',
     category: 'count',
     priority: 84,
-    trigger: { kind: 'count', type: 'ANY', count: 5 },
-    reward: { ip: 3, log: 'Relentless drive yields dividends' },
-    fxText: 'Relentless momentum maintained.'
+    trigger: { kind: 'threshold', metric: 'ipSpent', value: 9 },
+    reward: { ip: 3, log: 'Relentless spending yields dividends' },
+    fxText: 'Relentless spending grinds them down.'
   },
   {
     id: 'count_rare_circle',
@@ -266,12 +266,12 @@ const thresholdCombos: ComboDefinition[] = [
   {
     id: 'threshold_low_cost_4',
     name: 'Grassroots Push',
-    description: 'Deploy four low-cost cards (cost ≤ 2).',
+    description: 'Deploy three low-cost cards (cost ≤ 2).',
     category: 'threshold',
     priority: 79,
-    trigger: { kind: 'threshold', metric: 'lowCostCount', value: 4 },
+    trigger: { kind: 'threshold', metric: 'lowCostCount', value: 3 },
     reward: { truth: 2, log: 'Grassroots push builds trust' },
-    fxText: 'Grassroots surge mobilised.'
+    fxText: 'Grassroots surge mobilised quickly.'
   },
   {
     id: 'threshold_high_cost_2',

--- a/src/hooks/aiTurnActions.ts
+++ b/src/hooks/aiTurnActions.ts
@@ -1,4 +1,5 @@
 import type { GameCard } from '@/rules/mvp';
+import { normalizeMaxCardsPerTurn } from '@/config/turnLimits';
 import type { GameState } from './gameStateTypes';
 import type { AiCardPlayParams } from './aiHelpers';
 
@@ -50,6 +51,11 @@ export const processAiActions = async ({
     const latestAfterAction = await readLatestState();
     if (latestAfterAction.isGameOver) {
       return { gameOver: true };
+    }
+
+    const maxActionsThisTurn = normalizeMaxCardsPerTurn(latestAfterAction.maxCardsPerTurn);
+    if (latestAfterAction.cardsPlayedThisTurn >= maxActionsThisTurn) {
+      break;
     }
 
     if (index < actions.length - 1) {

--- a/src/hooks/gameStateTypes.ts
+++ b/src/hooks/gameStateTypes.ts
@@ -33,6 +33,7 @@ export interface GameState {
   truth: number;
   ip: number;
   aiIP: number;
+  maxCardsPerTurn: number;
   hand: GameCard[];
   aiHand: GameCard[];
   isGameOver: boolean;

--- a/src/mvp/engine.random.test.ts.disabled
+++ b/src/mvp/engine.random.test.ts.disabled
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'bun:test';
 import { playCard } from '@/mvp/engine';
 import type { Card, GameState } from '@/mvp/validator';
+import { DEFAULT_MAX_CARDS_PER_TURN } from '@/config/turnLimits';
 
 const createSeededRng = (seed: number): (() => number) => {
   let state = seed % 2147483647;
@@ -52,6 +53,7 @@ const createState = (): GameState => {
     turn: 1,
     currentPlayer: 'P1',
     truth: 50,
+    maxPlaysPerTurn: DEFAULT_MAX_CARDS_PER_TURN,
     playsThisTurn: 0,
     turnPlays: [],
     log: [],

--- a/src/mvp/engine.ts
+++ b/src/mvp/engine.ts
@@ -1,6 +1,7 @@
 declare const window: any;
 
 import { applyEffectsMvp, type PlayerId } from '@/engine/applyEffects-mvp';
+import { normalizeMaxCardsPerTurn } from '@/config/turnLimits';
 import { applyComboRewards, evaluateCombos, getComboSettings, formatComboReward } from '@/game/comboEngine';
 import type { ComboEvaluation, ComboOptions, ComboSummary, TurnPlay } from '@/game/combo.types';
 import { cloneGameState } from './validator';
@@ -73,7 +74,9 @@ export function canPlay(
   card: Card,
   targetStateId?: string,
 ): { ok: boolean; reason?: string } {
-  if (state.playsThisTurn >= 3) {
+  const maxPlaysPerTurn = normalizeMaxCardsPerTurn(state.maxPlaysPerTurn);
+
+  if (state.playsThisTurn >= maxPlaysPerTurn) {
     return { ok: false, reason: 'play-limit' };
   }
 

--- a/src/mvp/validator.ts
+++ b/src/mvp/validator.ts
@@ -42,6 +42,7 @@ export type GameState = {
   players: Record<PlayerId, PlayerState>;
   pressureByState: Record<string, { P1: number; P2: number }>;
   stateDefense: Record<string, number>;
+  maxPlaysPerTurn: number;
   playsThisTurn: number;
   turnPlays: TurnPlay[];
   log: string[];

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -33,6 +33,7 @@ import { getRandomAgenda } from '@/data/agendaDatabase';
 import { useCardCollection } from '@/hooks/useCardCollection';
 import { useSynergyDetection } from '@/hooks/useSynergyDetection';
 import { VisualEffectsCoordinator } from '@/utils/visualEffects';
+import { normalizeMaxCardsPerTurn } from '@/config/turnLimits';
 import {
   getSynergyEffectIdentifier,
   resolveParticleEffectType
@@ -459,6 +460,7 @@ const Index = () => {
   const [uiNotificationsEnabled, setUiNotificationsEnabled] = useState(() => areUiNotificationsEnabled());
   
   const { gameState, initGame, playCard, playCardAnimated, selectCard, selectTargetState, endTurn, closeNewspaper, executeAITurn, confirmNewCards, setGameState, saveGame, loadGame, getSaveInfo } = useGameState();
+  const maxCardsPerTurn = normalizeMaxCardsPerTurn(gameState.maxCardsPerTurn);
   const audio = useAudioContext();
   const { animatePlayCard, isAnimating } = useCardAnimation();
   const { discoverCard, playCard: recordCardPlay } = useCardCollection();
@@ -1080,9 +1082,9 @@ const Index = () => {
     }
 
     // Check if max cards played this turn
-    if (gameState.cardsPlayedThisTurn >= 3) {
+    if (gameState.cardsPlayedThisTurn >= maxCardsPerTurn) {
       if (uiNotificationsEnabled) {
-        toast.error('📋 Maximum 3 cards per turn!', {
+        toast.error(`📋 Maximum ${maxCardsPerTurn} cards per turn!`, {
           duration: 3000,
           style: { background: '#1f2937', color: '#f3f4f6', border: '1px solid #ef4444' }
         });
@@ -1365,7 +1367,7 @@ const Index = () => {
   }
 
   const isPlayerActionLocked = gameState.phase !== 'action' || gameState.animating || gameState.currentPlayer !== 'human';
-  const handInteractionDisabled = isPlayerActionLocked || gameState.cardsPlayedThisTurn >= 3;
+  const handInteractionDisabled = isPlayerActionLocked || gameState.cardsPlayedThisTurn >= maxCardsPerTurn;
 
   const renderIntelLog = (limit: number) => (
     <div className="space-y-1 text-xs text-newspaper-text/80">

--- a/src/systems/cardResolution.ts
+++ b/src/systems/cardResolution.ts
@@ -1,4 +1,5 @@
 import { applyEffectsMvp, type PlayerId } from '@/engine/applyEffects-mvp';
+import { normalizeMaxCardsPerTurn } from '@/config/turnLimits';
 import type { MediaResolutionOptions } from '@/mvp/media';
 import { cloneGameState, type Card, type GameState as EngineGameState } from '@/mvp';
 import type { GameCard } from '@/rules/mvp';
@@ -46,6 +47,7 @@ export interface GameSnapshot {
   aiIP: number;
   hand: GameCard[];
   aiHand: GameCard[];
+  maxCardsPerTurn?: number;
   controlledStates: string[];
   aiControlledStates?: string[];
   round: number;
@@ -138,6 +140,12 @@ const toEngineState = (
     aiStates.add(id);
   }
 
+  const candidateMax =
+    typeof snapshot.maxCardsPerTurn === 'number'
+      ? snapshot.maxCardsPerTurn
+      : (snapshot as unknown as { maxPlaysPerTurn?: number }).maxPlaysPerTurn;
+  const normalizedMax = normalizeMaxCardsPerTurn(candidateMax);
+
   return {
     turn: snapshot.turn,
     currentPlayer: PLAYER_ID,
@@ -164,6 +172,7 @@ const toEngineState = (
     },
     pressureByState,
     stateDefense,
+    maxPlaysPerTurn: normalizedMax,
     playsThisTurn: 0,
     turnPlays: [],
     log,

--- a/src/test/effectSystemValidation.ts
+++ b/src/test/effectSystemValidation.ts
@@ -2,6 +2,7 @@
 import { CARD_DATABASE } from '@/data/cardDatabase';
 import { CardTextGenerator } from '@/systems/CardTextGenerator';
 import { applyEffectsMvp } from '@/engine/applyEffects-mvp';
+import { DEFAULT_MAX_CARDS_PER_TURN } from '@/config/turnLimits';
 import { cloneGameState, type Card as EngineCard, type GameState as EngineGameState } from '@/mvp';
 
 // Test a few specific cards to verify they work correctly
@@ -28,6 +29,7 @@ export function validateFixedEffectSystem() {
       turn: 1,
       currentPlayer: 'P1',
       truth: 50,
+      maxPlaysPerTurn: DEFAULT_MAX_CARDS_PER_TURN,
       playsThisTurn: 0,
       turnPlays: [],
       log,


### PR DESCRIPTION
## Summary
- lower combo thresholds that previously required four or more plays and refresh their descriptions/effects text
- introduce a shared turn limit configuration helper and thread the max-per-turn value through engine, UI, AI helpers, and tutorials
- surface the new limit in onboarding/tutorial copy while keeping combo flow intact

## Testing
- npm run lint
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68d0eee055e48320898a617eae79d834