### PR TITLE
Adjust masthead chips layout for mobile

### DIFF
--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -1588,34 +1588,34 @@ const Index = () => {
             ⚙️
           </button>
         </div>
-        <div className="flex items-center gap-2 overflow-x-auto text-[11px] font-mono text-newspaper-text/80">
-          <div className="flex items-center gap-1 whitespace-nowrap rounded border border-newspaper-border bg-newspaper-text px-2 py-1 text-newspaper-bg shadow-sm">
+        <div className="flex flex-wrap items-center gap-2 text-[11px] font-mono text-newspaper-text/80 sm:flex-nowrap">
+          <div className="flex items-center gap-1 rounded border border-newspaper-border bg-newspaper-text px-2 py-1 text-newspaper-bg shadow-sm sm:whitespace-nowrap">
             <span className="font-bold uppercase tracking-wide">Round</span>
             <span>{gameState.turn}</span>
           </div>
           <MechanicsTooltip mechanic="ip">
-            <div className="flex items-center gap-1 whitespace-nowrap rounded border border-newspaper-border bg-newspaper-text px-2 py-1 text-newspaper-bg shadow-sm">
+            <div className="flex items-center gap-1 rounded border border-newspaper-border bg-newspaper-text px-2 py-1 text-newspaper-bg shadow-sm sm:whitespace-nowrap">
               <span className="font-bold uppercase tracking-wide">Your IP</span>
               <span>{gameState.ip}</span>
             </div>
           </MechanicsTooltip>
           <MechanicsTooltip mechanic="truth">
-            <div className="flex items-center gap-1 whitespace-nowrap rounded border border-newspaper-border bg-newspaper-text px-2 py-1 text-newspaper-bg shadow-sm">
+            <div className="flex items-center gap-1 rounded border border-newspaper-border bg-newspaper-text px-2 py-1 text-newspaper-bg shadow-sm sm:whitespace-nowrap">
               <span className="font-bold uppercase tracking-wide">Truth</span>
               <span>{gameState.truth}%</span>
             </div>
           </MechanicsTooltip>
           <MechanicsTooltip mechanic="zone">
-            <div className="flex items-center gap-1 whitespace-nowrap rounded border border-newspaper-border bg-newspaper-text px-2 py-1 text-newspaper-bg shadow-sm">
+            <div className="flex items-center gap-1 rounded border border-newspaper-border bg-newspaper-text px-2 py-1 text-newspaper-bg shadow-sm sm:whitespace-nowrap">
               <span className="font-bold uppercase tracking-wide">Your States</span>
               <span>{gameState.controlledStates.length}</span>
             </div>
           </MechanicsTooltip>
-          <div className="flex items-center gap-1 whitespace-nowrap rounded border border-newspaper-border bg-newspaper-text px-2 py-1 text-newspaper-bg shadow-sm">
+          <div className="flex items-center gap-1 rounded border border-newspaper-border bg-newspaper-text px-2 py-1 text-newspaper-bg shadow-sm sm:whitespace-nowrap">
             <span className="font-bold uppercase tracking-wide">AI IP</span>
             <span>{gameState.aiIP}</span>
           </div>
-          <div className="flex items-center gap-1 whitespace-nowrap rounded border border-newspaper-border bg-newspaper-text px-2 py-1 text-newspaper-bg shadow-sm">
+          <div className="flex items-center gap-1 rounded border border-newspaper-border bg-newspaper-text px-2 py-1 text-newspaper-bg shadow-sm sm:whitespace-nowrap">
             <span className="font-bold uppercase tracking-wide">AI States</span>
             <span>{gameState.states.filter(s => s.owner === 'ai').length}</span>
           </div>


### PR DESCRIPTION
## Summary
- allow masthead status chips to wrap on small screens instead of requiring horizontal scrolling
- gate chip `whitespace-nowrap` styling behind a `sm:` breakpoint so text can wrap on mobile while remaining single-line on larger viewports

## Testing
- npm run lint *(fails: missing dependency `@eslint/js` in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d1a9b5d1b48320aed9bfdd60b9bc65