### PR TITLE
Improve played cards layout responsiveness

### DIFF
--- a/src/components/game/PlayedCardsDock.tsx
+++ b/src/components/game/PlayedCardsDock.tsx
@@ -42,14 +42,16 @@ const PlayedCardsSection: React.FC<SectionProps> = ({ title, toneClass, cards, e
   >
     <h4 className="mb-2 text-[12px] font-extrabold uppercase tracking-[0.2em] text-black/70">{title}</h4>
     {cards.length > 0 ? (
-      <div className="grid grid-cols-3 gap-2 place-items-start">
-        {cards.map((entry, index) => (
-          <CardsInPlayCard
-            key={`${entry.card.id}-${index}`}
-            card={entry.card}
-            onInspect={onInspectCard}
-          />
-        ))}
+      <div className="overflow-x-auto pb-1">
+        <div className="grid place-items-start gap-2 [grid-template-columns:repeat(auto-fit,minmax(140px,_1fr))]">
+          {cards.map((entry, index) => (
+            <CardsInPlayCard
+              key={`${entry.card.id}-${index}`}
+              card={entry.card}
+              onInspect={onInspectCard}
+            />
+          ))}
+        </div>
       </div>
     ) : (
       <div className="grid min-h-[120px] place-items-center rounded border border-dashed border-black/20 bg-white/40 p-4 text-center text-[11px] font-mono uppercase tracking-wide text-black/50">


### PR DESCRIPTION
## Summary
- switch the played cards section to an auto-fit grid so cards reflow cleanly across screen sizes
- wrap the grid in a horizontal overflow container to preserve card readability when space is tight

## Testing
- npm run lint *(fails: missing dependencies; npm install blocked by 403 from registry)*

------
https://chatgpt.com/codex/tasks/task_e_68d151b5c874832097e5f06b7bdaf5e3