### PR TITLE
Adjust desktop hand layout to flex column

### DIFF
--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -1719,12 +1719,12 @@ const Index = () => {
   const rightPaneContent = !showDesktopHand
     ? null
     : (
-      <aside className="grid min-h-0 min-w-0 grid-rows-[auto_1fr_auto] rounded border-2 border-newspaper-border bg-newspaper-text text-newspaper-bg shadow-lg">
+      <aside className="flex min-h-0 min-w-0 flex-1 flex-col rounded border-2 border-newspaper-border bg-newspaper-text text-newspaper-bg shadow-lg">
         <header className="flex items-center justify-between gap-2 border-b border-newspaper-border/60 px-4 py-3">
           <h3 className="text-xs font-bold uppercase tracking-[0.35em]">Your Hand</h3>
           <span className="text-xs font-mono">IP {gameState.ip}</span>
         </header>
-        <div className="min-h-0 min-w-0 overflow-y-auto px-3 py-3">
+        <div className="flex-1 min-h-0 overflow-y-auto px-3 py-3">
           <EnhancedGameHand
             cards={gameState.hand}
             onPlayCard={handlePlayCard}
@@ -1736,7 +1736,7 @@ const Index = () => {
             onCardHover={setHoveredCard}
           />
         </div>
-        <footer className="sticky bottom-[var(--safe-bottom)] border-t border-newspaper-border/60 bg-newspaper-text px-3 pb-3 pt-2 sm:pt-3">
+        <footer className="shrink-0 sticky bottom-[var(--safe-bottom)] border-t border-newspaper-border/60 bg-newspaper-text px-3 pb-3 pt-2 sm:pt-3">
           <Button
             onClick={handleEndTurn}
             className="touch-target w-full border-2 border-black bg-black py-3 font-bold uppercase tracking-wide text-white transition duration-200 hover:bg-white hover:text-black disabled:opacity-60"


### PR DESCRIPTION
## Summary
- update the desktop hand aside to use a flex column layout so it grows with the surrounding pane
- allow the hand card list to flex and scroll independently while keeping the footer sticky
- prevent the End Turn footer from shrinking so the button stays anchored at the bottom of the column

## Testing
- `npm run build` *(fails: `vite: not found` because dependencies could not be installed in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d2b718d2d88320a497dd0d5c53b8b1