### PR TITLE
Ensure left pane layout scroll behavior works across breakpoints

### DIFF
--- a/src/components/layout/ResponsiveLayout.tsx
+++ b/src/components/layout/ResponsiveLayout.tsx
@@ -34,16 +34,16 @@ export default function ResponsiveLayout({ masthead, leftPane, rightPane }: Prop
             paddingRight: "var(--safe-right)",
           }}
         >
-          <div className="app-scroll flex flex-1 flex-col p-2 sm:p-4 md:p-6">
+          <div className="app-scroll flex flex-1 min-h-0 flex-col p-2 sm:p-4 md:p-6">
             <div
               className={clsx(
-                "flex flex-1 flex-col gap-4",
+                "flex flex-1 flex-col gap-4 min-h-0",
                 hasRightPane &&
                   "lg:grid lg:grid-cols-[minmax(0,1fr)_420px] lg:gap-6 lg:[&>*]:min-h-0 xl:grid-cols-[minmax(0,1fr)_480px]"
               )}
             >
-              <main className="flex min-w-0 flex-col gap-4 lg:min-h-0 lg:overflow-hidden">
-                <div className="flex min-w-0 flex-col gap-4 lg:min-h-0 lg:flex-1 lg:overflow-y-auto">
+              <main className="flex min-h-0 flex-1 min-w-0 flex-col gap-4 overflow-hidden">
+                <div className="flex min-h-0 flex-1 min-w-0 flex-col gap-4 overflow-y-auto">
                   {leftPane}
                 </div>
               </main>

--- a/src/index.css
+++ b/src/index.css
@@ -1305,9 +1305,15 @@ html, body, #root {
 
 .app-scroll {
   height: 100%;
-  overflow: hidden;
+  overflow-y: auto;
   -webkit-overflow-scrolling: touch;
   padding-bottom: var(--safe-bottom);
+}
+
+@media (min-width: 1024px) {
+  .app-scroll {
+    overflow-y: hidden;
+  }
 }
 
 .touch-target {


### PR DESCRIPTION
## Summary
- update the responsive layout wrappers so the left column keeps min-h-0 ancestry and can scroll at every breakpoint
- relax the app-scroll overflow rule on smaller viewports so nested scroll containers can expose their content

## Testing
- npm run lint *(fails: cannot find package '@eslint/js' required by eslint.config.js in the provided environment)*
- npm run dev -- --host 0.0.0.0 --port 4173 *(fails: local vite binary missing because dependencies cannot be installed in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d1b24252fc83208d498468abc3fd73