### PR TITLE
Integrate combination bonuses into gameplay

### DIFF
--- a/src/components/game/EnhancedGameHand.tsx
+++ b/src/components/game/EnhancedGameHand.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useRef } from 'react';
+import React, { useState, useRef, useMemo } from 'react';
 import clsx from 'clsx';
 import CardDetailOverlay from './CardDetailOverlay';
 import BaseCard from '@/components/game/cards/BaseCard';
@@ -22,6 +22,7 @@ interface EnhancedGameHandProps {
   currentIP: number;
   loadingCard?: string | null;
   onCardHover?: (card: (GameCard & { _hoverPosition?: { x: number; y: number } }) | null) => void;
+  getEffectiveCost?: (card: GameCard) => number;
 }
 
 const EnhancedGameHand: React.FC<EnhancedGameHandProps> = ({
@@ -32,7 +33,8 @@ const EnhancedGameHand: React.FC<EnhancedGameHandProps> = ({
   onSelectCard,
   currentIP,
   loadingCard,
-  onCardHover
+  onCardHover,
+  getEffectiveCost
 }) => {
   const [playingCard, setPlayingCard] = useState<string | null>(null);
   const [examinedCard, setExaminedCard] = useState<string | null>(null);
@@ -41,12 +43,23 @@ const EnhancedGameHand: React.FC<EnhancedGameHandProps> = ({
   const isMobile = useIsMobile();
   const handRef = useRef<HTMLDivElement>(null);
 
+  const displayedCards = useMemo(() => {
+    if (!getEffectiveCost) {
+      return cards;
+    }
+
+    return cards.map(card => {
+      const cost = getEffectiveCost(card);
+      return typeof cost === 'number' && cost !== card.cost ? { ...card, cost } : card;
+    });
+  }, [cards, getEffectiveCost]);
+
   const normalizeCardType = (type: string): MVPCardType => {
     return MVP_CARD_TYPES.includes(type as MVPCardType) ? type as MVPCardType : 'MEDIA';
   };
 
   const handlePlayCard = async (cardId: string) => {
-    const card = cards.find(c => c.id === cardId);
+    const card = displayedCards.find(c => c.id === cardId);
     if (!card) return;
     
     if (!canAffordCard(card)) {
@@ -86,17 +99,17 @@ const EnhancedGameHand: React.FC<EnhancedGameHandProps> = ({
   const swipeHandlers = useSwipeGestures({
     onSwipeLeft: () => {
       if (examinedCard) {
-        const currentIndex = cards.findIndex(c => c.id === examinedCard);
-        const nextIndex = (currentIndex + 1) % cards.length;
-        setExaminedCard(cards[nextIndex].id);
+        const currentIndex = displayedCards.findIndex(c => c.id === examinedCard);
+        const nextIndex = (currentIndex + 1) % displayedCards.length;
+        setExaminedCard(displayedCards[nextIndex].id);
         triggerHaptic('selection');
       }
     },
     onSwipeRight: () => {
       if (examinedCard) {
-        const currentIndex = cards.findIndex(c => c.id === examinedCard);
-        const prevIndex = currentIndex === 0 ? cards.length - 1 : currentIndex - 1;
-        setExaminedCard(cards[prevIndex].id);
+        const currentIndex = displayedCards.findIndex(c => c.id === examinedCard);
+        const prevIndex = currentIndex === 0 ? displayedCards.length - 1 : currentIndex - 1;
+        setExaminedCard(displayedCards[prevIndex].id);
         triggerHaptic('selection');
       }
     },
@@ -115,12 +128,12 @@ const EnhancedGameHand: React.FC<EnhancedGameHandProps> = ({
       onPointerLeave={() => onCardHover?.(null)}
     >
       <div className="grid w-full grid-cols-3 gap-3 justify-items-start items-start content-start">
-        {cards.length === 0 ? (
+        {displayedCards.length === 0 ? (
           <div className="col-span-full flex min-h-[160px] items-center justify-center rounded border border-dashed border-neutral-700 bg-neutral-900/60 p-6 text-sm font-mono text-white/60">
             No assets available
           </div>
         ) : (
-          cards.map((card, index) => {
+          displayedCards.map((card, index) => {
             const isSelected = selectedCard === card.id;
             const isPlaying = playingCard === card.id;
             const isLoading = loadingCard === card.id;
@@ -236,15 +249,15 @@ const EnhancedGameHand: React.FC<EnhancedGameHandProps> = ({
       {/* Card Detail Overlay - Redesigned */}
       {examinedCard && (
         <CardDetailOverlay
-          card={cards.find(c => c.id === examinedCard) || null}
-          canAfford={cards.find(c => c.id === examinedCard) ? canAffordCard(cards.find(c => c.id === examinedCard)!) : false}
+          card={displayedCards.find(c => c.id === examinedCard) || null}
+          canAfford={displayedCards.find(c => c.id === examinedCard) ? canAffordCard(displayedCards.find(c => c.id === examinedCard)!) : false}
           disabled={disabled}
           onClose={() => {
             setExaminedCard(null);
             triggerHaptic('light');
           }}
           onPlayCard={() => {
-            const card = cards.find(c => c.id === examinedCard);
+            const card = displayedCards.find(c => c.id === examinedCard);
             if (!card) return;
             
             if (!canAffordCard(card)) {
@@ -297,7 +310,7 @@ const EnhancedGameHand: React.FC<EnhancedGameHandProps> = ({
               </div>
               <div className="text-sm text-muted-foreground font-mono">
                 {(() => {
-                  const card = cards.find(c => c.id === playingCard);
+                  const card = displayedCards.find(c => c.id === playingCard);
                   return card ? `"${card.name}"` : 'Unknown Asset';
                 })()}
               </div>

--- a/src/game/combinationEffects.ts
+++ b/src/game/combinationEffects.ts
@@ -1,0 +1,150 @@
+import { STATE_COMBINATIONS, type StateCombination } from '@/data/stateCombinations';
+import type { GameCard } from '@/rules/mvp';
+import type { GameState } from '@/hooks/gameStateTypes';
+
+export interface CombinationModifiers {
+  flatIncomeBonus: number;
+  incomePerControlled: number;
+  incomePerNeutral: number;
+  mediaCostReduction: number;
+}
+
+export interface CombinationContext {
+  activeCombinations: StateCombination[];
+  modifiers: CombinationModifiers;
+}
+
+export interface CardCostAdjustment {
+  adjustedCost: number;
+  discount: number;
+}
+
+export interface IncomeBreakdown {
+  totalIncome: number;
+  comboBonus: number;
+  components: {
+    flat: number;
+    perControlled: number;
+    perNeutral: number;
+  };
+}
+
+const createEmptyModifiers = (): CombinationModifiers => ({
+  flatIncomeBonus: 0,
+  incomePerControlled: 0,
+  incomePerNeutral: 0,
+  mediaCostReduction: 0,
+});
+
+const normalizeStates = (states: string[] | undefined): Set<string> => {
+  if (!Array.isArray(states) || states.length === 0) {
+    return new Set();
+  }
+
+  return new Set(states.map(entry => entry.toUpperCase()));
+};
+
+export const getActiveCombinationsFromStates = (controlledStates: string[]): StateCombination[] => {
+  const normalized = normalizeStates(controlledStates);
+  if (normalized.size === 0) {
+    return [];
+  }
+
+  return STATE_COMBINATIONS.filter(combination =>
+    combination.requiredStates.every(state => normalized.has(state.toUpperCase())),
+  );
+};
+
+export const buildCombinationModifiers = (combinations: StateCombination[]): CombinationModifiers => {
+  const modifiers = createEmptyModifiers();
+
+  for (const combination of combinations) {
+    switch (combination.id) {
+      case 'wall_street_empire':
+        modifiers.flatIncomeBonus += 2;
+        break;
+      case 'silicon_valley_network':
+        modifiers.mediaCostReduction += 1;
+        break;
+      case 'oil_cartel':
+        modifiers.incomePerControlled += 1;
+        break;
+      case 'southern_border':
+        modifiers.incomePerNeutral += 1;
+        break;
+      default:
+        break;
+    }
+  }
+
+  return modifiers;
+};
+
+export const getCombinationContextFromControlledStates = (
+  controlledStates: string[],
+): CombinationContext => {
+  const activeCombinations = getActiveCombinationsFromStates(controlledStates);
+  const modifiers = buildCombinationModifiers(activeCombinations);
+  return { activeCombinations, modifiers };
+};
+
+export const getCombinationContextForOwner = (
+  state: Pick<GameState, 'controlledStates' | 'aiControlledStates'>,
+  owner: 'human' | 'ai',
+): CombinationContext => {
+  const controlled = owner === 'human' ? state.controlledStates : state.aiControlledStates ?? [];
+  return getCombinationContextFromControlledStates(controlled);
+};
+
+export const getCardCostAdjustment = (
+  card: GameCard,
+  context: CombinationContext,
+): CardCostAdjustment => {
+  const discount = card.type === 'MEDIA' ? context.modifiers.mediaCostReduction : 0;
+  const adjustedCost = Math.max(0, card.cost - discount);
+  return { adjustedCost, discount };
+};
+
+export const buildCardWithAdjustedCost = (
+  card: GameCard,
+  context: CombinationContext,
+): { card: GameCard; adjustedCost: number; discount: number } => {
+  const { adjustedCost, discount } = getCardCostAdjustment(card, context);
+  if (discount <= 0) {
+    return { card, adjustedCost, discount };
+  }
+
+  return {
+    card: { ...card, cost: adjustedCost },
+    adjustedCost,
+    discount,
+  };
+};
+
+export const calculateIncomeWithCombination = (
+  baseIncome: number,
+  stateIncome: number,
+  context: CombinationContext,
+  controlledStateCount: number,
+  neutralStateCount: number,
+): IncomeBreakdown => {
+  const flat = context.modifiers.flatIncomeBonus;
+  const perControlled = context.modifiers.incomePerControlled * controlledStateCount;
+  const perNeutral = context.modifiers.incomePerNeutral * neutralStateCount;
+  const comboBonus = flat + perControlled + perNeutral;
+  const totalIncome = baseIncome + stateIncome + comboBonus;
+
+  return {
+    totalIncome,
+    comboBonus,
+    components: {
+      flat,
+      perControlled,
+      perNeutral,
+    },
+  };
+};
+
+export const countNeutralStates = (state: Pick<GameState, 'states'>): number => {
+  return state.states.reduce((total, entry) => (entry.owner === 'neutral' ? total + 1 : total), 0);
+};

--- a/src/systems/cardResolution.ts
+++ b/src/systems/cardResolution.ts
@@ -2,7 +2,7 @@ import { applyEffectsMvp, type PlayerId } from '@/engine/applyEffects-mvp';
 import type { MediaResolutionOptions } from '@/mvp/media';
 import { cloneGameState, type Card, type GameState as EngineGameState } from '@/mvp';
 import type { GameCard } from '@/rules/mvp';
-import { setStateOccupation } from '@/data/usaStates';
+import { clearStateOccupation, setStateOccupation } from '@/data/usaStates';
 import type { PlayerStats } from '@/data/achievementSystem';
 
 type Faction = 'government' | 'truth';
@@ -237,6 +237,12 @@ export function resolveCardMVP(
     } else {
       nextControlledStates.delete(state.abbreviation);
       nextAiControlledStates.delete(state.abbreviation);
+      if (
+        owner === 'neutral' &&
+        (state.occupierCardId || state.occupierCardName || state.occupierLabel || state.occupierIcon)
+      ) {
+        clearStateOccupation(state);
+      }
     }
 
     if (previousOwner !== 'player' && owner === 'player') {


### PR DESCRIPTION
## Summary
- add a reusable combination effects helper that derives card cost discounts and income bonuses from active state sets
- apply combination modifiers to human and AI card resolution, income collection, and saved settings handling while clearing stale neutral occupations
- surface the effective costs in the player UI so discounted cards remain playable and clearly reflect synergy savings

## Testing
- `npm run lint` *(fails: missing @eslint/js in environment)*
- `npm run build` *(fails: vite binary unavailable in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d2cd28f83083209ed0a5e1c130e99c