### PR TITLE
Enhance AI secret agenda reveal display

### DIFF
--- a/src/components/game/AIStatus.tsx
+++ b/src/components/game/AIStatus.tsx
@@ -1,9 +1,11 @@
 import { Card } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import { Progress } from '@/components/ui/progress';
-import { Bot, Brain, Zap, Shield, Target, ChevronDown, ChevronUp, Lock } from 'lucide-react';
+import { Bot, Brain, Zap, Target, ChevronDown, ChevronUp, Lock } from 'lucide-react';
 import { type AIDifficulty } from '@/data/aiStrategy';
 import { useState } from 'react';
+import SecretAgendaCard from './SecretAgenda';
+import { SecretAgenda as AgendaType } from '@/data/agendaDatabase';
 
 interface AIStatusProps {
   difficulty: AIDifficulty;
@@ -14,17 +16,23 @@ interface AIStatusProps {
   assessmentText?: string;
   aiHandSize?: number;
   aiObjectiveProgress?: number;
+  secretAgenda?: (AgendaType & {
+    progress: number;
+    completed: boolean;
+    revealed: boolean;
+  }) | null;
 }
 
-const AIStatus = ({ 
-  difficulty, 
-  personalityName, 
-  isThinking = false, 
+const AIStatus = ({
+  difficulty,
+  personalityName,
+  isThinking = false,
   currentPlayer,
   aiControlledStates,
   assessmentText,
   aiHandSize = 0,
-  aiObjectiveProgress = 0
+  aiObjectiveProgress = 0,
+  secretAgenda = null
 }: AIStatusProps) => {
   const [isExpanded, setIsExpanded] = useState(false);
   const getDifficultyColor = (diff: AIDifficulty) => {
@@ -44,6 +52,8 @@ const AIStatus = ({
       case 'legendary': return <Target size={16} />;
     }
   };
+
+  const isAgendaRevealed = Boolean(secretAgenda?.revealed);
 
   return (
     <Card className="p-3 bg-gray-900 border-gray-700 cursor-pointer" onClick={() => setIsExpanded(!isExpanded)}>
@@ -110,28 +120,32 @@ const AIStatus = ({
             </div>
 
             {/* AI Objective Section */}
-            <div className="bg-black p-2 rounded border border-red-900/50 relative">
-              <div className="absolute inset-0 bg-gradient-to-br from-red-900/5 to-transparent rounded"></div>
-              <div className="relative z-10">
-                <div className="flex items-center gap-2 mb-2">
-                  <Lock size={12} className="text-red-400/70" />
-                  <h4 className="font-bold text-xs font-mono text-red-400/70">
-                    AI OBJECTIVE
-                  </h4>
-                </div>
-                <div className="flex items-center gap-2">
-                  <div className="flex-1 h-2 bg-gray-800 rounded">
-                    <div 
-                      className="h-full bg-red-400/70 rounded transition-all"
-                      style={{ width: `${aiObjectiveProgress}%` }}
-                    />
+            {isAgendaRevealed && secretAgenda ? (
+              <SecretAgendaCard agenda={secretAgenda} isPlayer={false} />
+            ) : (
+              <div className="bg-black p-2 rounded border border-red-900/50 relative">
+                <div className="absolute inset-0 bg-gradient-to-br from-red-900/5 to-transparent rounded"></div>
+                <div className="relative z-10">
+                  <div className="flex items-center gap-2 mb-2">
+                    <Lock size={12} className="text-red-400/70" />
+                    <h4 className="font-bold text-xs font-mono text-red-400/70">
+                      AI OBJECTIVE
+                    </h4>
                   </div>
-                  <div className="text-xs text-gray-400 font-mono">
-                    {Math.floor(aiObjectiveProgress)}%
+                  <div className="flex items-center gap-2">
+                    <div className="flex-1 h-2 bg-gray-800 rounded">
+                      <div
+                        className="h-full bg-red-400/70 rounded transition-all"
+                        style={{ width: `${aiObjectiveProgress}%` }}
+                      />
+                    </div>
+                    <div className="text-xs text-gray-400 font-mono">
+                      {Math.floor(aiObjectiveProgress)}%
+                    </div>
                   </div>
                 </div>
               </div>
-            </div>
+            )}
           </div>
         )}
 

--- a/src/components/game/SecretAgenda.tsx
+++ b/src/components/game/SecretAgenda.tsx
@@ -57,29 +57,78 @@ const SecretAgenda = ({ agenda, isPlayer = true }: SecretAgendaProps) => {
 
   const [isExpanded, setIsExpanded] = useState(false);
 
+  const statusLabel = agenda.revealed ? 'REVEALED' : 'HIDDEN';
+  const statusClasses = agenda.revealed
+    ? 'border-secret-red/60 bg-secret-red/15 text-secret-red'
+    : 'border-gray-700 bg-gray-900/80 text-gray-400';
+
+  const renderCompactContent = () => (
+    <div className="space-y-2 text-xs font-mono text-gray-300">
+      <div className="flex flex-col gap-1">
+        <div className="flex items-center justify-between gap-2">
+          <span className="font-bold text-secret-red/90 uppercase tracking-wide text-[10px]">
+            {agenda.title}
+          </span>
+          <span className={`px-1 py-0.5 rounded text-[10px] font-bold ${difficultyBadgeClass}`}>
+            {agenda.difficulty.toUpperCase()}
+          </span>
+        </div>
+        <div className="flex items-center justify-between text-[11px] text-gray-400">
+          <span>{agenda.progress}/{agenda.target}</span>
+          <span>{Math.round(progressPercent)}%</span>
+        </div>
+        <div className="h-1.5 w-full overflow-hidden rounded-full bg-secret-red/20">
+          <div className="h-full bg-secret-red transition-all" style={{ width: `${progressPercent}%` }} />
+        </div>
+      </div>
+      <div className="text-[10px] text-gray-400 line-clamp-2">
+        {agenda.description}
+      </div>
+      {agenda.completed && (
+        <div className="text-[10px] text-secret-red font-bold">
+          Objective Complete
+        </div>
+      )}
+    </div>
+  );
+
   // Opponent view - just a progress bar
   if (!isPlayer) {
     return (
       <Card className="p-2 bg-black text-white border border-secret-red/50 relative">
         <div className="absolute inset-0 bg-gradient-to-br from-secret-red/5 to-transparent"></div>
-        <div className="relative z-10">
-          <div className="flex items-center gap-2 mb-2">
-            <Lock size={12} className="text-secret-red/70" />
-            <h3 className="font-bold text-xs font-mono text-secret-red/70">
-              AI OBJECTIVE
-            </h3>
-          </div>
-          <div className="flex items-center gap-2">
-            <div className="flex-1 h-2 bg-gray-800 rounded">
-              <div 
-                className="h-full bg-secret-red/70 rounded transition-all"
-                style={{ width: `${progressPercent}%` }}
-              />
+        <div className="relative z-10 space-y-2">
+          <div className="flex items-center justify-between">
+            <div className="flex items-center gap-2">
+              {agenda.revealed ? (
+                <Eye size={12} className="text-secret-red/70" />
+              ) : (
+                <Lock size={12} className="text-secret-red/70" />
+              )}
+              <h3 className="font-bold text-xs font-mono text-secret-red/70">
+                AI OBJECTIVE
+              </h3>
             </div>
-            <div className="text-xs text-gray-400 font-mono">
-              {Math.floor(progressPercent)}%
-            </div>
+            <span className={`flex items-center gap-1 rounded-full border px-2 py-0.5 text-[9px] font-bold uppercase tracking-wide ${statusClasses}`}>
+              {agenda.revealed ? <Eye size={10} /> : <Lock size={10} />}
+              {statusLabel}
+            </span>
           </div>
+          {agenda.revealed ? (
+            renderCompactContent()
+          ) : (
+            <div className="flex items-center gap-2">
+              <div className="flex-1 h-2 bg-gray-800 rounded">
+                <div
+                  className="h-full bg-secret-red/70 rounded transition-all"
+                  style={{ width: `${progressPercent}%` }}
+                />
+              </div>
+              <div className="text-xs text-gray-400 font-mono">
+                {Math.floor(progressPercent)}%
+              </div>
+            </div>
+          )}
         </div>
       </Card>
     );
@@ -102,43 +151,27 @@ const SecretAgenda = ({ agenda, isPlayer = true }: SecretAgendaProps) => {
             <h3 className={`font-bold font-mono text-secret-red ${isExpanded ? 'text-sm' : 'text-xs'}`}>
               SECRET AGENDA
             </h3>
+            <span className={`hidden sm:flex items-center gap-1 rounded-full border px-2 py-0.5 text-[9px] font-bold uppercase tracking-wide ${statusClasses}`}>
+              {agenda.revealed ? <Eye size={10} /> : <Lock size={10} />}
+              {statusLabel}
+            </span>
           </div>
-          {isExpanded ? (
-            <ChevronUp size={14} className="text-secret-red" />
-          ) : (
-            <ChevronDown size={14} className="text-secret-red" />
-          )}
+          <div className="flex items-center gap-2">
+            <span className={`sm:hidden flex items-center gap-1 rounded-full border px-1.5 py-0.5 text-[9px] font-bold uppercase tracking-wide ${statusClasses}`}>
+              {agenda.revealed ? <Eye size={10} /> : <Lock size={10} />}
+              {statusLabel}
+            </span>
+            {isExpanded ? (
+              <ChevronUp size={14} className="text-secret-red" />
+            ) : (
+              <ChevronDown size={14} className="text-secret-red" />
+            )}
+          </div>
         </div>
 
         {!isExpanded ? (
           // Minimized view - show quick summary
-          <div className="space-y-2 text-xs font-mono text-gray-300">
-            <div className="flex flex-col gap-1">
-              <div className="flex items-center justify-between gap-2">
-                <span className="font-bold text-secret-red/90 uppercase tracking-wide text-[10px]">
-                  {agenda.title}
-                </span>
-                <span className={`px-1 py-0.5 rounded text-[10px] font-bold ${difficultyBadgeClass}`}>
-                  {agenda.difficulty.toUpperCase()}
-                </span>
-              </div>
-              <div className="flex items-center justify-between text-[11px] text-gray-400">
-                <span>{agenda.progress}/{agenda.target}</span>
-                <span>{Math.round(progressPercent)}%</span>
-              </div>
-              <div className="h-1.5 w-full overflow-hidden rounded-full bg-secret-red/20">
-                <div className="h-full bg-secret-red transition-all" style={{ width: `${progressPercent}%` }} />
-              </div>
-            </div>
-            <div className="text-[10px] text-gray-400 line-clamp-2">
-              {agenda.description}
-            </div>
-            {agenda.completed && (
-              <div className="text-[10px] text-secret-red font-bold">
-                Objective Complete
-              </div>
-            )}
-          </div>
+          renderCompactContent()
         ) : (
           // Expanded view - full details
           <div className="space-y-3">

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -1522,57 +1522,63 @@ const Index = () => {
     );
   };
 
-  const renderAiStatusPanel = () => (
-    <div className="space-y-3 text-[11px] text-newspaper-text/90">
-      <div className="flex items-center justify-between">
-        <span className="text-[10px] uppercase tracking-[0.3em] text-newspaper-text/60">Handler</span>
-        <span className="font-mono text-newspaper-text">
-          {gameState.aiStrategist?.personality.name || 'Unknown'}
-        </span>
-      </div>
-      <div className="grid grid-cols-2 gap-2 text-center">
-        <div className="rounded border border-newspaper-border/40 bg-newspaper-bg/30 px-2 py-1">
-          <div className="text-[9px] uppercase tracking-wide text-newspaper-text/60">Difficulty</div>
-          <div className="font-mono text-newspaper-text">{gameState.aiDifficulty.toUpperCase()}</div>
-        </div>
-        <div className="rounded border border-newspaper-border/40 bg-newspaper-bg/30 px-2 py-1">
-          <div className="text-[9px] uppercase tracking-wide text-newspaper-text/60">Territory</div>
-          <div className="font-mono text-newspaper-text">{aiControlledStates} states</div>
-        </div>
-      </div>
-      <div className="rounded border border-newspaper-border/40 bg-newspaper-bg/20 px-3 py-2">
-        <div className="flex items-center justify-between text-[10px] uppercase tracking-wide text-newspaper-text/60">
-          <span>Status</span>
-          <span
-            className={`font-mono ${
-              gameState.currentPlayer === 'ai' ? 'text-secret-red' : 'text-newspaper-text/70'
-            }`}
-          >
-            {gameState.currentPlayer === 'ai'
-              ? gameState.phase === 'ai_turn'
-                ? 'Calculating'
-                : 'Active'
-              : 'Waiting'}
+  const renderAiStatusPanel = () => {
+    return (
+      <div className="space-y-3 text-[11px] text-newspaper-text/90">
+        <div className="flex items-center justify-between">
+          <span className="text-[10px] uppercase tracking-[0.3em] text-newspaper-text/60">Handler</span>
+          <span className="font-mono text-newspaper-text">
+            {gameState.aiStrategist?.personality.name || 'Unknown'}
           </span>
         </div>
-        {gameState.phase === 'ai_turn' && (
-          <div className="mt-1 text-[11px] text-secret-red/80">Processing strategy...</div>
+        <div className="grid grid-cols-2 gap-2 text-center">
+          <div className="rounded border border-newspaper-border/40 bg-newspaper-bg/30 px-2 py-1">
+            <div className="text-[9px] uppercase tracking-wide text-newspaper-text/60">Difficulty</div>
+            <div className="font-mono text-newspaper-text">{gameState.aiDifficulty.toUpperCase()}</div>
+          </div>
+          <div className="rounded border border-newspaper-border/40 bg-newspaper-bg/30 px-2 py-1">
+            <div className="text-[9px] uppercase tracking-wide text-newspaper-text/60">Territory</div>
+            <div className="font-mono text-newspaper-text">{aiControlledStates} states</div>
+          </div>
+        </div>
+        <div className="rounded border border-newspaper-border/40 bg-newspaper-bg/20 px-3 py-2">
+          <div className="flex items-center justify-between text-[10px] uppercase tracking-wide text-newspaper-text/60">
+            <span>Status</span>
+            <span
+              className={`font-mono ${
+                gameState.currentPlayer === 'ai' ? 'text-secret-red' : 'text-newspaper-text/70'
+              }`}
+            >
+              {gameState.currentPlayer === 'ai'
+                ? gameState.phase === 'ai_turn'
+                  ? 'Calculating'
+                  : 'Active'
+                : 'Waiting'}
+            </span>
+          </div>
+          {gameState.phase === 'ai_turn' && (
+            <div className="mt-1 text-[11px] text-secret-red/80">Processing strategy...</div>
+          )}
+        </div>
+        {aiAgenda && aiAgenda.revealed ? (
+          <SecretAgenda agenda={aiAgenda} isPlayer={false} />
+        ) : (
+          <div>
+            <div className="flex items-center justify-between text-[11px] text-newspaper-text/70">
+              <span>Objective</span>
+              <span className="font-mono text-newspaper-text">{Math.floor(aiObjectiveProgress)}%</span>
+            </div>
+            <div className="mt-1 h-1.5 w-full overflow-hidden rounded-full bg-newspaper-border/40">
+              <div className="h-full bg-newspaper-text/80" style={{ width: `${aiObjectiveProgress}%` }} />
+            </div>
+          </div>
+        )}
+        {aiAssessment && (
+          <p className="text-[11px] italic text-newspaper-text/60">“{aiAssessment}”</p>
         )}
       </div>
-      <div>
-        <div className="flex items-center justify-between text-[11px] text-newspaper-text/70">
-          <span>Objective</span>
-          <span className="font-mono text-newspaper-text">{Math.floor(aiObjectiveProgress)}%</span>
-        </div>
-        <div className="mt-1 h-1.5 w-full overflow-hidden rounded-full bg-newspaper-border/40">
-          <div className="h-full bg-newspaper-text/80" style={{ width: `${aiObjectiveProgress}%` }} />
-        </div>
-      </div>
-      {aiAssessment && (
-        <p className="text-[11px] italic text-newspaper-text/60">“{aiAssessment}”</p>
-      )}
-    </div>
-  );
+    );
+  };
 
   const statusPanelConfigs = [
     {
@@ -1600,6 +1606,7 @@ const Index = () => {
             assessmentText={aiAssessment}
             aiHandSize={gameState.aiHand.length}
             aiObjectiveProgress={aiObjectiveProgress}
+            secretAgenda={aiAgenda && aiAgenda.revealed ? aiAgenda : null}
           />
         </div>
       ),


### PR DESCRIPTION
## Summary
- add hidden/revealed status badges and shared compact agenda view for both player and observer layouts
- surface the full AI secret agenda card when revealed in desktop and mobile status panels
- allow the AI status drawer to embed the secret agenda card when it becomes public

## Testing
- npm run lint *(fails: existing lint errors unrelated to this change)*

------
https://chatgpt.com/codex/tasks/task_e_68d73cff5c808320ac997e993840c222