### PR TITLE
Remove Event Database button from masthead

### DIFF
--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -1633,17 +1633,6 @@ const Index = () => {
           <button
             type="button"
             onClick={() => {
-              setBalancingInitialView('dev-tools');
-              setShowBalancing(true);
-            }}
-            className={mastheadButtonClass}
-            title="Event Database"
-          >
-            📰
-          </button>
-          <button
-            type="button"
-            onClick={() => {
               setShowPlayerHub(true);
               audio.playSFX('click');
             }}


### PR DESCRIPTION
## Summary
- remove the Event Database shortcut button now that its content lives in the Card Balancing dashboard

## Testing
- npm run dev -- --host 0.0.0.0 --port 4173

------
https://chatgpt.com/codex/tasks/task_e_68d65452322883209b71466439be9670