### PR TITLE
Refactor playfield layout with left rail foldouts

### DIFF
--- a/src/components/layout/FoldoutOverlayPanel.tsx
+++ b/src/components/layout/FoldoutOverlayPanel.tsx
@@ -1,56 +1,194 @@
-import { useState, type ReactNode } from "react";
+import { createPortal } from "react-dom";
+import { useEffect, useRef, useState, type KeyboardEvent, type ReactNode } from "react";
 import clsx from "clsx";
 
 interface FoldoutOverlayPanelProps {
+  id: string;
   title: string;
   children: ReactNode;
   defaultOpen?: boolean;
-  widthClassName?: string;
 }
 
+const focusableSelector = [
+  "a[href]",
+  "button:not([disabled])",
+  "textarea:not([disabled])",
+  "input:not([disabled])",
+  "select:not([disabled])",
+  "[tabindex]:not([tabindex='-1'])"
+].join(",");
+
 export default function FoldoutOverlayPanel({
+  id,
   title,
   children,
   defaultOpen = false,
-  widthClassName = "w-72",
 }: FoldoutOverlayPanelProps) {
   const [isOpen, setIsOpen] = useState(defaultOpen);
+  const [container, setContainer] = useState<HTMLElement | null>(null);
+  const [isMobile, setIsMobile] = useState(false);
+  const lastDesktopOpen = useRef(defaultOpen);
+  const isOpenRef = useRef(isOpen);
+  const panelRef = useRef<HTMLElement | null>(null);
+  const bodyRef = useRef<HTMLDivElement>(null);
+  const toggleRef = useRef<HTMLButtonElement>(null);
+  const bodyId = `${id}-panel`;
+  const labelId = `${id}-label`;
 
-  return (
-    <div className="pointer-events-auto">
-      <div
-        className={clsx(
-          "relative transition-all duration-300 ease-out",
-          widthClassName,
-          isOpen ? "translate-x-0" : "-translate-x-[calc(100%-3.75rem)]"
-        )}
+  useEffect(() => {
+    setContainer(document.getElementById("left-rail"));
+  }, []);
+
+  useEffect(() => {
+    isOpenRef.current = isOpen;
+  }, [isOpen]);
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+
+    const mediaQuery = window.matchMedia("(max-width: 768px)");
+
+    const applyMatch = (matches: boolean) => {
+      setIsMobile(matches);
+      if (matches) {
+        lastDesktopOpen.current = isOpenRef.current;
+        setIsOpen(false);
+      } else {
+        setIsOpen(lastDesktopOpen.current ?? defaultOpen);
+      }
+    };
+
+    applyMatch(mediaQuery.matches);
+
+    const handleChange = (event: MediaQueryListEvent) => {
+      applyMatch(event.matches);
+    };
+
+    mediaQuery.addEventListener("change", handleChange);
+    return () => mediaQuery.removeEventListener("change", handleChange);
+  }, [defaultOpen]);
+
+  useEffect(() => {
+    if (!isMobile) {
+      lastDesktopOpen.current = isOpen;
+    }
+  }, [isMobile, isOpen]);
+
+  useEffect(() => {
+    if (!isOpen) return;
+
+    const frame = window.requestAnimationFrame(() => {
+      const focusable = getFocusableElements();
+      if (focusable.length > 0) {
+        focusable[0].focus();
+      } else {
+        bodyRef.current?.focus();
+      }
+    });
+
+    return () => window.cancelAnimationFrame(frame);
+  }, [isOpen]);
+
+  const getFocusableElements = () => {
+    if (!bodyRef.current) return [] as HTMLElement[];
+    return Array.from(bodyRef.current.querySelectorAll<HTMLElement>(focusableSelector)).filter(
+      element => !element.hasAttribute("disabled") && !element.getAttribute("aria-hidden") && element.tabIndex !== -1
+    );
+  };
+
+  const closePanel = () => {
+    setIsOpen(false);
+    window.requestAnimationFrame(() => {
+      toggleRef.current?.focus();
+    });
+  };
+
+  const handleToggle = () => {
+    setIsOpen(prev => {
+      const next = !prev;
+      if (!next) {
+        window.requestAnimationFrame(() => {
+          toggleRef.current?.focus();
+        });
+      }
+      return next;
+    });
+  };
+
+  const handleKeyDown = (event: KeyboardEvent<HTMLDivElement>) => {
+    if (!isOpen) return;
+
+    if (event.key === "Escape") {
+      event.preventDefault();
+      closePanel();
+      return;
+    }
+
+    if (event.key !== "Tab") return;
+
+    const focusable = getFocusableElements();
+
+    if (focusable.length === 0) {
+      event.preventDefault();
+      bodyRef.current?.focus();
+      return;
+    }
+
+    const first = focusable[0];
+    const last = focusable[focusable.length - 1];
+    const active = document.activeElement as HTMLElement | null;
+
+    if (event.shiftKey) {
+      if (active === first || active === bodyRef.current) {
+        event.preventDefault();
+        last.focus();
+      }
+    } else if (active === last) {
+      event.preventDefault();
+      first.focus();
+    }
+  };
+
+  if (!container) return null;
+
+  return createPortal(
+    <section
+      className={clsx("panel foldout", isOpen && "foldout--open")}
+      aria-labelledby={labelId}
+      data-foldout-id={id}
+      onKeyDown={handleKeyDown}
+      ref={panelRef}
+    >
+      <button
+        ref={toggleRef}
+        type="button"
+        className="foldout__tab"
+        onClick={handleToggle}
+        aria-controls={bodyId}
+        aria-expanded={isOpen}
+        aria-label={isOpen ? `Collapse ${title}` : `Expand ${title}`}
       >
-        <div
-          className={clsx(
-            "overflow-hidden rounded-2xl border border-newspaper-border/60 bg-newspaper-bg/40",
-            "shadow-2xl backdrop-blur-lg transition-opacity duration-300",
-            isOpen ? "opacity-100" : "opacity-80 hover:opacity-100"
-          )}
-        >
-          <div className="flex items-center justify-between border-b border-newspaper-border/50 px-4 py-2">
-            <span className="text-[10px] font-semibold uppercase tracking-[0.3em] text-newspaper-text/70">
-              {title}
-            </span>
-            <button
-              type="button"
-              onClick={() => setIsOpen(prev => !prev)}
-              aria-expanded={isOpen}
-              aria-label={isOpen ? `Minimize ${title}` : `Expand ${title}`}
-              className="rounded-full border border-newspaper-border/60 bg-newspaper-text/10 px-2 py-1 text-[10px] font-bold uppercase text-newspaper-text/80 shadow-sm transition hover:bg-newspaper-text/20 focus:outline-none focus-visible:ring-2 focus-visible:ring-secret-red/60"
-            >
-              {isOpen ? "⟨" : "⟩"}
-            </button>
-          </div>
-          <div className="px-4 py-3 text-xs text-newspaper-text/90">
-            {children}
-          </div>
+        <span className="sr-only">{isOpen ? `Collapse ${title}` : `Expand ${title}`}</span>
+        <span aria-hidden className="foldout__tab-icon">{isOpen ? "‹" : "›"}</span>
+      </button>
+      <div
+        id={bodyId}
+        ref={bodyRef}
+        className="foldout__body"
+        role="region"
+        aria-labelledby={labelId}
+        tabIndex={-1}
+      >
+        <header className="foldout__header">
+          <h2 id={labelId} className="foldout__title">
+            {title}
+          </h2>
+        </header>
+        <div className="foldout__content text-xs text-newspaper-text/90">
+          {children}
         </div>
       </div>
-    </div>
+    </section>,
+    container
   );
 }

--- a/src/components/layout/ResponsiveLayout.tsx
+++ b/src/components/layout/ResponsiveLayout.tsx
@@ -43,9 +43,7 @@ export default function ResponsiveLayout({ masthead, leftPane, rightPane }: Prop
               )}
             >
               <main className="flex h-full min-h-0 min-w-0 flex-col overflow-hidden">
-                <div className="flex h-full min-h-0 min-w-0 flex-col overflow-y-auto">
-                  {leftPane}
-                </div>
+                {leftPane}
               </main>
               {hasRightPane && (
                 <div className="flex h-full min-h-0 min-w-0 flex-col overflow-hidden">{rightPane}</div>

--- a/src/index.css
+++ b/src/index.css
@@ -3048,3 +3048,187 @@ html, body, #root {
   0%, 100% { opacity: 0.8; }
   50% { opacity: 1; }
 }
+
+/* Playfield layout + foldout panels */
+.playfield {
+  position: relative;
+  display: grid;
+  grid-template-columns: 320px 1fr;
+  grid-template-rows: auto 1fr auto;
+  grid-template-areas:
+    "header header"
+    "left map"
+    "footer footer";
+  gap: 16px;
+  column-gap: 16px;
+  height: 100dvh;
+  overflow: hidden;
+}
+
+.playfield__header {
+  grid-area: header;
+  min-width: 0;
+}
+
+#ui-rails {
+  display: contents;
+}
+
+#left-rail {
+  grid-area: left;
+  position: relative;
+  width: 320px;
+  height: 100%;
+  z-index: 30;
+  pointer-events: none;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  padding: 12px;
+  box-sizing: border-box;
+  overflow: visible;
+}
+
+#left-rail .panel {
+  pointer-events: auto;
+}
+
+#map-box {
+  grid-area: map;
+  position: relative;
+  min-height: 0;
+  min-width: 0;
+  overflow: visible;
+  z-index: 10;
+}
+
+#tray {
+  grid-area: footer;
+  min-width: 0;
+}
+
+.foldout {
+  position: relative;
+  width: 100%;
+  max-width: 320px;
+  transform: translateX(calc(-100% + 28px));
+  transition: transform 220ms ease, opacity 120ms ease;
+  opacity: 0.98;
+  will-change: transform;
+}
+
+.foldout--open {
+  transform: translateX(0);
+}
+
+.foldout__tab {
+  position: absolute;
+  top: 16px;
+  right: -28px;
+  width: 28px;
+  height: 56px;
+  border-radius: 12px 0 0 12px;
+  backdrop-filter: blur(6px);
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(17, 17, 17, 0.75);
+  color: #f5f5f5;
+  border: 1px solid rgba(17, 17, 17, 0.4);
+  transition: background 160ms ease;
+}
+
+.foldout__tab:hover,
+.foldout__tab:focus-visible {
+  background: rgba(17, 17, 17, 0.9);
+  outline: none;
+}
+
+.foldout__tab-icon {
+  font-size: 18px;
+  line-height: 1;
+}
+
+.foldout__body {
+  border-radius: 16px;
+  background: rgba(255, 255, 255, 0.75);
+  box-shadow: 0 6px 24px rgba(0, 0, 0, 0.18);
+  backdrop-filter: blur(8px);
+  overflow: hidden;
+  outline: none;
+  display: flex;
+  flex-direction: column;
+}
+
+.foldout__body:focus-visible {
+  box-shadow: 0 0 0 3px rgba(239, 68, 68, 0.4), 0 6px 24px rgba(0, 0, 0, 0.18);
+}
+
+.foldout__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 12px 16px;
+  border-bottom: 1px solid rgba(17, 17, 17, 0.12);
+}
+
+.foldout__title {
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 0.3em;
+  text-transform: uppercase;
+  color: rgba(17, 17, 17, 0.65);
+}
+
+.foldout__content {
+  padding: 12px 16px 16px;
+  overflow-y: auto;
+  max-height: calc(100dvh - 160px);
+}
+
+@media (max-width: 1199px) {
+  .playfield {
+    grid-template-columns: 280px 1fr;
+  }
+
+  #left-rail {
+    width: 280px;
+  }
+
+  .foldout,
+  .foldout__body {
+    max-width: 280px;
+  }
+}
+
+@media (max-width: 768px) {
+  .playfield {
+    grid-template-columns: 1fr;
+    grid-template-areas:
+      "header"
+      "map"
+      "footer";
+  }
+
+  #left-rail {
+    position: absolute;
+    left: 0;
+    top: 64px;
+    bottom: 160px;
+    width: 85vw;
+    max-width: 360px;
+    pointer-events: none;
+    z-index: 40;
+    padding: 8px;
+    gap: 8px;
+  }
+
+  .foldout {
+    max-width: 100%;
+  }
+
+  .foldout__content {
+    max-height: none;
+  }
+}

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -1327,7 +1327,7 @@ const Index = () => {
       title: 'Victory Conditions',
       defaultOpen: true,
       overlay: () => (
-        <div className="space-y-3 text-[11px] text-newspaper-text/90">
+        <div className="space-y-3 text-[11px] text-newspaper-text/90" aria-live="polite">
           <p className="font-semibold uppercase tracking-[0.25em] text-[10px] text-newspaper-text/60">
             Mission Targets
           </p>
@@ -1628,62 +1628,74 @@ const Index = () => {
   );
 
   const leftPaneContent = (
-    <div className="flex h-full min-h-0 flex-col gap-4">
-      <div className="space-y-4 md:hidden">
-        {statusPanelConfigs.map(panel => (
-          <div key={`${panel.id}-mobile`}>{panel.mobile()}</div>
-        ))}
-      </div>
-      <div className="flex min-h-0 flex-1 flex-col gap-4">
-        <div className="relative flex min-h-[320px] flex-1 flex-col overflow-hidden rounded border-2 border-newspaper-border bg-white/80">
-          {gameState.selectedCard && gameState.hand.find(c => c.id === gameState.selectedCard)?.type === 'ZONE' && !gameState.targetState && (
-            <div className="pointer-events-none absolute top-4 right-4 z-30">
-              <div className="max-w-sm animate-pulse border-2 border-newspaper-border bg-newspaper-text p-4 font-mono text-newspaper-bg shadow-2xl">
-                <div className="mb-2 flex items-center gap-2 text-lg">
-                  🎯 <span className="font-bold">ZONE CARD ACTIVE</span>
+    <>
+      <div className="playfield">
+        <div className="playfield__header">
+          <div className="space-y-4 md:hidden">
+            {statusPanelConfigs.map(panel => (
+              <div key={`${panel.id}-mobile`}>{panel.mobile()}</div>
+            ))}
+          </div>
+        </div>
+
+        <div id="ui-rails">
+          <aside id="left-rail" aria-label="Game intelligence panels" />
+          {statusPanelConfigs.map(panel => (
+            <FoldoutOverlayPanel
+              key={panel.id}
+              id={panel.id}
+              title={panel.title}
+              defaultOpen={panel.defaultOpen}
+            >
+              {panel.overlay()}
+            </FoldoutOverlayPanel>
+          ))}
+        </div>
+
+        <div id="map-box" className="relative flex min-h-0 min-w-0 flex-col">
+          <div className="map-shell relative flex min-h-[320px] flex-1 flex-col">
+            <div className="map-surface relative flex flex-1 flex-col overflow-visible rounded border-2 border-newspaper-border bg-white/80">
+              {gameState.selectedCard && gameState.hand.find(c => c.id === gameState.selectedCard)?.type === 'ZONE' && !gameState.targetState && (
+                <div className="pointer-events-none absolute top-4 right-4 z-30">
+                  <div className="max-w-sm animate-pulse border-2 border-newspaper-border bg-newspaper-text p-4 font-mono text-newspaper-bg shadow-2xl">
+                    <div className="mb-2 flex items-center gap-2 text-lg">
+                      🎯 <span className="font-bold">ZONE CARD ACTIVE</span>
+                    </div>
+                    <div className="mb-3 text-sm">
+                      Click any <span className="font-bold text-yellow-400">NEUTRAL</span> or <span className="font-bold text-red-500">ENEMY</span> state to target
+                    </div>
+                    <div className="mb-2 rounded bg-black/20 p-2 text-xs">
+                      Card will deploy automatically when target is selected
+                    </div>
+                    <div className="flex items-center gap-1 text-xs text-yellow-400">
+                      ⚠️ Cannot target your own states
+                    </div>
+                  </div>
                 </div>
-                <div className="mb-3 text-sm">
-                  Click any <span className="font-bold text-yellow-400">NEUTRAL</span> or <span className="font-bold text-red-500">ENEMY</span> state to target
-                </div>
-                <div className="mb-2 rounded bg-black/20 p-2 text-xs">
-                  Card will deploy automatically when target is selected
-                </div>
-                <div className="flex items-center gap-1 text-xs text-yellow-400">
-                  ⚠️ Cannot target your own states
-                </div>
+              )}
+              <div className="relative flex-1">
+                <EnhancedUSAMap
+                  states={gameState.states}
+                  onStateClick={handleStateClick}
+                  selectedZoneCard={gameState.selectedCard}
+                  selectedState={gameState.targetState}
+                  audio={audio}
+                />
               </div>
-            </div>
-          )}
-          <div className="relative flex-1">
-            <EnhancedUSAMap
-              states={gameState.states}
-              onStateClick={handleStateClick}
-              selectedZoneCard={gameState.selectedCard}
-              selectedState={gameState.targetState}
-              audio={audio}
-            />
-            <div className="pointer-events-none absolute inset-0 z-20 hidden md:flex flex-col items-start gap-3 p-4">
-              {statusPanelConfigs.map(panel => (
-                <FoldoutOverlayPanel
-                  key={panel.id}
-                  title={panel.title}
-                  defaultOpen={panel.defaultOpen}
-                >
-                  {panel.overlay()}
-                </FoldoutOverlayPanel>
-              ))}
             </div>
           </div>
         </div>
-        <div className="rounded border-2 border-newspaper-border bg-newspaper-bg shadow-sm">
+
+        <div id="tray" className="rounded border-2 border-newspaper-border bg-newspaper-bg shadow-sm">
           <PlayedCardsDock
             playedCards={gameState.cardsPlayedThisRound}
             onInspectCard={(card) => setInspectedPlayedCard(card)}
           />
         </div>
       </div>
+
       <CardPreviewOverlay card={hoveredCard} />
-    </div>
+    </>
   );
 
   const rightPaneContent = (


### PR DESCRIPTION
## Summary
- restructure the playfield area into a two-column grid with a dedicated `#ui-rails` container and `#left-rail` sibling to the map and tray
- update `FoldoutOverlayPanel` to portal into the rail, add keyboard focus management, and support responsive auto-collapse
- add CSS for the rail, foldout animations, and responsive behavior while wiring the new structure into the main play page

## Testing
- npm run lint *(fails: repository has pre-existing lint issues across many files)*

------
https://chatgpt.com/codex/tasks/task_e_68d4e5aa1c4c8320b5085b52a39c7dea