### PR TITLE
Display event probabilities across tools and newspaper

### DIFF
--- a/src/hooks/eventEdition.ts
+++ b/src/hooks/eventEdition.ts
@@ -21,5 +21,11 @@ export const buildEditionEvents = (
   }
 
   const wasAlreadyPresent = state.currentEvents.some(event => event.id === triggeredEvent.id);
-  return wasAlreadyPresent ? state.currentEvents : [triggeredEvent];
+  if (!wasAlreadyPresent) {
+    return [triggeredEvent];
+  }
+
+  return state.currentEvents.map(event =>
+    event.id === triggeredEvent.id ? triggeredEvent : event,
+  );
 };


### PR DESCRIPTION
## Summary
- add trigger and conditional probability metadata to `GameEvent` and compute it when selecting events so callers know the per-turn odds
- keep current edition events up to date with refreshed metadata when the same event repeats in later turns
- upgrade the Event Viewer testing tools to accept faction/state inputs, surface real per-turn probabilities, and run simulations through the gating roll
- show per-turn and conditional event chances in the newspaper hero article and event wire using a shared formatter

## Testing
- npm run lint *(fails: repository has extensive pre-existing lint errors outside the touched files)*

------
https://chatgpt.com/codex/tasks/task_e_68d5ffe06724832085b07a71844d662f