### PR TITLE
Add reveal mechanics for AI secret agenda

### DIFF
--- a/src/data/core/truth-batch-2.ts
+++ b/src/data/core/truth-batch-2.ts
@@ -99,9 +99,10 @@ export const truthBatch2: GameCard[] = [
     "effects": {
       "ipDelta": {
         "opponent": 2
-      }
+      },
+      "revealSecretAgenda": true
     },
-    "flavor": "Sprinkles cover more than sugar."
+    "flavor": "Sprinkles cover more than sugar—the icing spells out the secret plan."
   },
   {
     "id": "TRUTH-059",

--- a/src/data/eventDatabase.ts
+++ b/src/data/eventDatabase.ts
@@ -20,6 +20,7 @@ export interface GameEvent {
     };
     skipTurn?: boolean;
     doubleIncome?: boolean;
+    revealSecretAgenda?: boolean;
   };
   conditions?: {
     minTurn?: number;
@@ -70,12 +71,12 @@ export const EVENT_DATABASE: GameEvent[] = [
     id: 'deepfile_dump_crochet_forum',
     title: 'Files on the Loose',
     headline: 'TOP SECRET PDFS UPLOADED TO CROCHET FORUM',
-    content: 'Redacted docs (with cat gifs) surface overnight. Spokesperson: "That\'s... not our watermark."',
+    content: 'Redacted docs (with cat gifs) surface overnight—including a spreadsheet literally titled "Secret Agenda - Do Not Share." Spokesperson: "That\'s... not our watermark."',
     type: 'truth',
     rarity: 'common',
-    effects: { truth: 8, ip: -1 },
+    effects: { truth: 8, ip: -1, revealSecretAgenda: true },
     weight: 6,
-    flavorText: 'BREAKING: Forum moderators created a new thread called "Chain Stitch, Chain of Custody." Downloads quadrupled after someone posted a granny-square pattern named "Annex B." Several diagrams now include tasteful yarn arrows.'
+    flavorText: 'BREAKING: Forum moderators created a new thread called "Chain Stitch, Chain of Custody." Downloads quadrupled after someone posted a granny-square pattern named "Annex B." The pinned comment now walks readers through the leaked agenda bullet points row by row.'
   },
   {
     id: 'algorithm_memeflood',

--- a/src/rules/mvp.ts
+++ b/src/rules/mvp.ts
@@ -16,6 +16,8 @@ export interface CardEffects {
   pressureDelta?: number;
   zoneDefense?: number;
   reduceFactor?: number;
+  /** Reveals the opponent's secret agenda to the player when triggered. */
+  revealSecretAgenda?: boolean;
   conditional?: {
     ifTruthAtLeast?: number;
     ifZonesControlledAtLeast?: number;

--- a/src/systems/cardResolution.ts
+++ b/src/systems/cardResolution.ts
@@ -65,6 +65,7 @@ export interface CardPlayResolution {
   selectedCard: string | null;
   logEntries: string[];
   damageDealt: number;
+  aiSecretAgendaRevealed?: boolean;
 }
 
 const PLAYER_ID: PlayerId = 'P1';
@@ -195,6 +196,9 @@ export function resolveCardMVP(
   const engineState = toEngineState(gameState, engineLog);
   const ownerId = actor === 'human' ? PLAYER_ID : AI_ID;
   const opponentId = ownerId === PLAYER_ID ? AI_ID : PLAYER_ID;
+  const revealsSecretAgenda =
+    actor === 'human' &&
+    Boolean((card.effects as { revealSecretAgenda?: boolean } | undefined)?.revealSecretAgenda);
 
   engineState.players[ownerId] = {
     ...engineState.players[ownerId],
@@ -302,6 +306,7 @@ export function resolveCardMVP(
     selectedCard: null,
     logEntries,
     damageDealt,
+    aiSecretAgendaRevealed: revealsSecretAgenda,
   };
 }
 


### PR DESCRIPTION
## Summary
- extend MVP card and event effect models to support a revealSecretAgenda flag and keep it through validation/resolution
- update game state handling to reveal the AI agenda with a log message when the new effect appears on cards or events
- mark an existing truth card and news event to expose the AI agenda and refresh their flavour text

## Testing
- npm run lint *(fails: existing lint errors in unrelated utility files)*

------
https://chatgpt.com/codex/tasks/task_e_68d70ae149b8832090d3638928bce8f2