### PR TITLE
Refactor status overlays to sit beside USA map

### DIFF
--- a/src/components/layout/FoldoutOverlayPanel.tsx
+++ b/src/components/layout/FoldoutOverlayPanel.tsx
@@ -6,6 +6,7 @@ interface FoldoutOverlayPanelProps {
   children: ReactNode;
   defaultOpen?: boolean;
   widthClassName?: string;
+  variant?: "overlay" | "sidebar";
 }
 
 export default function FoldoutOverlayPanel({
@@ -13,8 +14,10 @@ export default function FoldoutOverlayPanel({
   children,
   defaultOpen = false,
   widthClassName = "w-72",
+  variant = "overlay",
 }: FoldoutOverlayPanelProps) {
   const [isOpen, setIsOpen] = useState(defaultOpen);
+  const isOverlay = variant === "overlay";
 
   return (
     <div className="pointer-events-auto">
@@ -22,7 +25,9 @@ export default function FoldoutOverlayPanel({
         className={clsx(
           "relative transition-all duration-300 ease-out",
           widthClassName,
-          isOpen ? "translate-x-0" : "-translate-x-[calc(100%-3.75rem)]"
+          isOverlay
+            ? (isOpen ? "translate-x-0" : "-translate-x-[calc(100%-3.75rem)]")
+            : "translate-x-0"
         )}
       >
         <div

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -1665,44 +1665,47 @@ const Index = () => {
         ))}
       </div>
       <div className="flex min-h-0 flex-1 flex-col gap-4">
-        <div className="relative flex min-h-[320px] flex-1 flex-col overflow-hidden rounded border-2 border-newspaper-border bg-white/80">
-          {gameState.selectedCard && gameState.hand.find(c => c.id === gameState.selectedCard)?.type === 'ZONE' && !gameState.targetState && (
-            <div className="pointer-events-none absolute top-4 right-4 z-30">
-              <div className="max-w-sm animate-pulse border-2 border-newspaper-border bg-newspaper-text p-4 font-mono text-newspaper-bg shadow-2xl">
-                <div className="mb-2 flex items-center gap-2 text-lg">
-                  🎯 <span className="font-bold">ZONE CARD ACTIVE</span>
-                </div>
-                <div className="mb-3 text-sm">
-                  Click any <span className="font-bold text-yellow-400">NEUTRAL</span> or <span className="font-bold text-red-500">ENEMY</span> state to target
-                </div>
-                <div className="mb-2 rounded bg-black/20 p-2 text-xs">
-                  Card will deploy automatically when target is selected
-                </div>
-                <div className="flex items-center gap-1 text-xs text-yellow-400">
-                  ⚠️ Cannot target your own states
+        <div className="flex min-h-[320px] flex-1 flex-col gap-4 md:flex-row">
+          <div className="relative flex min-h-[320px] flex-1 flex-col overflow-hidden rounded border-2 border-newspaper-border bg-white/80">
+            {gameState.selectedCard && gameState.hand.find(c => c.id === gameState.selectedCard)?.type === 'ZONE' && !gameState.targetState && (
+              <div className="pointer-events-none absolute top-4 right-4 z-30">
+                <div className="max-w-sm animate-pulse border-2 border-newspaper-border bg-newspaper-text p-4 font-mono text-newspaper-bg shadow-2xl">
+                  <div className="mb-2 flex items-center gap-2 text-lg">
+                    🎯 <span className="font-bold">ZONE CARD ACTIVE</span>
+                  </div>
+                  <div className="mb-3 text-sm">
+                    Click any <span className="font-bold text-yellow-400">NEUTRAL</span> or <span className="font-bold text-red-500">ENEMY</span> state to target
+                  </div>
+                  <div className="mb-2 rounded bg-black/20 p-2 text-xs">
+                    Card will deploy automatically when target is selected
+                  </div>
+                  <div className="flex items-center gap-1 text-xs text-yellow-400">
+                    ⚠️ Cannot target your own states
+                  </div>
                 </div>
               </div>
+            )}
+            <div className="relative flex-1">
+              <EnhancedUSAMap
+                states={gameState.states}
+                onStateClick={handleStateClick}
+                selectedZoneCard={gameState.selectedCard}
+                selectedState={gameState.targetState}
+                audio={audio}
+              />
             </div>
-          )}
-          <div className="relative flex-1">
-            <EnhancedUSAMap
-              states={gameState.states}
-              onStateClick={handleStateClick}
-              selectedZoneCard={gameState.selectedCard}
-              selectedState={gameState.targetState}
-              audio={audio}
-            />
-            <div className="pointer-events-none absolute inset-0 z-20 hidden md:flex flex-col items-start gap-3 p-4">
-              {statusPanelConfigs.map(panel => (
-                <FoldoutOverlayPanel
-                  key={panel.id}
-                  title={panel.title}
-                  defaultOpen={panel.defaultOpen}
-                >
-                  {panel.overlay()}
-                </FoldoutOverlayPanel>
-              ))}
-            </div>
+          </div>
+          <div className="hidden w-72 shrink-0 flex-col gap-3 md:flex">
+            {statusPanelConfigs.map(panel => (
+              <FoldoutOverlayPanel
+                key={panel.id}
+                title={panel.title}
+                defaultOpen={panel.defaultOpen}
+                variant="sidebar"
+              >
+                {panel.overlay()}
+              </FoldoutOverlayPanel>
+            ))}
           </div>
         </div>
         <div className="rounded border-2 border-newspaper-border bg-newspaper-bg shadow-sm">


### PR DESCRIPTION
## Summary
- restructure the USA map layout so desktop status panels render in a dedicated sidebar instead of overlaying the map
- add a sidebar variant to `FoldoutOverlayPanel` to disable the slide-out translation when used outside the map overlay

## Testing
- npm run lint *(fails: Cannot find package '@eslint/js')*


------
https://chatgpt.com/codex/tasks/task_e_68d522bde31c83209b33e6cc6147c654