### PR TITLE
Integrate event tools into balancing dashboard

### DIFF
--- a/src/components/game/EnhancedBalancingDashboard.tsx
+++ b/src/components/game/EnhancedBalancingDashboard.tsx
@@ -21,6 +21,8 @@ import { Slider } from '@/components/ui/slider';
 import { Checkbox } from '@/components/ui/checkbox';
 import { Label } from '@/components/ui/label';
 import type { GameCard } from '@/rules/mvp';
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
+import EventViewer from '@/components/game/EventViewer';
 
 type HistogramBin = { label: string; count: number };
 
@@ -173,9 +175,14 @@ const HistogramCard = ({
 interface EnhancedBalancingDashboardProps {
   onClose: () => void;
   logEntries: string[];
+  initialView?: 'analysis' | 'dev-tools';
 }
 
-const EnhancedBalancingDashboard = ({ onClose, logEntries }: EnhancedBalancingDashboardProps) => {
+const EnhancedBalancingDashboard = ({
+  onClose,
+  logEntries,
+  initialView = 'analysis',
+}: EnhancedBalancingDashboardProps) => {
   const [expansionState, setExpansionState] = useState(() => ({
     ids: getEnabledExpansionIdsSnapshot(),
     cards: getExpansionCardsSnapshot(),
@@ -189,6 +196,7 @@ const EnhancedBalancingDashboard = ({ onClose, logEntries }: EnhancedBalancingDa
     MEDIA: true,
     ZONE: true,
   });
+  const [activeView, setActiveView] = useState<'analysis' | 'dev-tools'>(initialView);
 
   useEffect(() => {
     const unsubscribe = subscribeToExpansionChanges(payload => {
@@ -202,6 +210,10 @@ const EnhancedBalancingDashboard = ({ onClose, logEntries }: EnhancedBalancingDa
       setIncludeExpansions(false);
     }
   }, [expansionState.ids.length]);
+
+  useEffect(() => {
+    setActiveView(initialView);
+  }, [initialView]);
 
   const activeTypes = useMemo(
     () =>
@@ -393,8 +405,8 @@ const EnhancedBalancingDashboard = ({ onClose, logEntries }: EnhancedBalancingDa
   };
 
   return (
-    <div className="fixed inset-0 z-50 bg-black/80 flex items-center justify-center p-4">
-      <Card className="w-full max-w-5xl max-h-[90vh] bg-gray-950 border border-gray-700 overflow-hidden flex flex-col">
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/80 p-4">
+      <Card className="flex h-full max-h-[90vh] w-full max-w-5xl flex-col overflow-hidden border border-gray-700 bg-gray-950">
         <div className="flex items-center justify-between p-4 border-b border-gray-800 bg-gray-900/80">
           <div>
             <h2 className="text-lg font-semibold text-white font-mono tracking-wide">
@@ -409,7 +421,33 @@ const EnhancedBalancingDashboard = ({ onClose, logEntries }: EnhancedBalancingDa
           </Button>
         </div>
 
-        <div className="flex-1 overflow-y-auto p-6 space-y-6 text-sm text-slate-200">
+        <Tabs
+          value={activeView}
+          onValueChange={value => setActiveView(value as 'analysis' | 'dev-tools')}
+          className="flex flex-1 flex-col overflow-hidden"
+        >
+          <div className="px-6 pt-4">
+            <TabsList className="grid w-full grid-cols-2 gap-1 rounded-md border border-gray-800 bg-gray-900/60 p-1">
+              <TabsTrigger
+                value="analysis"
+                className="text-xs uppercase tracking-wide text-slate-400 data-[state=active]:bg-gray-800 data-[state=active]:text-emerald-300"
+              >
+                Balance Intel
+              </TabsTrigger>
+              <TabsTrigger
+                value="dev-tools"
+                className="text-xs uppercase tracking-wide text-slate-400 data-[state=active]:bg-gray-800 data-[state=active]:text-emerald-300"
+              >
+                Dev Tool Menu
+              </TabsTrigger>
+            </TabsList>
+          </div>
+
+          <TabsContent
+            value="analysis"
+            className="flex-1 overflow-hidden focus-visible:outline-none"
+          >
+            <div className="flex-1 overflow-y-auto p-6 space-y-6 text-sm text-slate-200">
           <section className="relative overflow-hidden rounded-xl border border-emerald-500/20 bg-gradient-to-br from-emerald-900/40 via-gray-950 to-slate-950 p-6">
             <div className="absolute inset-0 bg-[radial-gradient(circle_at_top,rgba(34,197,94,0.25),transparent_55%)]" />
             <div className="absolute inset-0 opacity-30 mix-blend-screen" style={{ backgroundImage: 'linear-gradient(120deg, transparent 0%, rgba(56,189,248,0.15) 50%, transparent 100%)' }} />
@@ -820,7 +858,18 @@ const EnhancedBalancingDashboard = ({ onClose, logEntries }: EnhancedBalancingDa
               <li>Legacy export formats and extension data have been retired for the MVP build.</li>
             </ul>
           </section>
-        </div>
+            </div>
+          </TabsContent>
+
+          <TabsContent
+            value="dev-tools"
+            className="flex-1 overflow-hidden focus-visible:outline-none"
+          >
+            <div className="h-full p-6">
+              <EventViewer variant="embedded" className="h-full" />
+            </div>
+          </TabsContent>
+        </Tabs>
       </Card>
     </div>
   );

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -13,7 +13,6 @@ import GameMenu from '@/components/game/GameMenu';
 import SecretAgenda from '@/components/game/SecretAgenda';
 import AIStatus from '@/components/game/AIStatus';
 import EnhancedBalancingDashboard from '@/components/game/EnhancedBalancingDashboard';
-import EventViewer from '@/components/game/EventViewer';
 import TutorialOverlay from '@/components/game/TutorialOverlay';
 import AchievementPanel from '@/components/game/AchievementPanel';
 import Options from '@/components/game/Options';
@@ -432,7 +431,7 @@ const Index = () => {
   const [showIntro, setShowIntro] = useState(true);
   const [isFullscreen, setIsFullscreen] = useState(false);
   const [showBalancing, setShowBalancing] = useState(false);
-  const [showEvents, setShowEvents] = useState(false);
+  const [balancingInitialView, setBalancingInitialView] = useState<'analysis' | 'dev-tools'>('analysis');
   const [showTutorial, setShowTutorial] = useState(false);
   const [showAchievements, setShowAchievements] = useState(false);
   const [loadingCard, setLoadingCard] = useState<string | null>(null);
@@ -1303,15 +1302,12 @@ const Index = () => {
     return <TutorialOverlay onClose={() => setShowTutorial(false)} />;
   }
 
-  if (showEvents) {
-    return <EventViewer onClose={() => setShowEvents(false)} />;
-  }
-
   if (showBalancing) {
     return (
       <EnhancedBalancingDashboard
         onClose={() => setShowBalancing(false)}
         logEntries={gameState.log}
+        initialView={balancingInitialView}
       />
     );
   }
@@ -1623,7 +1619,10 @@ const Index = () => {
           </button>
           <button
             type="button"
-            onClick={() => setShowBalancing(true)}
+            onClick={() => {
+              setBalancingInitialView('analysis');
+              setShowBalancing(true);
+            }}
             className={mastheadButtonClass}
             title="Card Balancing Dashboard"
           >
@@ -1631,7 +1630,10 @@ const Index = () => {
           </button>
           <button
             type="button"
-            onClick={() => setShowEvents(true)}
+            onClick={() => {
+              setBalancingInitialView('dev-tools');
+              setShowBalancing(true);
+            }}
             className={mastheadButtonClass}
             title="Event Database"
           >


### PR DESCRIPTION
## Summary
- add an embedded variant to the event viewer so the database and testing tools can render inside other overlays
- reorganize the MVP balancing briefing with tabs and surface the event tooling under a new Dev Tool Menu view
- route the masthead buttons to open the balancing briefing with either the analysis dashboard or the embedded event tools

## Testing
- npm run lint *(fails: repository contains existing lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68d6043db0f08320936951cea4575e42