### PR TITLE
Unify secret agenda data for victory logic and UI

### DIFF
--- a/src/hooks/gameStateTypes.ts
+++ b/src/hooks/gameStateTypes.ts
@@ -67,11 +67,6 @@ export interface GameState {
   eventManager?: EventManager;
   showNewspaper: boolean;
   log: string[];
-  agenda?: SecretAgenda & {
-    progress?: number;
-    complete?: boolean;
-    revealed?: boolean;
-  };
   secretAgenda?: SecretAgenda & {
     progress: number;
     completed: boolean;

--- a/src/hooks/useGameState.ts
+++ b/src/hooks/useGameState.ts
@@ -8,7 +8,7 @@ import {
   calculateDynamicIpBonus,
   createDefaultCombinationEffects,
 } from '@/data/stateCombinations';
-import { getRandomAgenda, SecretAgenda } from '@/data/agendaDatabase';
+import { getRandomAgenda } from '@/data/agendaDatabase';
 import { type AIDifficulty } from '@/data/aiStrategy';
 import { AIFactory } from '@/data/aiFactory';
 import { EnhancedAIStrategist } from '@/data/enhancedAIStrategy';
@@ -180,7 +180,6 @@ const updateSecretAgendaProgress = (state: GameState): GameState => {
   let logUpdates: string[] = [];
   let updatedSecretAgenda = state.secretAgenda;
   let updatedAiSecretAgenda = state.aiSecretAgenda;
-  let updatedAgenda = state.agenda;
 
   if (updatedSecretAgenda) {
     const snapshot = buildAgendaSnapshot(state, 'player');
@@ -257,36 +256,15 @@ const updateSecretAgendaProgress = (state: GameState): GameState => {
     }
   }
 
-  if (updatedAgenda) {
-    const snapshot = buildAgendaSnapshot(state, 'player');
-    const computedProgressRaw = Number(updatedAgenda.checkProgress?.(snapshot) ?? updatedAgenda.progress ?? 0);
-    const computedProgress = Number.isFinite(computedProgressRaw)
-      ? Math.max(0, computedProgressRaw)
-      : updatedAgenda.progress ?? 0;
-    const previousProgress = updatedAgenda.progress ?? 0;
-    const target = updatedAgenda.target ?? 0;
-    const isCompleted = computedProgress >= target;
-
-    if (computedProgress !== previousProgress || isCompleted !== !!updatedAgenda.complete) {
-      updatedAgenda = {
-        ...updatedAgenda,
-        progress: computedProgress,
-        complete: isCompleted,
-      };
-    }
-  }
-
   if (
     updatedSecretAgenda !== state.secretAgenda ||
     updatedAiSecretAgenda !== state.aiSecretAgenda ||
-    updatedAgenda !== state.agenda ||
     logUpdates.length > 0
   ) {
     return {
       ...state,
       secretAgenda: updatedSecretAgenda,
       aiSecretAgenda: updatedAiSecretAgenda,
-      agenda: updatedAgenda,
       log: logUpdates.length > 0 ? [...state.log, ...logUpdates] : state.log,
     };
   }
@@ -351,12 +329,6 @@ export const useGameState = (aiDifficultyOverride?: AIDifficulty) => {
       'Cards drawn: 5',
       `AI Difficulty: ${aiDifficulty}`
     ],
-    agenda: {
-      ...getRandomAgenda('truth'),
-      progress: 0,
-      complete: false,
-      revealed: false
-    },
     secretAgenda: {
       ...getRandomAgenda('truth'),
       progress: 0,


### PR DESCRIPTION
## Summary
- remove the redundant agenda field from the game state and ensure secretAgenda/aiSecretAgenda hold the canonical data
- derive victory checks, reports, and victory screen headlines from the unified secret agenda information
- update TabloidVictoryScreen and ExtraEditionNewspaper to consume the shared agenda summaries for player and AI objectives

## Testing
- npm run lint *(fails: existing lint errors across the project)*

------
https://chatgpt.com/codex/tasks/task_e_68d6fb188fd88320b158234b19859205