### PR TITLE
Restyle player hub to match balancing briefing

### DIFF
--- a/src/components/game/AchievementPanel.tsx
+++ b/src/components/game/AchievementPanel.tsx
@@ -33,7 +33,7 @@ export const AchievementsSection = ({
     exportData,
     importData,
     resetProgress,
-    clearNewlyUnlocked
+    clearNewlyUnlocked,
   } = useAchievements();
 
   const { toast } = useToast();
@@ -60,11 +60,16 @@ export const AchievementsSection = ({
 
   const getRarityColor = (rarity: string) => {
     switch (rarity) {
-      case 'common': return 'text-gray-400 bg-gray-900/20 border-gray-600';
-      case 'uncommon': return 'text-green-400 bg-green-900/20 border-green-600';
-      case 'rare': return 'text-blue-400 bg-blue-900/20 border-blue-600';
-      case 'legendary': return 'text-purple-400 bg-purple-900/20 border-purple-600';
-      default: return 'text-gray-400 bg-gray-900/20 border-gray-600';
+      case 'common':
+        return 'border border-slate-500/60 bg-slate-900/60 text-slate-300';
+      case 'uncommon':
+        return 'border border-emerald-400/60 bg-emerald-500/15 text-emerald-200';
+      case 'rare':
+        return 'border border-sky-400/60 bg-sky-500/15 text-sky-200';
+      case 'legendary':
+        return 'border border-fuchsia-400/60 bg-fuchsia-500/15 text-fuchsia-200';
+      default:
+        return 'border border-slate-500/60 bg-slate-900/60 text-slate-300';
     }
   };
 
@@ -125,76 +130,100 @@ export const AchievementsSection = ({
   };
 
   return (
-    <div className={`flex h-full flex-col ${className ?? ''}`}>
-      <div className="flex items-center justify-between border-b border-gray-700 p-4">
-        <div className="flex items-center gap-3">
-          <Trophy size={24} className="text-yellow-400" />
-          <div>
-            <h2 className="text-xl font-bold text-white font-mono">ACHIEVEMENTS</h2>
-            <div className="text-sm text-gray-400">
-              {progress.unlocked}/{progress.total} unlocked • {progress.totalPoints} points • {progress.rank}
+    <div className={`flex h-full flex-col gap-5 text-slate-200 ${className ?? ''}`}>
+      <div className="relative overflow-hidden rounded-2xl border border-emerald-500/30 bg-slate-950/85 px-5 py-4 shadow-[0_0_35px_rgba(16,185,129,0.2)]">
+        <div className="pointer-events-none absolute inset-0 opacity-45">
+          <div className="absolute inset-0 bg-[radial-gradient(circle_at_top_left,_rgba(16,185,129,0.25),_transparent_60%)]" />
+          <div className="absolute inset-0 bg-[linear-gradient(135deg,_rgba(56,189,248,0.16),_transparent_50%,_rgba(16,185,129,0.18))]" />
+        </div>
+        <div className="relative flex flex-wrap items-center justify-between gap-4">
+          <div className="flex items-center gap-4">
+            <div className="flex h-12 w-12 items-center justify-center rounded-full border border-emerald-400/60 bg-emerald-500/15 text-emerald-200 shadow-[0_0_35px_rgba(16,185,129,0.25)]">
+              <Trophy size={22} />
+            </div>
+            <div className="space-y-1">
+              <div className="font-mono text-xs uppercase tracking-[0.35em] text-emerald-200/80">Achievements Matrix</div>
+              <h2 className="font-mono text-xl font-semibold uppercase tracking-[0.15em] text-emerald-100">ACHIEVEMENTS</h2>
+              <div className="text-sm text-emerald-100/70">
+                {progress.unlocked}/{progress.total} unlocked • {progress.totalPoints} points • {progress.rank}
+              </div>
             </div>
           </div>
-        </div>
-        <div className="flex items-center gap-2">
-          <Button
-            onClick={exportProgress}
-            variant="outline"
-            size="sm"
-            className="text-green-400 border-green-600 hover:bg-green-900/20"
-          >
-            <Download size={16} className="mr-1" />
-            Export
-          </Button>
-          <Button
-            onClick={importProgress}
-            variant="outline"
-            size="sm"
-            className="text-blue-400 border-blue-600 hover:bg-blue-900/20"
-          >
-            <Upload size={16} className="mr-1" />
-            Import
-          </Button>
-          <Button
-            onClick={handleResetProgress}
-            variant="outline"
-            size="sm"
-            className="text-red-400 border-red-600 hover:bg-red-900/20"
-          >
-            <RotateCcw size={16} className="mr-1" />
-            Reset
-          </Button>
-          {showCloseButton && onClose && (
+          <div className="flex flex-wrap items-center gap-2">
             <Button
-              onClick={onClose}
+              onClick={exportProgress}
               variant="outline"
               size="sm"
-              className="text-gray-400 border-gray-600"
+              className="border-emerald-400/40 bg-emerald-500/10 text-emerald-200 transition hover:bg-emerald-500/20 hover:text-emerald-100"
             >
-              <X size={16} />
+              <Download size={16} className="mr-1" />
+              Export
             </Button>
-          )}
+            <Button
+              onClick={importProgress}
+              variant="outline"
+              size="sm"
+              className="border-sky-400/40 bg-sky-500/10 text-sky-200 transition hover:bg-sky-500/20 hover:text-sky-100"
+            >
+              <Upload size={16} className="mr-1" />
+              Import
+            </Button>
+            <Button
+              onClick={handleResetProgress}
+              variant="outline"
+              size="sm"
+              className="border-rose-400/40 bg-rose-500/10 text-rose-200 transition hover:bg-rose-500/20 hover:text-rose-100"
+            >
+              <RotateCcw size={16} className="mr-1" />
+              Reset
+            </Button>
+            {showCloseButton && onClose && (
+              <Button
+                onClick={onClose}
+                variant="outline"
+                size="sm"
+                className="border-emerald-400/30 bg-slate-950/60 text-slate-300 transition hover:bg-emerald-500/20 hover:text-emerald-100"
+              >
+                <X size={16} />
+              </Button>
+            )}
+          </div>
         </div>
       </div>
 
-      <div className="flex-1 overflow-hidden p-4">
-        <Tabs defaultValue="achievements" className="h-full">
-          <TabsList className="mb-4 grid w-full grid-cols-3 bg-gray-800">
-            <TabsTrigger value="achievements">Achievements</TabsTrigger>
-            <TabsTrigger value="statistics">Statistics</TabsTrigger>
-            <TabsTrigger value="progress">Progress</TabsTrigger>
+      <div className="flex-1 overflow-hidden rounded-2xl border border-emerald-500/25 bg-slate-950/80 p-5 shadow-inner shadow-emerald-500/15">
+        <Tabs defaultValue="achievements" className="flex h-full flex-col gap-5">
+          <TabsList className="grid w-full grid-cols-3 gap-2 rounded-lg border border-emerald-500/20 bg-slate-900/70 p-1 backdrop-blur">
+            <TabsTrigger
+              value="achievements"
+              className="rounded-md border border-transparent px-3 py-2 text-[11px] font-semibold uppercase tracking-[0.32em] text-slate-400 transition data-[state=active]:border-emerald-400/60 data-[state=active]:bg-emerald-500/15 data-[state=active]:text-emerald-200"
+            >
+              Achievements
+            </TabsTrigger>
+            <TabsTrigger
+              value="statistics"
+              className="rounded-md border border-transparent px-3 py-2 text-[11px] font-semibold uppercase tracking-[0.32em] text-slate-400 transition data-[state=active]:border-emerald-400/60 data-[state=active]:bg-emerald-500/15 data-[state=active]:text-emerald-200"
+            >
+              Statistics
+            </TabsTrigger>
+            <TabsTrigger
+              value="progress"
+              className="rounded-md border border-transparent px-3 py-2 text-[11px] font-semibold uppercase tracking-[0.32em] text-slate-400 transition data-[state=active]:border-emerald-400/60 data-[state=active]:bg-emerald-500/15 data-[state=active]:text-emerald-200"
+            >
+              Progress
+            </TabsTrigger>
           </TabsList>
 
-          <TabsContent value="achievements" className="h-full">
-            <div className="grid h-full grid-cols-1 gap-4 lg:grid-cols-3">
+          <TabsContent value="achievements" className="flex-1 overflow-hidden focus-visible:outline-none">
+            <div className="grid h-full grid-cols-1 gap-5 lg:grid-cols-3">
               <div className="lg:col-span-2">
-                <Card className="h-full border-gray-700 bg-gray-800 p-4">
-                  <div className="mb-4 flex items-center justify-between">
-                    <h3 className="text-lg font-semibold text-white">Achievement List</h3>
+                <Card className="flex h-full flex-col gap-4 rounded-2xl border border-emerald-500/20 bg-slate-950/75 p-5 shadow-[0_0_25px_rgba(16,185,129,0.15)]">
+                  <div className="flex flex-wrap items-center justify-between gap-3">
+                    <h3 className="text-lg font-semibold uppercase tracking-[0.2em] text-emerald-100">Achievement List</h3>
                     <select
                       value={filter}
                       onChange={(e) => setFilter(e.target.value)}
-                      className="rounded border border-gray-600 bg-gray-700 px-3 py-1 text-sm text-white"
+                      className="rounded-md border border-emerald-500/30 bg-slate-900/70 px-3 py-2 text-sm uppercase tracking-[0.2em] text-emerald-100 outline-none transition focus:border-emerald-400 focus:ring-2 focus:ring-emerald-400/40"
                     >
                       <option value="all">All Categories</option>
                       <option value="victory">Victory</option>
@@ -206,45 +235,46 @@ export const AchievementsSection = ({
                     </select>
                   </div>
 
-                  <ScrollArea className="h-[60vh]">
-                    <div className="space-y-4">
+                  <ScrollArea className="h-[60vh] pr-2">
+                    <div className="space-y-6">
                       {filteredUnlocked.length > 0 && (
                         <div>
-                          <h4 className="mb-3 text-sm font-bold uppercase tracking-wide text-green-400">
+                          <h4 className="mb-3 text-xs font-bold uppercase tracking-[0.3em] text-emerald-300">
                             Unlocked ({filteredUnlocked.length})
                           </h4>
                           <div className="space-y-2">
                             {filteredUnlocked.map(achievement => (
-                              <div
+                              <button
                                 key={achievement.id}
-                                className={`rounded p-3 transition-colors cursor-pointer ${
+                                type="button"
+                                className={`w-full rounded-xl border p-4 text-left transition-all ${
                                   selectedAchievement?.id === achievement.id
-                                    ? 'bg-blue-900/30 border border-blue-600'
-                                    : 'bg-gray-700 hover:bg-gray-600'
+                                    ? 'border-emerald-400/60 bg-emerald-500/15 shadow-[0_0_25px_rgba(16,185,129,0.3)]'
+                                    : 'border-emerald-500/20 bg-slate-900/60 hover:border-emerald-400/40 hover:bg-slate-900/80'
                                 }`}
                                 onClick={() => setSelectedAchievement(achievement)}
                               >
-                                <div className="flex items-center gap-3">
-                                  <div className="text-2xl">{achievement.icon}</div>
-                                  <div className="flex-1">
-                                    <div className="mb-1 flex items-center gap-2">
-                                      <h5 className="font-semibold text-white">{achievement.name}</h5>
-                                      <Badge className={getRarityColor(achievement.rarity)}>
+                                <div className="flex items-start gap-4">
+                                  <div className="text-3xl text-emerald-200">{achievement.icon}</div>
+                                  <div className="flex-1 space-y-2">
+                                    <div className="flex flex-wrap items-center gap-2">
+                                      <h5 className="text-base font-semibold text-slate-100">{achievement.name}</h5>
+                                      <Badge className={`${getRarityColor(achievement.rarity)} uppercase tracking-wide`}> 
                                         {achievement.rarity}
                                       </Badge>
-                                      <Badge className="bg-yellow-900/20 text-yellow-400">
+                                      <Badge className="border border-amber-400/60 bg-amber-500/15 text-amber-200">
                                         {achievement.points}pts
                                       </Badge>
                                     </div>
-                                    <p className="text-sm text-gray-300">{achievement.description}</p>
-                                    <div className="mt-1 flex items-center gap-2">
+                                    <p className="text-sm text-slate-300">{achievement.description}</p>
+                                    <div className="flex items-center gap-2 text-xs text-emerald-200/70">
                                       {getCategoryIcon(achievement.category)}
-                                      <span className="text-xs capitalize text-gray-500">{achievement.category}</span>
-                                      <span className="text-xs text-green-400">✓ Completed</span>
+                                      <span className="capitalize">{achievement.category}</span>
+                                      <span className="text-emerald-300">✓ Completed</span>
                                     </div>
                                   </div>
                                 </div>
-                              </div>
+                              </button>
                             ))}
                           </div>
                         </div>
@@ -252,41 +282,42 @@ export const AchievementsSection = ({
 
                       {filteredLocked.length > 0 && (
                         <div>
-                          <h4 className="mb-3 text-sm font-bold uppercase tracking-wide text-gray-400">
+                          <h4 className="mb-3 text-xs font-bold uppercase tracking-[0.3em] text-slate-400">
                             Locked ({filteredLocked.length})
                           </h4>
                           <div className="space-y-2">
                             {filteredLocked.map(achievement => (
-                              <div
+                              <button
                                 key={achievement.id}
-                                className={`rounded p-3 transition-colors opacity-60 cursor-pointer ${
+                                type="button"
+                                className={`w-full rounded-xl border p-4 text-left transition-all ${
                                   selectedAchievement?.id === achievement.id
-                                    ? 'bg-blue-900/30 border border-blue-600'
-                                    : 'bg-gray-700 hover:bg-gray-600'
-                                }`}
+                                    ? 'border-sky-400/60 bg-sky-500/15 shadow-[0_0_25px_rgba(56,189,248,0.25)]'
+                                    : 'border-emerald-500/15 bg-slate-900/50 hover:border-emerald-400/30 hover:bg-slate-900/70'
+                                } opacity-70`}
                                 onClick={() => setSelectedAchievement(achievement)}
                               >
-                                <div className="flex items-center gap-3">
-                                  <div className="text-2xl grayscale">{achievement.icon}</div>
-                                  <div className="flex-1">
-                                    <div className="mb-1 flex items-center gap-2">
-                                      <h5 className="font-semibold text-gray-300">{achievement.name}</h5>
-                                      <Badge className={getRarityColor(achievement.rarity)}>
+                                <div className="flex items-start gap-4">
+                                  <div className="text-3xl text-slate-400">{achievement.icon}</div>
+                                  <div className="flex-1 space-y-2">
+                                    <div className="flex flex-wrap items-center gap-2">
+                                      <h5 className="text-base font-semibold text-slate-200">{achievement.name}</h5>
+                                      <Badge className={`${getRarityColor(achievement.rarity)} uppercase tracking-wide`}>
                                         {achievement.rarity}
                                       </Badge>
-                                      <Badge className="bg-yellow-900/20 text-yellow-400">
+                                      <Badge className="border border-amber-400/60 bg-amber-500/10 text-amber-200">
                                         {achievement.points}pts
                                       </Badge>
                                     </div>
-                                    <p className="text-sm text-gray-400">{achievement.description}</p>
-                                    <div className="mt-1 flex items-center gap-2">
+                                    <p className="text-sm text-slate-400">{achievement.description}</p>
+                                    <div className="flex items-center gap-2 text-xs text-slate-400">
                                       {getCategoryIcon(achievement.category)}
-                                      <span className="text-xs capitalize text-gray-500">{achievement.category}</span>
-                                      <span className="text-xs text-gray-500">🔒 Locked</span>
+                                      <span className="capitalize">{achievement.category}</span>
+                                      <span>🔒 Locked</span>
                                     </div>
                                   </div>
                                 </div>
-                              </div>
+                              </button>
                             ))}
                           </div>
                         </div>
@@ -297,57 +328,57 @@ export const AchievementsSection = ({
               </div>
 
               <div>
-                <Card className="h-full border-gray-700 bg-gray-800 p-4">
-                  <h3 className="mb-4 text-lg font-semibold text-white">
+                <Card className="flex h-full flex-col rounded-2xl border border-emerald-500/20 bg-slate-950/75 p-5 shadow-[0_0_25px_rgba(16,185,129,0.15)]">
+                  <h3 className="mb-4 text-lg font-semibold uppercase tracking-[0.2em] text-emerald-100">
                     {selectedAchievement ? 'Achievement Details' : 'Select Achievement'}
                   </h3>
                   {selectedAchievement ? (
-                    <ScrollArea className="h-[60vh]">
-                      <div className="space-y-4">
+                    <ScrollArea className="h-[60vh] pr-2">
+                      <div className="space-y-5">
                         <div className="text-center">
-                          <div className="mb-2 text-6xl">{selectedAchievement.icon}</div>
-                          <h4 className="text-xl font-bold text-white">{selectedAchievement.name}</h4>
-                          <p className="mt-1 text-sm text-gray-300">{selectedAchievement.description}</p>
+                          <div className="mb-3 text-6xl text-emerald-200">{selectedAchievement.icon}</div>
+                          <h4 className="text-xl font-bold text-slate-100">{selectedAchievement.name}</h4>
+                          <p className="mt-2 text-sm text-slate-300">{selectedAchievement.description}</p>
                         </div>
 
-                        <div className="space-y-3">
-                          <div className="flex items-center justify-between">
-                            <span className="text-sm text-gray-400">Category:</span>
-                            <div className="flex items-center gap-1">
+                        <div className="space-y-4 text-sm">
+                          <div className="flex items-center justify-between text-slate-300">
+                            <span>Category</span>
+                            <div className="flex items-center gap-2 text-emerald-200">
                               {getCategoryIcon(selectedAchievement.category)}
-                              <span className="text-sm capitalize text-white">{selectedAchievement.category}</span>
+                              <span className="capitalize">{selectedAchievement.category}</span>
                             </div>
                           </div>
 
-                          <div className="flex items-center justify-between">
-                            <span className="text-sm text-gray-400">Rarity:</span>
-                            <Badge className={getRarityColor(selectedAchievement.rarity)}>
+                          <div className="flex items-center justify-between text-slate-300">
+                            <span>Rarity</span>
+                            <Badge className={`${getRarityColor(selectedAchievement.rarity)} uppercase tracking-wide`}>
                               {selectedAchievement.rarity}
                             </Badge>
                           </div>
 
-                          <div className="flex items-center justify-between">
-                            <span className="text-sm text-gray-400">Points:</span>
-                            <span className="text-sm font-bold text-yellow-400">{selectedAchievement.points}</span>
+                          <div className="flex items-center justify-between text-slate-300">
+                            <span>Points</span>
+                            <span className="font-semibold text-amber-300">{selectedAchievement.points}</span>
                           </div>
 
-                          <div className="flex items-center justify-between">
-                            <span className="text-sm text-gray-400">Status:</span>
+                          <div className="flex items-center justify-between text-slate-300">
+                            <span>Status</span>
                             <Badge className={
                               unlockedAchievements.find(a => a.id === selectedAchievement.id)
-                                ? 'text-green-400 bg-green-900/20'
-                                : 'text-red-400 bg-red-900/20'
+                                ? 'border border-emerald-400/60 bg-emerald-500/15 text-emerald-200'
+                                : 'border border-rose-400/60 bg-rose-500/15 text-rose-200'
                             }>
                               {unlockedAchievements.find(a => a.id === selectedAchievement.id) ? '✓ Unlocked' : '🔒 Locked'}
                             </Badge>
                           </div>
 
                           {selectedAchievement.requirements && (
-                            <div>
-                              <div className="mb-2 text-sm text-gray-400">Requirements:</div>
-                              <div className="space-y-1">
+                            <div className="space-y-2">
+                              <div className="text-xs uppercase tracking-[0.3em] text-slate-400">Requirements</div>
+                              <div className="space-y-2">
                                 {selectedAchievement.requirements.conditions.map((condition, index) => (
-                                  <div key={index} className="rounded bg-gray-700 p-2 text-xs text-gray-500">
+                                  <div key={index} className="rounded-lg border border-emerald-500/20 bg-slate-900/60 p-2 text-xs text-slate-300">
                                     {condition.key.replace(/_/g, ' ')}: {condition.operator || '=='} {condition.value}
                                   </div>
                                 ))}
@@ -356,14 +387,14 @@ export const AchievementsSection = ({
                           )}
 
                           {selectedAchievement.rewards && (
-                            <div>
-                              <div className="mb-2 text-sm text-gray-400">Rewards:</div>
-                              <div className="space-y-1">
+                            <div className="space-y-2">
+                              <div className="text-xs uppercase tracking-[0.3em] text-slate-400">Rewards</div>
+                              <div className="space-y-1 text-xs text-emerald-200">
                                 {selectedAchievement.rewards.title && (
-                                  <div className="text-xs text-yellow-400">Title: {selectedAchievement.rewards.title}</div>
+                                  <div>Title: {selectedAchievement.rewards.title}</div>
                                 )}
                                 {selectedAchievement.rewards.unlockTutorial && (
-                                  <div className="text-xs text-blue-400">
+                                  <div className="text-sky-200">
                                     Unlocks: {selectedAchievement.rewards.unlockTutorial} tutorial
                                   </div>
                                 )}
@@ -372,9 +403,9 @@ export const AchievementsSection = ({
                           )}
 
                           {selectedAchievement.hidden && (
-                            <div className="rounded border border-purple-600 bg-purple-900/20 p-3">
-                              <div className="text-sm font-bold text-purple-400">Hidden Achievement</div>
-                              <div className="mt-1 text-xs text-purple-300">
+                            <div className="rounded-xl border border-fuchsia-500/40 bg-fuchsia-500/10 p-4">
+                              <div className="text-sm font-semibold uppercase tracking-[0.2em] text-fuchsia-200">Hidden Achievement</div>
+                              <div className="mt-1 text-xs text-fuchsia-100/80">
                                 This is a secret achievement that was discovered through special actions.
                               </div>
                             </div>
@@ -383,12 +414,10 @@ export const AchievementsSection = ({
                       </div>
                     </ScrollArea>
                   ) : (
-                    <div className="py-8 text-center text-gray-500">
-                      <Trophy size={48} className="mx-auto mb-4 opacity-50" />
-                      <div className="mb-2 text-lg font-medium">Achievement Details</div>
-                      <div className="text-sm">
-                        Click on an achievement to view detailed information
-                      </div>
+                    <div className="flex h-full flex-col items-center justify-center gap-3 text-slate-500">
+                      <Trophy size={48} className="opacity-40" />
+                      <div className="text-lg font-medium text-slate-300">Achievement Details</div>
+                      <div className="text-sm text-slate-400">Click on an achievement to view detailed information</div>
                     </div>
                   )}
                 </Card>
@@ -396,107 +425,105 @@ export const AchievementsSection = ({
             </div>
           </TabsContent>
 
-          <TabsContent value="statistics" className="mt-4">
+          <TabsContent value="statistics" className="flex-1 overflow-y-auto focus-visible:outline-none">
             <div className="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-4">
-              <Card className="border-gray-700 bg-gray-800 p-4">
-                <div className="text-2xl font-bold text-white">{stats.total_games_played}</div>
-                <div className="text-sm text-gray-400">Games Played</div>
+              <Card className="rounded-2xl border border-emerald-500/20 bg-slate-950/75 p-5 text-slate-200 shadow-[0_0_25px_rgba(16,185,129,0.15)]">
+                <div className="text-2xl font-bold text-emerald-200">{stats.total_games_played}</div>
+                <div className="text-xs uppercase tracking-[0.3em] text-slate-400">Games Played</div>
               </Card>
-              <Card className="border-gray-700 bg-gray-800 p-4">
-                <div className="text-2xl font-bold text-green-400">{stats.games_won}</div>
-                <div className="text-sm text-gray-400">Games Won</div>
+              <Card className="rounded-2xl border border-emerald-500/20 bg-slate-950/75 p-5 text-slate-200 shadow-[0_0_25px_rgba(16,185,129,0.15)]">
+                <div className="text-2xl font-bold text-emerald-300">{stats.games_won}</div>
+                <div className="text-xs uppercase tracking-[0.3em] text-slate-400">Games Won</div>
               </Card>
-              <Card className="border-gray-700 bg-gray-800 p-4">
-                <div className="text-2xl font-bold text-yellow-400">{stats.max_win_streak}</div>
-                <div className="text-sm text-gray-400">Best Win Streak</div>
+              <Card className="rounded-2xl border border-emerald-500/20 bg-slate-950/75 p-5 text-slate-200 shadow-[0_0_25px_rgba(16,185,129,0.15)]">
+                <div className="text-2xl font-bold text-amber-300">{stats.max_win_streak}</div>
+                <div className="text-xs uppercase tracking-[0.3em] text-slate-400">Best Win Streak</div>
               </Card>
-              <Card className="border-gray-700 bg-gray-800 p-4">
-                <div className="text-2xl font-bold text-blue-400">{progress.totalPoints}</div>
-                <div className="text-sm text-gray-400">Achievement Points</div>
+              <Card className="rounded-2xl border border-emerald-500/20 bg-slate-950/75 p-5 text-slate-200 shadow-[0_0_25px_rgba(16,185,129,0.15)]">
+                <div className="text-2xl font-bold text-sky-300">{progress.totalPoints}</div>
+                <div className="text-xs uppercase tracking-[0.3em] text-slate-400">Achievement Points</div>
               </Card>
-              <Card className="border-gray-700 bg-gray-800 p-4">
-                <div className="text-2xl font-bold text-purple-400">{stats.legendary_cards_played}</div>
-                <div className="text-sm text-gray-400">Legendary Cards</div>
+              <Card className="rounded-2xl border border-emerald-500/20 bg-slate-950/75 p-5 text-slate-200 shadow-[0_0_25px_rgba(16,185,129,0.15)]">
+                <div className="text-2xl font-bold text-fuchsia-300">{stats.legendary_cards_played}</div>
+                <div className="text-xs uppercase tracking-[0.3em] text-slate-400">Legendary Cards</div>
               </Card>
-              <Card className="border-gray-700 bg-gray-800 p-4">
-                <div className="text-2xl font-bold text-red-400">{stats.max_states_controlled_single_game}</div>
-                <div className="text-sm text-gray-400">Max States Controlled</div>
+              <Card className="rounded-2xl border border-emerald-500/20 bg-slate-950/75 p-5 text-slate-200 shadow-[0_0_25px_rgba(16,185,129,0.15)]">
+                <div className="text-2xl font-bold text-rose-300">{stats.max_states_controlled_single_game}</div>
+                <div className="text-xs uppercase tracking-[0.3em] text-slate-400">Max States Controlled</div>
               </Card>
-              <Card className="border-gray-700 bg-gray-800 p-4">
-                <div className="text-2xl font-bold text-cyan-400">
-                  {stats.fastest_victory_turns === 999 ? '—' : stats.fastest_victory_turns}
-                </div>
-                <div className="text-sm text-gray-400">Fastest Victory (turns)</div>
+              <Card className="rounded-2xl border border-emerald-500/20 bg-slate-950/75 p-5 text-slate-200 shadow-[0_0_25px_rgba(16,185,129,0.15)]">
+                <div className="text-2xl font-bold text-cyan-300">{stats.fastest_victory_turns === 999 ? '—' : stats.fastest_victory_turns}</div>
+                <div className="text-xs uppercase tracking-[0.3em] text-slate-400">Fastest Victory (turns)</div>
               </Card>
-              <Card className="border-gray-700 bg-gray-800 p-4">
-                <div className="text-2xl font-bold text-orange-400">{Math.round(stats.total_play_time_minutes / 60)}h</div>
-                <div className="text-sm text-gray-400">Play Time</div>
+              <Card className="rounded-2xl border border-emerald-500/20 bg-slate-950/75 p-5 text-slate-200 shadow-[0_0_25px_rgba(16,185,129,0.15)]">
+                <div className="text-2xl font-bold text-orange-300">{Math.round(stats.total_play_time_minutes / 60)}h</div>
+                <div className="text-xs uppercase tracking-[0.3em] text-slate-400">Play Time</div>
               </Card>
-              <Card className="border-gray-700 bg-gray-800 p-4 md:col-span-2">
+              <Card className="rounded-2xl border border-emerald-500/20 bg-slate-950/75 p-5 text-slate-200 shadow-[0_0_25px_rgba(16,185,129,0.15)] md:col-span-2">
                 <div className="grid grid-cols-1 gap-4 sm:grid-cols-3">
                   <div>
-                    <div className="text-2xl font-bold text-fuchsia-400">{stats.total_combos_executed}</div>
-                    <div className="text-sm text-gray-400">Combos Triggered</div>
+                    <div className="text-2xl font-bold text-fuchsia-300">{stats.total_combos_executed}</div>
+                    <div className="text-xs uppercase tracking-[0.3em] text-slate-400">Combos Triggered</div>
                   </div>
                   <div>
-                    <div className="text-2xl font-bold text-sky-400">{stats.highest_combo_chain}</div>
-                    <div className="text-sm text-gray-400">Best Combo Chain</div>
+                    <div className="text-2xl font-bold text-sky-300">{stats.highest_combo_chain}</div>
+                    <div className="text-xs uppercase tracking-[0.3em] text-slate-400">Best Combo Chain</div>
                   </div>
                   <div>
-                    <div className="text-2xl font-bold text-amber-400">{stats.max_combos_in_single_game}</div>
-                    <div className="text-sm text-gray-400">Most Combos in a Game</div>
+                    <div className="text-2xl font-bold text-amber-300">{stats.max_combos_in_single_game}</div>
+                    <div className="text-xs uppercase tracking-[0.3em] text-slate-400">Most Combos in a Game</div>
                   </div>
                 </div>
               </Card>
-              <Card className="border-gray-700 bg-gray-800 p-4 md:col-span-2">
-                <h4 className="mb-3 text-sm font-semibold text-gray-200">Combo Category Breakdown</h4>
-                <div className="grid grid-cols-1 gap-2 text-sm text-gray-300 sm:grid-cols-2">
+              <Card className="rounded-2xl border border-emerald-500/20 bg-slate-950/75 p-5 text-slate-200 shadow-[0_0_25px_rgba(16,185,129,0.15)] md:col-span-2">
+                <h4 className="mb-3 text-xs font-semibold uppercase tracking-[0.35em] text-slate-400">Combo Category Breakdown</h4>
+                <div className="grid grid-cols-1 gap-2 text-sm text-slate-300 sm:grid-cols-2">
                   <div className="flex items-center justify-between">
                     <span>Sequence</span>
-                    <span className="font-semibold text-white">{stats.total_sequence_combos}</span>
+                    <span className="font-semibold text-slate-100">{stats.total_sequence_combos}</span>
                   </div>
                   <div className="flex items-center justify-between">
                     <span>Count</span>
-                    <span className="font-semibold text-white">{stats.total_count_combos}</span>
+                    <span className="font-semibold text-slate-100">{stats.total_count_combos}</span>
                   </div>
                   <div className="flex items-center justify-between">
                     <span>Threshold</span>
-                    <span className="font-semibold text-white">{stats.total_threshold_combos}</span>
+                    <span className="font-semibold text-slate-100">{stats.total_threshold_combos}</span>
                   </div>
                   <div className="flex items-center justify-between">
                     <span>State Control</span>
-                    <span className="font-semibold text-white">{stats.total_state_combos}</span>
+                    <span className="font-semibold text-slate-100">{stats.total_state_combos}</span>
                   </div>
                   <div className="flex items-center justify-between">
                     <span>Hybrid</span>
-                    <span className="font-semibold text-white">{stats.total_hybrid_combos}</span>
+                    <span className="font-semibold text-slate-100">{stats.total_hybrid_combos}</span>
                   </div>
                 </div>
               </Card>
             </div>
           </TabsContent>
 
-          <TabsContent value="progress" className="mt-4">
+          <TabsContent value="progress" className="flex-1 overflow-y-auto focus-visible:outline-none">
             <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
-              <Card className="border-gray-700 bg-gray-800 p-4">
-                <h3 className="mb-4 text-lg font-semibold text-white">Overall Progress</h3>
+              <Card className="rounded-2xl border border-emerald-500/20 bg-slate-950/75 p-5 text-slate-200 shadow-[0_0_25px_rgba(16,185,129,0.15)]">
+                <h3 className="mb-4 text-lg font-semibold uppercase tracking-[0.2em] text-emerald-100">Overall Progress</h3>
                 <div className="space-y-4">
                   <div>
-                    <div className="mb-1 flex justify-between text-sm">
+                    <div className="mb-2 flex justify-between text-xs uppercase tracking-[0.25em] text-slate-400">
                       <span>Achievements</span>
                       <span>{progress.unlocked}/{progress.total}</span>
                     </div>
-                    <Progress value={progress.completionRate} className="h-3" />
+                    <Progress value={progress.completionRate} className="h-3 bg-slate-900/60" />
                   </div>
-                  <div className="text-center">
-                    <div className="text-2xl font-bold text-white">{progress.rank}</div>
-                    <div className="text-sm text-gray-400">Current Rank</div>
+                  <div className="rounded-xl border border-emerald-500/20 bg-emerald-500/10 p-4 text-center">
+                    <div className="text-sm uppercase tracking-[0.35em] text-emerald-200/80">Current Rank</div>
+                    <div className="text-2xl font-bold text-emerald-100">{progress.rank}</div>
                   </div>
                 </div>
               </Card>
 
-              <Card className="border-gray-700 bg-gray-800 p-4">
-                <h3 className="mb-4 text-lg font-semibold text-white">Category Progress</h3>
+              <Card className="rounded-2xl border border-emerald-500/20 bg-slate-950/75 p-5 text-slate-200 shadow-[0_0_25px_rgba(16,185,129,0.15)]">
+                <h3 className="mb-4 text-lg font-semibold uppercase tracking-[0.2em] text-emerald-100">Category Progress</h3>
                 <div className="space-y-3">
                   {['victory', 'mastery', 'discovery', 'challenge', 'social', 'collection'].map(category => {
                     const total = ACHIEVEMENTS.filter(a => a.category === category && !a.hidden).length;
@@ -504,15 +531,15 @@ export const AchievementsSection = ({
                     const percentage = total > 0 ? Math.round((unlocked / total) * 100) : 0;
 
                     return (
-                      <div key={category}>
-                        <div className="mb-1 flex justify-between text-sm">
-                          <div className="flex items-center gap-1">
+                      <div key={category} className="space-y-2">
+                        <div className="flex items-center justify-between text-xs uppercase tracking-[0.25em] text-slate-400">
+                          <div className="flex items-center gap-2 text-slate-300">
                             {getCategoryIcon(category)}
-                            <span className="capitalize">{category}</span>
+                            <span className="capitalize tracking-normal">{category}</span>
                           </div>
                           <span>{unlocked}/{total}</span>
                         </div>
-                        <Progress value={percentage} className="h-2" />
+                        <Progress value={percentage} className="h-2 bg-slate-900/60" />
                       </div>
                     );
                   })}
@@ -533,8 +560,14 @@ interface AchievementPanelProps {
 const AchievementPanel = ({ onClose }: AchievementPanelProps) => {
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/80 p-4">
-      <Card className="h-[90vh] w-full max-w-7xl overflow-hidden border-gray-700 bg-gray-900">
-        <AchievementsSection onClose={onClose} showCloseButton className="h-full" />
+      <Card className="relative h-[90vh] w-full max-w-7xl overflow-hidden border border-emerald-500/25 bg-slate-950/95 text-slate-100 shadow-[0_0_80px_rgba(16,185,129,0.25)]">
+        <div className="pointer-events-none absolute inset-0 opacity-40">
+          <div className="absolute inset-0 bg-[radial-gradient(circle_at_top,_rgba(16,185,129,0.2),_transparent_60%)]" />
+          <div className="absolute inset-0 bg-[linear-gradient(135deg,_rgba(56,189,248,0.12),_transparent_55%)]" />
+        </div>
+        <div className="relative h-full p-6">
+          <AchievementsSection onClose={onClose} showCloseButton className="h-full" />
+        </div>
       </Card>
     </div>
   );

--- a/src/components/game/CardCollection.tsx
+++ b/src/components/game/CardCollection.tsx
@@ -50,6 +50,19 @@ export const CardCollectionContent = ({
     return matchesSearch && matchesType && matchesRarity;
   });
 
+  const getRarityClasses = (rarity: string) => {
+    switch (rarity) {
+      case 'legendary':
+        return 'border border-fuchsia-400/60 bg-fuchsia-500/10 text-fuchsia-200';
+      case 'rare':
+        return 'border border-sky-400/60 bg-sky-500/10 text-sky-200';
+      case 'uncommon':
+        return 'border border-emerald-400/60 bg-emerald-500/10 text-emerald-200';
+      default:
+        return 'border border-slate-500/60 bg-slate-900/60 text-slate-300';
+    }
+  };
+
   const CardItem = ({ card }: { card: GameCard }) => {
     const cardStats = getCardStats(card.id);
 
@@ -60,27 +73,29 @@ export const CardCollectionContent = ({
         className="w-full text-left"
         aria-label={`View details for ${card.name}`}
       >
-        <div className="rounded-lg border border-border bg-card p-4 transition-colors hover:bg-accent/50">
-          <div className="mb-2 flex items-start justify-between">
-            <h3 className="text-lg font-bold text-foreground">{card.name}</h3>
-            <div className="flex gap-2">
-              <Badge variant={card.rarity === 'legendary' ? 'destructive'
-                : card.rarity === 'rare' ? 'secondary' : 'outline'}>
-                {card.rarity}
+        <div className="group relative overflow-hidden rounded-2xl border border-emerald-500/20 bg-slate-950/70 p-5 transition-all hover:border-emerald-400/40 hover:bg-slate-950/80 hover:shadow-[0_0_25px_rgba(16,185,129,0.25)]">
+          <div className="pointer-events-none absolute inset-0 opacity-0 transition-opacity duration-300 group-hover:opacity-60">
+            <div className="absolute inset-0 bg-[radial-gradient(circle_at_top,_rgba(16,185,129,0.2),_transparent_60%)]" />
+          </div>
+          <div className="relative mb-3 flex flex-wrap items-start justify-between gap-3">
+            <h3 className="text-lg font-semibold text-emerald-100">{card.name}</h3>
+            <div className="flex flex-wrap gap-2">
+              <Badge className={getRarityClasses(card.rarity)}>{card.rarity}</Badge>
+              <Badge className="border border-slate-500/60 bg-slate-900/60 text-slate-300">
+                {normalizeCardType(card.type)}
               </Badge>
-              <Badge variant="outline">{normalizeCardType(card.type)}</Badge>
             </div>
           </div>
 
-          <p className="mb-3 text-sm text-muted-foreground">{card.text}</p>
+          <p className="mb-3 text-sm text-slate-300">{card.text}</p>
 
-          <div className="flex items-center justify-between text-xs text-muted-foreground">
+          <div className="flex flex-wrap items-center justify-between gap-3 text-xs text-emerald-200/80">
             <span>Cost: {card.cost} IP</span>
             <span>Played: {cardStats.timesPlayed} times</span>
           </div>
 
           {(card.flavor ?? card.flavorGov ?? card.flavorTruth) && (
-            <div className="mt-2 rounded bg-accent/30 p-2 text-xs italic text-muted-foreground">
+            <div className="mt-3 rounded-xl border border-emerald-500/20 bg-emerald-500/10 p-3 text-xs italic text-emerald-100/70">
               "{card.flavor ?? card.flavorGov ?? card.flavorTruth}"
             </div>
           )}
@@ -90,61 +105,64 @@ export const CardCollectionContent = ({
   };
 
   return (
-    <div className={`flex h-full flex-col ${className ?? ''}`}>
-      <div className="flex items-start justify-between gap-4 pb-4">
-        <div>
-          <h2 className="flex items-center gap-3 text-xl font-bold text-foreground">
-            📚 Card Collection
-            <span className="text-sm font-normal text-muted-foreground">
-              {stats.discoveredCards}/{stats.totalCards} cards ({stats.completionPercentage}%)
-            </span>
-          </h2>
-          <p className="text-sm text-muted-foreground">
-            Browse discovered cards, filter by type or rarity, and review usage stats.
-          </p>
+    <div className={`flex h-full flex-col gap-5 text-slate-200 ${className ?? ''}`}>
+      <div className="relative overflow-hidden rounded-2xl border border-emerald-500/30 bg-slate-950/85 px-5 py-4 shadow-[0_0_35px_rgba(16,185,129,0.2)]">
+        <div className="pointer-events-none absolute inset-0 opacity-45">
+          <div className="absolute inset-0 bg-[radial-gradient(circle_at_top_right,_rgba(56,189,248,0.25),_transparent_60%)]" />
+          <div className="absolute inset-0 bg-[linear-gradient(135deg,_rgba(16,185,129,0.16),_transparent_50%,_rgba(56,189,248,0.14))]" />
         </div>
-        {onClose && (
-          <Button
-            type="button"
-            variant="ghost"
-            size="icon"
-            onClick={onClose}
-            aria-label="Close card collection"
-          >
-            <X className="h-5 w-5" />
-          </Button>
-        )}
-      </div>
-
-      <div className="grid grid-cols-1 gap-4 pb-4 sm:grid-cols-3">
-        <div className="text-center">
-          <div className="text-2xl font-bold text-primary">{stats.discoveredCards}</div>
-          <div className="text-sm text-muted-foreground">Cards Discovered</div>
-        </div>
-        <div className="text-center">
-          <div className="text-2xl font-bold text-secondary">{stats.totalPlays}</div>
-          <div className="text-sm text-muted-foreground">Total Plays</div>
-        </div>
-        <div className="text-center">
-          <div className="text-2xl font-bold text-accent">{stats.completionPercentage}%</div>
-          <div className="text-sm text-muted-foreground">Complete</div>
+        <div className="relative flex flex-wrap items-start justify-between gap-4">
+          <div className="space-y-2">
+            <div className="font-mono text-xs uppercase tracking-[0.35em] text-emerald-200/80">Card Intelligence</div>
+            <h2 className="font-mono text-xl font-semibold uppercase tracking-[0.2em] text-emerald-100">CARD COLLECTION</h2>
+            <p className="max-w-xl text-sm text-emerald-100/70">
+              Browse discovered cards, filter by type or rarity, and review usage stats across the operation.
+            </p>
+          </div>
+          {onClose && (
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              onClick={onClose}
+              aria-label="Close card collection"
+              className="border-emerald-400/30 bg-slate-950/60 text-slate-300 transition hover:bg-emerald-500/20 hover:text-emerald-100"
+            >
+              <X className="h-5 w-5" />
+            </Button>
+          )}
         </div>
       </div>
 
-      <Progress value={stats.completionPercentage} className="mb-4" />
+      <div className="grid grid-cols-1 gap-4 pb-2 sm:grid-cols-3">
+        <div className="rounded-2xl border border-emerald-500/20 bg-slate-950/75 p-4 text-center shadow-[0_0_20px_rgba(16,185,129,0.15)]">
+          <div className="text-2xl font-bold text-emerald-200">{stats.discoveredCards}</div>
+          <div className="text-xs uppercase tracking-[0.3em] text-slate-400">Cards Discovered</div>
+        </div>
+        <div className="rounded-2xl border border-emerald-500/20 bg-slate-950/75 p-4 text-center shadow-[0_0_20px_rgba(16,185,129,0.15)]">
+          <div className="text-2xl font-bold text-sky-200">{stats.totalPlays}</div>
+          <div className="text-xs uppercase tracking-[0.3em] text-slate-400">Total Plays</div>
+        </div>
+        <div className="rounded-2xl border border-emerald-500/20 bg-slate-950/75 p-4 text-center shadow-[0_0_20px_rgba(16,185,129,0.15)]">
+          <div className="text-2xl font-bold text-emerald-100">{stats.completionPercentage}%</div>
+          <div className="text-xs uppercase tracking-[0.3em] text-slate-400">Complete</div>
+        </div>
+      </div>
 
-      <div className="mb-4 flex flex-col gap-4 sm:flex-row">
+      <Progress value={stats.completionPercentage} className="h-2 rounded-full bg-slate-900/60" />
+
+      <div className="flex flex-col gap-4 sm:flex-row">
         <Input
           placeholder="Search cards..."
           value={searchTerm}
           onChange={(e) => setSearchTerm(e.target.value)}
-          className="flex-1"
+          className="flex-1 rounded-xl border border-emerald-500/30 bg-slate-950/70 px-4 py-2 text-slate-200 placeholder:text-slate-500 focus:border-emerald-400 focus:ring-2 focus:ring-emerald-400/40"
         />
         <Select value={filterType} onValueChange={setFilterType}>
-          <SelectTrigger className="w-full sm:w-40">
+          <SelectTrigger className="w-full rounded-xl border border-emerald-500/30 bg-slate-950/70 px-4 py-2 text-slate-200 sm:w-40">
             <SelectValue placeholder="Type" />
           </SelectTrigger>
-          <SelectContent>
+          <SelectContent className="border border-emerald-500/30 bg-slate-950/95 text-slate-200">
             <SelectItem value="all">All Types</SelectItem>
             <SelectItem value="MEDIA">Media</SelectItem>
             <SelectItem value="ZONE">Zone</SelectItem>
@@ -152,10 +170,10 @@ export const CardCollectionContent = ({
           </SelectContent>
         </Select>
         <Select value={filterRarity} onValueChange={setFilterRarity}>
-          <SelectTrigger className="w-full sm:w-40">
+          <SelectTrigger className="w-full rounded-xl border border-emerald-500/30 bg-slate-950/70 px-4 py-2 text-slate-200 sm:w-40">
             <SelectValue placeholder="Rarity" />
           </SelectTrigger>
-          <SelectContent>
+          <SelectContent className="border border-emerald-500/30 bg-slate-950/95 text-slate-200">
             <SelectItem value="all">All Rarities</SelectItem>
             <SelectItem value="common">Common</SelectItem>
             <SelectItem value="uncommon">Uncommon</SelectItem>
@@ -167,7 +185,7 @@ export const CardCollectionContent = ({
 
       <div className="flex-1 overflow-y-auto">
         {filteredCards.length === 0 ? (
-          <div className="py-8 text-center text-muted-foreground">
+          <div className="flex h-full items-center justify-center rounded-2xl border border-emerald-500/20 bg-slate-950/70 text-slate-400">
             {discoveredCards.length === 0
               ? 'Start playing to discover cards!'
               : 'No cards match your search criteria.'}
@@ -202,7 +220,7 @@ interface CardCollectionProps {
 const CardCollection = ({ open, onOpenChange }: CardCollectionProps) => {
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="flex max-h-[90vh] max-w-4xl flex-col">
+      <DialogContent className="flex max-h-[90vh] max-w-4xl flex-col border border-emerald-500/30 bg-slate-950/95 text-slate-100 shadow-[0_0_60px_rgba(16,185,129,0.25)]">
         <CardCollectionContent
           isActive={open}
           onClose={() => onOpenChange(false)}

--- a/src/components/game/PlayerHubOverlay.tsx
+++ b/src/components/game/PlayerHubOverlay.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react';
 import { Card } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
+import { Badge } from '@/components/ui/badge';
 import { Trophy, Library, GraduationCap, X } from 'lucide-react';
 import { AchievementsSection } from './AchievementPanel';
 import { CardCollectionContent } from './CardCollection';
@@ -19,62 +20,99 @@ const PlayerHubOverlay = ({ onClose, onStartTutorial }: PlayerHubOverlayProps) =
 
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/80 p-4">
-      <Card className="flex h-[90vh] w-full max-w-7xl flex-col overflow-hidden border-gray-700 bg-gray-900">
-        <div className="flex items-center justify-between border-b border-gray-700 p-4">
-          <div>
-            <h2 className="text-xl font-bold text-white">AGENT DOSSIER HUB</h2>
-            <p className="text-sm text-gray-400">
-              Review your progress, browse unlocked cards, and continue your training.
-            </p>
+      <Card className="relative flex h-[90vh] w-full max-w-7xl flex-col overflow-hidden border border-emerald-500/30 bg-slate-950/95 text-slate-100 shadow-[0_0_80px_rgba(16,185,129,0.25)]">
+        <div className="pointer-events-none absolute inset-0">
+          <div className="absolute inset-0 opacity-60 bg-[radial-gradient(circle_at_top,_rgba(16,185,129,0.22),_transparent_55%)]" />
+          <div className="absolute inset-0 opacity-50 bg-[radial-gradient(circle_at_bottom,_rgba(56,189,248,0.18),_transparent_60%)]" />
+          <div
+            className="absolute inset-0 opacity-35 mix-blend-screen"
+            style={{ backgroundImage: 'linear-gradient(135deg, rgba(56,189,248,0.16), transparent 45%, rgba(16,185,129,0.12))' }}
+          />
+        </div>
+
+        <div className="relative border-b border-emerald-500/20 bg-gradient-to-r from-emerald-900/40 via-slate-950 to-slate-950/90 px-6 py-5 backdrop-blur">
+          <div className="flex flex-wrap items-start justify-between gap-6">
+            <div className="space-y-2">
+              <Badge className="border border-emerald-400/60 bg-emerald-500/15 font-mono text-[11px] uppercase tracking-[0.35em] text-emerald-200">
+                Operator Uplink
+              </Badge>
+              <h2 className="font-mono text-2xl font-semibold uppercase tracking-[0.2em] text-emerald-100">
+                AGENT DOSSIER HUB
+              </h2>
+              <p className="max-w-2xl text-sm text-emerald-100/70">
+                Review your progress, browse unlocked cards, and continue your training across the network.
+              </p>
+            </div>
+            <Button
+              onClick={onClose}
+              variant="outline"
+              size="sm"
+              className="border-emerald-400/40 bg-emerald-500/10 text-emerald-200 transition hover:bg-emerald-500/20 hover:text-emerald-100"
+            >
+              <X size={16} className="mr-1" />
+              Close
+            </Button>
           </div>
-          <Button
-            onClick={onClose}
-            variant="outline"
-            size="sm"
-            className="border-gray-600 text-gray-400"
-          >
-            <X size={16} />
-          </Button>
         </div>
 
         <Tabs
           value={activeTab}
-          onValueChange={(value) => setActiveTab(value as HubTab)}
-          className="flex h-full flex-col"
+          onValueChange={value => setActiveTab(value as HubTab)}
+          className="relative flex flex-1 flex-col overflow-hidden"
         >
-          <TabsList className="grid w-full grid-cols-3 bg-gray-800">
-            <TabsTrigger value="achievements" className="flex items-center gap-2">
-              <Trophy className="h-4 w-4" />
-              Achievements
-            </TabsTrigger>
-            <TabsTrigger value="cards" className="flex items-center gap-2">
-              <Library className="h-4 w-4" />
-              Card Collection
-            </TabsTrigger>
-            <TabsTrigger value="tutorials" className="flex items-center gap-2">
-              <GraduationCap className="h-4 w-4" />
-              Shadow Academy
-            </TabsTrigger>
-          </TabsList>
+          <div className="relative px-6 pt-6">
+            <TabsList className="grid w-full grid-cols-3 gap-2 rounded-lg border border-emerald-500/20 bg-slate-900/70 p-1 backdrop-blur">
+              <TabsTrigger
+                value="achievements"
+                className="flex items-center justify-center gap-2 rounded-md border border-transparent px-3 py-2 text-[11px] font-semibold uppercase tracking-[0.32em] text-slate-400 transition data-[state=active]:border-emerald-400/60 data-[state=active]:bg-emerald-500/15 data-[state=active]:text-emerald-200"
+              >
+                <Trophy className="h-4 w-4" />
+                Achievements
+              </TabsTrigger>
+              <TabsTrigger
+                value="cards"
+                className="flex items-center justify-center gap-2 rounded-md border border-transparent px-3 py-2 text-[11px] font-semibold uppercase tracking-[0.32em] text-slate-400 transition data-[state=active]:border-emerald-400/60 data-[state=active]:bg-emerald-500/15 data-[state=active]:text-emerald-200"
+              >
+                <Library className="h-4 w-4" />
+                Card Collection
+              </TabsTrigger>
+              <TabsTrigger
+                value="tutorials"
+                className="flex items-center justify-center gap-2 rounded-md border border-transparent px-3 py-2 text-[11px] font-semibold uppercase tracking-[0.32em] text-slate-400 transition data-[state=active]:border-emerald-400/60 data-[state=active]:bg-emerald-500/15 data-[state=active]:text-emerald-200"
+              >
+                <GraduationCap className="h-4 w-4" />
+                Shadow Academy
+              </TabsTrigger>
+            </TabsList>
+          </div>
 
-          <div className="flex-1 overflow-hidden">
-            <TabsContent value="achievements" className="h-full">
-              <AchievementsSection className="h-full" />
-            </TabsContent>
-            <TabsContent value="cards" className="h-full">
-              <CardCollectionContent
-                isActive={activeTab === 'cards'}
-                className="h-full"
-              />
-            </TabsContent>
-            <TabsContent value="tutorials" className="h-full">
-              <TutorialSection
-                isActive={activeTab === 'tutorials'}
-                onStartTutorial={onStartTutorial}
-                onClose={onClose}
-                className="h-full"
-              />
-            </TabsContent>
+          <div className="relative flex-1 overflow-hidden px-6 pb-6 pt-4">
+            <div className="relative flex h-full flex-col overflow-hidden rounded-2xl border border-emerald-500/25 bg-slate-950/80 shadow-[0_0_45px_rgba(16,185,129,0.15)]">
+              <div className="pointer-events-none absolute inset-0 opacity-45">
+                <div className="absolute inset-0 bg-[radial-gradient(circle_at_top,_rgba(16,185,129,0.18),_transparent_55%)]" />
+                <div className="absolute inset-0 bg-[linear-gradient(160deg,_rgba(56,189,248,0.12),_transparent_60%)]" />
+              </div>
+
+              <TabsContent value="achievements" className="relative h-full overflow-hidden p-6 focus-visible:outline-none">
+                <AchievementsSection className="h-full" />
+              </TabsContent>
+
+              <TabsContent value="cards" className="relative h-full overflow-hidden p-6 focus-visible:outline-none">
+                <CardCollectionContent
+                  isActive={activeTab === 'cards'}
+                  className="h-full"
+                />
+              </TabsContent>
+
+              <TabsContent value="tutorials" className="relative h-full overflow-hidden p-6 focus-visible:outline-none">
+                <TutorialSection
+                  isActive={activeTab === 'tutorials'}
+                  onStartTutorial={onStartTutorial}
+                  onClose={onClose}
+                  className="h-full"
+                />
+              </TabsContent>
+            </div>
           </div>
         </Tabs>
       </Card>

--- a/src/components/game/TutorialOverlay.tsx
+++ b/src/components/game/TutorialOverlay.tsx
@@ -57,19 +57,19 @@ export const TutorialSection = ({
 
   const getSequenceStatus = (sequence: TutorialSequence) => {
     if (completedSequences.includes(sequence.id)) {
-      return { status: 'completed', color: 'text-green-400 bg-green-900/20' };
+      return { status: 'completed', color: 'border border-emerald-400/50 bg-emerald-500/15 text-emerald-200' };
     } else if (tutorialManager.isSequenceAvailable(sequence.id)) {
-      return { status: 'available', color: 'text-blue-400 bg-blue-900/20' };
+      return { status: 'available', color: 'border border-sky-400/50 bg-sky-500/15 text-sky-200' };
     } else {
-      return { status: 'locked', color: 'text-gray-400 bg-gray-900/20' };
+      return { status: 'locked', color: 'border border-slate-500/50 bg-slate-900/60 text-slate-300' };
     }
   };
 
   const getDifficultyColor = (sequence: TutorialSequence) => {
     const stepCount = sequence.steps.length;
-    if (stepCount <= 5) return 'text-green-400 bg-green-900/20';
-    if (stepCount <= 10) return 'text-yellow-400 bg-yellow-900/20';
-    return 'text-red-400 bg-red-900/20';
+    if (stepCount <= 5) return 'border border-emerald-400/50 bg-emerald-500/15 text-emerald-200';
+    if (stepCount <= 10) return 'border border-amber-400/50 bg-amber-500/15 text-amber-200';
+    return 'border border-rose-400/50 bg-rose-500/15 text-rose-200';
   };
 
   const getDifficultyText = (sequence: TutorialSequence) => {
@@ -80,40 +80,49 @@ export const TutorialSection = ({
   };
 
   return (
-    <div className={`flex h-full flex-col ${className ?? ''}`}>
-      <div className="flex items-center justify-between border-b border-gray-700 p-4">
-        <div className="flex items-center gap-3">
-          <BookOpen size={24} className="text-blue-400" />
-          <div>
-            <h2 className="font-mono text-xl font-bold text-white">SHADOW ACADEMY</h2>
-            <div className="text-sm text-gray-400">Master the art of shadow operations</div>
-          </div>
+    <div className={`flex h-full flex-col gap-5 text-slate-200 ${className ?? ''}`}>
+      <div className="relative overflow-hidden rounded-2xl border border-emerald-500/30 bg-slate-950/85 px-5 py-4 shadow-[0_0_35px_rgba(16,185,129,0.2)]">
+        <div className="pointer-events-none absolute inset-0 opacity-45">
+          <div className="absolute inset-0 bg-[radial-gradient(circle_at_top_left,_rgba(56,189,248,0.25),_transparent_60%)]" />
+          <div className="absolute inset-0 bg-[linear-gradient(135deg,_rgba(16,185,129,0.16),_transparent_50%,_rgba(56,189,248,0.14))]" />
         </div>
-        {showCloseButton && onClose && (
-          <Button
-            onClick={onClose}
-            variant="outline"
-            size="sm"
-            className="border-gray-600 text-gray-400"
-          >
-            <X size={16} />
-          </Button>
-        )}
+        <div className="relative flex flex-wrap items-center justify-between gap-4">
+          <div className="flex items-center gap-4">
+            <div className="flex h-12 w-12 items-center justify-center rounded-full border border-sky-400/50 bg-sky-500/15 text-sky-200 shadow-[0_0_35px_rgba(56,189,248,0.3)]">
+              <BookOpen size={22} />
+            </div>
+            <div className="space-y-1">
+              <div className="font-mono text-xs uppercase tracking-[0.35em] text-emerald-200/80">Shadow Academy</div>
+              <h2 className="font-mono text-xl font-semibold uppercase tracking-[0.2em] text-emerald-100">TRAINING VAULT</h2>
+              <div className="text-sm text-emerald-100/70">Master the art of shadow operations</div>
+            </div>
+          </div>
+          {showCloseButton && onClose && (
+            <Button
+              onClick={onClose}
+              variant="outline"
+              size="sm"
+              className="border-emerald-400/30 bg-slate-950/60 text-slate-300 transition hover:bg-emerald-500/20 hover:text-emerald-100"
+            >
+              <X size={16} />
+            </Button>
+          )}
+        </div>
       </div>
 
-      <div className="flex-1 overflow-hidden p-4">
-        <div className="grid h-full grid-cols-1 gap-4 lg:grid-cols-3">
+      <div className="flex-1 overflow-hidden rounded-2xl border border-emerald-500/25 bg-slate-950/80 p-5 shadow-inner shadow-emerald-500/15">
+        <div className="grid h-full grid-cols-1 gap-5 lg:grid-cols-3">
           <div className="lg:col-span-2">
-            <Card className="h-full border-gray-700 bg-gray-800 p-4">
-              <div className="mb-4 flex items-center justify-between">
-                <h3 className="text-lg font-semibold text-white">Training Modules</h3>
-                <div className="flex items-center gap-4 text-sm text-gray-400">
-                  <div>Progress: {stats.completionRate}%</div>
-                  <Progress value={stats.completionRate} className="h-2 w-20" />
+            <Card className="flex h-full flex-col rounded-2xl border border-emerald-500/20 bg-slate-950/75 p-5 shadow-[0_0_25px_rgba(16,185,129,0.15)]">
+              <div className="mb-4 flex flex-wrap items-center justify-between gap-4">
+                <h3 className="text-lg font-semibold uppercase tracking-[0.2em] text-emerald-100">Training Modules</h3>
+                <div className="flex items-center gap-4 text-xs uppercase tracking-[0.3em] text-slate-400">
+                  <span>Progress: {stats.completionRate}%</span>
+                  <Progress value={stats.completionRate} className="h-2 w-24 bg-slate-900/60" />
                 </div>
               </div>
 
-              <div className="max-h-96 space-y-3 overflow-y-auto">
+              <div className="max-h-96 space-y-3 overflow-y-auto pr-1">
                 {TUTORIAL_SEQUENCES.map(sequence => {
                   const { status, color } = getSequenceStatus(sequence);
                   const isSelected = selectedSequence?.id === sequence.id;
@@ -121,42 +130,42 @@ export const TutorialSection = ({
                   return (
                     <div
                       key={sequence.id}
-                      className={`cursor-pointer rounded p-4 transition-all ${
+                      className={`rounded-2xl border p-4 transition-all ${
                         isSelected
-                          ? 'border border-blue-600 bg-blue-900/30'
-                          : 'bg-gray-700 hover:bg-gray-600'
-                      } ${status === 'locked' ? 'opacity-60' : ''}`}
+                          ? 'border-sky-400/60 bg-sky-500/15 shadow-[0_0_25px_rgba(56,189,248,0.25)]'
+                          : status === 'locked'
+                            ? 'border-emerald-500/15 bg-slate-900/50 opacity-60'
+                            : 'border-emerald-500/20 bg-slate-900/60 hover:border-emerald-400/40 hover:bg-slate-900/80'
+                      }`}
                       onClick={() => {
                         if (status !== 'locked') {
                           setSelectedSequence(sequence);
                         }
                       }}
                     >
-                      <div className="mb-2 flex items-center justify-between">
-                        <div className="flex items-center gap-3">
+                      <div className="mb-3 flex flex-wrap items-center justify-between gap-3">
+                        <div className="flex items-center gap-3 text-slate-200">
                           <div className={`h-3 w-3 rounded-full ${
-                            status === 'completed' ? 'bg-green-400'
-                              : status === 'available' ? 'bg-blue-400'
-                                : 'bg-gray-600'
+                            status === 'completed' ? 'bg-emerald-300' : status === 'available' ? 'bg-sky-300' : 'bg-slate-600'
                           }`} />
-                          <h4 className="font-semibold text-white">{sequence.name}</h4>
+                          <h4 className="font-semibold uppercase tracking-[0.1em] text-emerald-100">{sequence.name}</h4>
                         </div>
-                        <div className="flex items-center gap-2">
-                          <Badge className={color}>
+                        <div className="flex flex-wrap items-center gap-2">
+                          <Badge className={`${color} uppercase tracking-wide`}>
                             {status === 'completed' ? 'Completed'
                               : status === 'available' ? 'Available' : 'Locked'}
                           </Badge>
-                          <Badge className={getDifficultyColor(sequence)}>
+                          <Badge className={`${getDifficultyColor(sequence)} uppercase tracking-wide`}>
                             {getDifficultyText(sequence)}
                           </Badge>
                         </div>
                       </div>
 
-                      <div className="mb-2 text-sm text-gray-300">
+                      <div className="mb-2 text-sm text-slate-300">
                         {sequence.description}
                       </div>
 
-                      <div className="flex items-center justify-between text-xs text-gray-500">
+                      <div className="flex flex-wrap items-center justify-between text-xs text-slate-400">
                         <span>{sequence.steps.length} steps</span>
                         {sequence.prerequisites && (
                           <span>Requires: {sequence.prerequisites.join(', ')}</span>
@@ -170,42 +179,42 @@ export const TutorialSection = ({
           </div>
 
           <div>
-            <Card className="h-full border-gray-700 bg-gray-800 p-4">
+            <Card className="flex h-full flex-col rounded-2xl border border-emerald-500/20 bg-slate-950/75 p-5 shadow-[0_0_25px_rgba(16,185,129,0.15)]">
               {selectedSequence ? (
-                <div className="space-y-4">
-                  <div>
-                    <h3 className="mb-2 text-lg font-bold text-white">{selectedSequence.name}</h3>
-                    <div className="text-sm leading-relaxed text-gray-300">
+                <div className="flex h-full flex-col gap-5">
+                  <div className="space-y-2">
+                    <h3 className="text-lg font-bold text-emerald-100">{selectedSequence.name}</h3>
+                    <div className="text-sm leading-relaxed text-slate-300">
                       {selectedSequence.description}
                     </div>
                   </div>
 
-                  <div className="space-y-3">
+                  <div className="space-y-3 text-sm text-slate-300">
                     <div className="flex items-center justify-between">
-                      <span className="text-sm text-gray-400">Steps:</span>
-                      <span className="text-sm text-white">{selectedSequence.steps.length}</span>
+                      <span>Steps</span>
+                      <span className="text-emerald-200">{selectedSequence.steps.length}</span>
                     </div>
 
                     <div className="flex items-center justify-between">
-                      <span className="text-sm text-gray-400">Difficulty:</span>
-                      <Badge className={getDifficultyColor(selectedSequence)}>
+                      <span>Difficulty</span>
+                      <Badge className={`${getDifficultyColor(selectedSequence)} uppercase tracking-wide`}>
                         {getDifficultyText(selectedSequence)}
                       </Badge>
                     </div>
 
                     {selectedSequence.prerequisites && (
-                      <div className="space-y-1">
-                        <span className="text-sm text-gray-400">Prerequisites:</span>
+                      <div className="space-y-2">
+                        <span className="text-xs uppercase tracking-[0.3em] text-slate-400">Prerequisites</span>
                         <div className="space-y-1">
                           {selectedSequence.prerequisites.map(prereq => {
                             const isCompleted = completedSequences.includes(prereq);
                             const prereqSequence = TUTORIAL_SEQUENCES.find(s => s.id === prereq);
                             return (
-                              <div key={prereq} className="flex items-center gap-2 text-sm">
+                              <div key={prereq} className="flex items-center gap-2 text-xs">
                                 <div className={`h-2 w-2 rounded-full ${
-                                  isCompleted ? 'bg-green-400' : 'bg-red-400'
+                                  isCompleted ? 'bg-emerald-300' : 'bg-rose-300'
                                 }`} />
-                                <span className={isCompleted ? 'text-green-300' : 'text-red-300'}>
+                                <span className={isCompleted ? 'text-emerald-200' : 'text-rose-200'}>
                                   {prereqSequence?.name || prereq}
                                 </span>
                               </div>
@@ -216,37 +225,35 @@ export const TutorialSection = ({
                     )}
 
                     {selectedSequence.unlockAchievement && (
-                      <div className="flex items-center gap-2 text-sm">
-                        <Award size={14} className="text-yellow-400" />
-                        <span className="text-yellow-300">
-                          Unlocks achievement on completion
-                        </span>
+                      <div className="flex items-center gap-2 text-xs text-amber-200">
+                        <Award size={14} />
+                        <span>Unlocks achievement on completion</span>
                       </div>
                     )}
                   </div>
 
-                  <div className="border-t border-gray-700 pt-4">
+                  <div className="mt-auto border-t border-emerald-500/20 pt-4">
                     <Button
                       onClick={() => handleStartTutorial(selectedSequence.id)}
                       disabled={!availableSequences.includes(selectedSequence.id)}
-                      className="w-full bg-blue-600 text-white hover:bg-blue-700"
+                      className="w-full rounded-xl border border-sky-400/50 bg-sky-500/20 text-sky-100 transition hover:bg-sky-500/30"
                     >
                       <Play size={16} className="mr-2" />
                       {completedSequences.includes(selectedSequence.id) ? 'Replay Tutorial' : 'Start Tutorial'}
                     </Button>
 
                     {!availableSequences.includes(selectedSequence.id) && (
-                      <div className="mt-2 text-center text-xs text-red-400">
+                      <div className="mt-2 text-center text-xs text-rose-200">
                         Complete prerequisite tutorials first
                       </div>
                     )}
                   </div>
                 </div>
               ) : (
-                <div className="py-8 text-center text-gray-500">
-                  <BookOpen size={48} className="mx-auto mb-4 opacity-50" />
-                  <div className="mb-2 text-lg font-medium">Select a Tutorial</div>
-                  <div className="text-sm">
+                <div className="flex h-full flex-col items-center justify-center gap-3 text-slate-500">
+                  <BookOpen size={48} className="opacity-40" />
+                  <div className="text-lg font-medium text-slate-300">Select a Tutorial</div>
+                  <div className="text-sm text-slate-400">
                     Choose a training module to learn advanced shadow operations
                   </div>
                 </div>
@@ -267,13 +274,19 @@ interface TutorialOverlayProps {
 const TutorialOverlay = ({ onClose, onStartTutorial }: TutorialOverlayProps) => {
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/80 p-4">
-      <Card className="h-[80vh] w-full max-w-5xl overflow-hidden border-gray-700 bg-gray-900">
-        <TutorialSection
-          onClose={onClose}
-          onStartTutorial={onStartTutorial}
-          showCloseButton
-          className="h-full"
-        />
+      <Card className="relative h-[80vh] w-full max-w-5xl overflow-hidden border border-emerald-500/25 bg-slate-950/95 text-slate-100 shadow-[0_0_70px_rgba(16,185,129,0.25)]">
+        <div className="pointer-events-none absolute inset-0 opacity-40">
+          <div className="absolute inset-0 bg-[radial-gradient(circle_at_top,_rgba(16,185,129,0.2),_transparent_60%)]" />
+          <div className="absolute inset-0 bg-[linear-gradient(135deg,_rgba(56,189,248,0.14),_transparent_55%)]" />
+        </div>
+        <div className="relative h-full p-6">
+          <TutorialSection
+            onClose={onClose}
+            onStartTutorial={onStartTutorial}
+            showCloseButton
+            className="h-full"
+          />
+        </div>
       </Card>
     </div>
   );


### PR DESCRIPTION
## Summary
- restyle the Agent Dossier Hub shell with neon gradients, typography, and tab treatments consistent with the MVP Balancing Briefing
- refresh the Achievements, Card Collection, and Shadow Academy sections to use the new holographic panels, badges, and filter controls
- update standalone Achievement, Card Collection, and Tutorial overlays to inherit the same visual language and lighting effects

## Testing
- npm run lint *(fails: existing lint issues unrelated to this change)*

------
https://chatgpt.com/codex/tasks/task_e_68d67105ed748320947492e979f0e122