### PR TITLE
Align masthead background with newspaper color

### DIFF
--- a/src/components/layout/ResponsiveLayout.tsx
+++ b/src/components/layout/ResponsiveLayout.tsx
@@ -19,7 +19,7 @@ export default function ResponsiveLayout({ masthead, leftPane, rightPane }: Prop
     >
       {/* Masthead */}
       <header
-        className="shrink-0"
+        className="shrink-0 bg-newspaper-bg"
         style={{ height: "var(--masthead-h)" }}
       >
         {masthead}


### PR DESCRIPTION
## Summary
- apply the newspaper background color to the layout masthead wrapper so the top banner matches the rest of the interface

## Testing
- npm run lint *(fails: Cannot find package '@eslint/js' imported from eslint.config.js)*

------
https://chatgpt.com/codex/tasks/task_e_68d50d7249e8832086f448c279cfaaa9