### PR TITLE
feat: add unified player hub overlay

### DIFF
--- a/src/components/game/AchievementPanel.tsx
+++ b/src/components/game/AchievementPanel.tsx
@@ -10,31 +10,36 @@ import { ACHIEVEMENTS, type Achievement } from '@/data/achievementSystem';
 import { useAchievements } from '@/contexts/AchievementContext';
 import { useToast } from '@/hooks/use-toast';
 
-interface AchievementPanelProps {
-  onClose: () => void;
+interface AchievementsSectionProps {
+  onClose?: () => void;
+  className?: string;
+  showCloseButton?: boolean;
 }
 
-const AchievementPanel = ({ onClose }: AchievementPanelProps) => {
+export const AchievementsSection = ({
+  onClose,
+  className,
+  showCloseButton = false,
+}: AchievementsSectionProps) => {
   const [selectedAchievement, setSelectedAchievement] = useState<Achievement | null>(null);
   const [filter, setFilter] = useState<string>('all');
-  
-  const { 
-    manager, 
-    stats, 
-    unlockedAchievements, 
-    lockedAchievements, 
+
+  const {
+    manager,
+    stats,
+    unlockedAchievements,
+    lockedAchievements,
     newlyUnlocked,
     exportData,
     importData,
     resetProgress,
     clearNewlyUnlocked
   } = useAchievements();
-  
+
   const { toast } = useToast();
 
   const progress = manager.getProgress();
 
-  // Clear newly unlocked achievements when component mounts
   useEffect(() => {
     if (newlyUnlocked.length > 0) {
       clearNewlyUnlocked();
@@ -63,11 +68,13 @@ const AchievementPanel = ({ onClose }: AchievementPanelProps) => {
     }
   };
 
-  const filteredUnlocked = filter === 'all' ? unlockedAchievements : 
-    unlockedAchievements.filter(a => a.category === filter);
-  
-  const filteredLocked = filter === 'all' ? lockedAchievements : 
-    lockedAchievements.filter(a => a.category === filter);
+  const filteredUnlocked = filter === 'all'
+    ? unlockedAchievements
+    : unlockedAchievements.filter(a => a.category === filter);
+
+  const filteredLocked = filter === 'all'
+    ? lockedAchievements
+    : lockedAchievements.filter(a => a.category === filter);
 
   const exportProgress = () => {
     const data = exportData();
@@ -78,10 +85,10 @@ const AchievementPanel = ({ onClose }: AchievementPanelProps) => {
     link.download = `shadow-government-progress-${new Date().toISOString().split('T')[0]}.json`;
     link.click();
     URL.revokeObjectURL(url);
-    
+
     toast({
-      title: "Progress Exported",
-      description: "Your achievements and statistics have been downloaded",
+      title: 'Progress Exported',
+      description: 'Your achievements and statistics have been downloaded',
     });
   };
 
@@ -99,9 +106,9 @@ const AchievementPanel = ({ onClose }: AchievementPanelProps) => {
             importData(data);
           } catch (error) {
             toast({
-              title: "Import Failed",
-              description: "Invalid file format",
-              variant: "destructive",
+              title: 'Import Failed',
+              description: 'Invalid file format',
+              variant: 'destructive',
             });
           }
         };
@@ -118,46 +125,46 @@ const AchievementPanel = ({ onClose }: AchievementPanelProps) => {
   };
 
   return (
-    <div className="fixed inset-0 z-50 bg-black/80 flex items-center justify-center p-4">
-      <Card className="w-full max-w-7xl h-[90vh] bg-gray-900 border-gray-700 overflow-hidden">
-        <div className="flex items-center justify-between p-4 border-b border-gray-700">
-          <div className="flex items-center gap-3">
-            <Trophy size={24} className="text-yellow-400" />
-            <div>
-              <h2 className="text-xl font-bold text-white font-mono">ACHIEVEMENTS</h2>
-              <div className="text-sm text-gray-400">
-                {progress.unlocked}/{progress.total} unlocked • {progress.totalPoints} points • {progress.rank}
-              </div>
+    <div className={`flex h-full flex-col ${className ?? ''}`}>
+      <div className="flex items-center justify-between border-b border-gray-700 p-4">
+        <div className="flex items-center gap-3">
+          <Trophy size={24} className="text-yellow-400" />
+          <div>
+            <h2 className="text-xl font-bold text-white font-mono">ACHIEVEMENTS</h2>
+            <div className="text-sm text-gray-400">
+              {progress.unlocked}/{progress.total} unlocked • {progress.totalPoints} points • {progress.rank}
             </div>
           </div>
-          <div className="flex items-center gap-2">
-            <Button
-              onClick={exportProgress}
-              variant="outline"
-              size="sm"
-              className="text-green-400 border-green-600 hover:bg-green-900/20"
-            >
-              <Download size={16} className="mr-1" />
-              Export
-            </Button>
-            <Button
-              onClick={importProgress}
-              variant="outline"
-              size="sm"
-              className="text-blue-400 border-blue-600 hover:bg-blue-900/20"
-            >
-              <Upload size={16} className="mr-1" />
-              Import
-            </Button>
-            <Button
-              onClick={handleResetProgress}
-              variant="outline"
-              size="sm"
-              className="text-red-400 border-red-600 hover:bg-red-900/20"
-            >
-              <RotateCcw size={16} className="mr-1" />
-              Reset
-            </Button>
+        </div>
+        <div className="flex items-center gap-2">
+          <Button
+            onClick={exportProgress}
+            variant="outline"
+            size="sm"
+            className="text-green-400 border-green-600 hover:bg-green-900/20"
+          >
+            <Download size={16} className="mr-1" />
+            Export
+          </Button>
+          <Button
+            onClick={importProgress}
+            variant="outline"
+            size="sm"
+            className="text-blue-400 border-blue-600 hover:bg-blue-900/20"
+          >
+            <Upload size={16} className="mr-1" />
+            Import
+          </Button>
+          <Button
+            onClick={handleResetProgress}
+            variant="outline"
+            size="sm"
+            className="text-red-400 border-red-600 hover:bg-red-900/20"
+          >
+            <RotateCcw size={16} className="mr-1" />
+            Reset
+          </Button>
+          {showCloseButton && onClose && (
             <Button
               onClick={onClose}
               variant="outline"
@@ -166,352 +173,368 @@ const AchievementPanel = ({ onClose }: AchievementPanelProps) => {
             >
               <X size={16} />
             </Button>
-          </div>
+          )}
         </div>
+      </div>
 
-        <div className="p-4 h-full overflow-hidden">
-          <Tabs defaultValue="achievements" className="h-full">
-            <TabsList className="grid w-full grid-cols-3 bg-gray-800 mb-4">
-              <TabsTrigger value="achievements">Achievements</TabsTrigger>
-              <TabsTrigger value="statistics">Statistics</TabsTrigger>
-              <TabsTrigger value="progress">Progress</TabsTrigger>
-            </TabsList>
+      <div className="flex-1 overflow-hidden p-4">
+        <Tabs defaultValue="achievements" className="h-full">
+          <TabsList className="mb-4 grid w-full grid-cols-3 bg-gray-800">
+            <TabsTrigger value="achievements">Achievements</TabsTrigger>
+            <TabsTrigger value="statistics">Statistics</TabsTrigger>
+            <TabsTrigger value="progress">Progress</TabsTrigger>
+          </TabsList>
 
-            <TabsContent value="achievements" className="h-full">
-              <div className="grid grid-cols-1 lg:grid-cols-3 gap-4 h-full">
-                <div className="lg:col-span-2">
-                  <Card className="p-4 bg-gray-800 border-gray-700 h-full">
-                    <div className="flex items-center justify-between mb-4">
-                      <h3 className="text-lg font-semibold text-white">Achievement List</h3>
-                      <select
-                        value={filter}
-                        onChange={(e) => setFilter(e.target.value)}
-                        className="bg-gray-700 text-white border border-gray-600 rounded px-3 py-1 text-sm"
-                      >
-                        <option value="all">All Categories</option>
-                        <option value="victory">Victory</option>
-                        <option value="mastery">Mastery</option>
-                        <option value="discovery">Discovery</option>
-                        <option value="challenge">Challenge</option>
-                        <option value="social">Social</option>
-                        <option value="collection">Collection</option>
-                      </select>
+          <TabsContent value="achievements" className="h-full">
+            <div className="grid h-full grid-cols-1 gap-4 lg:grid-cols-3">
+              <div className="lg:col-span-2">
+                <Card className="h-full border-gray-700 bg-gray-800 p-4">
+                  <div className="mb-4 flex items-center justify-between">
+                    <h3 className="text-lg font-semibold text-white">Achievement List</h3>
+                    <select
+                      value={filter}
+                      onChange={(e) => setFilter(e.target.value)}
+                      className="rounded border border-gray-600 bg-gray-700 px-3 py-1 text-sm text-white"
+                    >
+                      <option value="all">All Categories</option>
+                      <option value="victory">Victory</option>
+                      <option value="mastery">Mastery</option>
+                      <option value="discovery">Discovery</option>
+                      <option value="challenge">Challenge</option>
+                      <option value="social">Social</option>
+                      <option value="collection">Collection</option>
+                    </select>
+                  </div>
+
+                  <ScrollArea className="h-[60vh]">
+                    <div className="space-y-4">
+                      {filteredUnlocked.length > 0 && (
+                        <div>
+                          <h4 className="mb-3 text-sm font-bold uppercase tracking-wide text-green-400">
+                            Unlocked ({filteredUnlocked.length})
+                          </h4>
+                          <div className="space-y-2">
+                            {filteredUnlocked.map(achievement => (
+                              <div
+                                key={achievement.id}
+                                className={`rounded p-3 transition-colors cursor-pointer ${
+                                  selectedAchievement?.id === achievement.id
+                                    ? 'bg-blue-900/30 border border-blue-600'
+                                    : 'bg-gray-700 hover:bg-gray-600'
+                                }`}
+                                onClick={() => setSelectedAchievement(achievement)}
+                              >
+                                <div className="flex items-center gap-3">
+                                  <div className="text-2xl">{achievement.icon}</div>
+                                  <div className="flex-1">
+                                    <div className="mb-1 flex items-center gap-2">
+                                      <h5 className="font-semibold text-white">{achievement.name}</h5>
+                                      <Badge className={getRarityColor(achievement.rarity)}>
+                                        {achievement.rarity}
+                                      </Badge>
+                                      <Badge className="bg-yellow-900/20 text-yellow-400">
+                                        {achievement.points}pts
+                                      </Badge>
+                                    </div>
+                                    <p className="text-sm text-gray-300">{achievement.description}</p>
+                                    <div className="mt-1 flex items-center gap-2">
+                                      {getCategoryIcon(achievement.category)}
+                                      <span className="text-xs capitalize text-gray-500">{achievement.category}</span>
+                                      <span className="text-xs text-green-400">✓ Completed</span>
+                                    </div>
+                                  </div>
+                                </div>
+                              </div>
+                            ))}
+                          </div>
+                        </div>
+                      )}
+
+                      {filteredLocked.length > 0 && (
+                        <div>
+                          <h4 className="mb-3 text-sm font-bold uppercase tracking-wide text-gray-400">
+                            Locked ({filteredLocked.length})
+                          </h4>
+                          <div className="space-y-2">
+                            {filteredLocked.map(achievement => (
+                              <div
+                                key={achievement.id}
+                                className={`rounded p-3 transition-colors opacity-60 cursor-pointer ${
+                                  selectedAchievement?.id === achievement.id
+                                    ? 'bg-blue-900/30 border border-blue-600'
+                                    : 'bg-gray-700 hover:bg-gray-600'
+                                }`}
+                                onClick={() => setSelectedAchievement(achievement)}
+                              >
+                                <div className="flex items-center gap-3">
+                                  <div className="text-2xl grayscale">{achievement.icon}</div>
+                                  <div className="flex-1">
+                                    <div className="mb-1 flex items-center gap-2">
+                                      <h5 className="font-semibold text-gray-300">{achievement.name}</h5>
+                                      <Badge className={getRarityColor(achievement.rarity)}>
+                                        {achievement.rarity}
+                                      </Badge>
+                                      <Badge className="bg-yellow-900/20 text-yellow-400">
+                                        {achievement.points}pts
+                                      </Badge>
+                                    </div>
+                                    <p className="text-sm text-gray-400">{achievement.description}</p>
+                                    <div className="mt-1 flex items-center gap-2">
+                                      {getCategoryIcon(achievement.category)}
+                                      <span className="text-xs capitalize text-gray-500">{achievement.category}</span>
+                                      <span className="text-xs text-gray-500">🔒 Locked</span>
+                                    </div>
+                                  </div>
+                                </div>
+                              </div>
+                            ))}
+                          </div>
+                        </div>
+                      )}
                     </div>
+                  </ScrollArea>
+                </Card>
+              </div>
 
+              <div>
+                <Card className="h-full border-gray-700 bg-gray-800 p-4">
+                  <h3 className="mb-4 text-lg font-semibold text-white">
+                    {selectedAchievement ? 'Achievement Details' : 'Select Achievement'}
+                  </h3>
+                  {selectedAchievement ? (
                     <ScrollArea className="h-[60vh]">
                       <div className="space-y-4">
-                        {/* Unlocked Achievements */}
-                        {filteredUnlocked.length > 0 && (
-                          <div>
-                            <h4 className="text-sm font-bold text-green-400 mb-3 uppercase tracking-wide">
-                              Unlocked ({filteredUnlocked.length})
-                            </h4>
-                            <div className="space-y-2">
-                              {filteredUnlocked.map(achievement => (
-                                <div 
-                                  key={achievement.id}
-                                  className={`p-3 rounded cursor-pointer transition-colors ${
-                                    selectedAchievement?.id === achievement.id 
-                                      ? 'bg-blue-900/30 border border-blue-600' 
-                                      : 'bg-gray-700 hover:bg-gray-600'
-                                  }`}
-                                  onClick={() => setSelectedAchievement(achievement)}
-                                >
-                                  <div className="flex items-center gap-3">
-                                    <div className="text-2xl">{achievement.icon}</div>
-                                    <div className="flex-1">
-                                      <div className="flex items-center gap-2 mb-1">
-                                        <h5 className="font-semibold text-white">{achievement.name}</h5>
-                                        <Badge className={getRarityColor(achievement.rarity)}>
-                                          {achievement.rarity}
-                                        </Badge>
-                                        <Badge className="text-yellow-400 bg-yellow-900/20">
-                                          {achievement.points}pts
-                                        </Badge>
-                                      </div>
-                                      <p className="text-sm text-gray-300">{achievement.description}</p>
-                                      <div className="flex items-center gap-2 mt-1">
-                                        {getCategoryIcon(achievement.category)}
-                                        <span className="text-xs text-gray-500 capitalize">{achievement.category}</span>
-                                        <span className="text-xs text-green-400">✓ Completed</span>
-                                      </div>
-                                    </div>
-                                  </div>
-                                </div>
-                              ))}
-                            </div>
-                          </div>
-                        )}
+                        <div className="text-center">
+                          <div className="mb-2 text-6xl">{selectedAchievement.icon}</div>
+                          <h4 className="text-xl font-bold text-white">{selectedAchievement.name}</h4>
+                          <p className="mt-1 text-sm text-gray-300">{selectedAchievement.description}</p>
+                        </div>
 
-                        {/* Locked Achievements */}
-                        {filteredLocked.length > 0 && (
-                          <div>
-                            <h4 className="text-sm font-bold text-gray-400 mb-3 uppercase tracking-wide">
-                              Locked ({filteredLocked.length})
-                            </h4>
-                            <div className="space-y-2">
-                              {filteredLocked.map(achievement => (
-                                <div 
-                                  key={achievement.id}
-                                  className={`p-3 rounded cursor-pointer transition-colors opacity-60 ${
-                                    selectedAchievement?.id === achievement.id 
-                                      ? 'bg-blue-900/30 border border-blue-600' 
-                                      : 'bg-gray-700 hover:bg-gray-600'
-                                  }`}
-                                  onClick={() => setSelectedAchievement(achievement)}
-                                >
-                                  <div className="flex items-center gap-3">
-                                    <div className="text-2xl grayscale">{achievement.icon}</div>
-                                    <div className="flex-1">
-                                      <div className="flex items-center gap-2 mb-1">
-                                        <h5 className="font-semibold text-gray-300">{achievement.name}</h5>
-                                        <Badge className={getRarityColor(achievement.rarity)}>
-                                          {achievement.rarity}
-                                        </Badge>
-                                        <Badge className="text-yellow-400 bg-yellow-900/20">
-                                          {achievement.points}pts
-                                        </Badge>
-                                      </div>
-                                      <p className="text-sm text-gray-400">{achievement.description}</p>
-                                      <div className="flex items-center gap-2 mt-1">
-                                        {getCategoryIcon(achievement.category)}
-                                        <span className="text-xs text-gray-500 capitalize">{achievement.category}</span>
-                                        <span className="text-xs text-gray-500">🔒 Locked</span>
-                                      </div>
-                                    </div>
-                                  </div>
-                                </div>
-                              ))}
+                        <div className="space-y-3">
+                          <div className="flex items-center justify-between">
+                            <span className="text-sm text-gray-400">Category:</span>
+                            <div className="flex items-center gap-1">
+                              {getCategoryIcon(selectedAchievement.category)}
+                              <span className="text-sm capitalize text-white">{selectedAchievement.category}</span>
                             </div>
                           </div>
-                        )}
+
+                          <div className="flex items-center justify-between">
+                            <span className="text-sm text-gray-400">Rarity:</span>
+                            <Badge className={getRarityColor(selectedAchievement.rarity)}>
+                              {selectedAchievement.rarity}
+                            </Badge>
+                          </div>
+
+                          <div className="flex items-center justify-between">
+                            <span className="text-sm text-gray-400">Points:</span>
+                            <span className="text-sm font-bold text-yellow-400">{selectedAchievement.points}</span>
+                          </div>
+
+                          <div className="flex items-center justify-between">
+                            <span className="text-sm text-gray-400">Status:</span>
+                            <Badge className={
+                              unlockedAchievements.find(a => a.id === selectedAchievement.id)
+                                ? 'text-green-400 bg-green-900/20'
+                                : 'text-red-400 bg-red-900/20'
+                            }>
+                              {unlockedAchievements.find(a => a.id === selectedAchievement.id) ? '✓ Unlocked' : '🔒 Locked'}
+                            </Badge>
+                          </div>
+
+                          {selectedAchievement.requirements && (
+                            <div>
+                              <div className="mb-2 text-sm text-gray-400">Requirements:</div>
+                              <div className="space-y-1">
+                                {selectedAchievement.requirements.conditions.map((condition, index) => (
+                                  <div key={index} className="rounded bg-gray-700 p-2 text-xs text-gray-500">
+                                    {condition.key.replace(/_/g, ' ')}: {condition.operator || '=='} {condition.value}
+                                  </div>
+                                ))}
+                              </div>
+                            </div>
+                          )}
+
+                          {selectedAchievement.rewards && (
+                            <div>
+                              <div className="mb-2 text-sm text-gray-400">Rewards:</div>
+                              <div className="space-y-1">
+                                {selectedAchievement.rewards.title && (
+                                  <div className="text-xs text-yellow-400">Title: {selectedAchievement.rewards.title}</div>
+                                )}
+                                {selectedAchievement.rewards.unlockTutorial && (
+                                  <div className="text-xs text-blue-400">
+                                    Unlocks: {selectedAchievement.rewards.unlockTutorial} tutorial
+                                  </div>
+                                )}
+                              </div>
+                            </div>
+                          )}
+
+                          {selectedAchievement.hidden && (
+                            <div className="rounded border border-purple-600 bg-purple-900/20 p-3">
+                              <div className="text-sm font-bold text-purple-400">Hidden Achievement</div>
+                              <div className="mt-1 text-xs text-purple-300">
+                                This is a secret achievement that was discovered through special actions.
+                              </div>
+                            </div>
+                          )}
+                        </div>
                       </div>
                     </ScrollArea>
-                  </Card>
-                </div>
-
-                <div>
-                  <Card className="p-4 bg-gray-800 border-gray-700 h-full">
-                    <h3 className="text-lg font-semibold text-white mb-4">
-                      {selectedAchievement ? 'Achievement Details' : 'Select Achievement'}
-                    </h3>
-                    {selectedAchievement ? (
-                      <ScrollArea className="h-[60vh]">
-                        <div className="space-y-4">
-                          <div className="text-center">
-                            <div className="text-6xl mb-2">{selectedAchievement.icon}</div>
-                            <h4 className="text-xl font-bold text-white">{selectedAchievement.name}</h4>
-                            <p className="text-sm text-gray-300 mt-1">{selectedAchievement.description}</p>
-                          </div>
-
-                          <div className="space-y-3">
-                            <div className="flex items-center justify-between">
-                              <span className="text-sm text-gray-400">Category:</span>
-                              <div className="flex items-center gap-1">
-                                {getCategoryIcon(selectedAchievement.category)}
-                                <span className="text-sm text-white capitalize">{selectedAchievement.category}</span>
-                              </div>
-                            </div>
-
-                            <div className="flex items-center justify-between">
-                              <span className="text-sm text-gray-400">Rarity:</span>
-                              <Badge className={getRarityColor(selectedAchievement.rarity)}>
-                                {selectedAchievement.rarity}
-                              </Badge>
-                            </div>
-
-                            <div className="flex items-center justify-between">
-                              <span className="text-sm text-gray-400">Points:</span>
-                              <span className="text-sm font-bold text-yellow-400">{selectedAchievement.points}</span>
-                            </div>
-
-                            <div className="flex items-center justify-between">
-                              <span className="text-sm text-gray-400">Status:</span>
-                              <Badge className={
-                                unlockedAchievements.find(a => a.id === selectedAchievement.id)
-                                  ? 'text-green-400 bg-green-900/20'
-                                  : 'text-red-400 bg-red-900/20'
-                              }>
-                                {unlockedAchievements.find(a => a.id === selectedAchievement.id) ? '✓ Unlocked' : '🔒 Locked'}
-                              </Badge>
-                            </div>
-
-                            {selectedAchievement.requirements && (
-                              <div>
-                                <div className="text-sm text-gray-400 mb-2">Requirements:</div>
-                                <div className="space-y-1">
-                                  {selectedAchievement.requirements.conditions.map((condition, index) => (
-                                    <div key={index} className="text-xs text-gray-500 bg-gray-700 p-2 rounded">
-                                      {condition.key.replace(/_/g, ' ')}: {condition.operator || '=='} {condition.value}
-                                    </div>
-                                  ))}
-                                </div>
-                              </div>
-                            )}
-
-                            {selectedAchievement.rewards && (
-                              <div>
-                                <div className="text-sm text-gray-400 mb-2">Rewards:</div>
-                                <div className="space-y-1">
-                                  {selectedAchievement.rewards.title && (
-                                    <div className="text-xs text-yellow-400">Title: {selectedAchievement.rewards.title}</div>
-                                  )}
-                                  {selectedAchievement.rewards.unlockTutorial && (
-                                    <div className="text-xs text-blue-400">Unlocks: {selectedAchievement.rewards.unlockTutorial} tutorial</div>
-                                  )}
-                                </div>
-                              </div>
-                            )}
-
-                            {selectedAchievement.hidden && (
-                              <div className="p-3 bg-purple-900/20 border border-purple-600 rounded">
-                                <div className="text-sm text-purple-400 font-bold">Hidden Achievement</div>
-                                <div className="text-xs text-purple-300 mt-1">
-                                  This is a secret achievement that was discovered through special actions.
-                                </div>
-                              </div>
-                            )}
-                          </div>
-                        </div>
-                      </ScrollArea>
-                    ) : (
-                      <div className="text-center text-gray-500 py-8">
-                        <Trophy size={48} className="mx-auto mb-4 opacity-50" />
-                        <div className="text-lg font-medium mb-2">Achievement Details</div>
-                        <div className="text-sm">
-                          Click on an achievement to view detailed information
-                        </div>
+                  ) : (
+                    <div className="py-8 text-center text-gray-500">
+                      <Trophy size={48} className="mx-auto mb-4 opacity-50" />
+                      <div className="mb-2 text-lg font-medium">Achievement Details</div>
+                      <div className="text-sm">
+                        Click on an achievement to view detailed information
                       </div>
-                    )}
-                  </Card>
+                    </div>
+                  )}
+                </Card>
+              </div>
+            </div>
+          </TabsContent>
+
+          <TabsContent value="statistics" className="mt-4">
+            <div className="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-4">
+              <Card className="border-gray-700 bg-gray-800 p-4">
+                <div className="text-2xl font-bold text-white">{stats.total_games_played}</div>
+                <div className="text-sm text-gray-400">Games Played</div>
+              </Card>
+              <Card className="border-gray-700 bg-gray-800 p-4">
+                <div className="text-2xl font-bold text-green-400">{stats.games_won}</div>
+                <div className="text-sm text-gray-400">Games Won</div>
+              </Card>
+              <Card className="border-gray-700 bg-gray-800 p-4">
+                <div className="text-2xl font-bold text-yellow-400">{stats.max_win_streak}</div>
+                <div className="text-sm text-gray-400">Best Win Streak</div>
+              </Card>
+              <Card className="border-gray-700 bg-gray-800 p-4">
+                <div className="text-2xl font-bold text-blue-400">{progress.totalPoints}</div>
+                <div className="text-sm text-gray-400">Achievement Points</div>
+              </Card>
+              <Card className="border-gray-700 bg-gray-800 p-4">
+                <div className="text-2xl font-bold text-purple-400">{stats.legendary_cards_played}</div>
+                <div className="text-sm text-gray-400">Legendary Cards</div>
+              </Card>
+              <Card className="border-gray-700 bg-gray-800 p-4">
+                <div className="text-2xl font-bold text-red-400">{stats.max_states_controlled_single_game}</div>
+                <div className="text-sm text-gray-400">Max States Controlled</div>
+              </Card>
+              <Card className="border-gray-700 bg-gray-800 p-4">
+                <div className="text-2xl font-bold text-cyan-400">
+                  {stats.fastest_victory_turns === 999 ? '—' : stats.fastest_victory_turns}
                 </div>
-              </div>
-            </TabsContent>
-
-            <TabsContent value="statistics" className="mt-4">
-              <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4">
-                <Card className="p-4 bg-gray-800 border-gray-700">
-                  <div className="text-2xl font-bold text-white">{stats.total_games_played}</div>
-                  <div className="text-sm text-gray-400">Games Played</div>
-                </Card>
-                <Card className="p-4 bg-gray-800 border-gray-700">
-                  <div className="text-2xl font-bold text-green-400">{stats.games_won}</div>
-                  <div className="text-sm text-gray-400">Games Won</div>
-                </Card>
-                <Card className="p-4 bg-gray-800 border-gray-700">
-                  <div className="text-2xl font-bold text-yellow-400">{stats.max_win_streak}</div>
-                  <div className="text-sm text-gray-400">Best Win Streak</div>
-                </Card>
-                <Card className="p-4 bg-gray-800 border-gray-700">
-                  <div className="text-2xl font-bold text-blue-400">{progress.totalPoints}</div>
-                  <div className="text-sm text-gray-400">Achievement Points</div>
-                </Card>
-                <Card className="p-4 bg-gray-800 border-gray-700">
-                  <div className="text-2xl font-bold text-purple-400">{stats.legendary_cards_played}</div>
-                  <div className="text-sm text-gray-400">Legendary Cards</div>
-                </Card>
-                <Card className="p-4 bg-gray-800 border-gray-700">
-                  <div className="text-2xl font-bold text-red-400">{stats.max_states_controlled_single_game}</div>
-                  <div className="text-sm text-gray-400">Max States Controlled</div>
-                </Card>
-                <Card className="p-4 bg-gray-800 border-gray-700">
-                  <div className="text-2xl font-bold text-cyan-400">{stats.fastest_victory_turns === 999 ? '—' : stats.fastest_victory_turns}</div>
-                  <div className="text-sm text-gray-400">Fastest Victory (turns)</div>
-                </Card>
-                <Card className="p-4 bg-gray-800 border-gray-700">
-                  <div className="text-2xl font-bold text-orange-400">{Math.round(stats.total_play_time_minutes / 60)}h</div>
-                  <div className="text-sm text-gray-400">Play Time</div>
-                </Card>
-                <Card className="p-4 bg-gray-800 border-gray-700 md:col-span-2">
-                  <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
-                    <div>
-                      <div className="text-2xl font-bold text-fuchsia-400">{stats.total_combos_executed}</div>
-                      <div className="text-sm text-gray-400">Combos Triggered</div>
-                    </div>
-                    <div>
-                      <div className="text-2xl font-bold text-sky-400">{stats.highest_combo_chain}</div>
-                      <div className="text-sm text-gray-400">Best Combo Chain</div>
-                    </div>
-                    <div>
-                      <div className="text-2xl font-bold text-amber-400">{stats.max_combos_in_single_game}</div>
-                      <div className="text-sm text-gray-400">Most Combos in a Game</div>
-                    </div>
+                <div className="text-sm text-gray-400">Fastest Victory (turns)</div>
+              </Card>
+              <Card className="border-gray-700 bg-gray-800 p-4">
+                <div className="text-2xl font-bold text-orange-400">{Math.round(stats.total_play_time_minutes / 60)}h</div>
+                <div className="text-sm text-gray-400">Play Time</div>
+              </Card>
+              <Card className="border-gray-700 bg-gray-800 p-4 md:col-span-2">
+                <div className="grid grid-cols-1 gap-4 sm:grid-cols-3">
+                  <div>
+                    <div className="text-2xl font-bold text-fuchsia-400">{stats.total_combos_executed}</div>
+                    <div className="text-sm text-gray-400">Combos Triggered</div>
                   </div>
-                </Card>
-                <Card className="p-4 bg-gray-800 border-gray-700 md:col-span-2">
-                  <h4 className="text-sm font-semibold text-gray-200 mb-3">Combo Category Breakdown</h4>
-                  <div className="grid grid-cols-1 sm:grid-cols-2 gap-2 text-sm text-gray-300">
-                    <div className="flex items-center justify-between">
-                      <span>Sequence</span>
-                      <span className="font-semibold text-white">{stats.total_sequence_combos}</span>
-                    </div>
-                    <div className="flex items-center justify-between">
-                      <span>Count</span>
-                      <span className="font-semibold text-white">{stats.total_count_combos}</span>
-                    </div>
-                    <div className="flex items-center justify-between">
-                      <span>Threshold</span>
-                      <span className="font-semibold text-white">{stats.total_threshold_combos}</span>
-                    </div>
-                    <div className="flex items-center justify-between">
-                      <span>State Control</span>
-                      <span className="font-semibold text-white">{stats.total_state_combos}</span>
-                    </div>
-                    <div className="flex items-center justify-between">
-                      <span>Hybrid</span>
-                      <span className="font-semibold text-white">{stats.total_hybrid_combos}</span>
-                    </div>
+                  <div>
+                    <div className="text-2xl font-bold text-sky-400">{stats.highest_combo_chain}</div>
+                    <div className="text-sm text-gray-400">Best Combo Chain</div>
                   </div>
-                </Card>
-              </div>
-            </TabsContent>
-
-            <TabsContent value="progress" className="mt-4">
-              <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-                <Card className="p-4 bg-gray-800 border-gray-700">
-                  <h3 className="text-lg font-semibold text-white mb-4">Overall Progress</h3>
-                  <div className="space-y-4">
-                    <div>
-                      <div className="flex justify-between text-sm mb-1">
-                        <span>Achievements</span>
-                        <span>{progress.unlocked}/{progress.total}</span>
-                      </div>
-                      <Progress value={progress.completionRate} className="h-3" />
-                    </div>
-                    <div className="text-center">
-                      <div className="text-2xl font-bold text-white">{progress.rank}</div>
-                      <div className="text-sm text-gray-400">Current Rank</div>
-                    </div>
+                  <div>
+                    <div className="text-2xl font-bold text-amber-400">{stats.max_combos_in_single_game}</div>
+                    <div className="text-sm text-gray-400">Most Combos in a Game</div>
                   </div>
-                </Card>
+                </div>
+              </Card>
+              <Card className="border-gray-700 bg-gray-800 p-4 md:col-span-2">
+                <h4 className="mb-3 text-sm font-semibold text-gray-200">Combo Category Breakdown</h4>
+                <div className="grid grid-cols-1 gap-2 text-sm text-gray-300 sm:grid-cols-2">
+                  <div className="flex items-center justify-between">
+                    <span>Sequence</span>
+                    <span className="font-semibold text-white">{stats.total_sequence_combos}</span>
+                  </div>
+                  <div className="flex items-center justify-between">
+                    <span>Count</span>
+                    <span className="font-semibold text-white">{stats.total_count_combos}</span>
+                  </div>
+                  <div className="flex items-center justify-between">
+                    <span>Threshold</span>
+                    <span className="font-semibold text-white">{stats.total_threshold_combos}</span>
+                  </div>
+                  <div className="flex items-center justify-between">
+                    <span>State Control</span>
+                    <span className="font-semibold text-white">{stats.total_state_combos}</span>
+                  </div>
+                  <div className="flex items-center justify-between">
+                    <span>Hybrid</span>
+                    <span className="font-semibold text-white">{stats.total_hybrid_combos}</span>
+                  </div>
+                </div>
+              </Card>
+            </div>
+          </TabsContent>
 
-                <Card className="p-4 bg-gray-800 border-gray-700">
-                  <h3 className="text-lg font-semibold text-white mb-4">Category Progress</h3>
-                  <div className="space-y-3">
-                    {['victory', 'mastery', 'discovery', 'challenge', 'social', 'collection'].map(category => {
-                      const total = ACHIEVEMENTS.filter(a => a.category === category && !a.hidden).length;
-                      const unlocked = unlockedAchievements.filter(a => a.category === category).length;
-                      const percentage = total > 0 ? Math.round((unlocked / total) * 100) : 0;
-                      
-                      return (
-                        <div key={category}>
-                          <div className="flex justify-between text-sm mb-1">
-                            <div className="flex items-center gap-1">
-                              {getCategoryIcon(category)}
-                              <span className="capitalize">{category}</span>
-                            </div>
-                            <span>{unlocked}/{total}</span>
+          <TabsContent value="progress" className="mt-4">
+            <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+              <Card className="border-gray-700 bg-gray-800 p-4">
+                <h3 className="mb-4 text-lg font-semibold text-white">Overall Progress</h3>
+                <div className="space-y-4">
+                  <div>
+                    <div className="mb-1 flex justify-between text-sm">
+                      <span>Achievements</span>
+                      <span>{progress.unlocked}/{progress.total}</span>
+                    </div>
+                    <Progress value={progress.completionRate} className="h-3" />
+                  </div>
+                  <div className="text-center">
+                    <div className="text-2xl font-bold text-white">{progress.rank}</div>
+                    <div className="text-sm text-gray-400">Current Rank</div>
+                  </div>
+                </div>
+              </Card>
+
+              <Card className="border-gray-700 bg-gray-800 p-4">
+                <h3 className="mb-4 text-lg font-semibold text-white">Category Progress</h3>
+                <div className="space-y-3">
+                  {['victory', 'mastery', 'discovery', 'challenge', 'social', 'collection'].map(category => {
+                    const total = ACHIEVEMENTS.filter(a => a.category === category && !a.hidden).length;
+                    const unlocked = unlockedAchievements.filter(a => a.category === category).length;
+                    const percentage = total > 0 ? Math.round((unlocked / total) * 100) : 0;
+
+                    return (
+                      <div key={category}>
+                        <div className="mb-1 flex justify-between text-sm">
+                          <div className="flex items-center gap-1">
+                            {getCategoryIcon(category)}
+                            <span className="capitalize">{category}</span>
                           </div>
-                          <Progress value={percentage} className="h-2" />
+                          <span>{unlocked}/{total}</span>
                         </div>
-                      );
-                    })}
-                  </div>
-                </Card>
-              </div>
-            </TabsContent>
-          </Tabs>
-        </div>
+                        <Progress value={percentage} className="h-2" />
+                      </div>
+                    );
+                  })}
+                </div>
+              </Card>
+            </div>
+          </TabsContent>
+        </Tabs>
+      </div>
+    </div>
+  );
+};
+
+interface AchievementPanelProps {
+  onClose: () => void;
+}
+
+const AchievementPanel = ({ onClose }: AchievementPanelProps) => {
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/80 p-4">
+      <Card className="h-[90vh] w-full max-w-7xl overflow-hidden border-gray-700 bg-gray-900">
+        <AchievementsSection onClose={onClose} showCloseButton className="h-full" />
       </Card>
     </div>
   );

--- a/src/components/game/CardCollection.tsx
+++ b/src/components/game/CardCollection.tsx
@@ -1,20 +1,27 @@
 import React, { useEffect, useState } from 'react';
-import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog';
+import { Dialog, DialogContent } from '@/components/ui/dialog';
 import { Badge } from '@/components/ui/badge';
 import { Input } from '@/components/ui/input';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { Progress } from '@/components/ui/progress';
+import { Button } from '@/components/ui/button';
+import { X } from 'lucide-react';
 import { useCardCollection } from '@/hooks/useCardCollection';
 import type { GameCard, MVPCardType } from '@/rules/mvp';
 import { MVP_CARD_TYPES } from '@/rules/mvp';
 import CardDetailOverlay from '@/components/game/CardDetailOverlay';
 
-interface CardCollectionProps {
-  open: boolean;
-  onOpenChange: (open: boolean) => void;
+interface CardCollectionContentProps {
+  isActive?: boolean;
+  onClose?: () => void;
+  className?: string;
 }
 
-const CardCollection = ({ open, onOpenChange }: CardCollectionProps) => {
+export const CardCollectionContent = ({
+  isActive = true,
+  onClose,
+  className,
+}: CardCollectionContentProps) => {
   const { getDiscoveredCards, getCardStats, getCollectionStats } = useCardCollection();
   const [searchTerm, setSearchTerm] = useState('');
   const [filterType, setFilterType] = useState<string>('all');
@@ -22,22 +29,21 @@ const CardCollection = ({ open, onOpenChange }: CardCollectionProps) => {
   const [selectedCard, setSelectedCard] = useState<GameCard | null>(null);
 
   useEffect(() => {
-    if (!open) {
+    if (!isActive) {
       setSelectedCard(null);
     }
-  }, [open]);
-  
+  }, [isActive]);
+
   const stats = getCollectionStats();
   const discoveredCards = getDiscoveredCards();
-  
+
   const normalizeCardType = (type: string): MVPCardType => {
     return MVP_CARD_TYPES.includes(type as MVPCardType) ? type as MVPCardType : 'MEDIA';
   };
 
-  // Filter cards based on search and filters
   const filteredCards = discoveredCards.filter(card => {
     const matchesSearch = card.name.toLowerCase().includes(searchTerm.toLowerCase()) ||
-                         card.text.toLowerCase().includes(searchTerm.toLowerCase());
+      card.text.toLowerCase().includes(searchTerm.toLowerCase());
     const matchesType = filterType === 'all' || normalizeCardType(card.type) === filterType;
     const matchesRarity = filterRarity === 'all' || card.rarity === filterRarity;
 
@@ -54,19 +60,19 @@ const CardCollection = ({ open, onOpenChange }: CardCollectionProps) => {
         className="w-full text-left"
         aria-label={`View details for ${card.name}`}
       >
-        <div className="bg-card border border-border rounded-lg p-4 hover:bg-accent/50 transition-colors">
-          <div className="flex items-start justify-between mb-2">
-            <h3 className="font-bold text-lg text-foreground">{card.name}</h3>
+        <div className="rounded-lg border border-border bg-card p-4 transition-colors hover:bg-accent/50">
+          <div className="mb-2 flex items-start justify-between">
+            <h3 className="text-lg font-bold text-foreground">{card.name}</h3>
             <div className="flex gap-2">
-              <Badge variant={card.rarity === 'legendary' ? 'destructive' :
-                             card.rarity === 'rare' ? 'secondary' : 'outline'}>
+              <Badge variant={card.rarity === 'legendary' ? 'destructive'
+                : card.rarity === 'rare' ? 'secondary' : 'outline'}>
                 {card.rarity}
               </Badge>
               <Badge variant="outline">{normalizeCardType(card.type)}</Badge>
             </div>
           </div>
 
-          <p className="text-sm text-muted-foreground mb-3">{card.text}</p>
+          <p className="mb-3 text-sm text-muted-foreground">{card.text}</p>
 
           <div className="flex items-center justify-between text-xs text-muted-foreground">
             <span>Cost: {card.cost} IP</span>
@@ -74,7 +80,7 @@ const CardCollection = ({ open, onOpenChange }: CardCollectionProps) => {
           </div>
 
           {(card.flavor ?? card.flavorGov ?? card.flavorTruth) && (
-            <div className="mt-2 p-2 bg-accent/30 rounded text-xs italic text-muted-foreground">
+            <div className="mt-2 rounded bg-accent/30 p-2 text-xs italic text-muted-foreground">
               "{card.flavor ?? card.flavorGov ?? card.flavorTruth}"
             </div>
           )}
@@ -84,86 +90,97 @@ const CardCollection = ({ open, onOpenChange }: CardCollectionProps) => {
   };
 
   return (
-    <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="max-w-4xl max-h-[90vh] flex flex-col">
-        <DialogHeader>
-          <DialogTitle className="flex items-center gap-4">
+    <div className={`flex h-full flex-col ${className ?? ''}`}>
+      <div className="flex items-start justify-between gap-4 pb-4">
+        <div>
+          <h2 className="flex items-center gap-3 text-xl font-bold text-foreground">
             📚 Card Collection
-            <div className="text-sm text-muted-foreground">
+            <span className="text-sm font-normal text-muted-foreground">
               {stats.discoveredCards}/{stats.totalCards} cards ({stats.completionPercentage}%)
-            </div>
-          </DialogTitle>
-        </DialogHeader>
-        
-        {/* Collection Stats */}
-        <div className="grid grid-cols-3 gap-4 mb-4">
-          <div className="text-center">
-            <div className="text-2xl font-bold text-primary">{stats.discoveredCards}</div>
-            <div className="text-sm text-muted-foreground">Cards Discovered</div>
-          </div>
-          <div className="text-center">
-            <div className="text-2xl font-bold text-secondary">{stats.totalPlays}</div>
-            <div className="text-sm text-muted-foreground">Total Plays</div>
-          </div>
-          <div className="text-center">
-            <div className="text-2xl font-bold text-accent">{stats.completionPercentage}%</div>
-            <div className="text-sm text-muted-foreground">Complete</div>
-          </div>
+            </span>
+          </h2>
+          <p className="text-sm text-muted-foreground">
+            Browse discovered cards, filter by type or rarity, and review usage stats.
+          </p>
         </div>
-        
-        <Progress value={stats.completionPercentage} className="mb-4" />
-        
-        {/* Filters */}
-        <div className="flex gap-4 mb-4">
-          <Input
-            placeholder="Search cards..."
-            value={searchTerm}
-            onChange={(e) => setSearchTerm(e.target.value)}
-            className="flex-1"
-          />
-          <Select value={filterType} onValueChange={setFilterType}>
-            <SelectTrigger className="w-40">
-              <SelectValue placeholder="Type" />
-            </SelectTrigger>
-            <SelectContent>
-              <SelectItem value="all">All Types</SelectItem>
-              <SelectItem value="MEDIA">Media</SelectItem>
-              <SelectItem value="ZONE">Zone</SelectItem>
-              <SelectItem value="ATTACK">Attack</SelectItem>
-            </SelectContent>
-          </Select>
-          <Select value={filterRarity} onValueChange={setFilterRarity}>
-            <SelectTrigger className="w-40">
-              <SelectValue placeholder="Rarity" />
-            </SelectTrigger>
-            <SelectContent>
-              <SelectItem value="all">All Rarities</SelectItem>
-              <SelectItem value="common">Common</SelectItem>
-              <SelectItem value="uncommon">Uncommon</SelectItem>
-              <SelectItem value="rare">Rare</SelectItem>
-              <SelectItem value="legendary">Legendary</SelectItem>
-            </SelectContent>
-          </Select>
+        {onClose && (
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon"
+            onClick={onClose}
+            aria-label="Close card collection"
+          >
+            <X className="h-5 w-5" />
+          </Button>
+        )}
+      </div>
+
+      <div className="grid grid-cols-1 gap-4 pb-4 sm:grid-cols-3">
+        <div className="text-center">
+          <div className="text-2xl font-bold text-primary">{stats.discoveredCards}</div>
+          <div className="text-sm text-muted-foreground">Cards Discovered</div>
         </div>
-        
-        {/* Cards Grid */}
-        <div className="flex-1 overflow-y-auto">
-          {filteredCards.length === 0 ? (
-            <div className="text-center py-8 text-muted-foreground">
-              {discoveredCards.length === 0 ? 
-                "Start playing to discover cards!" : 
-                "No cards match your search criteria."
-              }
-            </div>
-          ) : (
-            <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-              {filteredCards.map(card => (
-                <CardItem key={card.id} card={card} />
-              ))}
-            </div>
-          )}
+        <div className="text-center">
+          <div className="text-2xl font-bold text-secondary">{stats.totalPlays}</div>
+          <div className="text-sm text-muted-foreground">Total Plays</div>
         </div>
-      </DialogContent>
+        <div className="text-center">
+          <div className="text-2xl font-bold text-accent">{stats.completionPercentage}%</div>
+          <div className="text-sm text-muted-foreground">Complete</div>
+        </div>
+      </div>
+
+      <Progress value={stats.completionPercentage} className="mb-4" />
+
+      <div className="mb-4 flex flex-col gap-4 sm:flex-row">
+        <Input
+          placeholder="Search cards..."
+          value={searchTerm}
+          onChange={(e) => setSearchTerm(e.target.value)}
+          className="flex-1"
+        />
+        <Select value={filterType} onValueChange={setFilterType}>
+          <SelectTrigger className="w-full sm:w-40">
+            <SelectValue placeholder="Type" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="all">All Types</SelectItem>
+            <SelectItem value="MEDIA">Media</SelectItem>
+            <SelectItem value="ZONE">Zone</SelectItem>
+            <SelectItem value="ATTACK">Attack</SelectItem>
+          </SelectContent>
+        </Select>
+        <Select value={filterRarity} onValueChange={setFilterRarity}>
+          <SelectTrigger className="w-full sm:w-40">
+            <SelectValue placeholder="Rarity" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="all">All Rarities</SelectItem>
+            <SelectItem value="common">Common</SelectItem>
+            <SelectItem value="uncommon">Uncommon</SelectItem>
+            <SelectItem value="rare">Rare</SelectItem>
+            <SelectItem value="legendary">Legendary</SelectItem>
+          </SelectContent>
+        </Select>
+      </div>
+
+      <div className="flex-1 overflow-y-auto">
+        {filteredCards.length === 0 ? (
+          <div className="py-8 text-center text-muted-foreground">
+            {discoveredCards.length === 0
+              ? 'Start playing to discover cards!'
+              : 'No cards match your search criteria.'}
+          </div>
+        ) : (
+          <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+            {filteredCards.map(card => (
+              <CardItem key={card.id} card={card} />
+            ))}
+          </div>
+        )}
+      </div>
+
       {selectedCard && (
         <CardDetailOverlay
           card={selectedCard}
@@ -173,6 +190,24 @@ const CardCollection = ({ open, onOpenChange }: CardCollectionProps) => {
           onPlayCard={() => setSelectedCard(null)}
         />
       )}
+    </div>
+  );
+};
+
+interface CardCollectionProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+const CardCollection = ({ open, onOpenChange }: CardCollectionProps) => {
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="flex max-h-[90vh] max-w-4xl flex-col">
+        <CardCollectionContent
+          isActive={open}
+          onClose={() => onOpenChange(false)}
+        />
+      </DialogContent>
     </Dialog>
   );
 };

--- a/src/components/game/PlayerHubOverlay.tsx
+++ b/src/components/game/PlayerHubOverlay.tsx
@@ -1,0 +1,85 @@
+import { useState } from 'react';
+import { Card } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
+import { Trophy, Library, GraduationCap, X } from 'lucide-react';
+import { AchievementsSection } from './AchievementPanel';
+import { CardCollectionContent } from './CardCollection';
+import { TutorialSection } from './TutorialOverlay';
+
+interface PlayerHubOverlayProps {
+  onClose: () => void;
+  onStartTutorial?: (sequenceId: string) => void;
+}
+
+type HubTab = 'achievements' | 'cards' | 'tutorials';
+
+const PlayerHubOverlay = ({ onClose, onStartTutorial }: PlayerHubOverlayProps) => {
+  const [activeTab, setActiveTab] = useState<HubTab>('achievements');
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/80 p-4">
+      <Card className="flex h-[90vh] w-full max-w-7xl flex-col overflow-hidden border-gray-700 bg-gray-900">
+        <div className="flex items-center justify-between border-b border-gray-700 p-4">
+          <div>
+            <h2 className="text-xl font-bold text-white">AGENT DOSSIER HUB</h2>
+            <p className="text-sm text-gray-400">
+              Review your progress, browse unlocked cards, and continue your training.
+            </p>
+          </div>
+          <Button
+            onClick={onClose}
+            variant="outline"
+            size="sm"
+            className="border-gray-600 text-gray-400"
+          >
+            <X size={16} />
+          </Button>
+        </div>
+
+        <Tabs
+          value={activeTab}
+          onValueChange={(value) => setActiveTab(value as HubTab)}
+          className="flex h-full flex-col"
+        >
+          <TabsList className="grid w-full grid-cols-3 bg-gray-800">
+            <TabsTrigger value="achievements" className="flex items-center gap-2">
+              <Trophy className="h-4 w-4" />
+              Achievements
+            </TabsTrigger>
+            <TabsTrigger value="cards" className="flex items-center gap-2">
+              <Library className="h-4 w-4" />
+              Card Collection
+            </TabsTrigger>
+            <TabsTrigger value="tutorials" className="flex items-center gap-2">
+              <GraduationCap className="h-4 w-4" />
+              Shadow Academy
+            </TabsTrigger>
+          </TabsList>
+
+          <div className="flex-1 overflow-hidden">
+            <TabsContent value="achievements" className="h-full">
+              <AchievementsSection className="h-full" />
+            </TabsContent>
+            <TabsContent value="cards" className="h-full">
+              <CardCollectionContent
+                isActive={activeTab === 'cards'}
+                className="h-full"
+              />
+            </TabsContent>
+            <TabsContent value="tutorials" className="h-full">
+              <TutorialSection
+                isActive={activeTab === 'tutorials'}
+                onStartTutorial={onStartTutorial}
+                onClose={onClose}
+                className="h-full"
+              />
+            </TabsContent>
+          </div>
+        </Tabs>
+      </Card>
+    </div>
+  );
+};
+
+export default PlayerHubOverlay;

--- a/src/components/game/TutorialOverlay.tsx
+++ b/src/components/game/TutorialOverlay.tsx
@@ -7,12 +7,21 @@ import { X, Play, BookOpen, Award } from 'lucide-react';
 import { TutorialManager, TUTORIAL_SEQUENCES, type TutorialSequence } from '@/data/tutorialSystem';
 import { useToast } from '@/hooks/use-toast';
 
-interface TutorialOverlayProps {
-  onClose: () => void;
+interface TutorialSectionProps {
+  onClose?: () => void;
   onStartTutorial?: (sequenceId: string) => void;
+  className?: string;
+  showCloseButton?: boolean;
+  isActive?: boolean;
 }
 
-const TutorialOverlay = ({ onClose, onStartTutorial }: TutorialOverlayProps) => {
+export const TutorialSection = ({
+  onClose,
+  onStartTutorial,
+  className,
+  showCloseButton = false,
+  isActive = true,
+}: TutorialSectionProps) => {
   const [tutorialManager] = useState(() => new TutorialManager());
   const [selectedSequence, setSelectedSequence] = useState<TutorialSequence | null>(null);
   const { toast } = useToast();
@@ -21,20 +30,27 @@ const TutorialOverlay = ({ onClose, onStartTutorial }: TutorialOverlayProps) => 
   const availableSequences = tutorialManager.getAvailableSequences();
   const completedSequences = tutorialManager.getCompletedSequences();
 
+  useEffect(() => {
+    if (!isActive) {
+      setSelectedSequence(null);
+    }
+  }, [isActive]);
+
   const handleStartTutorial = (sequenceId: string) => {
     const success = tutorialManager.startSequence(sequenceId);
     if (success) {
+      const sequence = TUTORIAL_SEQUENCES.find(s => s.id === sequenceId);
       toast({
-        title: "Tutorial Started",
-        description: `Beginning ${selectedSequence?.name || 'tutorial sequence'}`,
+        title: 'Tutorial Started',
+        description: `Beginning ${sequence?.name ?? 'tutorial sequence'}`,
       });
       onStartTutorial?.(sequenceId);
-      onClose();
+      onClose?.();
     } else {
       toast({
-        title: "Tutorial Unavailable", 
-        description: "Complete prerequisite tutorials first",
-        variant: "destructive"
+        title: 'Tutorial Unavailable',
+        description: 'Complete prerequisite tutorials first',
+        variant: 'destructive'
       });
     }
   };
@@ -64,195 +80,200 @@ const TutorialOverlay = ({ onClose, onStartTutorial }: TutorialOverlayProps) => 
   };
 
   return (
-    <div className="fixed inset-0 z-50 bg-black/80 flex items-center justify-center p-4">
-      <Card className="w-full max-w-5xl h-[80vh] bg-gray-900 border-gray-700 overflow-hidden">
-        <div className="flex items-center justify-between p-4 border-b border-gray-700">
-          <div className="flex items-center gap-3">
-            <BookOpen size={24} className="text-blue-400" />
-            <div>
-              <h2 className="text-xl font-bold text-white font-mono">SHADOW ACADEMY</h2>
-              <div className="text-sm text-gray-400">Master the art of shadow operations</div>
-            </div>
+    <div className={`flex h-full flex-col ${className ?? ''}`}>
+      <div className="flex items-center justify-between border-b border-gray-700 p-4">
+        <div className="flex items-center gap-3">
+          <BookOpen size={24} className="text-blue-400" />
+          <div>
+            <h2 className="font-mono text-xl font-bold text-white">SHADOW ACADEMY</h2>
+            <div className="text-sm text-gray-400">Master the art of shadow operations</div>
           </div>
+        </div>
+        {showCloseButton && onClose && (
           <Button
             onClick={onClose}
             variant="outline"
             size="sm"
-            className="text-gray-400 border-gray-600"
+            className="border-gray-600 text-gray-400"
           >
             <X size={16} />
           </Button>
-        </div>
+        )}
+      </div>
 
-        <div className="p-4 h-full overflow-hidden">
-          <div className="grid grid-cols-1 lg:grid-cols-3 gap-4 h-full">
-            {/* Tutorial List */}
-            <div className="lg:col-span-2">
-              <Card className="p-4 bg-gray-800 border-gray-700 h-full">
-                <div className="flex items-center justify-between mb-4">
-                  <h3 className="text-lg font-semibold text-white">Training Modules</h3>
-                  <div className="flex items-center gap-4 text-sm text-gray-400">
-                    <div>Progress: {stats.completionRate}%</div>
-                    <Progress value={stats.completionRate} className="w-20 h-2" />
-                  </div>
+      <div className="flex-1 overflow-hidden p-4">
+        <div className="grid h-full grid-cols-1 gap-4 lg:grid-cols-3">
+          <div className="lg:col-span-2">
+            <Card className="h-full border-gray-700 bg-gray-800 p-4">
+              <div className="mb-4 flex items-center justify-between">
+                <h3 className="text-lg font-semibold text-white">Training Modules</h3>
+                <div className="flex items-center gap-4 text-sm text-gray-400">
+                  <div>Progress: {stats.completionRate}%</div>
+                  <Progress value={stats.completionRate} className="h-2 w-20" />
                 </div>
+              </div>
 
-                <div className="space-y-3 max-h-96 overflow-y-auto">
-                  {TUTORIAL_SEQUENCES.map(sequence => {
-                    const { status, color } = getSequenceStatus(sequence);
-                    const isSelected = selectedSequence?.id === sequence.id;
-                    
-                    return (
-                      <div 
-                        key={sequence.id}
-                        className={`p-4 rounded cursor-pointer transition-all ${
-                          isSelected 
-                            ? 'bg-blue-900/30 border border-blue-600' 
-                            : 'bg-gray-700 hover:bg-gray-600'
-                        } ${status === 'locked' ? 'opacity-60' : ''}`}
-                        onClick={() => setSelectedSequence(sequence)}
-                      >
-                        <div className="flex items-center justify-between mb-2">
-                          <div className="flex items-center gap-3">
-                            <div className={`w-3 h-3 rounded-full ${
-                              status === 'completed' ? 'bg-green-400' :
-                              status === 'available' ? 'bg-blue-400' : 'bg-gray-600'
-                            }`} />
-                            <h4 className="font-semibold text-white">{sequence.name}</h4>
-                          </div>
-                          <div className="flex items-center gap-2">
-                            <Badge className={color}>
-                              {status === 'completed' ? 'Completed' : 
-                               status === 'available' ? 'Available' : 'Locked'}
-                            </Badge>
-                            <Badge className={getDifficultyColor(sequence)}>
-                              {getDifficultyText(sequence)}
-                            </Badge>
-                          </div>
+              <div className="max-h-96 space-y-3 overflow-y-auto">
+                {TUTORIAL_SEQUENCES.map(sequence => {
+                  const { status, color } = getSequenceStatus(sequence);
+                  const isSelected = selectedSequence?.id === sequence.id;
+
+                  return (
+                    <div
+                      key={sequence.id}
+                      className={`cursor-pointer rounded p-4 transition-all ${
+                        isSelected
+                          ? 'border border-blue-600 bg-blue-900/30'
+                          : 'bg-gray-700 hover:bg-gray-600'
+                      } ${status === 'locked' ? 'opacity-60' : ''}`}
+                      onClick={() => {
+                        if (status !== 'locked') {
+                          setSelectedSequence(sequence);
+                        }
+                      }}
+                    >
+                      <div className="mb-2 flex items-center justify-between">
+                        <div className="flex items-center gap-3">
+                          <div className={`h-3 w-3 rounded-full ${
+                            status === 'completed' ? 'bg-green-400'
+                              : status === 'available' ? 'bg-blue-400'
+                                : 'bg-gray-600'
+                          }`} />
+                          <h4 className="font-semibold text-white">{sequence.name}</h4>
                         </div>
-                        
-                        <div className="text-sm text-gray-300 mb-2">
-                          {sequence.description}
-                        </div>
-                        
-                        <div className="flex items-center justify-between text-xs text-gray-500">
-                          <span>{sequence.steps.length} steps</span>
-                          {sequence.prerequisites && (
-                            <span>Requires: {sequence.prerequisites.join(', ')}</span>
-                          )}
+                        <div className="flex items-center gap-2">
+                          <Badge className={color}>
+                            {status === 'completed' ? 'Completed'
+                              : status === 'available' ? 'Available' : 'Locked'}
+                          </Badge>
+                          <Badge className={getDifficultyColor(sequence)}>
+                            {getDifficultyText(sequence)}
+                          </Badge>
                         </div>
                       </div>
-                    );
-                  })}
-                </div>
-              </Card>
-            </div>
 
-            {/* Tutorial Details & Controls */}
-            <div>
-              <Card className="p-4 bg-gray-800 border-gray-700 h-full">
-                {selectedSequence ? (
-                  <div className="space-y-4">
-                    <div>
-                      <h3 className="text-lg font-bold text-white mb-2">
-                        {selectedSequence.name}
-                      </h3>
-                      <div className="text-sm text-gray-300 leading-relaxed">
-                        {selectedSequence.description}
+                      <div className="mb-2 text-sm text-gray-300">
+                        {sequence.description}
+                      </div>
+
+                      <div className="flex items-center justify-between text-xs text-gray-500">
+                        <span>{sequence.steps.length} steps</span>
+                        {sequence.prerequisites && (
+                          <span>Requires: {sequence.prerequisites.join(', ')}</span>
+                        )}
                       </div>
                     </div>
+                  );
+                })}
+              </div>
+            </Card>
+          </div>
 
-                    <div className="space-y-3">
-                      <div className="flex items-center justify-between">
-                        <span className="text-sm text-gray-400">Steps:</span>
-                        <span className="text-sm text-white">{selectedSequence.steps.length}</span>
-                      </div>
-                      
-                      <div className="flex items-center justify-between">
-                        <span className="text-sm text-gray-400">Difficulty:</span>
-                        <Badge className={getDifficultyColor(selectedSequence)}>
-                          {getDifficultyText(selectedSequence)}
-                        </Badge>
-                      </div>
+          <div>
+            <Card className="h-full border-gray-700 bg-gray-800 p-4">
+              {selectedSequence ? (
+                <div className="space-y-4">
+                  <div>
+                    <h3 className="mb-2 text-lg font-bold text-white">{selectedSequence.name}</h3>
+                    <div className="text-sm leading-relaxed text-gray-300">
+                      {selectedSequence.description}
+                    </div>
+                  </div>
 
-                      {selectedSequence.prerequisites && (
+                  <div className="space-y-3">
+                    <div className="flex items-center justify-between">
+                      <span className="text-sm text-gray-400">Steps:</span>
+                      <span className="text-sm text-white">{selectedSequence.steps.length}</span>
+                    </div>
+
+                    <div className="flex items-center justify-between">
+                      <span className="text-sm text-gray-400">Difficulty:</span>
+                      <Badge className={getDifficultyColor(selectedSequence)}>
+                        {getDifficultyText(selectedSequence)}
+                      </Badge>
+                    </div>
+
+                    {selectedSequence.prerequisites && (
+                      <div className="space-y-1">
+                        <span className="text-sm text-gray-400">Prerequisites:</span>
                         <div className="space-y-1">
-                          <span className="text-sm text-gray-400">Prerequisites:</span>
-                          <div className="space-y-1">
-                            {selectedSequence.prerequisites.map(prereq => {
-                              const isCompleted = completedSequences.includes(prereq);
-                              const prereqSequence = TUTORIAL_SEQUENCES.find(s => s.id === prereq);
-                              return (
-                                <div key={prereq} className="flex items-center gap-2 text-sm">
-                                  <div className={`w-2 h-2 rounded-full ${
-                                    isCompleted ? 'bg-green-400' : 'bg-red-400'
-                                  }`} />
-                                  <span className={isCompleted ? 'text-green-300' : 'text-red-300'}>
-                                    {prereqSequence?.name || prereq}
-                                  </span>
-                                </div>
-                              );
-                            })}
-                          </div>
+                          {selectedSequence.prerequisites.map(prereq => {
+                            const isCompleted = completedSequences.includes(prereq);
+                            const prereqSequence = TUTORIAL_SEQUENCES.find(s => s.id === prereq);
+                            return (
+                              <div key={prereq} className="flex items-center gap-2 text-sm">
+                                <div className={`h-2 w-2 rounded-full ${
+                                  isCompleted ? 'bg-green-400' : 'bg-red-400'
+                                }`} />
+                                <span className={isCompleted ? 'text-green-300' : 'text-red-300'}>
+                                  {prereqSequence?.name || prereq}
+                                </span>
+                              </div>
+                            );
+                          })}
                         </div>
-                      )}
-
-                      {selectedSequence.unlockAchievement && (
-                        <div className="flex items-center gap-2 text-sm">
-                          <Award size={14} className="text-yellow-400" />
-                          <span className="text-yellow-300">
-                            Unlocks achievement on completion
-                          </span>
-                        </div>
-                      )}
-                    </div>
-
-                    <div className="space-y-2">
-                      <h4 className="text-sm font-semibold text-white">Tutorial Steps:</h4>
-                      <div className="space-y-2 max-h-40 overflow-y-auto">
-                        {selectedSequence.steps.map((step, index) => (
-                          <div key={step.id} className="text-xs text-gray-400 p-2 bg-gray-700 rounded">
-                            <div className="font-medium text-gray-300">
-                              {index + 1}. {step.title}
-                            </div>
-                            <div className="mt-1">
-                              {step.description}
-                            </div>
-                          </div>
-                        ))}
                       </div>
-                    </div>
+                    )}
 
-                    <div className="pt-4 border-t border-gray-700">
-                      <Button
-                        onClick={() => handleStartTutorial(selectedSequence.id)}
-                        disabled={!tutorialManager.isSequenceAvailable(selectedSequence.id)}
-                        className="w-full bg-blue-600 hover:bg-blue-700 text-white"
-                      >
-                        <Play size={16} className="mr-2" />
-                        {completedSequences.includes(selectedSequence.id) ? 'Replay Tutorial' : 'Start Tutorial'}
-                      </Button>
-                      
-                      {!tutorialManager.isSequenceAvailable(selectedSequence.id) && (
-                        <div className="text-xs text-red-400 text-center mt-2">
-                          Complete prerequisite tutorials first
-                        </div>
-                      )}
-                    </div>
+                    {selectedSequence.unlockAchievement && (
+                      <div className="flex items-center gap-2 text-sm">
+                        <Award size={14} className="text-yellow-400" />
+                        <span className="text-yellow-300">
+                          Unlocks achievement on completion
+                        </span>
+                      </div>
+                    )}
                   </div>
-                ) : (
-                  <div className="text-center text-gray-500 py-8">
-                    <BookOpen size={48} className="mx-auto mb-4 opacity-50" />
-                    <div className="text-lg font-medium mb-2">Select a Tutorial</div>
-                    <div className="text-sm">
-                      Choose a training module to learn advanced shadow operations
-                    </div>
+
+                  <div className="border-t border-gray-700 pt-4">
+                    <Button
+                      onClick={() => handleStartTutorial(selectedSequence.id)}
+                      disabled={!availableSequences.includes(selectedSequence.id)}
+                      className="w-full bg-blue-600 text-white hover:bg-blue-700"
+                    >
+                      <Play size={16} className="mr-2" />
+                      {completedSequences.includes(selectedSequence.id) ? 'Replay Tutorial' : 'Start Tutorial'}
+                    </Button>
+
+                    {!availableSequences.includes(selectedSequence.id) && (
+                      <div className="mt-2 text-center text-xs text-red-400">
+                        Complete prerequisite tutorials first
+                      </div>
+                    )}
                   </div>
-                )}
-              </Card>
-            </div>
+                </div>
+              ) : (
+                <div className="py-8 text-center text-gray-500">
+                  <BookOpen size={48} className="mx-auto mb-4 opacity-50" />
+                  <div className="mb-2 text-lg font-medium">Select a Tutorial</div>
+                  <div className="text-sm">
+                    Choose a training module to learn advanced shadow operations
+                  </div>
+                </div>
+              )}
+            </Card>
           </div>
         </div>
+      </div>
+    </div>
+  );
+};
+
+interface TutorialOverlayProps {
+  onClose: () => void;
+  onStartTutorial?: (sequenceId: string) => void;
+}
+
+const TutorialOverlay = ({ onClose, onStartTutorial }: TutorialOverlayProps) => {
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/80 p-4">
+      <Card className="h-[80vh] w-full max-w-5xl overflow-hidden border-gray-700 bg-gray-900">
+        <TutorialSection
+          onClose={onClose}
+          onStartTutorial={onStartTutorial}
+          showCloseButton
+          className="h-full"
+        />
       </Card>
     </div>
   );

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -13,8 +13,6 @@ import GameMenu from '@/components/game/GameMenu';
 import SecretAgenda from '@/components/game/SecretAgenda';
 import AIStatus from '@/components/game/AIStatus';
 import EnhancedBalancingDashboard from '@/components/game/EnhancedBalancingDashboard';
-import TutorialOverlay from '@/components/game/TutorialOverlay';
-import AchievementPanel from '@/components/game/AchievementPanel';
 import Options from '@/components/game/Options';
 import { useGameState } from '@/hooks/useGameState';
 import { useAudioContext } from '@/contexts/AudioContext';
@@ -27,9 +25,9 @@ import CardPreviewOverlay from '@/components/game/CardPreviewOverlay';
 import ContextualHelp from '@/components/game/ContextualHelp';
 import InteractiveOnboarding from '@/components/game/InteractiveOnboarding';
 import MechanicsTooltip from '@/components/game/MechanicsTooltip';
-import CardCollection from '@/components/game/CardCollection';
+import PlayerHubOverlay from '@/components/game/PlayerHubOverlay';
 import NewCardsPresentation from '@/components/game/NewCardsPresentation';
-import { Maximize, Menu, Minimize } from 'lucide-react';
+import { Maximize, Menu, Minimize, UserCircle2 } from 'lucide-react';
 import { getRandomAgenda } from '@/data/agendaDatabase';
 import { useCardCollection } from '@/hooks/useCardCollection';
 import { useSynergyDetection } from '@/hooks/useSynergyDetection';
@@ -432,8 +430,7 @@ const Index = () => {
   const [isFullscreen, setIsFullscreen] = useState(false);
   const [showBalancing, setShowBalancing] = useState(false);
   const [balancingInitialView, setBalancingInitialView] = useState<'analysis' | 'dev-tools'>('analysis');
-  const [showTutorial, setShowTutorial] = useState(false);
-  const [showAchievements, setShowAchievements] = useState(false);
+  const [showPlayerHub, setShowPlayerHub] = useState(false);
   const [loadingCard, setLoadingCard] = useState<string | null>(null);
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
   const [subtitle, setSubtitle] = useState('Truth Seeker Operative');
@@ -450,7 +447,6 @@ const Index = () => {
   const [victoryState, setVictoryState] = useState<{ isVictory: boolean; type: 'states' | 'ip' | 'truth' | 'agenda' | null }>({ isVictory: false, type: null });
   const [showOnboarding, setShowOnboarding] = useState(false);
   const [showInGameOptions, setShowInGameOptions] = useState(false);
-  const [showCardCollection, setShowCardCollection] = useState(false);
   const [gameOverReport, setGameOverReport] = useState<GameOverReport | null>(null);
   const [showExtraEdition, setShowExtraEdition] = useState(false);
   const [paranormalSightings, setParanormalSightings] = useState<ParanormalSighting[]>([]);
@@ -1294,12 +1290,15 @@ const Index = () => {
     );
   }
 
-  if (showAchievements) {
-    return <AchievementPanel onClose={() => setShowAchievements(false)} />;
-  }
-
-  if (showTutorial) {
-    return <TutorialOverlay onClose={() => setShowTutorial(false)} />;
+  if (showPlayerHub) {
+    return (
+      <PlayerHubOverlay
+        onClose={() => {
+          setShowPlayerHub(false);
+          audio.playSFX('click');
+        }}
+      />
+    );
   }
 
   if (showBalancing) {
@@ -1322,7 +1321,10 @@ const Index = () => {
         }
       }}
       audio={audio}
-      onShowCardCollection={() => setShowCardCollection(true)}
+      onShowCardCollection={() => {
+        setShowPlayerHub(true);
+        audio.playSFX('click');
+      }}
       onBackToMainMenu={() => {
         setShowMenu(true);
         // Reset any game state if needed
@@ -1641,30 +1643,14 @@ const Index = () => {
           </button>
           <button
             type="button"
-            onClick={() => setShowTutorial(true)}
-            className={mastheadButtonClass}
-            title="Tutorial & Training"
-          >
-            🎓
-          </button>
-          <button
-            type="button"
-            onClick={() => setShowAchievements(true)}
-            className={mastheadButtonClass}
-            title="Achievements"
-          >
-            🏆
-          </button>
-          <button
-            type="button"
             onClick={() => {
-              setShowCardCollection(true);
+              setShowPlayerHub(true);
               audio.playSFX('click');
             }}
             className={mastheadButtonClass}
-            title="Card Collection"
+            title="Player Hub"
           >
-            📚
+            <UserCircle2 className="h-4 w-4" />
           </button>
           <button
             type="button"
@@ -1946,11 +1932,6 @@ const Index = () => {
         onComplete={() => setShowOnboarding(false)}
         onSkip={() => setShowOnboarding(false)}
         gameState={gameState}
-      />
-
-      <CardCollection
-        open={showCardCollection}
-        onOpenChange={setShowCardCollection}
       />
 
       <NewCardsPresentation


### PR DESCRIPTION
## Summary
- create a PlayerHubOverlay that hosts achievements, the card collection, and the Shadow Academy in a single tabbed interface
- refactor AchievementPanel, CardCollection, and TutorialOverlay to expose reusable sections that the hub and legacy dialogs can render
- update the main Index page to open the new hub and remove the individual overlay toggles

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d64b0544a88320ac5cb832b6909fe0