### PR TITLE
Retheme interface with tabloid newsroom phrasing

### DIFF
--- a/docs/_archive/ShadowGov-Rules-v2.1.md
+++ b/docs/_archive/ShadowGov-Rules-v2.1.md
@@ -150,7 +150,7 @@ Humor: 10% chance to make a “stupid” move with a funny log.
 - ZONE captures immediate.  
 - Defense prompt: Yes/No (4s).  
 - Newspaper capped to 3–4 articles.  
-- Hotkeys: 1–9 play cards, Space = End Turn, Esc = Cancel.  
+- Hotkeys: 1–9 play cards, Space = Go To Press, Esc = Cancel.
 
 ---
 

--- a/src/components/game/GameMenu.tsx
+++ b/src/components/game/GameMenu.tsx
@@ -395,7 +395,7 @@ const GameMenu = ({ onStartGame, onFactionHover, audio, onBackToMainMenu, onSave
               HOTKEYS:
             </div>
             <div className="text-xs font-mono text-newspaper-text/60">
-              Space = End Turn | T = Select Card
+              Space = Go To Press | T = Select Card
             </div>
             <div className="text-xs font-mono text-newspaper-text/60">
               U = Upgrades | S = Stats | Q/L = Save/Load

--- a/src/components/game/InGameOptions.tsx
+++ b/src/components/game/InGameOptions.tsx
@@ -243,7 +243,7 @@ const InGameOptions = ({
             <div className="grid md:grid-cols-2 gap-4 text-sm font-mono text-newspaper-text/80">
               <div>
                 <div><kbd className="bg-newspaper-text/20 px-2 py-1 rounded">ESC</kbd> - Options Menu</div>
-                <div><kbd className="bg-newspaper-text/20 px-2 py-1 rounded">SPACE</kbd> - End Turn</div>
+                <div><kbd className="bg-newspaper-text/20 px-2 py-1 rounded">SPACE</kbd> - Go To Press</div>
                 <div><kbd className="bg-newspaper-text/20 px-2 py-1 rounded">1-9</kbd> - Play Card</div>
               </div>
               <div>

--- a/src/components/game/InteractiveOnboarding.tsx
+++ b/src/components/game/InteractiveOnboarding.tsx
@@ -36,8 +36,8 @@ const InteractiveOnboarding = ({ isActive, onComplete, onSkip, gameState }: Inte
     },
     {
       id: 'hand',
-      title: '🎴 Your Hand',
-      description: 'These are your cards. Each has a cost (circle) and type. Click cards to examine them closely.',
+      title: '🎴 Newsroom Desk',
+      description: 'These are your cards. Each has a cost (circle) and type. Click cards to examine them closely before they hit the presses.',
       target: '#enhanced-hand',
       action: 'Click on a card to examine it'
     },
@@ -62,14 +62,14 @@ const InteractiveOnboarding = ({ isActive, onComplete, onSkip, gameState }: Inte
     },
     {
       id: 'turn-end',
-      title: '⏭️ End Turn',
-      description: 'When you\'re done playing cards, click "End Turn". You can play up to 3 cards per turn.',
+      title: '🗞️ Go To Press',
+      description: 'When you\'re done playing cards, click "Go To Press". You can play up to 3 cards per turn before filing the edition.',
       target: '#end-turn-button'
     },
     {
       id: 'victory',
-      title: '🏆 Victory Conditions',
-      description: 'Win by controlling 10 states, reaching 300 IP, or hitting your truth threshold (95% for Truth, 5% for Government). Watch these in the header!',
+      title: '📰 Mission Brief',
+      description: 'Win by controlling 10 states, reaching 300 IP, or hitting your truth threshold (95% for Truth, 5% for Government). Read the Mission Brief banner for live progress!',
       target: '#victory-conditions'
     }
   ];

--- a/src/components/game/Options.tsx
+++ b/src/components/game/Options.tsx
@@ -527,7 +527,7 @@ const Options = ({ onClose, onBackToMainMenu, onSaveGame }: OptionsProps) => {
               </div>
 
               <div className="flex items-center justify-between">
-                <label className="text-sm font-medium text-newspaper-text">Auto End Turn</label>
+                <label className="text-sm font-medium text-newspaper-text">Auto Go To Press</label>
                 <Switch
                   checked={settings.autoEndTurn}
                   onCheckedChange={checked => updateSettings({ autoEndTurn: checked })}
@@ -781,7 +781,7 @@ const Options = ({ onClose, onBackToMainMenu, onSaveGame }: OptionsProps) => {
           <h3 className="font-bold text-xl text-newspaper-text mb-4 flex items-center">⌨️ COVERT OPERATIONS MANUAL</h3>
           <div className="grid md:grid-cols-2 gap-4 text-sm text-newspaper-text">
             <div>
-              <div className="font-mono">SPACE - End Turn</div>
+              <div className="font-mono">SPACE - Go To Press</div>
               <div className="font-mono">T - Select Card</div>
               <div className="font-mono">U - View Upgrades</div>
               <div className="font-mono">S - View Statistics</div>

--- a/src/components/game/PlayedCardsDock.tsx
+++ b/src/components/game/PlayedCardsDock.tsx
@@ -66,7 +66,7 @@ const PlayedCardsDock: React.FC<PlayedCardsDockProps> = ({ playedCards, onInspec
   return (
     <div className="flex h-full min-h-0 flex-col">
       <header className="border-b border-black/10 px-3 py-2 text-sm font-extrabold tracking-wide text-newspaper-text">
-        CARDS IN PLAY THIS ROUND
+        FRONT PAGE LAYOUT
       </header>
       <div className="grid grid-cols-1 gap-2 p-2 lg:grid-cols-2">
         <PlayedCardsSection

--- a/src/components/game/VictoryConditions.tsx
+++ b/src/components/game/VictoryConditions.tsx
@@ -17,19 +17,22 @@ export const VictoryConditions: React.FC<VictoryConditionsProps> = ({
   const [isExpanded, setIsExpanded] = useState(true);
 
   return (
-    <div className="bg-newspaper-text text-newspaper-bg p-2 mb-3 border border-newspaper-border">
-      <div 
+    <div id="victory-conditions" className="bg-newspaper-text text-newspaper-bg p-2 mb-3 border border-newspaper-border">
+      <div
         className="flex items-center justify-between cursor-pointer"
         onClick={() => setIsExpanded(!isExpanded)}
       >
-        <h3 className="font-bold text-xs text-center flex-1">VICTORY CONDITIONS</h3>
+        <div className="flex-1 text-center">
+          <div className="text-[8px] uppercase tracking-[0.35em] text-newspaper-bg/70">Editorial Desk</div>
+          <h3 className="font-bold text-xs tracking-[0.25em]">MISSION BRIEF</h3>
+        </div>
         {isExpanded ? (
           <ChevronUp className="w-3 h-3 ml-1" />
         ) : (
           <ChevronDown className="w-3 h-3 ml-1" />
         )}
       </div>
-      
+
       {isExpanded && (
         <div className="mt-2">
           {isMobile ? (

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState, useCallback } from 'react';
+import { useEffect, useState, useCallback, useMemo } from 'react';
 import clsx from 'clsx';
 import { Button } from '@/components/ui/button';
 import ResponsiveLayout from '@/components/layout/ResponsiveLayout';
@@ -1214,6 +1214,16 @@ const Index = () => {
     }
   }, [showIntro, showMenu, audio]);
 
+  const tabloidDateline = useMemo(() => {
+    const now = new Date();
+    return now.toLocaleDateString('en-US', {
+      weekday: 'long',
+      month: 'long',
+      day: 'numeric',
+      year: 'numeric'
+    });
+  }, []);
+
   if (showIntro) {
     return (
       <div 
@@ -1319,10 +1329,11 @@ const Index = () => {
   const objectiveSections = [
     {
       id: 'victory' as const,
-      label: 'Victory Conditions',
+      label: 'Mission Brief (Editorial Desk)',
       overlayContent: (
         <>
-          <p className="font-semibold uppercase tracking-[0.25em] text-[10px] text-newspaper-text/60">
+          <div className="text-[9px] uppercase tracking-[0.4em] text-newspaper-text/50">Editorial Desk Dispatch</div>
+          <p className="mt-1 font-semibold uppercase tracking-[0.25em] text-[10px] text-newspaper-text">
             Mission Targets
           </p>
           <ul className="space-y-1 font-mono">
@@ -1532,28 +1543,35 @@ const Index = () => {
   const mastheadButtonClass = "touch-target inline-flex items-center justify-center rounded-md border border-newspaper-border bg-newspaper-text px-3 text-sm font-semibold text-newspaper-bg shadow-sm transition hover:bg-newspaper-text/80 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-newspaper-border focus-visible:ring-offset-2 focus-visible:ring-offset-newspaper-bg";
 
   const mastheadContent = (
-    <div className="flex h-full items-center gap-4 border-b-4 border-newspaper-border bg-newspaper-bg px-2 sm:px-4">
-      <div className="flex items-center gap-3">
-        <Sheet open={isSidebarOpen} onOpenChange={setIsSidebarOpen}>
-          <SheetTrigger asChild>
-            <button type="button" className={`${mastheadButtonClass} md:hidden`}>
-              <Menu className="h-5 w-5" />
-              <span className="sr-only">Open command panel</span>
-            </button>
-          </SheetTrigger>
-          <SheetContent side="right" className="w-full p-0 sm:max-w-sm">
-            <div className="app-scroll h-full p-4">
-              {renderSidebar()}
-            </div>
-          </SheetContent>
-        </Sheet>
-        <div className="leading-tight">
-          <p className="text-[10px] uppercase tracking-[0.3em] text-newspaper-text/60">The Paranoid Times</p>
-          <h1 className="text-lg font-bold text-newspaper-text sm:text-2xl">THE PARANOID TIMES</h1>
-          <p className="text-[11px] font-medium text-newspaper-text/70 sm:text-xs">{subtitle}</p>
+    <div className="flex h-full flex-col justify-center gap-2 border-b-4 border-newspaper-border bg-newspaper-bg px-2 py-2 sm:px-4">
+      <div className="flex items-start justify-between gap-4">
+        <div className="flex items-center gap-3">
+          <Sheet open={isSidebarOpen} onOpenChange={setIsSidebarOpen}>
+            <SheetTrigger asChild>
+              <button type="button" className={`${mastheadButtonClass} md:hidden`}>
+                <Menu className="h-5 w-5" />
+                <span className="sr-only">Open command panel</span>
+              </button>
+            </SheetTrigger>
+            <SheetContent side="right" className="w-full p-0 sm:max-w-sm">
+              <div className="app-scroll h-full p-4">
+                {renderSidebar()}
+              </div>
+            </SheetContent>
+          </Sheet>
+          <div className="leading-tight">
+            <p className="text-[9px] uppercase tracking-[0.45em] text-newspaper-text/50">The Paranoid Times</p>
+            <h1 className="font-black uppercase tracking-[0.25em] text-newspaper-text text-2xl sm:text-3xl">THE PARANOID TIMES</h1>
+            <p className="text-[11px] font-medium italic text-newspaper-text/70 sm:text-xs">{subtitle}</p>
+          </div>
+        </div>
+        <div className="flex flex-col items-end text-right text-newspaper-text">
+          <div className="text-[9px] uppercase tracking-[0.45em] text-newspaper-text/60">Vol. 13</div>
+          <div className="text-xs font-semibold uppercase tracking-wide sm:text-sm">{tabloidDateline}</div>
+          <div className="text-[10px] uppercase tracking-[0.3em] text-newspaper-text/70">Round {currentRoundNumber}</div>
         </div>
       </div>
-      <div className="flex flex-1 flex-col justify-center gap-1 overflow-hidden">
+      <div className="flex flex-col gap-2">
         <div className="flex items-center justify-end gap-2">
           <button
             type="button"
@@ -1620,18 +1638,18 @@ const Index = () => {
         </div>
         <div className="flex items-center gap-2 overflow-x-auto text-[11px] font-mono text-newspaper-text/80">
           <div className="flex items-center gap-1 whitespace-nowrap rounded border border-newspaper-border bg-newspaper-text px-2 py-1 text-newspaper-bg shadow-sm">
-            <span className="font-bold uppercase tracking-wide">Round</span>
-            <span>{gameState.turn}</span>
+            <span className="font-bold uppercase tracking-wide">Edition</span>
+            <span>Round {currentRoundNumber}</span>
           </div>
           <MechanicsTooltip mechanic="ip">
             <div className="flex items-center gap-1 whitespace-nowrap rounded border border-newspaper-border bg-newspaper-text px-2 py-1 text-newspaper-bg shadow-sm">
-              <span className="font-bold uppercase tracking-wide">Your IP</span>
+              <span className="flex items-center gap-1 font-bold uppercase tracking-wide"><span aria-hidden>🗞️</span>Circulation</span>
               <span>{gameState.ip}</span>
             </div>
           </MechanicsTooltip>
           <MechanicsTooltip mechanic="truth">
             <div className="flex items-center gap-1 whitespace-nowrap rounded border border-newspaper-border bg-newspaper-text px-2 py-1 text-newspaper-bg shadow-sm">
-              <span className="font-bold uppercase tracking-wide">Truth</span>
+              <span className="flex items-center gap-1 font-bold uppercase tracking-wide"><span aria-hidden>📰</span>Credibility</span>
               <span>{gameState.truth}%</span>
             </div>
           </MechanicsTooltip>
@@ -1716,8 +1734,8 @@ const Index = () => {
   const rightPaneContent = (
     <aside className="h-full min-h-0 min-w-0 flex flex-col rounded border-2 border-newspaper-border bg-newspaper-text text-newspaper-bg shadow-lg">
       <header className="flex items-center justify-between gap-2 border-b border-newspaper-border/60 px-4 py-3">
-        <h3 className="text-xs font-bold uppercase tracking-[0.35em]">Your Hand</h3>
-        <span className="text-xs font-mono">IP {gameState.ip}</span>
+        <h3 className="text-xs font-bold uppercase tracking-[0.35em]">NEWSROOM DESK</h3>
+        <span className="text-xs font-mono flex items-center gap-1"><span aria-hidden>🗞️</span>{gameState.ip}</span>
       </header>
       <div className="flex-1 min-h-0 min-w-0 overflow-y-auto overflow-x-hidden px-3 py-3">
         <EnhancedGameHand
@@ -1733,6 +1751,7 @@ const Index = () => {
       </div>
       <footer className="border-t border-newspaper-border/60 px-3 pb-3 pt-2 sm:pt-3">
         <Button
+          id="end-turn-button"
           onClick={handleEndTurn}
           className="touch-target w-full border-2 border-black bg-black py-3 font-bold uppercase tracking-wide text-white transition duration-200 hover:bg-white hover:text-black disabled:opacity-60"
           disabled={isPlayerActionLocked}
@@ -1743,7 +1762,7 @@ const Index = () => {
               AI Thinking...
             </span>
           ) : (
-            'End Turn'
+            'GO TO PRESS'
           )}
         </Button>
       </footer>

--- a/src/ui/CardFrame.tsx
+++ b/src/ui/CardFrame.tsx
@@ -6,7 +6,7 @@ type Props = { children: React.ReactNode; size?: Size };
 export default function CardFrame({ children, size = "modal" }: Props) {
   // FINJUSTÉR SKALA HER:
   // - boardMini: senket til 0.56 for å unngå scroll i "Cards in Play"
-  // - handMini: beholdt 0.78 (god lesbarhet i Your Hand)
+  // - handMini: beholdt 0.78 (god lesbarhet i Newsroom Desk)
   const scale = size === "modal" ? 1 : size === "boardMini" ? 0.56 : 0.78;
 
   // Basemål MÅ matche fullkortets outer size (inkl. border)


### PR DESCRIPTION
## Summary
- restyled the main masthead with a condensed Paranoid Times banner, dateline, and renamed circulation/credibility stats
- retitled key UI zones to newsroom-themed labels, including the Mission Brief panel and Newsroom Desk hand area
- updated onboarding, docks, hotkey hints, and docs to use the new “Go To Press” terminology

## Testing
- npm run lint *(fails: existing repository lint violations unrelated to this change)*

------
https://chatgpt.com/codex/tasks/task_e_68d4fafbcd5c83208c242bf63351f5a4