### PR TITLE
Adjust masthead background to match paper tone

### DIFF
--- a/src/components/layout/ResponsiveLayout.tsx
+++ b/src/components/layout/ResponsiveLayout.tsx
@@ -19,8 +19,11 @@ export default function ResponsiveLayout({ masthead, leftPane, rightPane }: Prop
     >
       {/* Masthead */}
       <header
-        className="shrink-0 bg-newspaper-bg"
-        style={{ height: "var(--masthead-h)" }}
+        className="shrink-0"
+        style={{
+          height: "var(--masthead-h)",
+          background: "var(--paper)",
+        }}
       >
         {masthead}
       </header>

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -1532,7 +1532,10 @@ const Index = () => {
   const mastheadButtonClass = "touch-target inline-flex items-center justify-center rounded-md border border-newspaper-border bg-newspaper-text px-3 text-sm font-semibold text-newspaper-bg shadow-sm transition hover:bg-newspaper-text/80 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-newspaper-border focus-visible:ring-offset-2 focus-visible:ring-offset-newspaper-bg";
 
   const mastheadContent = (
-    <div className="flex h-full items-center gap-4 border-b-4 border-newspaper-border bg-newspaper-bg px-2 sm:px-4">
+    <div
+      className="flex h-full items-center gap-4 border-b-4 border-newspaper-border px-2 sm:px-4"
+      style={{ background: "var(--paper)" }}
+    >
       <div className="flex items-center gap-3">
         <Sheet open={isSidebarOpen} onOpenChange={setIsSidebarOpen}>
           <SheetTrigger asChild>


### PR DESCRIPTION
## Summary
- update the responsive layout masthead wrapper to use the shared paper background tone
- ensure the index page masthead content inherits the paper background instead of the brighter newspaper surface

## Testing
- `npm run lint` *(fails: missing @eslint/js dependency before install, npm install blocked by peer dependency conflict)*

------
https://chatgpt.com/codex/tasks/task_e_68d50f03c3a88320a776c0c08c2c2fa5