### PR TITLE
Ensure desktop hand column keeps footer visible

### DIFF
--- a/src/components/layout/ResponsiveLayout.tsx
+++ b/src/components/layout/ResponsiveLayout.tsx
@@ -48,7 +48,9 @@ export default function ResponsiveLayout({ masthead, leftPane, rightPane }: Prop
                 </div>
               </main>
               {hasRightPane && (
-                <div className="min-w-0 lg:flex lg:min-h-0 lg:flex-col lg:overflow-hidden">{rightPane}</div>
+                <div className="min-w-0 lg:flex lg:min-h-0 lg:flex-col lg:[&>*]:min-h-0 lg:[&>*]:flex-1">
+                  {rightPane}
+                </div>
               )}
             </div>
           </div>


### PR DESCRIPTION
## Summary
- let the right pane wrapper participate in the flex layout on large screens
- ensure children of the right pane wrapper can shrink and grow to fill the column height so the footer remains visible

## Testing
- npm run lint *(fails: missing dependency @eslint/js in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d2b1110b90832090cc4e303b97ecac