### PR TITLE
Align recovery tooling with ValidationSummary schema

### DIFF
--- a/src/mvp/validator.ts
+++ b/src/mvp/validator.ts
@@ -337,6 +337,7 @@ const createMvpText = (
             ? 'Opponent discards 1 card'
             : `Opponent discards ${attack.discardOpponent} cards`,
         );
+      }
       if (attack.revealSecretAgenda) {
         parts.push('Reveal enemy secret agenda');
       }


### PR DESCRIPTION
## Summary
- type RecoveryReport.validationSummary with CardTextGenerator's ValidationSummary and adjust report output
- update the database recovery UI to show the new validation metrics and computed success rates
- fix a syntax error in the MVP validator revealed by the stricter build

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d742da90348320a7111d9d2b6c305f