### PR TITLE
Move intel log into balancing dashboard

### DIFF
--- a/src/components/game/EnhancedBalancingDashboard.tsx
+++ b/src/components/game/EnhancedBalancingDashboard.tsx
@@ -62,9 +62,10 @@ const HistogramCard = ({
 
 interface EnhancedBalancingDashboardProps {
   onClose: () => void;
+  logEntries: string[];
 }
 
-const EnhancedBalancingDashboard = ({ onClose }: EnhancedBalancingDashboardProps) => {
+const EnhancedBalancingDashboard = ({ onClose, logEntries }: EnhancedBalancingDashboardProps) => {
   const report = useMemo(() => analyzeCardBalanceEnhanced(false), []);
   const simulation = useMemo(() => runBalanceSimulationEnhanced(500, false), []);
   const [expansionState, setExpansionState] = useState(() => ({
@@ -137,6 +138,11 @@ const EnhancedBalancingDashboard = ({ onClose }: EnhancedBalancingDashboardProps
     return bins;
   }, [metrics.hist.pressure]);
 
+  const latestIntelEntries = useMemo(
+    () => logEntries.slice(-20).reverse(),
+    [logEntries],
+  );
+
   const formatDelta = (card: EnhancedCardAnalysis) => {
     if (card.costDelta === null) return '—';
     const symbol = card.costDelta > 0 ? '+' : '';
@@ -188,6 +194,25 @@ const EnhancedBalancingDashboard = ({ onClose }: EnhancedBalancingDashboardProps
                 {metrics.counts.truth}/{metrics.counts.government}
               </div>
               <p className="text-xs text-slate-400">Truth / Government card counts in the active pool.</p>
+            </div>
+          </section>
+
+          <section className="space-y-3">
+            <h3 className="text-lg font-semibold text-white font-mono">Intel Log</h3>
+            <div className="bg-gray-900/60 border border-gray-800 rounded-lg p-4 max-h-60 overflow-y-auto space-y-2">
+              {latestIntelEntries.length > 0 ? (
+                latestIntelEntries.map((entry, index) => (
+                  <div
+                    key={`${entry}-${index}`}
+                    className="flex items-start gap-3 text-xs text-slate-300"
+                  >
+                    <span className="font-mono text-emerald-400 mt-0.5">▲</span>
+                    <span className="leading-snug flex-1">{entry}</span>
+                  </div>
+                ))
+              ) : (
+                <p className="text-xs text-slate-500 italic">No intel recorded yet.</p>
+              )}
             </div>
           </section>
 

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -1256,7 +1256,12 @@ const Index = () => {
   }
 
   if (showBalancing) {
-    return <EnhancedBalancingDashboard onClose={() => setShowBalancing(false)} />;
+    return (
+      <EnhancedBalancingDashboard
+        onClose={() => setShowBalancing(false)}
+        logEntries={gameState.log}
+      />
+    );
   }
 
   if (showMenu) {
@@ -1302,20 +1307,6 @@ const Index = () => {
 
   const isPlayerActionLocked = gameState.phase !== 'action' || gameState.animating || gameState.currentPlayer !== 'human';
   const handInteractionDisabled = isPlayerActionLocked || gameState.cardsPlayedThisTurn >= 3;
-
-  const renderIntelLog = (limit: number) => (
-    <div className="space-y-1 text-xs text-newspaper-text/80">
-      {gameState.log.slice(-limit).map((entry, index) => (
-        <div key={`${entry}-${index}`} className="flex items-start gap-1">
-          <span className="font-mono text-newspaper-text">▲</span>
-          <span className="flex-1 leading-snug">{entry}</span>
-        </div>
-      ))}
-      {gameState.log.length === 0 && (
-        <div className="text-newspaper-text/50">No intel yet.</div>
-      )}
-    </div>
-  );
 
   const playerAgenda = gameState.secretAgenda;
   const agendaProgress = playerAgenda ? Math.min(100, Math.round((playerAgenda.progress / playerAgenda.target) * 100)) : 0;
@@ -1520,25 +1511,6 @@ const Index = () => {
             aiHandSize={gameState.aiHand.length}
             aiObjectiveProgress={aiObjectiveProgress}
           />
-        </div>
-      ),
-    },
-    {
-      id: 'intel-log',
-      title: 'Intel Log',
-      defaultOpen: false,
-      overlay: () => (
-        <div className="space-y-2 text-[11px] text-newspaper-text/90">
-          <p className="text-[10px] uppercase tracking-[0.3em] text-newspaper-text/60">Latest Briefings</p>
-          <div className="max-h-60 overflow-y-auto pr-1">
-            {renderIntelLog(12)}
-          </div>
-        </div>
-      ),
-      mobile: () => (
-        <div className="rounded border border-newspaper-border bg-newspaper-bg p-3 shadow-sm">
-          <h3 className="text-xs font-bold uppercase tracking-wide text-newspaper-text">Intel Log</h3>
-          <div className="mt-2">{renderIntelLog(6)}</div>
         </div>
       ),
     },


### PR DESCRIPTION
## Summary
- remove the Intel Log panel from the main game interface now that the balancing dashboard will act as the dev tool
- pass live log entries into the Enhanced Balancing Dashboard and surface them in a dedicated Intel Log section without touching existing card analytics

## Testing
- bun run lint *(fails: existing lint violations across the repository unrelated to this change)*

------
https://chatgpt.com/codex/tasks/task_e_68d4f2cfc91c8320becc79d70d812252