### PR TITLE
Improve caption token scaling on high-resolution displays

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -57,7 +57,7 @@ All colors MUST be HSL.
     --h1: clamp(28px, 6vh, 64px);
     --h2: clamp(18px, 3.2vh, 40px);
     --btn: clamp(14px, 2.6vh, 28px);
-    --cap: clamp(10px, 1.6vh, 13px);
+    --cap: clamp(10px, calc(1.2vh + 0.2vw), 20px);
 
     /* Tabloid newspaper theme tokens */
     --paper: #f4f3f1;
@@ -151,7 +151,7 @@ All colors MUST be HSL.
       --h1: clamp(24px, 5.2vh, 52px);
       --h2: clamp(16px, 2.6vh, 34px);
       --btn: clamp(12px, 2.2vh, 22px);
-      --cap: clamp(9px, 1.4vh, 12px);
+      --cap: clamp(9px, calc(1.1vh + 0.15vw), 14px);
     }
   }
 


### PR DESCRIPTION
## Summary
- adjust the `--cap` typography token to mix viewport height and width so captions can grow on ultra-high-resolution screens
- update the compact-height override to maintain balance while preventing oversized captions on short displays

## Testing
- npm run lint *(fails: missing dependencies due to registry access restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68d152d841e48320bfe42ff11897e841