### PR TITLE
Add configurable UI scale setting

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -13,6 +13,7 @@ import { initializeExtensionsOnStartup } from './data/extensionIntegration';
 import { AchievementProvider } from './contexts/AchievementContext';
 import UiOverlays from "./ui/UiOverlays";
 import { areUiNotificationsEnabled } from './state/settings';
+import { applyUiScale, getStoredUiScale, normalizeUiScale } from './state/uiScale';
 
 const queryClient = new QueryClient();
 
@@ -38,17 +39,29 @@ const App = () => {
       }
     };
 
+    const handleUiScaleChange = (event: Event) => {
+      const detail = (event as CustomEvent<{ value?: unknown }>).detail;
+      if (detail && typeof detail.value !== 'undefined') {
+        applyUiScale(normalizeUiScale(detail.value, getStoredUiScale()));
+      } else {
+        applyUiScale(getStoredUiScale());
+      }
+    };
+
     const handleStorage = (event: StorageEvent) => {
       if (event.key === 'gameSettings') {
         setUiNotificationsEnabled(areUiNotificationsEnabled());
+        applyUiScale(getStoredUiScale());
       }
     };
 
     window.addEventListener('shadowgov:ui-notifications-toggled', handleToggle);
+    window.addEventListener('shadowgov:ui-scale-changed', handleUiScaleChange);
     window.addEventListener('storage', handleStorage);
 
     return () => {
       window.removeEventListener('shadowgov:ui-notifications-toggled', handleToggle);
+      window.removeEventListener('shadowgov:ui-scale-changed', handleUiScaleChange);
       window.removeEventListener('storage', handleStorage);
     };
   }, []);

--- a/src/index.css
+++ b/src/index.css
@@ -10,6 +10,9 @@ All colors MUST be HSL.
 
 @layer base {
   :root {
+    --ui-scale: 1;
+    font-size: calc(16px * var(--ui-scale));
+
     --background: 0 0% 100%;
     --foreground: 222.2 84% 4.9%;
 

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -2,11 +2,14 @@ import { createRoot } from 'react-dom/client';
 import App from './App.tsx';
 import './index.css';
 import { initializeExpansions } from '@/data/expansions/state';
+import { applyUiScale, getStoredUiScale } from '@/state/uiScale';
 
 const rootElement = document.getElementById('root');
 if (!rootElement) {
   throw new Error('Root element not found');
 }
+
+applyUiScale(getStoredUiScale());
 
 initializeExpansions()
   .catch(error => {

--- a/src/state/uiScale.ts
+++ b/src/state/uiScale.ts
@@ -1,0 +1,53 @@
+export const GAME_SETTINGS_STORAGE_KEY = 'gameSettings';
+
+export const UI_SCALE_OPTIONS = [100, 125, 150] as const;
+
+export type UiScale = (typeof UI_SCALE_OPTIONS)[number];
+
+export const DEFAULT_UI_SCALE: UiScale = 100;
+
+export const isUiScale = (value: unknown): value is UiScale =>
+  typeof value === 'number' && UI_SCALE_OPTIONS.some(option => option === value);
+
+export const normalizeUiScale = (value: unknown, fallback: UiScale = DEFAULT_UI_SCALE): UiScale => {
+  if (isUiScale(value)) {
+    return value;
+  }
+
+  if (typeof value === 'string') {
+    const parsed = Number.parseInt(value, 10);
+    if (isUiScale(parsed)) {
+      return parsed;
+    }
+  }
+
+  return fallback;
+};
+
+export const applyUiScale = (scale: UiScale) => {
+  if (typeof document === 'undefined') {
+    return;
+  }
+
+  const normalized = Math.max(50, Math.min(200, scale));
+  document.documentElement.style.setProperty('--ui-scale', String(normalized / 100));
+};
+
+export const getStoredUiScale = (): UiScale => {
+  if (typeof localStorage === 'undefined') {
+    return DEFAULT_UI_SCALE;
+  }
+
+  try {
+    const stored = localStorage.getItem(GAME_SETTINGS_STORAGE_KEY);
+    if (!stored) {
+      return DEFAULT_UI_SCALE;
+    }
+
+    const parsed = JSON.parse(stored) as { uiScale?: unknown } | null;
+    return normalizeUiScale(parsed?.uiScale, DEFAULT_UI_SCALE);
+  } catch (error) {
+    console.warn('Failed to read stored UI scale:', error);
+    return DEFAULT_UI_SCALE;
+  }
+};


### PR DESCRIPTION
## Summary
- add a reusable uiScale helper module and extend persisted game settings with the new field
- apply the stored UI scale on startup and in response to local changes/storage events so the root font size scales globally
- expose an Interface Scale selector in the options panel that updates React state, localStorage and broadcasts scale changes

## Testing
- npm run lint *(fails: Cannot find package '@eslint/js' from eslint.config.js)*
- npm install *(fails: 403 Forbidden fetching ts-node from npm registry)*

------
https://chatgpt.com/codex/tasks/task_e_68d1543c6a8c8320a629f212986f466d