### PR TITLE
Adjust default music volume and persist playback level

### DIFF
--- a/src/components/game/Options.tsx
+++ b/src/components/game/Options.tsx
@@ -290,7 +290,7 @@ const Options = ({ onClose, onBackToMainMenu, onSaveGame }: OptionsProps) => {
   const resetToDefaults = () => {
     const defaultSettings: GameSettings = {
       masterVolume: 80,
-      musicVolume: 20,
+      musicVolume: 12,
       sfxVolume: 80,
       enableAnimations: true,
       autoEndTurn: false,


### PR DESCRIPTION
## Summary
- default the music volume slider to 12% for new sessions and resets
- track the last active music output level so subsequent tracks reuse the current volume

## Testing
- bun run lint *(fails: repository has existing lint errors unrelated to this change)*

------
https://chatgpt.com/codex/tasks/task_e_68d511a5ad6c83208bca8fdaba1d7324