### PR TITLE
Fix next track selection to use current index

### DIFF
--- a/src/hooks/useAudio.ts
+++ b/src/hooks/useAudio.ts
@@ -379,10 +379,11 @@ export const useAudio = () => {
       return null;
     }
     const currentIndex = currentTrackIndex.current[musicType];
+    const trackToPlay = tracks[currentIndex];
     const nextIndex = (currentIndex + 1) % tracks.length;
     currentTrackIndex.current[musicType] = nextIndex;
-    console.log('🎵 Selected track index:', nextIndex, 'of', tracks.length);
-    return tracks[nextIndex];
+    console.log('🎵 Selected track index:', currentIndex, 'of', tracks.length);
+    return trackToPlay;
   }, []);
 
   const switchTrack = useCallback((fromAudio: HTMLAudioElement | null, toAudio: HTMLAudioElement | null) => {


### PR DESCRIPTION
## Summary
- ensure getNextTrack returns the current track before advancing the index so playback order is correct

## Testing
- npm run dev *(fails: vite not found because dependencies cannot be installed in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d2cca195d08320afb9e816ce475923