### PR TITLE
Implement synergy bonuses in MVP engine

### DIFF
--- a/src/engine/applyEffects-mvp.ts
+++ b/src/engine/applyEffects-mvp.ts
@@ -1,6 +1,7 @@
 declare const window: any;
 
 import { computeMediaTruthDelta_MVP, warnIfMediaScaling, type MediaResolutionOptions } from '@/mvp/media';
+import { recalculateCombinationEffects } from '@/mvp/combinationEffects';
 import { applyTruthDelta } from '@/utils/truth';
 import type {
   Card,
@@ -50,6 +51,13 @@ export function discardRandom(
   } satisfies PlayerState;
 }
 
+function getCombinationBreakdown(state: GameState, player: PlayerId) {
+  if (!state.combinationEffects) {
+    recalculateCombinationEffects(state);
+  }
+  return state.combinationEffects?.[player]?.breakdown;
+}
+
 function applyAttackEffect(
   state: GameState,
   owner: PlayerId,
@@ -57,7 +65,9 @@ function applyAttackEffect(
   rng: () => number,
 ) {
   const opponent = otherPlayer(owner);
-  const damage = Math.max(0, effects.ipDelta?.opponent ?? 0);
+  const breakdown = getCombinationBreakdown(state, owner);
+  const bonusDamage = breakdown?.attackDamageBonus ?? 0;
+  const damage = Math.max(0, (effects.ipDelta?.opponent ?? 0) + bonusDamage);
   const before = state.players[opponent].ip;
   state.players[opponent].ip = clampIP(before - damage);
   const delta = state.players[opponent].ip - before;
@@ -79,7 +89,12 @@ function applyZoneEffect(
 ) {
   const opponent = otherPlayer(owner);
   const currentPressure = state.pressureByState[targetStateId] ?? { P1: 0, P2: 0 };
-  const updatedOwnerPressure = (currentPressure[owner] ?? 0) + effects.pressureDelta;
+  const ownerBreakdown = getCombinationBreakdown(state, owner);
+  const opponentBreakdown = getCombinationBreakdown(state, opponent);
+  const bonusPressure = ownerBreakdown?.zonePressureBonus ?? 0;
+  const resistance = opponentBreakdown?.incomingPressureReduction ?? 0;
+  const appliedPressure = Math.max(0, effects.pressureDelta + bonusPressure - resistance);
+  const updatedOwnerPressure = (currentPressure[owner] ?? 0) + appliedPressure;
 
   let pressureByState: GameState['pressureByState'] = {
     ...state.pressureByState,
@@ -92,7 +107,8 @@ function applyZoneEffect(
     [opponent]: { ...state.players[opponent] },
   };
 
-  const defense = state.stateDefense[targetStateId] ?? Infinity;
+  const defenseBonus = opponentBreakdown?.stateDefenseBonus ?? 0;
+  const defense = (state.stateDefense[targetStateId] ?? Infinity) + defenseBonus;
   const captured = updatedOwnerPressure >= defense;
   if (captured) {
     pressureByState = {
@@ -123,6 +139,10 @@ function applyZoneEffect(
   if (captured && typeof window !== 'undefined' && (window as any).uiFlashState) {
     (window as any).uiFlashState(targetStateId, owner);
   }
+
+  if (captured) {
+    recalculateCombinationEffects(state);
+  }
 }
 
 export function applyEffectsMvp(
@@ -139,7 +159,17 @@ export function applyEffectsMvp(
   }
 
   if (card.type === 'MEDIA') {
-    const delta = computeMediaTruthDelta_MVP(state.players[owner], card, opts);
+    const baseDelta = computeMediaTruthDelta_MVP(state.players[owner], card, opts);
+    const breakdown = getCombinationBreakdown(state, owner);
+    let delta = baseDelta;
+    if (breakdown) {
+      delta *= breakdown.truthMultiplier;
+      if (card.faction === 'government' && breakdown.governmentTruthBonus !== 0) {
+        const adjustment = breakdown.governmentTruthBonus;
+        delta += delta >= 0 ? adjustment : -adjustment;
+      }
+    }
+    delta = Math.round(delta);
     warnIfMediaScaling(card, delta);
     applyTruthDelta(state, delta, owner);
     return state;

--- a/src/mvp/combinationEffects.ts
+++ b/src/mvp/combinationEffects.ts
@@ -1,0 +1,162 @@
+import { STATE_COMBINATIONS } from '@/data/stateCombinations';
+import { USA_STATES } from '@/data/usaStates';
+import type {
+  CombinationEffectBreakdown,
+  CombinationEffectSummary,
+  GameState,
+  PlayerId,
+} from './validator';
+
+const TOTAL_STATES = USA_STATES.length;
+
+const OPPONENT: Record<PlayerId, PlayerId> = { P1: 'P2', P2: 'P1' };
+
+const createEmptyBreakdown = (): CombinationEffectBreakdown => ({
+  flatIpBonus: 0,
+  ipPerControlledState: 0,
+  ipPerNeutralState: 0,
+  extraCardDraw: 0,
+  mediaCostModifier: 0,
+  attackDamageBonus: 0,
+  zonePressureBonus: 0,
+  incomingPressureReduction: 0,
+  stateDefenseBonus: 0,
+  truthMultiplier: 1,
+  governmentTruthBonus: 0,
+  rareDrawBias: false,
+  canPeekOpponentHand: false,
+  canTransferPressure: false,
+  preventEventPressureLoss: false,
+});
+
+const cloneBreakdown = (breakdown: CombinationEffectBreakdown): CombinationEffectBreakdown => ({
+  ...breakdown,
+});
+
+const mapActiveCombination = (combo: (typeof STATE_COMBINATIONS)[number]) => ({
+  id: combo.id,
+  name: combo.name,
+  bonusIP: combo.bonusIP,
+  bonusEffect: combo.bonusEffect,
+  category: combo.category,
+  description: combo.description,
+});
+
+const evaluateForPlayer = (state: GameState, playerId: PlayerId): CombinationEffectSummary => {
+  const playerStates = new Set(state.players[playerId]?.states ?? []);
+  const opponentStates = new Set(state.players[OPPONENT[playerId]]?.states ?? []);
+  const neutralStates = Math.max(0, TOTAL_STATES - playerStates.size - opponentStates.size);
+
+  const activeCombinations = STATE_COMBINATIONS.filter(combo =>
+    combo.requiredStates.every(abbr => playerStates.has(abbr)),
+  );
+
+  const totalBonusIP = activeCombinations.reduce((sum, combo) => sum + combo.bonusIP, 0);
+  const breakdown = createEmptyBreakdown();
+
+  for (const combo of activeCombinations) {
+    switch (combo.id) {
+      case 'wall_street_empire': {
+        breakdown.flatIpBonus += 2;
+        break;
+      }
+      case 'silicon_valley_network': {
+        breakdown.mediaCostModifier -= 1;
+        break;
+      }
+      case 'oil_cartel': {
+        breakdown.ipPerControlledState += 1;
+        break;
+      }
+      case 'military_triangle': {
+        breakdown.attackDamageBonus += 1;
+        breakdown.zonePressureBonus += 1;
+        break;
+      }
+      case 'nuclear_triad': {
+        breakdown.stateDefenseBonus += 1;
+        break;
+      }
+      case 'space_program': {
+        breakdown.canPeekOpponentHand = true;
+        break;
+      }
+      case 'intel_web': {
+        breakdown.extraCardDraw += 1;
+        break;
+      }
+      case 'academic_elite': {
+        breakdown.truthMultiplier = Math.max(breakdown.truthMultiplier, 1.5);
+        break;
+      }
+      case 'midwest_backbone': {
+        breakdown.incomingPressureReduction += 1;
+        break;
+      }
+      case 'deep_south': {
+        breakdown.governmentTruthBonus += 2;
+        break;
+      }
+      case 'new_england_conspiracy': {
+        breakdown.rareDrawBias = true;
+        break;
+      }
+      case 'transport_control': {
+        breakdown.canTransferPressure = true;
+        break;
+      }
+      case 'southern_border': {
+        breakdown.ipPerNeutralState += 1;
+        break;
+      }
+      case 'food_supply': {
+        breakdown.preventEventPressureLoss = true;
+        break;
+      }
+      default:
+        break;
+    }
+  }
+
+  const computedTurnBonus =
+    totalBonusIP +
+    breakdown.flatIpBonus +
+    breakdown.ipPerControlledState * playerStates.size +
+    breakdown.ipPerNeutralState * neutralStates;
+
+  return {
+    activeCombinations: activeCombinations.map(mapActiveCombination),
+    totalBonusIP,
+    breakdown,
+    computedTurnBonus,
+    appliedTurnBonus: 0,
+    controlledStateCount: playerStates.size,
+    neutralStateCount: neutralStates,
+  };
+};
+
+export const cloneCombinationSummary = (
+  summary: CombinationEffectSummary | undefined,
+): CombinationEffectSummary | undefined => {
+  if (!summary) {
+    return undefined;
+  }
+
+  return {
+    ...summary,
+    activeCombinations: summary.activeCombinations.map(combo => ({ ...combo })),
+    breakdown: cloneBreakdown(summary.breakdown),
+  };
+};
+
+export const recalculateCombinationEffects = (
+  state: GameState,
+): Record<PlayerId, CombinationEffectSummary> => {
+  const computed = {
+    P1: evaluateForPlayer(state, 'P1'),
+    P2: evaluateForPlayer(state, 'P2'),
+  } as Record<PlayerId, CombinationEffectSummary>;
+
+  state.combinationEffects = computed;
+  return computed;
+};


### PR DESCRIPTION
## Summary
- add a combination-effects evaluator for MVP games and persist synergy summaries on the game state
- apply synergy bonuses to start-of-turn income, draw size, card costs, and card resolution logic while logging per-turn gains
- update the synergy HUD hook to expose applied bonuses and surface detailed synergy breakdowns in the HUD

## Testing
- npm run lint *(fails: Cannot find package '@eslint/js')*


------
https://chatgpt.com/codex/tasks/task_e_68d0f350b1e88320be6ac7256c24454f