### PR TITLE
Track truth streak progress for secret agendas

### DIFF
--- a/src/data/agendaDatabase.ts
+++ b/src/data/agendaDatabase.ts
@@ -77,8 +77,15 @@ export const AGENDA_DATABASE: SecretAgenda[] = [
     target: 3,
     difficulty: 'hard',
     checkProgress: (gameState) => {
-      // This would need turn-based tracking logic
-      return gameState.truth >= 80 ? 1 : 0;
+      if (typeof gameState.truthAbove80Streak === 'number') {
+        return gameState.truthAbove80Streak;
+      }
+
+      if (typeof gameState.timeBasedGoalCounters?.truthAbove80Streak === 'number') {
+        return gameState.timeBasedGoalCounters.truthAbove80Streak;
+      }
+
+      return 0;
     },
     flavorText: 'When truth reaches critical mass, reality shifts.'
   },
@@ -217,8 +224,15 @@ export const AGENDA_DATABASE: SecretAgenda[] = [
     target: 3,
     difficulty: 'hard',
     checkProgress: (gameState) => {
-      // This would need turn-based tracking logic
-      return gameState.truth <= 20 ? 1 : 0;
+      if (typeof gameState.truthBelow20Streak === 'number') {
+        return gameState.truthBelow20Streak;
+      }
+
+      if (typeof gameState.timeBasedGoalCounters?.truthBelow20Streak === 'number') {
+        return gameState.timeBasedGoalCounters.truthBelow20Streak;
+      }
+
+      return 0;
     },
     flavorText: 'Some truths are too dangerous for public consumption.'
   },

--- a/src/hooks/gameStateTypes.ts
+++ b/src/hooks/gameStateTypes.ts
@@ -90,4 +90,7 @@ export interface GameState {
   stateCombinationBonusIP: number;
   activeStateCombinationIds: string[];
   stateCombinationEffects: StateCombinationEffects;
+  truthAbove80Streak: number;
+  truthBelow20Streak: number;
+  timeBasedGoalCounters: Record<string, number>;
 }


### PR DESCRIPTION
## Summary
- add truth streak counters to the game state along with flexible time-based goal tracking
- update end-of-turn processing, agenda snapshots, and secret agenda logging to use streak progression
- return streak counts for truth threshold agendas and ensure saved games initialize the new counters

## Testing
- npm run lint *(fails: existing lint errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68d704cf719c832097a9a8a5721218fc