### PR TITLE
Add IP maintenance system for MVP turn income

### DIFF
--- a/DESIGN_DOC_MVP.md
+++ b/DESIGN_DOC_MVP.md
@@ -478,7 +478,11 @@ startTurn(s):
 
 
 
-me.ip += 5 + me.states.length
+me.ip += max(0, (5 + me.states.length) - upkeep)
+
+upkeep = max(0, floor((me.ip - 40) / 10))
+
+(40 og 10 er standardverdier; juster DEFAULT_IP_MAINTENANCE i engine.ts ved behov)
 
 
 

--- a/docs/TECHNICAL_README.md
+++ b/docs/TECHNICAL_README.md
@@ -11,7 +11,7 @@
 ## Game loop fundamentals
 The MVP design defines a duel between the Truth Seekers and the Government, each managing Influence Points (IP), a shared Truth meter, and pressure on individual U.S. states. Win conditions include controlling 10 states, pushing Truth to faction-specific thresholds, or accumulating 300 IP.【F:DESIGN_DOC_MVP.md†L7-L63】 These core concepts are implemented directly in the runtime engine:
 
-- **Turn start:** `startTurn` clones game state, awards `5 + controlledStates` IP to the active player, and refills their hand to five cards.【F:src/mvp/engine.ts†L50-L68】
+- **Turn start:** `startTurn` clones game state, uses `computeTurnIpIncome` to award `5 + controlledStates` IP minus any maintenance for stockpiled reserves, logs upkeep when applied, and refills the active player's hand to five cards.【F:src/mvp/engine.ts†L50-L91】
 - **Card play gating:** `canPlay` enforces the three-card-per-turn limit, IP costs, and ZONE targeting rules before a card resolves.【F:src/mvp/engine.ts†L71-L99】
 - **Playing a card:** `playCard` removes the card from hand, deducts IP, logs the play, and calls `resolve` to apply effects.【F:src/mvp/engine.ts†L101-L215】
 - **Effect resolution:** `resolve` relies on `applyEffectsMvp` to adjust IP, Truth, and pressure while tracking capture metadata for end-of-turn summaries.【F:src/mvp/engine.ts†L157-L215】【F:src/engine/applyEffects-mvp.ts†L53-L157】

--- a/src/mvp/__tests__/engine.income.test.ts
+++ b/src/mvp/__tests__/engine.income.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from 'bun:test';
+
+import {
+  DEFAULT_IP_MAINTENANCE,
+  computeTurnIpIncome,
+  startTurn,
+} from '@/mvp/engine';
+import type { GameState, PlayerState } from '@/mvp/validator';
+
+type PartialPlayer = Partial<PlayerState> & Pick<PlayerState, 'ip'>;
+
+const makePlayer = (partial: PartialPlayer): PlayerState => ({
+  id: partial.id ?? 'P1',
+  faction: partial.faction ?? 'truth',
+  deck: partial.deck ?? [],
+  hand: partial.hand ?? [],
+  discard: partial.discard ?? [],
+  ip: partial.ip,
+  states: partial.states ?? [],
+});
+
+const makeState = (currentPlayer: PlayerState, opponentIp = 0): GameState => ({
+  turn: 1,
+  currentPlayer: currentPlayer.id,
+  truth: 50,
+  players: {
+    P1: currentPlayer.id === 'P1' ? currentPlayer : makePlayer({ id: 'P1', ip: opponentIp }),
+    P2: currentPlayer.id === 'P2' ? currentPlayer : makePlayer({ id: 'P2', faction: 'government', ip: opponentIp }),
+  },
+  pressureByState: {},
+  stateDefense: {},
+  playsThisTurn: 0,
+  turnPlays: [],
+  log: [],
+});
+
+describe('computeTurnIpIncome', () => {
+  it('returns full base income when under the maintenance threshold', () => {
+    const player = makePlayer({ id: 'P1', ip: 20, states: ['ca', 'ny'] });
+
+    const result = computeTurnIpIncome(player);
+
+    expect(result).toEqual({ baseIncome: 7, maintenance: 0, netIncome: 7 });
+  });
+
+  it('applies maintenance when reserves exceed the threshold', () => {
+    const player = makePlayer({ id: 'P1', ip: 65, states: ['tx'] });
+
+    const result = computeTurnIpIncome(player);
+
+    expect(result).toEqual({ baseIncome: 6, maintenance: 2, netIncome: 4 });
+  });
+
+  it('never yields negative net income even with massive reserves', () => {
+    const player = makePlayer({ id: 'P1', ip: 200, states: [] });
+
+    const result = computeTurnIpIncome(player);
+
+    expect(result.netIncome).toBe(0);
+    expect(result.maintenance).toBeGreaterThanOrEqual(DEFAULT_IP_MAINTENANCE.divisor);
+  });
+});
+
+describe('startTurn upkeep integration', () => {
+  it('adds log entries and reduces income when maintenance applies', () => {
+    const player = makePlayer({ id: 'P1', ip: 65, states: ['fl'] });
+    const state = makeState(player);
+
+    const updated = startTurn(state);
+    const updatedPlayer = updated.players.P1;
+
+    expect(updatedPlayer.ip).toBe(65 + 4);
+    const maintenanceLog = updated.log.at(-1);
+    expect(maintenanceLog).toBeDefined();
+    expect(maintenanceLog).toContain('maintenance -2 IP');
+    expect(maintenanceLog).toContain(`threshold ${DEFAULT_IP_MAINTENANCE.threshold}`);
+    expect(maintenanceLog).toContain(`divisor ${DEFAULT_IP_MAINTENANCE.divisor}`);
+  });
+});


### PR DESCRIPTION
## Summary
- add configurable `computeTurnIpIncome` helper that applies IP maintenance when reserves exceed the threshold
- update `startTurn` to use the helper, log upkeep deductions, and document the maintenance formula in the MVP design guides
- cover high-IP scenarios with new bun tests for the income helper and upkeep logging

## Testing
- bun test

------
https://chatgpt.com/codex/tasks/task_e_68d638b96ac48320b3105c14b1ae85b5