### PR TITLE
Ensure left pane layout can scroll at all sizes

### DIFF
--- a/src/components/layout/ResponsiveLayout.tsx
+++ b/src/components/layout/ResponsiveLayout.tsx
@@ -42,7 +42,7 @@ export default function ResponsiveLayout({ masthead, leftPane, rightPane }: Prop
                   "lg:grid lg:grid-cols-[minmax(0,1fr)_420px] lg:gap-6 lg:[&>*]:min-h-0 xl:grid-cols-[minmax(0,1fr)_480px]"
               )}
             >
-              <main className="flex min-h-0 flex-1 min-w-0 flex-col gap-4 overflow-hidden">
+              <main className="flex min-h-0 flex-1 min-w-0 flex-col gap-4">
                 <div className="flex min-h-0 flex-1 min-w-0 flex-col gap-4 overflow-y-auto">
                   {leftPane}
                 </div>

--- a/src/index.css
+++ b/src/index.css
@@ -1312,7 +1312,7 @@ html, body, #root {
 
 @media (min-width: 1024px) {
   .app-scroll {
-    overflow-y: hidden;
+    overflow-y: auto;
   }
 }
 


### PR DESCRIPTION
## Summary
- allow the left column wrapper in `ResponsiveLayout` to keep its scrollable behavior across all breakpoints by removing the parent overflow clamp
- stop the `.app-scroll` helper from hiding overflow on large screens so the inner column manages scrolling without losing access to the dock

## Testing
- `npm run lint` *(fails: missing dependencies due to npm install restrictions in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d243143d9c83209a5d53d6ab1a159b