### PR TITLE
Adjust board mini card sizing and grid layout

### DIFF
--- a/src/components/game/PlayedCardsDock.tsx
+++ b/src/components/game/PlayedCardsDock.tsx
@@ -4,6 +4,8 @@ import type { CardPlayRecord } from '@/hooks/gameStateTypes';
 import type { GameCard } from '@/rules/mvp';
 import BaseCard from '@/components/game/cards/BaseCard';
 
+const BOARD_MINI_CARD_WIDTH = 160; // 320px base width * 0.5 boardMini scale
+
 interface PlayedCardsDockProps {
   playedCards: CardPlayRecord[];
   onInspectCard?: (card: GameCard) => void;
@@ -42,16 +44,17 @@ const PlayedCardsSection: React.FC<SectionProps> = ({ title, toneClass, cards, e
   >
     <h4 className="mb-2 text-[12px] font-extrabold uppercase tracking-[0.2em] text-black/70">{title}</h4>
     {cards.length > 0 ? (
-      <div className="overflow-x-auto pb-1">
-        <div className="grid place-items-start gap-2 [grid-template-columns:repeat(auto-fit,minmax(140px,_1fr))]">
-          {cards.map((entry, index) => (
-            <CardsInPlayCard
-              key={`${entry.card.id}-${index}`}
-              card={entry.card}
-              onInspect={onInspectCard}
-            />
-          ))}
-        </div>
+      <div
+        className="grid items-start justify-items-center gap-2"
+        style={{ gridTemplateColumns: `repeat(auto-fit, minmax(${BOARD_MINI_CARD_WIDTH}px, 1fr))` }}
+      >
+        {cards.map((entry, index) => (
+          <CardsInPlayCard
+            key={`${entry.card.id}-${index}`}
+            card={entry.card}
+            onInspect={onInspectCard}
+          />
+        ))}
       </div>
     ) : (
       <div className="grid min-h-[120px] place-items-center rounded border border-dashed border-black/20 bg-white/40 p-4 text-center text-[11px] font-mono uppercase tracking-wide text-black/50">

--- a/src/components/game/cards/BaseCard.tsx
+++ b/src/components/game/cards/BaseCard.tsx
@@ -17,7 +17,7 @@ export type CardFrameSize = 'modal' | 'boardMini' | 'handMini';
 
 const SIZE_TO_SCALE: Record<CardFrameSize, number> = {
   modal: 1,
-  boardMini: 0.56,
+  boardMini: 0.5,
   handMini: 0.78,
 };
 

--- a/src/ui/CardFrame.tsx
+++ b/src/ui/CardFrame.tsx
@@ -9,9 +9,9 @@ type Props = {
 
 export default function CardFrame({ children, size = "modal", scaleOverride }: Props) {
   // FINJUSTÉR SKALA HER:
-  // - boardMini: senket til 0.56 for å unngå scroll i "Cards in Play"
+  // - boardMini: senket til 0.5 for å passe gridbredden i "Cards in Play"
   // - handMini: beholdt 0.78 (god lesbarhet i Your Hand)
-  const defaultScale = size === "modal" ? 1 : size === "boardMini" ? 0.56 : 0.78;
+  const defaultScale = size === "modal" ? 1 : size === "boardMini" ? 0.5 : 0.78;
   const scale = typeof scaleOverride === "number" ? scaleOverride : defaultScale;
 
   // Basemål MÅ matche fullkortets outer size (inkl. border)


### PR DESCRIPTION
## Summary
- shrink the board mini card scale to 0.5 so the rendered width matches the played cards layout
- update the played cards dock to use an auto-wrapping grid sized to the board mini cards

## Testing
- npm run lint *(fails: missing dependencies due to 403 when installing ts-node from npm registry)*

------
https://chatgpt.com/codex/tasks/task_e_68d19c72cf388320a587c3f03cfd2243