### PR TITLE
Ensure expansion cards retain set metadata in mixed decks

### DIFF
--- a/src/components/game/ManageExpansions.tsx
+++ b/src/components/game/ManageExpansions.tsx
@@ -77,7 +77,7 @@ const EXPANSION_ID_SET = new Set(EXPANSION_MANIFEST.map(pack => pack.id));
 const summarizeExpansionCards = (cards: GameCard[]): Record<string, number> => {
   const counts: Record<string, number> = {};
   cards.forEach(card => {
-    const extId = card.extId;
+    const extId = card.extId ?? (card as { _setId?: string })._setId;
     if (!extId || !EXPANSION_ID_SET.has(extId)) {
       return;
     }


### PR DESCRIPTION
## Summary
- ensure sanitized card pools attach set identifiers so expansion draws keep their source metadata
- fall back to stored set identifiers when summarizing expansion cards in the management dashboard

## Testing
- npm run lint *(fails: existing repository lint errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68d5ecc3c5d483209705b85a7b866c53