### PR TITLE
Wire front page layout props and flavor hotspots

### DIFF
--- a/src/components/game/PlayedCardsDock.tsx
+++ b/src/components/game/PlayedCardsDock.tsx
@@ -1,89 +1,37 @@
-import React from 'react';
-import { cn } from '@/lib/utils';
-import type { CardPlayRecord } from '@/hooks/gameStateTypes';
+import type { CardPlayRecord, EvidenceTrackState, PublicFrenzyState } from '@/hooks/gameStateTypes';
 import type { GameCard } from '@/rules/mvp';
-import BaseCard from '@/components/game/cards/BaseCard';
+import { FrontPageLayout } from '@/features/ui/frontPage/FrontPageLayout';
 
 interface PlayedCardsDockProps {
   playedCards: CardPlayRecord[];
   onInspectCard?: (card: GameCard) => void;
+  faction: 'truth' | 'government';
+  evidence: EvidenceTrackState;
+  publicFrenzy: PublicFrenzyState;
+  truth: number;
 }
 
-const CardsInPlayCard = ({ card, onInspect }: { card: GameCard; onInspect?: (card: GameCard) => void }) => (
-  <button
-    type="button"
-    onClick={() => onInspect?.(card)}
-    className="group relative flex w-full items-center justify-center rounded-lg border border-transparent bg-transparent p-0 transition-transform duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-offset-yellow-200 focus-visible:ring-yellow-400"
-  >
-    <span className="sr-only">View {card.name}</span>
-    <BaseCard
-      card={card}
-      hideStamp
-      polaroidHover={false}
-      size="boardMini"
-      className="pointer-events-none select-none transition-transform duration-200 group-hover:scale-[1.04]"
-    />
-  </button>
-);
-
-interface SectionProps {
-  title: string;
-  toneClass: string;
-  cards: CardPlayRecord[];
-  emptyMessage: string;
-  ariaLabel: string;
-  onInspectCard?: (card: GameCard) => void;
-}
-
-const PlayedCardsSection: React.FC<SectionProps> = ({ title, toneClass, cards, emptyMessage, ariaLabel, onInspectCard }) => (
-  <section
-    aria-label={ariaLabel}
-    className={cn('rounded-md p-3 text-black', toneClass)}
-  >
-    <h4 className="mb-2 text-[12px] font-extrabold uppercase tracking-[0.2em] text-black/70">{title}</h4>
-    {cards.length > 0 ? (
-      <div className="grid grid-cols-3 gap-2 place-items-start">
-        {cards.map((entry, index) => (
-          <CardsInPlayCard
-            key={`${entry.card.id}-${index}`}
-            card={entry.card}
-            onInspect={onInspectCard}
-          />
-        ))}
-      </div>
-    ) : (
-      <div className="grid min-h-[120px] place-items-center rounded border border-dashed border-black/20 bg-white/40 p-4 text-center text-[11px] font-mono uppercase tracking-wide text-black/50">
-        {emptyMessage}
-      </div>
-    )}
-  </section>
-);
-
-const PlayedCardsDock: React.FC<PlayedCardsDockProps> = ({ playedCards, onInspectCard }) => {
-  const humanCards = playedCards.filter(card => card.player === 'human');
-  const aiCards = playedCards.filter(card => card.player === 'ai');
-
+const PlayedCardsDock: React.FC<PlayedCardsDockProps> = ({
+  playedCards,
+  onInspectCard,
+  faction,
+  evidence,
+  publicFrenzy,
+  truth,
+}) => {
   return (
     <div className="flex h-full min-h-0 flex-col">
       <header className="border-b border-black/10 px-3 py-2 text-sm font-extrabold tracking-wide text-newspaper-text">
-        CARDS IN PLAY THIS ROUND
+        FRONT PAGE BATTLE REPORT
       </header>
-      <div className="grid grid-cols-1 gap-2 p-2 lg:grid-cols-2">
-        <PlayedCardsSection
-          title="OPPONENT"
-          ariaLabel="Opponent Cards"
-          cards={aiCards}
-          emptyMessage="Opponent has no cards in play."
-          toneClass="bg-[image:var(--halftone-red)] bg-[length:8px_8px] bg-repeat bg-red-50/40"
+      <div className="flex-1 overflow-y-auto p-3">
+        <FrontPageLayout
+          cards={playedCards}
           onInspectCard={onInspectCard}
-        />
-        <PlayedCardsSection
-          title="YOU"
-          ariaLabel="Your Cards"
-          cards={humanCards}
-          emptyMessage="No cards deployed this turn."
-          toneClass="bg-[image:var(--halftone-blue)] bg-[length:8px_8px] bg-repeat bg-blue-50/40"
-          onInspectCard={onInspectCard}
+          faction={faction}
+          evidence={evidence}
+          publicFrenzy={publicFrenzy}
+          truth={truth}
         />
       </div>
     </div>

--- a/src/data/usaStates.ts
+++ b/src/data/usaStates.ts
@@ -8,6 +8,7 @@ export interface StateData {
   specialBonus?: string; // Special bonus description
   bonusValue?: number;   // Bonus amount
   population: 'low' | 'medium' | 'high' | 'mega'; // Affects various mechanics
+  hotspot?: string;    // Flavor hotspot label for UI stunts
 }
 
 // Extended state interface for runtime game state
@@ -25,71 +26,71 @@ export interface EnhancedStateData extends StateData {
 
 export const USA_STATES: StateData[] = [
   // Mega States (High IP, High Defense)
-  { id: '06', name: 'California', abbreviation: 'CA', baseIP: 4, defense: 4, specialBonus: 'Tech Hub', bonusValue: 2, population: 'mega' },
-  { id: '48', name: 'Texas', abbreviation: 'TX', baseIP: 4, defense: 4, specialBonus: 'Oil Revenue', bonusValue: 3, population: 'mega' },
-  { id: '36', name: 'New York', abbreviation: 'NY', baseIP: 5, defense: 5, specialBonus: 'Financial Center', bonusValue: 4, population: 'mega' },
-  { id: '12', name: 'Florida', abbreviation: 'FL', baseIP: 2, defense: 2, specialBonus: 'Florida Man Chaos', bonusValue: 1, population: 'mega' },
+  { id: '06', name: 'California', abbreviation: 'CA', baseIP: 4, defense: 4, specialBonus: 'Tech Hub', bonusValue: 2, population: 'mega', hotspot: 'Mulholland Mind-Control Repeater' },
+  { id: '48', name: 'Texas', abbreviation: 'TX', baseIP: 4, defense: 4, specialBonus: 'Oil Revenue', bonusValue: 3, population: 'mega', hotspot: 'Black Budget Rodeo Grounds' },
+  { id: '36', name: 'New York', abbreviation: 'NY', baseIP: 5, defense: 5, specialBonus: 'Financial Center', bonusValue: 4, population: 'mega', hotspot: 'Empire State Listening Array' },
+  { id: '12', name: 'Florida', abbreviation: 'FL', baseIP: 2, defense: 2, specialBonus: 'Florida Man Chaos', bonusValue: 1, population: 'mega', hotspot: 'Everglades Gator Cult HQ' },
   
   // High Value States
-  { id: '17', name: 'Illinois', abbreviation: 'IL', baseIP: 3, defense: 3, specialBonus: 'Transport Hub', bonusValue: 2, population: 'high' },
-  { id: '42', name: 'Pennsylvania', abbreviation: 'PA', baseIP: 3, defense: 3, specialBonus: 'Steel Industry Legacy', bonusValue: 2, population: 'high' },
-  { id: '39', name: 'Ohio', abbreviation: 'OH', baseIP: 3, defense: 3, specialBonus: 'Industrial Midwest', bonusValue: 1, population: 'high' },
-  { id: '13', name: 'Georgia', abbreviation: 'GA', baseIP: 3, defense: 3, specialBonus: 'CDC Headquarters', bonusValue: 2, population: 'high' },
-  { id: '37', name: 'North Carolina', abbreviation: 'NC', baseIP: 3, defense: 3, specialBonus: 'Research Triangle', bonusValue: 2, population: 'high' },
-  { id: '26', name: 'Michigan', abbreviation: 'MI', baseIP: 3, defense: 3, specialBonus: 'Auto Industry', bonusValue: 2, population: 'high' },
+  { id: '17', name: 'Illinois', abbreviation: 'IL', baseIP: 3, defense: 3, specialBonus: 'Transport Hub', bonusValue: 2, population: 'high', hotspot: 'Chicago Deep-Dish Portal' },
+  { id: '42', name: 'Pennsylvania', abbreviation: 'PA', baseIP: 3, defense: 3, specialBonus: 'Steel Industry Legacy', bonusValue: 2, population: 'high', hotspot: 'Liberty Bell Resonance Lab' },
+  { id: '39', name: 'Ohio', abbreviation: 'OH', baseIP: 3, defense: 3, specialBonus: 'Industrial Midwest', bonusValue: 1, population: 'high', hotspot: 'Cincinnati Crop Glyph Control' },
+  { id: '13', name: 'Georgia', abbreviation: 'GA', baseIP: 3, defense: 3, specialBonus: 'CDC Headquarters', bonusValue: 2, population: 'high', hotspot: 'CDC Bio-Mystery Vault' },
+  { id: '37', name: 'North Carolina', abbreviation: 'NC', baseIP: 3, defense: 3, specialBonus: 'Research Triangle', bonusValue: 2, population: 'high', hotspot: 'Research Triangle Wormhole Hub' },
+  { id: '26', name: 'Michigan', abbreviation: 'MI', baseIP: 3, defense: 3, specialBonus: 'Auto Industry', bonusValue: 2, population: 'high', hotspot: 'Detroit Auto Gremlin Plant' },
   
   // Strategic States
-  { id: '11', name: 'Washington DC', abbreviation: 'DC', baseIP: 5, defense: 5, specialBonus: 'Government Control', bonusValue: 5, population: 'medium' },
-  { id: '53', name: 'Washington', abbreviation: 'WA', baseIP: 3, defense: 3, specialBonus: 'Tech Industry', bonusValue: 2, population: 'high' },
-  { id: '32', name: 'Nevada', abbreviation: 'NV', baseIP: 2, defense: 2, specialBonus: 'Area 51 Access', bonusValue: 3, population: 'medium' },
-  { id: '08', name: 'Colorado', abbreviation: 'CO', baseIP: 2, defense: 2, specialBonus: 'Denver Airport Tunnels', bonusValue: 2, population: 'medium' },
+  { id: '11', name: 'Washington DC', abbreviation: 'DC', baseIP: 5, defense: 5, specialBonus: 'Government Control', bonusValue: 5, population: 'medium', hotspot: 'Pentagon Spin Room Annex' },
+  { id: '53', name: 'Washington', abbreviation: 'WA', baseIP: 3, defense: 3, specialBonus: 'Tech Industry', bonusValue: 2, population: 'high', hotspot: 'Puget Sound Men in Black Marina' },
+  { id: '32', name: 'Nevada', abbreviation: 'NV', baseIP: 2, defense: 2, specialBonus: 'Area 51 Access', bonusValue: 3, population: 'medium', hotspot: 'Area 51 Gift Shop Annex' },
+  { id: '08', name: 'Colorado', abbreviation: 'CO', baseIP: 2, defense: 2, specialBonus: 'Denver Airport Tunnels', bonusValue: 2, population: 'medium', hotspot: 'Denver Airport Illuminati Tram' },
   
   // Medium States
-  { id: '51', name: 'Virginia', abbreviation: 'VA', baseIP: 3, defense: 3, specialBonus: 'CIA Headquarters', bonusValue: 3, population: 'high' },
-  { id: '24', name: 'Maryland', abbreviation: 'MD', baseIP: 3, defense: 3, specialBonus: 'NSA Access', bonusValue: 2, population: 'medium' },
-  { id: '22', name: 'Louisiana', abbreviation: 'LA', baseIP: 2, defense: 2, specialBonus: 'Voodoo Protection', bonusValue: 1, population: 'medium' },
-  { id: '47', name: 'Tennessee', abbreviation: 'TN', baseIP: 2, defense: 2, specialBonus: 'Music Industry', bonusValue: 1, population: 'medium' },
-  { id: '01', name: 'Alabama', abbreviation: 'AL', baseIP: 2, defense: 2, specialBonus: 'Space Program', bonusValue: 2, population: 'medium' },
-  { id: '21', name: 'Kentucky', abbreviation: 'KY', baseIP: 2, defense: 2, specialBonus: 'Coal Reserves', bonusValue: 1, population: 'medium' },
-  { id: '45', name: 'South Carolina', abbreviation: 'SC', baseIP: 2, defense: 2, specialBonus: 'Military Bases', bonusValue: 2, population: 'medium' },
-  { id: '05', name: 'Arkansas', abbreviation: 'AR', baseIP: 2, defense: 2, specialBonus: 'Walmart Empire', bonusValue: 1, population: 'medium' },
-  { id: '28', name: 'Mississippi', abbreviation: 'MS', baseIP: 2, defense: 2, specialBonus: 'River Control', bonusValue: 1, population: 'medium' },
-  { id: '04', name: 'Arizona', abbreviation: 'AZ', baseIP: 2, defense: 2, specialBonus: 'Desert Bases', bonusValue: 1, population: 'medium' },
-  { id: '49', name: 'Utah', abbreviation: 'UT', baseIP: 2, defense: 2, specialBonus: 'NSA Data Center', bonusValue: 2, population: 'medium' },
-  { id: '35', name: 'New Mexico', abbreviation: 'NM', baseIP: 2, defense: 2, specialBonus: 'Alien Activity', bonusValue: 2, population: 'low' },
+  { id: '51', name: 'Virginia', abbreviation: 'VA', baseIP: 3, defense: 3, specialBonus: 'CIA Headquarters', bonusValue: 3, population: 'high', hotspot: 'Langley Memory Wipe Center' },
+  { id: '24', name: 'Maryland', abbreviation: 'MD', baseIP: 3, defense: 3, specialBonus: 'NSA Access', bonusValue: 2, population: 'medium', hotspot: 'Fort Meade Psychic Switchboard' },
+  { id: '22', name: 'Louisiana', abbreviation: 'LA', baseIP: 2, defense: 2, specialBonus: 'Voodoo Protection', bonusValue: 1, population: 'medium', hotspot: 'Bayou Rougarou Parade Route' },
+  { id: '47', name: 'Tennessee', abbreviation: 'TN', baseIP: 2, defense: 2, specialBonus: 'Music Industry', bonusValue: 1, population: 'medium', hotspot: 'Nashville Subliminal Studio' },
+  { id: '01', name: 'Alabama', abbreviation: 'AL', baseIP: 2, defense: 2, specialBonus: 'Space Program', bonusValue: 2, population: 'medium', hotspot: 'Huntsville Rocket Seance' },
+  { id: '21', name: 'Kentucky', abbreviation: 'KY', baseIP: 2, defense: 2, specialBonus: 'Coal Reserves', bonusValue: 1, population: 'medium', hotspot: 'Mammoth Cave Echo Chamber' },
+  { id: '45', name: 'South Carolina', abbreviation: 'SC', baseIP: 2, defense: 2, specialBonus: 'Military Bases', bonusValue: 2, population: 'medium', hotspot: 'Charleston Phantom Fleet Yard' },
+  { id: '05', name: 'Arkansas', abbreviation: 'AR', baseIP: 2, defense: 2, specialBonus: 'Walmart Empire', bonusValue: 1, population: 'medium', hotspot: 'Ozark Crystal Receiver' },
+  { id: '28', name: 'Mississippi', abbreviation: 'MS', baseIP: 2, defense: 2, specialBonus: 'River Control', bonusValue: 1, population: 'medium', hotspot: 'Delta Fog Cloaking Field' },
+  { id: '04', name: 'Arizona', abbreviation: 'AZ', baseIP: 2, defense: 2, specialBonus: 'Desert Bases', bonusValue: 1, population: 'medium', hotspot: 'Sedona Vortex Tollbooth' },
+  { id: '49', name: 'Utah', abbreviation: 'UT', baseIP: 2, defense: 2, specialBonus: 'NSA Data Center', bonusValue: 2, population: 'medium', hotspot: 'Provo Data Prism Vault' },
+  { id: '35', name: 'New Mexico', abbreviation: 'NM', baseIP: 2, defense: 2, specialBonus: 'Alien Activity', bonusValue: 2, population: 'low', hotspot: 'Roswell Crash Debris Vault' },
   
   // Swing States
-  { id: '55', name: 'Wisconsin', abbreviation: 'WI', baseIP: 2, defense: 2, specialBonus: 'Dairy Industry', bonusValue: 1, population: 'medium' },
-  { id: '27', name: 'Minnesota', abbreviation: 'MN', baseIP: 2, defense: 2, specialBonus: 'Mining Wealth', bonusValue: 2, population: 'medium' },
-  { id: '29', name: 'Missouri', abbreviation: 'MO', baseIP: 2, defense: 2, specialBonus: 'Gateway Control', bonusValue: 1, population: 'medium' },
-  { id: '18', name: 'Indiana', abbreviation: 'IN', baseIP: 2, defense: 2, specialBonus: 'Crossroads', bonusValue: 1, population: 'medium' },
-  { id: '09', name: 'Connecticut', abbreviation: 'CT', baseIP: 3, defense: 3, specialBonus: 'Insurance Capital', bonusValue: 2, population: 'medium' },
-  { id: '41', name: 'Oregon', abbreviation: 'OR', baseIP: 2, defense: 2, specialBonus: 'Conspiracy Theorists', bonusValue: 1, population: 'medium' },
+  { id: '55', name: 'Wisconsin', abbreviation: 'WI', baseIP: 2, defense: 2, specialBonus: 'Dairy Industry', bonusValue: 1, population: 'medium', hotspot: 'Cheesehead ESP Convention Center' },
+  { id: '27', name: 'Minnesota', abbreviation: 'MN', baseIP: 2, defense: 2, specialBonus: 'Mining Wealth', bonusValue: 2, population: 'medium', hotspot: 'Boundary Waters Aurora Relay' },
+  { id: '29', name: 'Missouri', abbreviation: 'MO', baseIP: 2, defense: 2, specialBonus: 'Gateway Control', bonusValue: 1, population: 'medium', hotspot: 'Gateway Arch Wormhole Gate' },
+  { id: '18', name: 'Indiana', abbreviation: 'IN', baseIP: 2, defense: 2, specialBonus: 'Crossroads', bonusValue: 1, population: 'medium', hotspot: 'Indianapolis Speedway Leyline' },
+  { id: '09', name: 'Connecticut', abbreviation: 'CT', baseIP: 3, defense: 3, specialBonus: 'Insurance Capital', bonusValue: 2, population: 'medium', hotspot: 'New Haven Skull and Bones Annex' },
+  { id: '41', name: 'Oregon', abbreviation: 'OR', baseIP: 2, defense: 2, specialBonus: 'Conspiracy Theorists', bonusValue: 1, population: 'medium', hotspot: 'Portland Sasquatch Co-op' },
   
   // Low Population States
-  { id: '02', name: 'Alaska', abbreviation: 'AK', baseIP: 1, defense: 1, specialBonus: 'Oil Reserves', bonusValue: 3, population: 'low' },
-  { id: '15', name: 'Hawaii', abbreviation: 'HI', baseIP: 1, defense: 1, specialBonus: 'Pacific Base', bonusValue: 2, population: 'low' },
-  { id: '56', name: 'Wyoming', abbreviation: 'WY', baseIP: 1, defense: 1, specialBonus: 'Nuclear Silos', bonusValue: 2, population: 'low' },
-  { id: '50', name: 'Vermont', abbreviation: 'VT', baseIP: 1, defense: 1, specialBonus: 'Maple Syrup Monopoly', bonusValue: 1, population: 'low' },
-  { id: '10', name: 'Delaware', abbreviation: 'DE', baseIP: 2, defense: 2, specialBonus: 'Corporate Haven', bonusValue: 2, population: 'low' },
-  { id: '33', name: 'New Hampshire', abbreviation: 'NH', baseIP: 1, defense: 1, specialBonus: 'First Primary', bonusValue: 1, population: 'low' },
-  { id: '44', name: 'Rhode Island', abbreviation: 'RI', baseIP: 1, defense: 1, specialBonus: 'Organized Crime', bonusValue: 1, population: 'low' },
-  { id: '23', name: 'Maine', abbreviation: 'ME', baseIP: 1, defense: 1, specialBonus: 'Lobster Cartel', bonusValue: 1, population: 'low' },
-  { id: '25', name: 'Massachusetts', abbreviation: 'MA', baseIP: 3, defense: 3, specialBonus: 'Elite Universities', bonusValue: 2, population: 'high' },
-  { id: '34', name: 'New Jersey', abbreviation: 'NJ', baseIP: 3, defense: 3, specialBonus: 'Pharmaceutical Giants', bonusValue: 2, population: 'high' },
+  { id: '02', name: 'Alaska', abbreviation: 'AK', baseIP: 1, defense: 1, specialBonus: 'Oil Reserves', bonusValue: 3, population: 'low', hotspot: 'Anchorage Northern Lights Lab' },
+  { id: '15', name: 'Hawaii', abbreviation: 'HI', baseIP: 1, defense: 1, specialBonus: 'Pacific Base', bonusValue: 2, population: 'low', hotspot: 'Mauna Loa Volcano Listening Post' },
+  { id: '56', name: 'Wyoming', abbreviation: 'WY', baseIP: 1, defense: 1, specialBonus: 'Nuclear Silos', bonusValue: 2, population: 'low', hotspot: 'Yellowstone Geyser Launchpad' },
+  { id: '50', name: 'Vermont', abbreviation: 'VT', baseIP: 1, defense: 1, specialBonus: 'Maple Syrup Monopoly', bonusValue: 1, population: 'low', hotspot: 'Maple Time Slip Observatory' },
+  { id: '10', name: 'Delaware', abbreviation: 'DE', baseIP: 2, defense: 2, specialBonus: 'Corporate Haven', bonusValue: 2, population: 'low', hotspot: 'Dover Shell Company Bunker' },
+  { id: '33', name: 'New Hampshire', abbreviation: 'NH', baseIP: 1, defense: 1, specialBonus: 'First Primary', bonusValue: 1, population: 'low', hotspot: 'Mount Washington Weather Mind' },
+  { id: '44', name: 'Rhode Island', abbreviation: 'RI', baseIP: 1, defense: 1, specialBonus: 'Organized Crime', bonusValue: 1, population: 'low', hotspot: 'Providence Mob Seance Den' },
+  { id: '23', name: 'Maine', abbreviation: 'ME', baseIP: 1, defense: 1, specialBonus: 'Lobster Cartel', bonusValue: 1, population: 'low', hotspot: 'Lobster Boat Periscope Fleet' },
+  { id: '25', name: 'Massachusetts', abbreviation: 'MA', baseIP: 3, defense: 3, specialBonus: 'Elite Universities', bonusValue: 2, population: 'high', hotspot: 'Boston Harbor Zeitgeist Scanner' },
+  { id: '34', name: 'New Jersey', abbreviation: 'NJ', baseIP: 3, defense: 3, specialBonus: 'Pharmaceutical Giants', bonusValue: 2, population: 'high', hotspot: 'Pine Barrens Jersey Devil Aviary' },
   
   // Plains States
-  { id: '31', name: 'Nebraska', abbreviation: 'NE', baseIP: 1, defense: 1, specialBonus: 'Corn Empire', bonusValue: 1, population: 'low' },
-  { id: '20', name: 'Kansas', abbreviation: 'KS', baseIP: 1, defense: 1, specialBonus: 'Wheat Fields', bonusValue: 1, population: 'low' },
-  { id: '38', name: 'North Dakota', abbreviation: 'ND', baseIP: 1, defense: 1, specialBonus: 'Oil Boom', bonusValue: 2, population: 'low' },
-  { id: '46', name: 'South Dakota', abbreviation: 'SD', baseIP: 1, defense: 1, specialBonus: 'Gold Mines', bonusValue: 2, population: 'low' },
-  { id: '19', name: 'Iowa', abbreviation: 'IA', baseIP: 1, defense: 1, specialBonus: 'Alien Corn Circles', bonusValue: 1, population: 'low' },
-  { id: '40', name: 'Oklahoma', abbreviation: 'OK', baseIP: 2, defense: 2, specialBonus: 'Oil Wells', bonusValue: 1, population: 'medium' },
+  { id: '31', name: 'Nebraska', abbreviation: 'NE', baseIP: 1, defense: 1, specialBonus: 'Corn Empire', bonusValue: 1, population: 'low', hotspot: 'Cornhusker Crop Circle Depot' },
+  { id: '20', name: 'Kansas', abbreviation: 'KS', baseIP: 1, defense: 1, specialBonus: 'Wheat Fields', bonusValue: 1, population: 'low', hotspot: 'Twister Drone Control Barn' },
+  { id: '38', name: 'North Dakota', abbreviation: 'ND', baseIP: 1, defense: 1, specialBonus: 'Oil Boom', bonusValue: 2, population: 'low', hotspot: 'Williston Fracking Stargate' },
+  { id: '46', name: 'South Dakota', abbreviation: 'SD', baseIP: 1, defense: 1, specialBonus: 'Gold Mines', bonusValue: 2, population: 'low', hotspot: 'Badlands Pheasant Recon Post' },
+  { id: '19', name: 'Iowa', abbreviation: 'IA', baseIP: 1, defense: 1, specialBonus: 'Alien Corn Circles', bonusValue: 1, population: 'low', hotspot: 'Des Moines Hybrid Corn Lab' },
+  { id: '40', name: 'Oklahoma', abbreviation: 'OK', baseIP: 2, defense: 2, specialBonus: 'Oil Wells', bonusValue: 1, population: 'medium', hotspot: 'Tulsa Tornado Surveillance Dome' },
   
   // Mountain States  
-  { id: '30', name: 'Montana', abbreviation: 'MT', baseIP: 1, defense: 1, specialBonus: 'Militia Groups', bonusValue: 1, population: 'low' },
-  { id: '16', name: 'Idaho', abbreviation: 'ID', baseIP: 1, defense: 1, specialBonus: 'Potato Cartel', bonusValue: 1, population: 'low' },
-  { id: '54', name: 'West Virginia', abbreviation: 'WV', baseIP: 1, defense: 1, specialBonus: 'Underground Bunkers', bonusValue: 1, population: 'low' }
+  { id: '30', name: 'Montana', abbreviation: 'MT', baseIP: 1, defense: 1, specialBonus: 'Militia Groups', bonusValue: 1, population: 'low', hotspot: 'Blackfoot Ridge Watchtower' },
+  { id: '16', name: 'Idaho', abbreviation: 'ID', baseIP: 1, defense: 1, specialBonus: 'Potato Cartel', bonusValue: 1, population: 'low', hotspot: 'Boise Potato Psy Ops Silo' },
+  { id: '54', name: 'West Virginia', abbreviation: 'WV', baseIP: 1, defense: 1, specialBonus: 'Underground Bunkers', bonusValue: 1, population: 'low', hotspot: 'Greenbrier Bunker Ballroom' }
 ];
 
 // Helper functions

--- a/src/features/ui/frontPage/EvidenceTrackMeter.tsx
+++ b/src/features/ui/frontPage/EvidenceTrackMeter.tsx
@@ -1,0 +1,85 @@
+import type { EvidenceTrackState } from '@/hooks/gameStateTypes';
+
+interface EvidenceTrackMeterProps {
+  truth: number;
+  evidence: EvidenceTrackState;
+  faction: 'truth' | 'government';
+}
+
+const clamp = (value: number, min: number, max: number) => Math.max(min, Math.min(max, value));
+
+const ThresholdMarker = ({ value, label }: { value: number; label: string }) => (
+  <div
+    className="absolute top-0 h-full"
+    style={{ left: `${value}%` }}
+  >
+    <div className="h-full w-[2px] bg-black/30" />
+    <div className="mt-1 text-[10px] font-mono text-black/60 -translate-x-1/2">{label}</div>
+  </div>
+);
+
+export const EvidenceTrackMeter = ({ truth, evidence, faction }: EvidenceTrackMeterProps) => {
+  const normalized = clamp(truth, 0, 100);
+  const exposeOwner = evidence.exposeOwner;
+  const obfuscateOwner = evidence.obfuscateOwner;
+  const exposeReady = evidence.exposeReady;
+  const obfuscateReady = evidence.obfuscateReady;
+
+  const exposeLabel = exposeReady
+    ? exposeOwner === 'human'
+      ? 'Expose! Ready for you'
+      : 'Expose! Ready for rival'
+    : 'Expose! idle';
+
+  const obfuscateLabel = obfuscateReady
+    ? obfuscateOwner === 'human'
+      ? 'Obfuscate primed for you'
+      : 'Obfuscate primed for rival'
+    : 'Obfuscate dormant';
+
+  const alignmentLabel = faction === 'truth' ? 'Truth coalition' : 'Government division';
+
+  return (
+    <div className="w-full rounded-xl border-2 border-black bg-white p-3 shadow-[3px_3px_0_#000]">
+      <div className="flex items-baseline justify-between">
+        <div>
+          <div className="text-xs font-black uppercase tracking-widest text-black/60">Evidence vs. Red Tape</div>
+          <div className="text-[10px] uppercase text-black/50">{alignmentLabel}</div>
+        </div>
+        <div className="text-sm font-mono font-black text-black">{normalized}% TRUTH</div>
+      </div>
+      <div className="relative mt-3 h-5 overflow-hidden rounded-full border border-black/30 bg-gradient-to-r from-slate-200 via-white to-amber-100">
+        <div
+          className="absolute inset-y-0 left-0 bg-gradient-to-r from-red-500 via-yellow-400 to-sky-400 transition-all"
+          style={{ width: `${normalized}%` }}
+        />
+        <ThresholdMarker value={10} label="CLASSIFIED" />
+        <ThresholdMarker value={30} label="Red Tape" />
+        <ThresholdMarker value={70} label="Expose" />
+        <ThresholdMarker value={90} label="Smoking Gun" />
+      </div>
+      <div className="mt-2 grid grid-cols-2 gap-2 text-[11px] font-mono uppercase">
+        <div
+          className={`rounded border px-2 py-1 text-center ${
+            exposeReady
+              ? 'border-red-500 text-red-600 shadow-[2px_2px_0_rgba(220,38,38,0.4)]'
+              : 'border-black/20 text-black/60'
+          }`}
+        >
+          {exposeLabel}
+        </div>
+        <div
+          className={`rounded border px-2 py-1 text-center ${
+            obfuscateReady
+              ? 'border-blue-600 text-blue-700 shadow-[2px_2px_0_rgba(37,99,235,0.35)]'
+              : 'border-black/20 text-black/60'
+          }`}
+        >
+          {obfuscateLabel}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default EvidenceTrackMeter;

--- a/src/features/ui/frontPage/FrontPageLayout.tsx
+++ b/src/features/ui/frontPage/FrontPageLayout.tsx
@@ -1,0 +1,232 @@
+import { useEffect, useMemo, useState } from 'react';
+import BaseCard from '@/components/game/cards/BaseCard';
+import type { CardPlayRecord } from '@/hooks/gameStateTypes';
+import type { GameCard } from '@/rules/mvp';
+import { FRONT_PAGE_SLOT_META } from '@/game/frontPage';
+import { getStateByAbbreviation, getStateById } from '@/data/usaStates';
+import { EvidenceTrackMeter } from './EvidenceTrackMeter';
+import { PublicFrenzyMeter } from './PublicFrenzyMeter';
+import { TickerTape } from './TickerTape';
+import { StuntBadge } from './StuntBadge';
+import type { EvidenceTrackState, PublicFrenzyState } from '@/hooks/gameStateTypes';
+import { useAudioContext } from '@/contexts/AudioContext';
+
+interface FrontPageLayoutProps {
+  cards: CardPlayRecord[];
+  onInspectCard?: (card: GameCard) => void;
+  faction: 'truth' | 'government';
+  evidence: EvidenceTrackState;
+  publicFrenzy: PublicFrenzyState;
+  truth: number;
+}
+
+const resolveHotspot = (stateId?: string | null): string | null => {
+  if (!stateId) return null;
+  const byId = getStateById(stateId);
+  if (byId && 'hotspot' in byId && typeof (byId as any).hotspot === 'string') {
+    return (byId as any).hotspot;
+  }
+  const byAbbr = getStateByAbbreviation(stateId.toUpperCase());
+  if (byAbbr && 'hotspot' in byAbbr && typeof (byAbbr as any).hotspot === 'string') {
+    return (byAbbr as any).hotspot;
+  }
+  return null;
+};
+
+const extractPressure = (record: CardPlayRecord): number | null => {
+  if (record.card.type !== 'ZONE') {
+    return null;
+  }
+  const effects = record.card.effects as { pressureDelta?: number } | undefined;
+  return typeof effects?.pressureDelta === 'number' ? effects.pressureDelta : null;
+};
+
+const CardTile = ({
+  record,
+  highlight,
+  onInspect,
+}: {
+  record: CardPlayRecord;
+  highlight: boolean;
+  onInspect?: (card: GameCard) => void;
+}) => {
+  const factionLabel = record.faction === 'truth' ? 'Truth' : 'Government';
+  const truthDelta = record.truthDelta;
+  const ipDelta = record.player === 'human' ? record.ipDelta : record.aiIpDelta;
+  return (
+    <button
+      type="button"
+      onClick={() => onInspect?.(record.card)}
+      className={`group relative w-full text-left transition-transform duration-200 ${
+        highlight ? 'scale-[1.03]' : 'hover:scale-[1.02]'
+      }`}
+    >
+      <div
+        className={`rounded-lg border-2 border-black bg-white p-2 shadow-[4px_4px_0_#000] ${
+          highlight ? 'ring-2 ring-yellow-400' : ''
+        }`}
+      >
+        <div className="flex items-center justify-between text-[11px] font-mono uppercase text-black/70">
+          <span>{factionLabel}</span>
+          <span>{record.card.type}</span>
+        </div>
+        <div className="mt-2">
+          <BaseCard card={record.card} size="boardMini" polaroidHover={false} />
+        </div>
+        <div className="mt-2 text-[11px] font-mono uppercase text-black/70">
+          {truthDelta !== 0 && <div>Truth {truthDelta > 0 ? '+' : ''}{truthDelta}%</div>}
+          {ipDelta !== 0 && <div>IP {ipDelta > 0 ? '+' : ''}{ipDelta}</div>}
+        </div>
+      </div>
+    </button>
+  );
+};
+
+export const FrontPageLayout = ({
+  cards,
+  onInspectCard,
+  faction,
+  evidence,
+  publicFrenzy,
+  truth,
+}: FrontPageLayoutProps) => {
+  const [highlightedId, setHighlightedId] = useState<string | null>(null);
+  const audio = useAudioContext();
+
+  useEffect(() => {
+    let timeout: number | null = null;
+    const handler = (event: Event) => {
+      const custom = event as CustomEvent<{ cardId?: string }>;
+      if (!custom.detail?.cardId) {
+        return;
+      }
+      setHighlightedId(custom.detail.cardId);
+      audio?.playSFX?.('typewriter');
+      if (timeout) {
+        window.clearTimeout(timeout);
+      }
+      timeout = window.setTimeout(() => setHighlightedId(null), 1600);
+    };
+
+    window.addEventListener('frontPageSlotReveal', handler as EventListener);
+    return () => {
+      if (timeout) {
+        window.clearTimeout(timeout);
+      }
+      window.removeEventListener('frontPageSlotReveal', handler as EventListener);
+    };
+  }, [audio]);
+
+  const grouped = useMemo(() => {
+    return cards.reduce<Record<'top-banner' | 'main-photo' | 'sidebar', CardPlayRecord[]>>(
+      (acc, record) => {
+        acc[record.frontPageSlot].push(record);
+        return acc;
+      },
+      { 'top-banner': [], 'main-photo': [], sidebar: [] },
+    );
+  }, [cards]);
+
+  const tickerMessages = useMemo(() => {
+    return cards
+      .slice(-5)
+      .reverse()
+      .map(record => `${record.faction === 'truth' ? 'Truth' : 'Gov'} ${record.card.type} — ${record.card.name}`);
+  }, [cards]);
+
+  const mainFeature = grouped['main-photo'][0];
+  const secondaryFeature = grouped['main-photo'].slice(1);
+
+  return (
+    <div className="space-y-4">
+      <div className="grid gap-4 lg:grid-cols-[2fr_1fr]">
+        <div className="space-y-3">
+          <EvidenceTrackMeter truth={truth} evidence={evidence} faction={faction} />
+          <div className="rounded-2xl border-4 border-black bg-[#fdf7e3] p-4 shadow-[6px_6px_0_#000]">
+            <header className="mb-3 border-b-2 border-dashed border-black/40 pb-2">
+              <div className="text-lg font-black uppercase tracking-[0.4em]">{FRONT_PAGE_SLOT_META['top-banner'].label}</div>
+              <div className="text-[11px] font-mono uppercase text-black/60">{FRONT_PAGE_SLOT_META['top-banner'].caption}</div>
+            </header>
+            <div className="grid gap-3 md:grid-cols-2">
+              {grouped['top-banner'].map(record => (
+                <CardTile
+                  key={`${record.card.id}-${record.turn}`}
+                  record={record}
+                  highlight={highlightedId === record.card.id}
+                  onInspect={onInspectCard}
+                />
+              ))}
+              {grouped['top-banner'].length === 0 && (
+                <div className="col-span-full rounded border border-dashed border-black/20 bg-white/70 p-4 text-center text-[11px] font-mono uppercase text-black/50">
+                  Awaiting fresh leaks for the banner.
+                </div>
+              )}
+            </div>
+          </div>
+          <div className="rounded-2xl border-4 border-black bg-white p-4 shadow-[6px_6px_0_#000]">
+            <header className="mb-3 border-b-2 border-dashed border-black/40 pb-2">
+              <div className="text-lg font-black uppercase tracking-[0.4em]">{FRONT_PAGE_SLOT_META['main-photo'].label}</div>
+              <div className="text-[11px] font-mono uppercase text-black/60">{FRONT_PAGE_SLOT_META['main-photo'].caption}</div>
+            </header>
+            {mainFeature ? (
+              <div>
+                <CardTile
+                  record={mainFeature}
+                  highlight={highlightedId === mainFeature.card.id}
+                  onInspect={onInspectCard}
+                />
+                <StuntBadge
+                  hotspot={resolveHotspot(mainFeature.targetState)}
+                  pressure={extractPressure(mainFeature)}
+                />
+              </div>
+            ) : (
+              <div className="rounded border border-dashed border-black/20 bg-white/70 p-6 text-center text-[11px] font-mono uppercase text-black/50">
+                No stunts captured on camera this round.
+              </div>
+            )}
+            {secondaryFeature.length > 0 && (
+              <div className="mt-4 grid gap-3 md:grid-cols-2">
+                {secondaryFeature.map(record => (
+                  <CardTile
+                    key={`${record.card.id}-${record.turn}`}
+                    record={record}
+                    highlight={highlightedId === record.card.id}
+                    onInspect={onInspectCard}
+                  />
+                ))}
+              </div>
+            )}
+          </div>
+          <TickerTape messages={tickerMessages} />
+        </div>
+        <aside className="space-y-3">
+          <PublicFrenzyMeter frenzy={publicFrenzy} />
+          <div className="rounded-2xl border-4 border-black bg-[#f4f9ff] p-4 shadow-[6px_6px_0_#000]">
+            <header className="mb-3 border-b-2 border-dashed border-black/30 pb-2">
+              <div className="text-lg font-black uppercase tracking-[0.4em]">{FRONT_PAGE_SLOT_META.sidebar.label}</div>
+              <div className="text-[11px] font-mono uppercase text-black/60">{FRONT_PAGE_SLOT_META.sidebar.caption}</div>
+            </header>
+            <div className="space-y-3">
+              {grouped.sidebar.map(record => (
+                <CardTile
+                  key={`${record.card.id}-${record.turn}`}
+                  record={record}
+                  highlight={highlightedId === record.card.id}
+                  onInspect={onInspectCard}
+                />
+              ))}
+              {grouped.sidebar.length === 0 && (
+                <div className="rounded border border-dashed border-black/20 bg-white/70 p-4 text-center text-[11px] font-mono uppercase text-black/50">
+                  Sidebar memos pending clearance.
+                </div>
+              )}
+            </div>
+          </div>
+        </aside>
+      </div>
+    </div>
+  );
+};
+
+export default FrontPageLayout;

--- a/src/features/ui/frontPage/PublicFrenzyMeter.tsx
+++ b/src/features/ui/frontPage/PublicFrenzyMeter.tsx
@@ -1,0 +1,59 @@
+import type { PublicFrenzyState } from '@/hooks/gameStateTypes';
+
+interface PublicFrenzyMeterProps {
+  frenzy: PublicFrenzyState;
+}
+
+const clamp = (value: number, min: number, max: number) => Math.max(min, Math.min(max, value));
+
+export const PublicFrenzyMeter = ({ frenzy }: PublicFrenzyMeterProps) => {
+  const normalized = clamp(frenzy.value, 0, 100);
+  const bonusActive = frenzy.bonusHeadlineActiveFor;
+  const initiativeActive = frenzy.governmentInitiativeActiveFor;
+
+  return (
+    <div className="rounded-xl border-2 border-black bg-white p-3 shadow-[3px_3px_0_#000]">
+      <div className="flex items-baseline justify-between">
+        <div>
+          <div className="text-xs font-black uppercase tracking-widest text-black/60">Public Frenzy Meter</div>
+          <div className="text-[10px] uppercase text-black/50">Tabloid hysteria vs. government calm</div>
+        </div>
+        <div className="text-sm font-mono font-black text-black">{normalized}%</div>
+      </div>
+      <div className="relative mt-3 h-4 overflow-hidden rounded-full border border-black/30 bg-gradient-to-r from-blue-200 via-white to-rose-200">
+        <div
+          className="absolute inset-y-0 left-0 bg-gradient-to-r from-blue-600 via-purple-400 to-rose-600 transition-all"
+          style={{ width: `${normalized}%` }}
+        />
+        <div className="absolute inset-y-0 left-[60%] w-[2px] bg-black/30" />
+        <div className="absolute inset-y-0 left-[40%] w-[2px] bg-black/20" />
+      </div>
+      <div className="mt-2 grid grid-cols-2 gap-2 text-[11px] font-mono uppercase">
+        <div
+          className={`rounded border px-2 py-1 text-center ${
+            bonusActive
+              ? 'border-rose-500 text-rose-600 shadow-[2px_2px_0_rgba(244,63,94,0.35)]'
+              : 'border-black/20 text-black/60'
+          }`}
+        >
+          {bonusActive
+            ? `Bonus headline slot held by ${bonusActive === 'human' ? 'you' : 'AI'}`
+            : 'No bonus headline slot'}
+        </div>
+        <div
+          className={`rounded border px-2 py-1 text-center ${
+            initiativeActive
+              ? 'border-blue-500 text-blue-600 shadow-[2px_2px_0_rgba(59,130,246,0.35)]'
+              : 'border-black/20 text-black/60'
+          }`}
+        >
+          {initiativeActive
+            ? `Initiative claimed by ${initiativeActive === 'human' ? 'you' : 'AI'}`
+            : 'Initiative neutral'}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default PublicFrenzyMeter;

--- a/src/features/ui/frontPage/StuntBadge.tsx
+++ b/src/features/ui/frontPage/StuntBadge.tsx
@@ -1,0 +1,23 @@
+interface StuntBadgeProps {
+  hotspot?: string | null;
+  pressure?: number | null;
+}
+
+export const StuntBadge = ({ hotspot, pressure }: StuntBadgeProps) => {
+  if (!hotspot && !pressure) {
+    return null;
+  }
+
+  const label = hotspot ? hotspot : 'Regional Stunt';
+  const pressureLabel = typeof pressure === 'number' && pressure !== 0 ? `${pressure > 0 ? '+' : ''}${pressure} Pressure` : null;
+
+  return (
+    <div className="mt-2 inline-flex items-center gap-2 rounded-full border border-dashed border-black/30 bg-amber-100/70 px-3 py-1 text-[11px] font-mono uppercase text-black/70">
+      <span role="img" aria-hidden="true">🎪</span>
+      <span>{label}</span>
+      {pressureLabel && <span className="rounded bg-black/10 px-2 py-0.5 text-[10px]">{pressureLabel}</span>}
+    </div>
+  );
+};
+
+export default StuntBadge;

--- a/src/features/ui/frontPage/TickerTape.tsx
+++ b/src/features/ui/frontPage/TickerTape.tsx
@@ -1,0 +1,27 @@
+import { useMemo } from 'react';
+
+interface TickerTapeProps {
+  messages: string[];
+}
+
+export const TickerTape = ({ messages }: TickerTapeProps) => {
+  const visible = useMemo(() => messages.slice(0, 3), [messages]);
+
+  if (visible.length === 0) {
+    return null;
+  }
+
+  return (
+    <div
+      className="mt-3 overflow-hidden rounded border-2 border-black bg-black text-[11px] font-mono uppercase text-yellow-300 shadow-[2px_2px_0_rgba(0,0,0,0.45)]"
+    >
+      <div className="flex animate-[ticker_18s_linear_infinite] gap-8 whitespace-nowrap py-1 px-3">
+        {visible.map((message, index) => (
+          <span key={`${message}-${index}`}>🛰️ {message}</span>
+        ))}
+      </div>
+    </div>
+  );
+};
+
+export default TickerTape;

--- a/src/game/frontPage.ts
+++ b/src/game/frontPage.ts
@@ -1,0 +1,93 @@
+import type { GameCard, FrontPageSlot, MVPCardType } from '@/rules/mvp';
+
+const DEFAULT_SLOT_BY_TYPE: Record<MVPCardType, FrontPageSlot> = {
+  MEDIA: 'top-banner',
+  ZONE: 'main-photo',
+  ATTACK: 'sidebar',
+};
+
+const FRONT_PAGE_SLOT_ALIASES: Record<string, FrontPageSlot> = {
+  banner: 'top-banner',
+  headline: 'top-banner',
+  masthead: 'top-banner',
+  photo: 'main-photo',
+  center: 'main-photo',
+  feature: 'main-photo',
+  sidebar: 'sidebar',
+  bulletin: 'sidebar',
+};
+
+export const FRONT_PAGE_SLOT_META: Record<FrontPageSlot, {
+  label: string;
+  caption: string;
+  icon: string;
+  toneClass: string;
+}> = {
+  'top-banner': {
+    label: 'Top Banner',
+    caption: 'Media exclusives scream across the masthead.',
+    icon: '📰',
+    toneClass: 'from-amber-100 via-yellow-50 to-amber-200',
+  },
+  'main-photo': {
+    label: 'Main Photo',
+    caption: 'Zone stunts splatter ink across the centerfold.',
+    icon: '📸',
+    toneClass: 'from-sky-200 via-indigo-100 to-sky-300',
+  },
+  sidebar: {
+    label: 'Sidebar',
+    caption: 'Attack memos whisper in the margins.',
+    icon: '📋',
+    toneClass: 'from-rose-100 via-pink-50 to-rose-200',
+  },
+};
+
+const normalizeSlotText = (slot?: string | null): FrontPageSlot | null => {
+  if (!slot) {
+    return null;
+  }
+
+  const normalized = slot.trim().toLowerCase();
+  if (!normalized.length) {
+    return null;
+  }
+
+  if ((['top-banner', 'main-photo', 'sidebar'] as const).includes(normalized as FrontPageSlot)) {
+    return normalized as FrontPageSlot;
+  }
+
+  const alias = FRONT_PAGE_SLOT_ALIASES[normalized];
+  if (alias) {
+    return alias;
+  }
+
+  const slug = normalized.replace(/[^a-z]+/g, '-').replace(/^-+|-+$/g, '');
+  if ((['top-banner', 'main-photo', 'sidebar'] as const).includes(slug as FrontPageSlot)) {
+    return slug as FrontPageSlot;
+  }
+
+  return null;
+};
+
+export function resolveFrontPageSlot(card: Pick<GameCard, 'type' | 'frontPageSlot'>): FrontPageSlot {
+  const explicit = normalizeSlotText(card.frontPageSlot ?? null);
+  if (explicit) {
+    return explicit;
+  }
+
+  const type = (card.type ?? 'MEDIA').toString().toUpperCase() as MVPCardType;
+  if (type in DEFAULT_SLOT_BY_TYPE) {
+    return DEFAULT_SLOT_BY_TYPE[type];
+  }
+
+  return 'sidebar';
+}
+
+export function describeFrontPageSlot(slot: FrontPageSlot): string {
+  return `${FRONT_PAGE_SLOT_META[slot].icon} ${FRONT_PAGE_SLOT_META[slot].label}`;
+}
+
+export function isFrontPageSlot(value: string): value is FrontPageSlot {
+  return (['top-banner', 'main-photo', 'sidebar'] as const).includes(value as FrontPageSlot);
+}

--- a/src/game/momentum.ts
+++ b/src/game/momentum.ts
@@ -1,0 +1,182 @@
+import type { GameCard } from '@/rules/mvp';
+import type {
+  EvidenceTrackState,
+  GameState,
+  PublicFrenzyState,
+} from '@/hooks/gameStateTypes';
+
+export const createEvidenceTrackState = (): EvidenceTrackState => ({
+  exposeReady: false,
+  exposeOwner: null,
+  exposeTriggered: false,
+  obfuscateReady: false,
+  obfuscateOwner: null,
+  obfuscateTriggered: false,
+});
+
+export const createPublicFrenzyState = (initialTruth: number = 50): PublicFrenzyState => ({
+  value: 50,
+  bonusHeadlineActiveFor: null,
+  governmentInitiativeActiveFor: null,
+  lastTruthSample: initialTruth,
+  underReviewState: null,
+});
+
+const clamp = (value: number, min: number, max: number): number => {
+  if (Number.isNaN(value)) {
+    return min;
+  }
+  return Math.max(min, Math.min(max, value));
+};
+
+const TRUTH_THRESHOLD_EXPOSE = 70;
+const TRUTH_THRESHOLD_OBFUSCATE = 30;
+const EXPOSE_RESET_THRESHOLD = 60;
+const OBFUSCATE_RESET_THRESHOLD = 40;
+const FRENZY_TRUTH_SPIKE = 60;
+const FRENZY_GOVERNMENT_LOCK = 40;
+export const BASE_PLAY_LIMIT = 3;
+
+const resolveTruthController = (state: GameState): { truth: 'human' | 'ai'; government: 'human' | 'ai' } => {
+  const truth = state.faction === 'truth' ? 'human' : 'ai';
+  return { truth, government: truth === 'human' ? 'ai' : 'human' };
+};
+
+interface TruthMomentumOptions {
+  previousTruth: number;
+  newTruth: number;
+  state: GameState;
+  actor: 'human' | 'ai';
+  card?: GameCard;
+}
+
+export function withTruthMomentum(options: TruthMomentumOptions): GameState {
+  const { previousTruth, newTruth, state } = options;
+  const { truth: truthController, government: governmentController } = resolveTruthController(state);
+
+  const evidence = state.evidenceTrack ? { ...state.evidenceTrack } : createEvidenceTrackState();
+  const frenzy = state.publicFrenzy
+    ? { ...state.publicFrenzy }
+    : createPublicFrenzyState(previousTruth ?? 50);
+  const log = [...(state.log ?? [])];
+
+  const next: GameState = {
+    ...state,
+    log,
+    evidenceTrack: evidence,
+    publicFrenzy: frenzy,
+  };
+
+  // Evidence vs. Red Tape milestones
+  if (!evidence.exposeTriggered && previousTruth < TRUTH_THRESHOLD_EXPOSE && newTruth >= TRUTH_THRESHOLD_EXPOSE) {
+    evidence.exposeReady = true;
+    evidence.exposeOwner = truthController;
+    evidence.exposeTriggered = true;
+    log.push('Expose! Evidence stash hits 70% — headline coupons unlocked.');
+  } else if (evidence.exposeTriggered && newTruth <= EXPOSE_RESET_THRESHOLD) {
+    evidence.exposeTriggered = false;
+    if (!evidence.exposeReady) {
+      evidence.exposeOwner = null;
+    }
+  }
+
+  if (!evidence.obfuscateTriggered && previousTruth > TRUTH_THRESHOLD_OBFUSCATE && newTruth <= TRUTH_THRESHOLD_OBFUSCATE) {
+    evidence.obfuscateReady = true;
+    evidence.obfuscateOwner = governmentController;
+    evidence.obfuscateTriggered = true;
+    log.push('Obfuscate protocol engaged — red tape discount secured.');
+  } else if (evidence.obfuscateTriggered && newTruth >= OBFUSCATE_RESET_THRESHOLD) {
+    evidence.obfuscateTriggered = false;
+    if (!evidence.obfuscateReady) {
+      evidence.obfuscateOwner = null;
+    }
+  }
+
+  // Public Frenzy momentum (react to ~10% truth swings)
+  const truthDelta = newTruth - frenzy.lastTruthSample;
+  const swingUnits = Math.trunc(truthDelta / 10);
+  if (swingUnits !== 0) {
+    const previousFrenzy = frenzy.value;
+    const updated = clamp(previousFrenzy + swingUnits * 10, 0, 100);
+    frenzy.value = updated;
+
+    if (previousFrenzy < FRENZY_TRUTH_SPIKE && updated >= FRENZY_TRUTH_SPIKE) {
+      frenzy.bonusHeadlineActiveFor = truthController;
+      log.push('Public Frenzy erupts! Truth side gains a bonus headline slot.');
+    }
+
+    if (previousFrenzy > FRENZY_GOVERNMENT_LOCK && updated <= FRENZY_GOVERNMENT_LOCK) {
+      frenzy.governmentInitiativeActiveFor = governmentController;
+      frenzy.underReviewState = options.card?.targetState ?? null;
+      log.push('Bureaucrats stamp UNDER REVIEW — government seizes initiative.');
+    }
+  }
+
+  frenzy.lastTruthSample = newTruth;
+
+  return next;
+}
+
+export const consumeExpose = (state: GameState, actor: 'human' | 'ai'): GameState => {
+  if (!state.evidenceTrack.exposeReady || state.evidenceTrack.exposeOwner !== actor) {
+    return state;
+  }
+
+  return {
+    ...state,
+    log: [...state.log, 'Expose! discount cashed in.'],
+    evidenceTrack: {
+      ...state.evidenceTrack,
+      exposeReady: false,
+      exposeOwner: null,
+    },
+  };
+};
+
+export const consumeObfuscate = (state: GameState, actor: 'human' | 'ai'): GameState => {
+  if (!state.evidenceTrack.obfuscateReady || state.evidenceTrack.obfuscateOwner !== actor) {
+    return state;
+  }
+
+  return {
+    ...state,
+    log: [...state.log, 'Obfuscate! paperwork bribes a fresh lead.'],
+    evidenceTrack: {
+      ...state.evidenceTrack,
+      obfuscateReady: false,
+      obfuscateOwner: null,
+    },
+  };
+};
+
+export const clearHeadlineBonus = (state: GameState, actor: 'human' | 'ai'): GameState => {
+  if (state.publicFrenzy.bonusHeadlineActiveFor !== actor) {
+    return state;
+  }
+  return {
+    ...state,
+    publicFrenzy: {
+      ...state.publicFrenzy,
+      bonusHeadlineActiveFor: null,
+    },
+  };
+};
+
+export const clearGovernmentInitiative = (state: GameState, actor: 'human' | 'ai'): GameState => {
+  if (state.publicFrenzy.governmentInitiativeActiveFor !== actor) {
+    return state;
+  }
+  return {
+    ...state,
+    publicFrenzy: {
+      ...state.publicFrenzy,
+      governmentInitiativeActiveFor: null,
+      underReviewState: null,
+    },
+  };
+};
+
+export const getMaxPlaysForTurn = (state: GameState, actor: 'human' | 'ai'): number => {
+  const bonus = state.publicFrenzy.bonusHeadlineActiveFor === actor ? 1 : 0;
+  return BASE_PLAY_LIMIT + bonus;
+};

--- a/src/hooks/aiHelpers.ts
+++ b/src/hooks/aiHelpers.ts
@@ -1,6 +1,15 @@
 import type { GameCard, Rarity } from '@/rules/mvp';
 import { featureFlags } from '@/state/featureFlags';
 import { resolveCardMVP, type AchievementTracker, type CardPlayResolution } from '@/systems/cardResolution';
+import { generateWeightedDeck } from '@/data/weightedCardDistribution';
+import {
+  consumeExpose,
+  consumeObfuscate,
+  clearHeadlineBonus,
+  clearGovernmentInitiative,
+  withTruthMomentum,
+} from '@/game/momentum';
+import { resolveFrontPageSlot } from '@/game/frontPage';
 import type { TurnPlay } from '@/game/combo.types';
 import type { PlayerId } from '@/mvp/validator';
 
@@ -51,6 +60,7 @@ export const createPlayedCardRecord = (params: {
     turn: params.turn,
     timestamp: Date.now(),
     logEntries: [...logEntries],
+    frontPageSlot: resolveFrontPageSlot(params.card),
   };
 };
 
@@ -267,10 +277,41 @@ export const applyAiCardPlay = (
     };
   }
 
-  const resolution = resolveCardMVP(prev, resolvedCard, targetState ?? null, 'ai', achievements);
+  const baseResolution = resolveCardMVP(prev, resolvedCard, targetState ?? null, 'ai', achievements);
+  const resolution = {
+    ...baseResolution,
+    logEntries: [...(baseResolution.logEntries ?? [])],
+  };
+
+  const exposeActive = prev.evidenceTrack.exposeReady && prev.evidenceTrack.exposeOwner === 'ai';
+  if (exposeActive) {
+    resolution.aiIP = resolution.aiIP + 1;
+    resolution.logEntries.push('Expose! Agency accountants skimmed +1 IP for the AI.');
+  }
+
+  const initiativeActive = prev.publicFrenzy.governmentInitiativeActiveFor === 'ai';
+  if (initiativeActive) {
+    resolution.aiIP = resolution.aiIP + 1;
+    resolution.logEntries.push('Initiative bonus: dossier stamped before the humans reacted (+1 IP).');
+  }
+
+  const obfuscateActive = prev.evidenceTrack.obfuscateReady && prev.evidenceTrack.obfuscateOwner === 'ai';
+  let updatedAiDeck = prev.aiDeck;
+  let bonusAiCards: GameCard[] = [];
+  if (obfuscateActive) {
+    if (updatedAiDeck.length === 0) {
+      const refillFaction = prev.faction === 'truth' ? 'government' : 'truth';
+      updatedAiDeck = generateWeightedDeck(40, refillFaction);
+    }
+    if (updatedAiDeck.length > 0) {
+      bonusAiCards = [updatedAiDeck[0]];
+      updatedAiDeck = updatedAiDeck.slice(1);
+      resolution.logEntries.push('Obfuscate! Bureaucrats slipped an extra directive into the AI dossier (+1 card).');
+    }
+  }
+
   const logEntries = [...prev.log, ...resolution.logEntries];
   const strategyLogEntries = buildStrategyLogEntries(reasoning, strategyDetails);
-
   if (strategyLogEntries.length) {
     logEntries.push(...strategyLogEntries);
   }
@@ -296,7 +337,7 @@ export const applyAiCardPlay = (
     resolution,
   });
 
-  const nextState: GameState = {
+  let nextState: GameState = {
     ...prev,
     ip: resolution.ip,
     aiIP: resolution.aiIP,
@@ -305,12 +346,37 @@ export const applyAiCardPlay = (
     controlledStates: resolution.controlledStates,
     aiControlledStates: resolution.aiControlledStates,
     targetState: resolution.targetState,
-    aiHand: prev.aiHand.filter(c => c.id !== resolvedCard.id),
+    aiHand: [...prev.aiHand.filter(c => c.id !== resolvedCard.id), ...bonusAiCards],
+    aiDeck: updatedAiDeck,
     cardsPlayedThisRound: [...prev.cardsPlayedThisRound, playedCardRecord],
     playHistory: [...prev.playHistory, playedCardRecord],
     turnPlays: [...prev.turnPlays, ...turnPlayEntries],
     log: logEntries,
   };
+
+  if (initiativeActive) {
+    nextState = clearGovernmentInitiative(nextState, 'ai');
+  }
+
+  if (exposeActive) {
+    nextState = consumeExpose(nextState, 'ai');
+  }
+
+  if (obfuscateActive) {
+    nextState = consumeObfuscate(nextState, 'ai');
+  }
+
+  if (prev.publicFrenzy.bonusHeadlineActiveFor === 'ai') {
+    nextState = clearHeadlineBonus(nextState, 'ai');
+  }
+
+  nextState = withTruthMomentum({
+    previousTruth: prev.truth,
+    newTruth: resolution.truth,
+    state: nextState,
+    actor: 'ai',
+    card: resolvedCard,
+  });
 
   return {
     nextState,

--- a/src/hooks/gameStateTypes.ts
+++ b/src/hooks/gameStateTypes.ts
@@ -1,4 +1,4 @@
-import type { GameCard } from '@/rules/mvp';
+import type { FrontPageSlot, GameCard } from '@/rules/mvp';
 import type { EventManager, GameEvent } from '@/data/eventDatabase';
 import type { SecretAgenda } from '@/data/agendaDatabase';
 import type { EnhancedAIStrategist } from '@/data/enhancedAIStrategy';
@@ -20,6 +20,24 @@ export interface CardPlayRecord {
   turn: number;
   timestamp: number;
   logEntries: string[];
+  frontPageSlot: FrontPageSlot;
+}
+
+export interface EvidenceTrackState {
+  exposeReady: boolean;
+  exposeOwner: 'human' | 'ai' | null;
+  exposeTriggered: boolean;
+  obfuscateReady: boolean;
+  obfuscateOwner: 'human' | 'ai' | null;
+  obfuscateTriggered: boolean;
+}
+
+export interface PublicFrenzyState {
+  value: number;
+  bonusHeadlineActiveFor: 'human' | 'ai' | null;
+  governmentInitiativeActiveFor: 'human' | 'ai' | null;
+  lastTruthSample: number;
+  underReviewState?: string | null;
 }
 
 export interface GameState {
@@ -66,6 +84,8 @@ export interface GameState {
   eventManager?: EventManager;
   showNewspaper: boolean;
   log: string[];
+  evidenceTrack: EvidenceTrackState;
+  publicFrenzy: PublicFrenzyState;
   agenda?: SecretAgenda & {
     progress?: number;
     complete?: boolean;

--- a/src/hooks/useGameState.ts
+++ b/src/hooks/useGameState.ts
@@ -28,6 +28,16 @@ import {
   type AiCardPlayParams,
 } from './aiHelpers';
 import { evaluateCombosForTurn } from './comboAdapter';
+import {
+  createEvidenceTrackState,
+  createPublicFrenzyState,
+  withTruthMomentum,
+  consumeExpose,
+  consumeObfuscate,
+  clearHeadlineBonus,
+  clearGovernmentInitiative,
+  getMaxPlaysForTurn,
+} from '@/game/momentum';
 
 const omitClashKey = (key: string, value: unknown) => (key === 'clash' ? undefined : value);
 
@@ -199,6 +209,8 @@ export const useGameState = (aiDifficultyOverride?: AIDifficulty) => {
     currentEvents: [],
     eventManager,
     showNewspaper: false,
+    evidenceTrack: createEvidenceTrackState(),
+    publicFrenzy: createPublicFrenzyState(50),
     log: [
       'Game started - Truth Seekers faction selected',
       'Starting Truth: 50%',
@@ -317,6 +329,8 @@ export const useGameState = (aiDifficultyOverride?: AIDifficulty) => {
         `Cards drawn: ${handSize} (${drawMode} mode)`,
         `Controlled states: ${initialControl.player.join(', ')}`
       ],
+      evidenceTrack: createEvidenceTrackState(),
+      publicFrenzy: createPublicFrenzyState(startingTruth),
       drawMode,
       cardDrawState: {
         cardsPlayedLastTurn: 0,
@@ -325,55 +339,124 @@ export const useGameState = (aiDifficultyOverride?: AIDifficulty) => {
     }));
   }, [achievements, aiDifficulty]);
 
+  const finalizeHumanPlay = (
+    prev: GameState,
+    card: GameCard,
+    targetState: string | null,
+    baseResolution: CardPlayResolution,
+  ): GameState => {
+    const resolution = {
+      ...baseResolution,
+      logEntries: [...(baseResolution.logEntries ?? [])],
+    };
+
+    const exposeActive = prev.evidenceTrack.exposeReady && prev.evidenceTrack.exposeOwner === 'human';
+    if (exposeActive) {
+      resolution.ip = resolution.ip + 1;
+      resolution.logEntries.push('Expose! Coupon clipped the tabloid budget (+1 IP).');
+    }
+
+    const initiativeActive = prev.publicFrenzy.governmentInitiativeActiveFor === 'human';
+    if (initiativeActive) {
+      resolution.ip = resolution.ip + 1;
+      resolution.logEntries.push('Initiative bonus: bureaucracy fast-tracked +1 IP.');
+    }
+
+    const obfuscateActive = prev.evidenceTrack.obfuscateReady && prev.evidenceTrack.obfuscateOwner === 'human';
+    let updatedDeck = prev.deck;
+    let bonusCards: GameCard[] = [];
+    if (obfuscateActive) {
+      const drawResult = drawCardsFromDeck(updatedDeck, 1, prev.faction);
+      bonusCards = drawResult.drawn;
+      updatedDeck = drawResult.deck;
+      if (bonusCards.length > 0) {
+        resolution.logEntries.push('Obfuscate! Red tape unearthed a replacement dossier (+1 card).');
+      }
+    }
+
+    const playedCardRecord = createPlayedCardRecord({
+      card,
+      player: 'human',
+      faction: prev.faction,
+      targetState,
+      resolution,
+      previousTruth: prev.truth,
+      previousIp: prev.ip,
+      previousAiIP: prev.aiIP,
+      round: prev.round,
+      turn: prev.turn,
+    });
+
+    const turnPlayEntries = createTurnPlayEntries({
+      state: prev,
+      card,
+      owner: 'human',
+      targetState,
+      resolution,
+    });
+
+    const handWithoutCard = prev.hand.filter(c => c.id !== card.id);
+    let nextState: GameState = {
+      ...prev,
+      hand: bonusCards.length > 0 ? [...handWithoutCard, ...bonusCards] : handWithoutCard,
+      deck: updatedDeck,
+      ip: resolution.ip,
+      aiIP: resolution.aiIP,
+      truth: resolution.truth,
+      states: resolution.states,
+      controlledStates: resolution.controlledStates,
+      aiControlledStates: resolution.aiControlledStates,
+      cardsPlayedThisTurn: prev.cardsPlayedThisTurn + 1,
+      cardsPlayedThisRound: [...prev.cardsPlayedThisRound, playedCardRecord],
+      playHistory: [...prev.playHistory, playedCardRecord],
+      turnPlays: [...prev.turnPlays, ...turnPlayEntries],
+      targetState: resolution.targetState,
+      selectedCard: resolution.selectedCard,
+      log: [...prev.log, ...resolution.logEntries],
+    };
+
+    if (initiativeActive) {
+      nextState = clearGovernmentInitiative(nextState, 'human');
+    }
+
+    if (exposeActive) {
+      nextState = consumeExpose(nextState, 'human');
+    }
+
+    if (obfuscateActive) {
+      nextState = consumeObfuscate(nextState, 'human');
+    }
+
+    const hadHeadlineBonus = prev.publicFrenzy.bonusHeadlineActiveFor === 'human';
+    const previousMax = getMaxPlaysForTurn(prev, 'human');
+    if (hadHeadlineBonus && prev.cardsPlayedThisTurn + 1 >= previousMax) {
+      nextState = clearHeadlineBonus(nextState, 'human');
+    }
+
+    nextState = withTruthMomentum({
+      previousTruth: prev.truth,
+      newTruth: resolution.truth,
+      state: nextState,
+      actor: 'human',
+      card,
+    });
+
+    return nextState;
+  };
+
   const playCard = useCallback((cardId: string, targetOverride?: string | null) => {
     setGameState(prev => {
       const card = prev.hand.find(c => c.id === cardId);
-      if (!card || prev.ip < card.cost || prev.cardsPlayedThisTurn >= 3 || prev.animating) {
+      const maxPlays = getMaxPlaysForTurn(prev, 'human');
+      if (!card || prev.ip < card.cost || prev.cardsPlayedThisTurn >= maxPlays || prev.animating) {
         return prev;
       }
 
       achievements.onCardPlayed(cardId, card.type, card.rarity);
 
       const targetState = targetOverride ?? prev.targetState ?? null;
-      const resolution = resolveCardEffects(prev, card, targetState);
-      const playedCardRecord = createPlayedCardRecord({
-        card,
-        player: 'human',
-        faction: prev.faction,
-        targetState,
-        resolution,
-        previousTruth: prev.truth,
-        previousIp: prev.ip,
-        previousAiIP: prev.aiIP,
-        round: prev.round,
-        turn: prev.turn,
-      });
-
-      const turnPlayEntries = createTurnPlayEntries({
-        state: prev,
-        card,
-        owner: 'human',
-        targetState,
-        resolution,
-      });
-
-      return {
-        ...prev,
-        hand: prev.hand.filter(c => c.id !== cardId),
-        ip: resolution.ip,
-        aiIP: resolution.aiIP,
-        truth: resolution.truth,
-        states: resolution.states,
-        controlledStates: resolution.controlledStates,
-        aiControlledStates: resolution.aiControlledStates,
-        cardsPlayedThisTurn: prev.cardsPlayedThisTurn + 1,
-        cardsPlayedThisRound: [...prev.cardsPlayedThisRound, playedCardRecord],
-        playHistory: [...prev.playHistory, playedCardRecord],
-        turnPlays: [...prev.turnPlays, ...turnPlayEntries],
-        targetState: resolution.targetState,
-        selectedCard: resolution.selectedCard,
-        log: [...prev.log, ...resolution.logEntries]
-      };
+      const baseResolution = resolveCardEffects(prev, card, targetState);
+      return finalizeHumanPlay(prev, card, targetState, baseResolution);
     });
   }, [achievements, resolveCardEffects]);
 
@@ -383,15 +466,15 @@ export const useGameState = (aiDifficultyOverride?: AIDifficulty) => {
     explicitTargetState?: string
   ) => {
     const card = gameState.hand.find(c => c.id === cardId);
-    if (!card || gameState.ip < card.cost || gameState.cardsPlayedThisTurn >= 3 || gameState.animating) {
+    const maxPlays = getMaxPlaysForTurn(gameState, 'human');
+    if (!card || gameState.ip < card.cost || gameState.cardsPlayedThisTurn >= maxPlays || gameState.animating) {
       return;
     }
 
     achievements.onCardPlayed(cardId, card.type, card.rarity);
 
     const targetState = explicitTargetState ?? gameState.targetState ?? null;
-    let pendingRecord: ReturnType<typeof createPlayedCardRecord> | null = null;
-    let pendingTurnPlays: ReturnType<typeof createTurnPlayEntries> | null = null;
+    let pendingResolution: CardPlayResolution | null = null;
 
     setGameState(prev => {
       if (prev.animating) {
@@ -399,26 +482,7 @@ export const useGameState = (aiDifficultyOverride?: AIDifficulty) => {
       }
 
       const resolution = resolveCardEffects(prev, card, targetState);
-      pendingRecord = createPlayedCardRecord({
-        card,
-        player: 'human',
-        faction: prev.faction,
-        targetState,
-        resolution,
-        previousTruth: prev.truth,
-        previousIp: prev.ip,
-        previousAiIP: prev.aiIP,
-        round: prev.round,
-        turn: prev.turn,
-      });
-
-      pendingTurnPlays = createTurnPlayEntries({
-        state: prev,
-        card,
-        owner: 'human',
-        targetState,
-        resolution,
-      });
+      pendingResolution = resolution;
 
       return {
         ...prev,
@@ -442,61 +506,25 @@ export const useGameState = (aiDifficultyOverride?: AIDifficulty) => {
       });
 
       setGameState(prev => {
-        const record = pendingRecord ?? {
-          card,
-          player: 'human' as const,
-          faction: prev.faction,
-          targetState: targetState ?? null,
-          truthDelta: 0,
-          ipDelta: 0,
-          aiIpDelta: 0,
-          capturedStates: [],
-          damageDealt: 0,
-          round: prev.round,
-          turn: prev.turn,
-          timestamp: Date.now(),
-          logEntries: [],
-        };
+        const baseResolution = pendingResolution ?? resolveCardEffects(prev, card, targetState);
+        const finalized = finalizeHumanPlay(prev, card, targetState ?? null, baseResolution);
         return {
-          ...prev,
-          hand: prev.hand.filter(c => c.id !== cardId),
-          cardsPlayedThisTurn: prev.cardsPlayedThisTurn + 1,
-          cardsPlayedThisRound: [...prev.cardsPlayedThisRound, record],
-          playHistory: [...prev.playHistory, record],
-          turnPlays: [...prev.turnPlays, ...(pendingTurnPlays ?? [])],
+          ...finalized,
+          animating: false,
           selectedCard: null,
           targetState: null,
-          animating: false,
         };
       });
     } catch (error) {
       console.error('Card animation failed:', error);
       setGameState(prev => {
-        const record = pendingRecord ?? {
-          card,
-          player: 'human' as const,
-          faction: prev.faction,
-          targetState: targetState ?? null,
-          truthDelta: 0,
-          ipDelta: 0,
-          aiIpDelta: 0,
-          capturedStates: [],
-          damageDealt: 0,
-          round: prev.round,
-          turn: prev.turn,
-          timestamp: Date.now(),
-          logEntries: [],
-        };
+        const baseResolution = pendingResolution ?? resolveCardEffects(prev, card, targetState);
+        const finalized = finalizeHumanPlay(prev, card, targetState ?? null, baseResolution);
         return {
-          ...prev,
-          hand: prev.hand.filter(c => c.id !== cardId),
-          cardsPlayedThisTurn: prev.cardsPlayedThisTurn + 1,
-          cardsPlayedThisRound: [...prev.cardsPlayedThisRound, record],
-          playHistory: [...prev.playHistory, record],
-          turnPlays: [...prev.turnPlays, ...(pendingTurnPlays ?? [])],
+          ...finalized,
+          animating: false,
           selectedCard: null,
           targetState: null,
-          animating: false,
         };
       });
     }
@@ -618,13 +646,21 @@ export const useGameState = (aiDifficultyOverride?: AIDifficulty) => {
         applyTruthDelta(nextState, truthModifier, 'human');
         nextState.log.push(`AI ${prev.aiStrategist?.personality.name} is thinking...`);
 
-        return nextState;
+        let adjusted = nextState;
+        if (nextState.publicFrenzy.bonusHeadlineActiveFor === 'human') {
+          adjusted = clearHeadlineBonus(adjusted, 'human');
+        }
+        if (nextState.publicFrenzy.governmentInitiativeActiveFor === 'human') {
+          adjusted = clearGovernmentInitiative(adjusted, 'human');
+        }
+
+        return adjusted;
       }
 
       const comboLog =
         comboResult.logEntries.length > 0 ? [...prev.log, ...comboResult.logEntries] : [...prev.log];
 
-      return {
+      let aiPhaseState: GameState = {
         ...prev,
         round: prev.round + 1,
         phase: 'newspaper',
@@ -638,6 +674,15 @@ export const useGameState = (aiDifficultyOverride?: AIDifficulty) => {
         comboTruthDeltaThisRound: prev.comboTruthDeltaThisRound + comboResult.truthDelta,
         log: [...comboLog, 'AI turn completed']
       };
+
+      if (aiPhaseState.publicFrenzy.bonusHeadlineActiveFor === 'ai') {
+        aiPhaseState = clearHeadlineBonus(aiPhaseState, 'ai');
+      }
+      if (aiPhaseState.publicFrenzy.governmentInitiativeActiveFor === 'ai') {
+        aiPhaseState = clearGovernmentInitiative(aiPhaseState, 'ai');
+      }
+
+      return aiPhaseState;
     });
   }, []);
 
@@ -957,6 +1002,12 @@ export const useGameState = (aiDifficultyOverride?: AIDifficulty) => {
           : [],
         comboTruthDeltaThisRound:
           typeof saveData.comboTruthDeltaThisRound === 'number' ? saveData.comboTruthDeltaThisRound : 0,
+        evidenceTrack: saveData.evidenceTrack
+          ? { ...createEvidenceTrackState(), ...saveData.evidenceTrack }
+          : createEvidenceTrackState(),
+        publicFrenzy: saveData.publicFrenzy
+          ? { ...createPublicFrenzyState(saveData.truth ?? prev.truth ?? 50), ...saveData.publicFrenzy }
+          : createPublicFrenzyState(saveData.truth ?? prev.truth ?? 50),
         // Ensure objects are properly reconstructed
         eventManager: prev.eventManager, // Keep the current event manager
         aiStrategist: prev.aiStrategist || AIFactory.createStrategist(saveData.aiDifficulty || 'medium')

--- a/src/index.css
+++ b/src/index.css
@@ -2202,6 +2202,15 @@ html, body, #root {
 
 /* === Enhanced Special Effects Styles === */
 
+@keyframes ticker {
+  0% {
+    transform: translateX(0%);
+  }
+  100% {
+    transform: translateX(-100%);
+  }
+}
+
 /* Breaking News Ticker */
 .breaking-news-ticker {
   position: fixed;

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -1541,6 +1541,10 @@ const Index = () => {
             <PlayedCardsDock
               playedCards={gameState.cardsPlayedThisRound}
               onInspectCard={(card) => setInspectedPlayedCard(card)}
+              faction={gameState.faction}
+              evidence={gameState.evidenceTrack}
+              publicFrenzy={gameState.publicFrenzy}
+              truth={gameState.truth}
             />
           </div>
         </div>

--- a/src/rules/mvp.ts
+++ b/src/rules/mvp.ts
@@ -29,6 +29,8 @@ export interface CardTarget {
   count: number;
 }
 
+export type FrontPageSlot = 'top-banner' | 'main-photo' | 'sidebar';
+
 export interface GameCard {
   id: string;
   name: string;
@@ -43,6 +45,7 @@ export interface GameCard {
   effects?: CardEffects;
   target?: CardTarget;
   extId?: string;
+  frontPageSlot?: FrontPageSlot;
 }
 
 export const MVP_COST_TABLE: Record<MVPCardType, Record<Rarity, number>> = {


### PR DESCRIPTION
## Summary
- Added Paranoid Times front-page slot support, momentum systems, and ability tracking across the game state, AI helper logic, and the MVP engine.
- Built new UI components for the evidence track, public frenzy meter, ticker, and stunt badge, plus the overall front-page layout, and switched the played-cards dock to render it.
- Passed the required front-page props from the main index page, enriched USA state data with tabloid hotspots for stunt badges, and wired the ticker animation CSS.

## Testing
- npm run lint *(fails: missing @eslint/js because npm install cannot fetch ts-node from the registry in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d3e029b77c832092ff663e2e98402b