### PR TITLE
Create translucent foldout overlays for left status panels

### DIFF
--- a/src/components/layout/FoldoutOverlayPanel.tsx
+++ b/src/components/layout/FoldoutOverlayPanel.tsx
@@ -1,0 +1,56 @@
+import { useState, type ReactNode } from "react";
+import clsx from "clsx";
+
+interface FoldoutOverlayPanelProps {
+  title: string;
+  children: ReactNode;
+  defaultOpen?: boolean;
+  widthClassName?: string;
+}
+
+export default function FoldoutOverlayPanel({
+  title,
+  children,
+  defaultOpen = false,
+  widthClassName = "w-72",
+}: FoldoutOverlayPanelProps) {
+  const [isOpen, setIsOpen] = useState(defaultOpen);
+
+  return (
+    <div className="pointer-events-auto">
+      <div
+        className={clsx(
+          "relative transition-all duration-300 ease-out",
+          widthClassName,
+          isOpen ? "translate-x-0" : "-translate-x-[calc(100%-3.75rem)]"
+        )}
+      >
+        <div
+          className={clsx(
+            "overflow-hidden rounded-2xl border border-newspaper-border/60 bg-newspaper-bg/40",
+            "shadow-2xl backdrop-blur-lg transition-opacity duration-300",
+            isOpen ? "opacity-100" : "opacity-80 hover:opacity-100"
+          )}
+        >
+          <div className="flex items-center justify-between border-b border-newspaper-border/50 px-4 py-2">
+            <span className="text-[10px] font-semibold uppercase tracking-[0.3em] text-newspaper-text/70">
+              {title}
+            </span>
+            <button
+              type="button"
+              onClick={() => setIsOpen(prev => !prev)}
+              aria-expanded={isOpen}
+              aria-label={isOpen ? `Minimize ${title}` : `Expand ${title}`}
+              className="rounded-full border border-newspaper-border/60 bg-newspaper-text/10 px-2 py-1 text-[10px] font-bold uppercase text-newspaper-text/80 shadow-sm transition hover:bg-newspaper-text/20 focus:outline-none focus-visible:ring-2 focus-visible:ring-secret-red/60"
+            >
+              {isOpen ? "⟨" : "⟩"}
+            </button>
+          </div>
+          <div className="px-4 py-3 text-xs text-newspaper-text/90">
+            {children}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- replace the static left column with translucent foldout overlays that slide over the map for victory, agenda, AI, and intel information
- share panel configuration between the new overlays, the mobile sidebar sheet, and the compact mobile layout
- add a reusable `FoldoutOverlayPanel` component to handle the foldout animation and styling

## Testing
- npm run lint *(fails: repository contains pre-existing lint errors unrelated to this change)*

------
https://chatgpt.com/codex/tasks/task_e_68d4d84e2a248320b99f498a178d6f59