### PR TITLE
Clear neutral state occupation metadata

### DIFF
--- a/src/systems/__tests__/cardResolution.test.ts
+++ b/src/systems/__tests__/cardResolution.test.ts
@@ -147,4 +147,47 @@ describe('resolveCardMVP', () => {
       max_states_controlled_single_game: 1,
     });
   });
+
+  it('clears occupation metadata when a state resolves to neutral', () => {
+    const tracker = createTracker();
+    const gameState = createBaseSnapshot({
+      states: [
+        {
+          id: 'NM',
+          name: 'New Mexico',
+          abbreviation: 'NM',
+          baseIP: 2,
+          defense: 2,
+          pressure: 0,
+          contested: false,
+          owner: 'neutral',
+          occupierCardId: 'zone-keeper',
+          occupierCardName: 'Zone Keeper',
+          occupierLabel: '👁️ Truth Beacon: Zone Keeper',
+          occupierIcon: '👁️',
+          occupierUpdatedAt: 123456789,
+        },
+      ],
+    });
+
+    const card: GameCard = {
+      id: 'noop-attack',
+      name: 'Quiet Watch',
+      type: 'ATTACK',
+      faction: 'truth',
+      rarity: 'common',
+      cost: 0,
+      effects: {},
+    };
+
+    const result = resolveCardMVP(gameState, card, null, actor, tracker);
+    const resolvedState = result.states[0];
+
+    expect(resolvedState?.owner).toBe('neutral');
+    expect(resolvedState?.occupierCardId).toBeNull();
+    expect(resolvedState?.occupierCardName).toBeNull();
+    expect(resolvedState?.occupierLabel).toBeNull();
+    expect(resolvedState?.occupierIcon).toBeNull();
+    expect(resolvedState?.occupierUpdatedAt).toBeUndefined();
+  });
 });

--- a/src/systems/cardResolution.ts
+++ b/src/systems/cardResolution.ts
@@ -3,7 +3,7 @@ import { normalizeMaxCardsPerTurn } from '@/config/turnLimits';
 import type { MediaResolutionOptions } from '@/mvp/media';
 import { cloneGameState, type Card, type GameState as EngineGameState } from '@/mvp';
 import type { GameCard } from '@/rules/mvp';
-import { setStateOccupation } from '@/data/usaStates';
+import { clearStateOccupation, setStateOccupation } from '@/data/usaStates';
 import type { PlayerStats } from '@/data/achievementSystem';
 
 type Faction = 'government' | 'truth';
@@ -244,6 +244,7 @@ export function resolveCardMVP(
       nextControlledStates.delete(state.abbreviation);
       nextAiControlledStates.add(state.abbreviation);
     } else {
+      clearStateOccupation(state);
       nextControlledStates.delete(state.abbreviation);
       nextAiControlledStates.delete(state.abbreviation);
     }


### PR DESCRIPTION
## Summary
- call `clearStateOccupation` when card resolution leaves a state neutral so prior occupiers are removed
- re-enable the card resolution test suite and add coverage confirming neutral states clear occupation metadata

## Testing
- bun test --coverage --coverage-reporter=text

------
https://chatgpt.com/codex/tasks/task_e_68d28d95b3a48320b9f1b45cf1529b99