### PR TITLE
Introduce agenda issues and align newspapers with secret agendas

### DIFF
--- a/src/components/game/TabloidNewspaperLegacy.tsx
+++ b/src/components/game/TabloidNewspaperLegacy.tsx
@@ -6,6 +6,7 @@ import { X, TrendingUp, AlertTriangle } from 'lucide-react';
 import type { GameCard } from '@/rules/mvp';
 import type { GameEvent } from '@/data/eventDatabase';
 import type { ParanormalSighting } from '@/types/paranormal';
+import type { AgendaIssueState } from '@/data/agendaIssues';
 import CardImage from '@/components/game/CardImage';
 import { formatComboReward, getLastComboSummary } from '@/game/comboEngine';
 
@@ -25,6 +26,7 @@ export interface TabloidNewspaperProps {
   comboTruthDelta?: number;
   onClose: () => void;
   sightings?: ParanormalSighting[];
+  agendaIssue?: AgendaIssueState;
 }
 
 interface NewspaperData {

--- a/src/components/game/TabloidNewspaperV2.tsx
+++ b/src/components/game/TabloidNewspaperV2.tsx
@@ -175,6 +175,7 @@ const TabloidNewspaperV2 = ({
   comboTruthDelta = 0,
   onClose,
   sightings = [],
+  agendaIssue,
 }: TabloidNewspaperProps) => {
   const [data, setData] = useState<NewspaperData | null>(null);
   const [masthead, setMasthead] = useState('THE PARANOID TIMES');
@@ -444,6 +445,7 @@ const TabloidNewspaperV2 = ({
           eventsTruthDelta,
           comboTruthDelta,
           comboSummary: comboSummary ?? null,
+          agendaIssueId: agendaIssue?.id,
         });
         if (!cancelled) {
           setIssue(generated);
@@ -461,7 +463,7 @@ const TabloidNewspaperV2 = ({
     return () => {
       cancelled = true;
     };
-  }, [dataset, narrativePlayedCards, eventsTruthDelta, comboTruthDelta, comboSummary]);
+  }, [dataset, narrativePlayedCards, eventsTruthDelta, comboTruthDelta, comboSummary, agendaIssue?.id]);
 
   const narrativeContext = useMemo(
     () => buildRoundContext(playerNarrativeCards, opponentNarrativeCards, eventsTruthDelta, comboTruthDelta),
@@ -624,6 +626,11 @@ const TabloidNewspaperV2 = ({
             <p className="text-xs font-semibold uppercase tracking-[0.35em] text-newspaper-text/60">
               {faction === 'truth' ? 'Truth Coalition Dispatch' : 'Official Government Bulletin'}
             </p>
+            {agendaIssue ? (
+              <p className="text-[10px] font-semibold uppercase tracking-[0.4em] text-newspaper-text/50">
+                Issue Focus: {agendaIssue.label}
+              </p>
+            ) : null}
           </div>
         </header>
 

--- a/src/data/__tests__/agendaIssues.test.ts
+++ b/src/data/__tests__/agendaIssues.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'bun:test';
+import {
+  agendaIssueToState,
+  applyIssueVerbOverlay,
+  getAgendaIssueById,
+  getIssueQuip,
+  getIssueTags,
+  weightForIssue,
+} from '@/data/agendaIssues';
+
+describe('agendaIssues helpers', () => {
+  it('creates an agenda issue state with derived tags', () => {
+    const issue = getAgendaIssueById('ufo');
+    expect(issue).toBeTruthy();
+    const state = agendaIssueToState(issue!);
+
+    expect(state).toEqual({
+      id: 'ufo',
+      label: 'Cosmic Cover Stories',
+      description: 'Saucer sightings, crash cart buffets, and orbital bake-offs dominate the rumor mill.',
+      tags: ['#IssueUFO', '#SaucerSeason'],
+    });
+  });
+
+  it('applies weighting based on the active issue', () => {
+    expect(weightForIssue('ufo', 'Desert Disclosure')).toBe(2.5);
+    expect(weightForIssue('ufo', 'Truth Momentum')).toBe(1.6);
+    expect(weightForIssue('coverup', 'Nonexistent Theme')).toBeCloseTo(0.85);
+    expect(weightForIssue(undefined, 'Desert Disclosure')).toBe(1);
+    expect(weightForIssue('ufo', undefined)).toBe(1);
+  });
+
+  it('merges issue verbs ahead of base verbs without duplicates', () => {
+    const merged = applyIssueVerbOverlay(['HIJACKS COSMIC FEED', 'BASE VERB'], 'ufo', 'MEDIA');
+
+    expect(merged).toEqual([
+      'HIJACKS COSMIC FEED',
+      'BEAMS TRANSMISSION FROM ORBIT',
+      'LOOPS SAUCER TELEMETRY',
+      'BASE VERB',
+    ]);
+  });
+
+  it('provides deterministic quips when seeded', () => {
+    expect(getIssueQuip('ufo', 'truth', 0)).toBe('Truth kitchen radios hum in sympathy with the mothership.');
+    expect(getIssueQuip('ufo', 'truth', 3)).toBe('Station gossip wonders if the cafeteria roof will open again tonight.');
+    expect(getIssueQuip('ufo', 'government', -4)).toBe('Archivists arrange foil hats by alphabetical order, just in case.');
+  });
+
+  it('returns configured tags with fallback when unknown', () => {
+    expect(getIssueTags('cryptid')).toEqual(['#IssueCryptid', '#MonsterMixer']);
+    expect(getIssueTags('unknown')).toEqual(['#Issue-UNKNOWN']);
+    expect(getIssueTags(undefined)).toEqual(['#Issue-MYSTERY']);
+  });
+});

--- a/src/data/agendaIssues.ts
+++ b/src/data/agendaIssues.ts
@@ -1,0 +1,402 @@
+import type { Card } from '@/types';
+
+export type AgendaIssueId = 'ufo' | 'cryptid' | 'coverup';
+
+type CardTone = Card['type'];
+
+export interface AgendaIssueDefinition {
+  id: AgendaIssueId;
+  label: string;
+  description: string;
+  priorityThemes: string[];
+  supportingThemes?: string[];
+  fallbackWeight?: number;
+  factionQuips: {
+    truth: string[];
+    government: string[];
+    neutral?: string[];
+  };
+  newspaper?: {
+    verbs?: Partial<Record<CardTone, string[]>>;
+    subheads?: Partial<Record<'truth' | 'government', string[]>>;
+    tags?: string[];
+    heroKickers?: string[];
+  };
+}
+
+export interface AgendaIssueState {
+  id: AgendaIssueId;
+  label: string;
+  description: string;
+  tags: string[];
+}
+
+const createIssueState = (issue: AgendaIssueDefinition): AgendaIssueState => ({
+  id: issue.id,
+  label: issue.label,
+  description: issue.description,
+  tags: issue.newspaper?.tags ?? [`#Issue-${issue.id.toUpperCase()}`],
+});
+
+const ISSUE_ROTATION_KEY = 'shadowgov.agendaIssueRotation';
+const ISSUE_ACTIVE_KEY = 'shadowgov.activeAgendaIssue';
+
+const baseIssues: AgendaIssueDefinition[] = [
+  {
+    id: 'ufo',
+    label: 'Cosmic Cover Stories',
+    description: 'Saucer sightings, crash cart buffets, and orbital bake-offs dominate the rumor mill.',
+    priorityThemes: ['Desert Disclosure', 'Statewide Spectacle', 'Crash Site Compliance'],
+    supportingThemes: ['Truth Momentum', 'Traveling Influence'],
+    factionQuips: {
+      truth: [
+        'Truth kitchen radios hum in sympathy with the mothership.',
+        'Operatives swap recipes for meteorite reduction glaze.',
+        'Witness hotline interns keep binoculars next to the blenders.',
+      ],
+      government: [
+        'Containment crews log every contrail as “decorative mist.”',
+        'Briefing rooms circulate the phrase “optical swamp gas.”',
+        'Audit squads requisition anti-gravity disclaimers by the crate.',
+      ],
+      neutral: [
+        'Station gossip wonders if the cafeteria roof will open again tonight.',
+        'Archivists arrange foil hats by alphabetical order, just in case.',
+      ],
+    },
+    newspaper: {
+      verbs: {
+        ATTACK: [
+          'CRACKS SECRET HANGAR',
+          'BREACHES ORBITAL BUFFET',
+          'OVERRIDES LAUNCH PAD LOCKDOWN',
+        ],
+        MEDIA: [
+          'HIJACKS COSMIC FEED',
+          'BEAMS TRANSMISSION FROM ORBIT',
+          'LOOPS SAUCER TELEMETRY',
+        ],
+        ZONE: [
+          'FORTIFIES LANDING STRIP',
+          'GRIDLOCKS ABDUCTION CORRIDOR',
+          'MAPS CONSTELLATION SUPPLY LINES',
+        ],
+      },
+      subheads: {
+        truth: [
+          'Witness hotlines jam as neon contrails paint the sky over every safehouse.',
+          'Field reporters swear the stars blink back in Morse code.',
+        ],
+        government: [
+          'Containment desk distributes anti-gravity disclaimers and complimentary blindfolds.',
+          'Officials insist the glowing crop circles are patriotic training exercises.',
+        ],
+      },
+      tags: ['#IssueUFO', '#SaucerSeason'],
+      heroKickers: [
+        'This week’s tabloid focus: Saucer Season',
+        'Cosmic Cover Stories headline the edition',
+      ],
+    },
+  },
+  {
+    id: 'cryptid',
+    label: 'Cryptid Culinary Summit',
+    description: 'Mythic potlucks, creature diplomacy, and monster RSVP lists keep the presses running hot.',
+    priorityThemes: ['Mythic Diplomacy', 'Cryptid Hospitality', 'Traveling Influence'],
+    supportingThemes: ['Statewide Spectacle'],
+    factionQuips: {
+      truth: [
+        'Scout teams leave gluten-free offerings for every hoofprint.',
+        'Archivists label coolers “fang-friendly” and hope for the best.',
+        'Potluck coordinators debate whether swamp gas counts as seasoning.',
+      ],
+      government: [
+        'Containment liaisons practice smiling while holding tranquilizer darts.',
+        'Logistics briefs rename cryptids as “unregistered catering staff.”',
+        'Budget monitors request itemized receipts for every claw mark.',
+      ],
+      neutral: [
+        'Local diners post “Cryptids Eat Free” chalkboards just to stay on theme.',
+      ],
+    },
+    newspaper: {
+      verbs: {
+        ATTACK: [
+          'DE-FANGS FOREST RUMORS',
+          'TRAPS SWAMP LEGENDS',
+          'AMBUSHES ROGUE HOWLERS',
+        ],
+        MEDIA: [
+          'SPOTLIGHTS BEASTLY BUFFET',
+          'STREAMS SASQUATCH SOIREE',
+          'PRINTS CLAW-SIGNED REVIEWS',
+        ],
+        ZONE: [
+          'CORDONS OFF CRYPTID CAMPSITE',
+          'STAKES OUT HOOFPRINT HOTELS',
+          'LINES TRAIL WITH OFFERING TABLES',
+        ],
+      },
+      subheads: {
+        truth: [
+          'Conspiracy caterers swear the howling harmonizes with their playlist.',
+          'Witnesses report potluck tables levitating to make room for scaled VIPs.',
+        ],
+        government: [
+          'Containment crews release “Do Not Feed the Monster” pamphlets in six languages.',
+          'Officials stress the claws on the guest list are purely decorative.',
+        ],
+      },
+      tags: ['#IssueCryptid', '#MonsterMixer'],
+      heroKickers: [
+        'Weekly focus: Cryptid Catering Ops',
+        'All eyes on the Cryptid Culinary Summit',
+      ],
+    },
+  },
+  {
+    id: 'coverup',
+    label: 'Coverup Control Grid',
+    description: 'Budget smokescreens, narrative lockdowns, and classified casseroles set the tempo.',
+    priorityThemes: ['Narrative Containment', 'Information Discipline', 'Fiscal Obfuscation'],
+    supportingThemes: ['Narrative Fusion', 'Synergy Sustainment'],
+    fallbackWeight: 0.85,
+    factionQuips: {
+      truth: [
+        'Leaks division double-binds every memo with twine and conspiracy twinkle.',
+        'Whistle chefs garnish casseroles with shredded nondisclosure agreements.',
+        'Radio hosts practice whispering “follow the money” in seven octaves.',
+      ],
+      government: [
+        'Spin rooms install emergency shredders next to every serving tray.',
+        'Budget auditors label each ladle as a potential breach vector.',
+        'Briefing captains assign code names to every casserole lid.',
+      ],
+      neutral: [
+        'Interns rehearse plausible deniability between coffee runs.',
+        'Archivists sort cover stories by degree of scorch marks.',
+      ],
+    },
+    newspaper: {
+      verbs: {
+        ATTACK: [
+          'SHREDS REDACTION WALL',
+          'BREACHES COVER STORY VAULT',
+          'DETACHES SPIN HUB',
+        ],
+        MEDIA: [
+          'LEAKS THE PLAYBOOK',
+          'PUBLISHES BUDGET GHOSTS',
+          'TELEVISES REDACTION DRILLS',
+        ],
+        DEFENSIVE: [
+          'SANDBAGS INFORMATION LEAKS',
+          'PATCHES CLASSIFIED GASKETS',
+          'LOCKS DOWN THE BRIEFING WING',
+        ],
+      },
+      subheads: {
+        truth: [
+          'Leaks taskforce says the documents smell faintly of barbecue smoke.',
+          'Sources insist the cover story tripped over its own budget line.',
+        ],
+        government: [
+          'Containment desk adds extra binders to weigh down suspiciously buoyant files.',
+          'Officials deny the smell of burnt ledger even as alarms blink politely.',
+        ],
+      },
+      tags: ['#IssueCoverup', '#RedactionRodeo'],
+      heroKickers: [
+        'Special edition: Coverup Control Grid',
+        'Narrative containment drills headline this issue',
+      ],
+    },
+  },
+];
+
+export const AGENDA_ISSUES = baseIssues;
+
+const ISSUE_MAP = new Map<AgendaIssueId, AgendaIssueDefinition>(
+  baseIssues.map(issue => [issue.id, issue]),
+);
+
+export const getAgendaIssueById = (id?: string | null): AgendaIssueDefinition | undefined => {
+  if (!id) {
+    return undefined;
+  }
+  return ISSUE_MAP.get(id as AgendaIssueId);
+};
+
+const clampIndex = (index: number, length: number): number => {
+  if (!Number.isFinite(index) || length <= 0) {
+    return 0;
+  }
+  const normalized = index % length;
+  return normalized < 0 ? normalized + length : normalized;
+};
+
+const withLocalStorage = <T,>(fallback: T, fn: (storage: Storage) => T): T => {
+  if (typeof window === 'undefined' || !window.localStorage) {
+    return fallback;
+  }
+  try {
+    return fn(window.localStorage);
+  } catch {
+    return fallback;
+  }
+};
+
+export const peekActiveAgendaIssue = (): AgendaIssueDefinition => {
+  const fallback = AGENDA_ISSUES[0];
+  return withLocalStorage(fallback, storage => {
+    const activeId = storage.getItem(ISSUE_ACTIVE_KEY) as AgendaIssueId | null;
+    const active = activeId ? getAgendaIssueById(activeId) : undefined;
+    if (active) {
+      return active;
+    }
+    const rotationIndex = parseInt(storage.getItem(ISSUE_ROTATION_KEY) ?? '0', 10);
+    const index = clampIndex(rotationIndex, AGENDA_ISSUES.length);
+    const issue = AGENDA_ISSUES[index] ?? fallback;
+    storage.setItem(ISSUE_ACTIVE_KEY, issue.id);
+    return issue;
+  });
+};
+
+export const advanceAgendaIssue = (): AgendaIssueDefinition => {
+  const fallback = AGENDA_ISSUES[0];
+  return withLocalStorage(fallback, storage => {
+    const rotationIndexRaw = parseInt(storage.getItem(ISSUE_ROTATION_KEY) ?? '0', 10);
+    const rotationIndex = clampIndex(rotationIndexRaw, AGENDA_ISSUES.length);
+    const issue = AGENDA_ISSUES[rotationIndex] ?? fallback;
+    const nextIndex = clampIndex(rotationIndex + 1, AGENDA_ISSUES.length);
+    storage.setItem(ISSUE_ROTATION_KEY, nextIndex.toString());
+    storage.setItem(ISSUE_ACTIVE_KEY, issue.id);
+    return issue;
+  });
+};
+
+export const ensureAgendaIssueState = (issue?: AgendaIssueDefinition | null): AgendaIssueState => {
+  return createIssueState(issue ?? peekActiveAgendaIssue());
+};
+
+export const resolveIssueStateById = (id?: string | null): AgendaIssueState => {
+  const match = getAgendaIssueById(id);
+  return ensureAgendaIssueState(match ?? null);
+};
+
+export const getIssueQuip = (
+  issueId: string | undefined,
+  faction: 'truth' | 'government',
+  seed?: number,
+): string | null => {
+  const config = getAgendaIssueById(issueId);
+  if (!config) {
+    return null;
+  }
+  const pools = [config.factionQuips[faction] ?? [], config.factionQuips.neutral ?? []].filter(
+    (pool): pool is string[] => Array.isArray(pool) && pool.length > 0,
+  );
+  if (!pools.length) {
+    return null;
+  }
+  const merged = pools.flat();
+  if (!merged.length) {
+    return null;
+  }
+  if (typeof seed === 'number' && Number.isFinite(seed)) {
+    const index = Math.abs(seed) % merged.length;
+    return merged[index] ?? null;
+  }
+  const index = Math.floor(Math.random() * merged.length);
+  return merged[index] ?? null;
+};
+
+export const applyIssueVerbOverlay = (
+  base: string[],
+  issueId?: string,
+  tone?: CardTone,
+): string[] => {
+  const config = getAgendaIssueById(issueId);
+  const overlay = tone ? config?.newspaper?.verbs?.[tone] ?? [] : [];
+  if (!overlay?.length) {
+    return base;
+  }
+  const seen = new Set<string>();
+  const combined: string[] = [];
+  for (const item of overlay) {
+    if (!seen.has(item)) {
+      combined.push(item);
+      seen.add(item);
+    }
+  }
+  for (const item of base) {
+    if (!seen.has(item)) {
+      combined.push(item);
+      seen.add(item);
+    }
+  }
+  return combined;
+};
+
+export const applyIssueSubheadOverlay = (
+  base: string[],
+  issueId: string | undefined,
+  faction: 'truth' | 'government',
+): string[] => {
+  const config = getAgendaIssueById(issueId);
+  const overlay = config?.newspaper?.subheads?.[faction] ?? [];
+  if (!overlay?.length) {
+    return base;
+  }
+  const seen = new Set<string>();
+  const combined: string[] = [];
+  for (const item of overlay) {
+    if (!seen.has(item)) {
+      combined.push(item);
+      seen.add(item);
+    }
+  }
+  for (const item of base) {
+    if (!seen.has(item)) {
+      combined.push(item);
+      seen.add(item);
+    }
+  }
+  return combined;
+};
+
+export const getIssueTags = (issueId?: string | null): string[] => {
+  const config = getAgendaIssueById(issueId ?? undefined);
+  return config?.newspaper?.tags ?? [`#Issue-${(issueId ?? 'mystery').toUpperCase()}`];
+};
+
+export const getIssueHeroKicker = (issueId?: string | null): string | null => {
+  const config = getAgendaIssueById(issueId ?? undefined);
+  const pool = config?.newspaper?.heroKickers;
+  if (!pool || pool.length === 0) {
+    return null;
+  }
+  const index = Math.floor(Math.random() * pool.length);
+  return pool[index] ?? null;
+};
+
+export const weightForIssue = (issueId: string | undefined, theme: string | undefined): number => {
+  if (!issueId || !theme) {
+    return 1;
+  }
+  const config = getAgendaIssueById(issueId);
+  if (!config) {
+    return 1;
+  }
+  if (config.priorityThemes.includes(theme)) {
+    return 2.5;
+  }
+  if (config.supportingThemes?.includes(theme)) {
+    return 1.6;
+  }
+  return typeof config.fallbackWeight === 'number' ? config.fallbackWeight : 1;
+};
+
+export const agendaIssueToState = (issue: AgendaIssueDefinition): AgendaIssueState => createIssueState(issue);
+

--- a/src/engine/newspaper/IssueGenerator.ts
+++ b/src/engine/newspaper/IssueGenerator.ts
@@ -4,6 +4,7 @@ import type { Card } from '@/types';
 import { loadCardLexicon } from './CardLexicon';
 import { composeCardStory, composeComboStory, type CardStory, type ComboStory } from './StoryComposer';
 import type { ComboSummary } from '@/game/combo.types';
+import type { AgendaIssueId } from '@/data/agendaIssues';
 
 export interface PlayedCardInput {
   card: Card;
@@ -50,6 +51,7 @@ export interface IssueGeneratorInput {
   eventsTruthDelta?: number;
   comboTruthDelta?: number;
   comboSummary?: ComboSummary | null;
+  agendaIssueId?: AgendaIssueId;
 }
 
 const FALLBACK_ADS = ['All advertising temporarily redacted.'];
@@ -268,6 +270,7 @@ export async function generateIssue(input: IssueGeneratorInput): Promise<Narrati
       pressureDelta: pressure ?? undefined,
       targetStateName: targetName ?? undefined,
       capturedStateNames: capturedNames,
+      issueId: input.agendaIssueId,
     });
 
     return mapCardToArticle(entry, story, truth, ip, pressure, targetName, capturedNames);

--- a/src/hooks/gameStateTypes.ts
+++ b/src/hooks/gameStateTypes.ts
@@ -1,6 +1,7 @@
 import type { GameCard } from '@/rules/mvp';
 import type { EventManager, GameEvent } from '@/data/eventDatabase';
 import type { SecretAgenda } from '@/data/agendaDatabase';
+import type { AgendaIssueState } from '@/data/agendaIssues';
 import type { EnhancedAIStrategist } from '@/data/enhancedAIStrategy';
 import type { DrawMode, CardDrawState } from '@/data/cardDrawingSystem';
 import type { AIDifficulty } from '@/data/aiStrategy';
@@ -67,6 +68,9 @@ export interface GameState {
   eventManager?: EventManager;
   showNewspaper: boolean;
   log: string[];
+  agendaIssue: AgendaIssueState;
+  agendaIssueCounters: Record<string, number>;
+  agendaRoundCounters: Record<string, number>;
   secretAgenda?: SecretAgenda & {
     progress: number;
     completed: boolean;

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -469,7 +469,23 @@ const Index = () => {
   const [isSidebarOpen, setIsSidebarOpen] = useState(false);
   const [activeObjectivePanel, setActiveObjectivePanel] = useState<ObjectiveSectionId>('victory');
   
-  const { gameState, initGame, playCard, playCardAnimated, selectCard, selectTargetState, endTurn, closeNewspaper, executeAITurn, confirmNewCards, setGameState, saveGame, loadGame, getSaveInfo } = useGameState();
+  const {
+    gameState,
+    initGame,
+    playCard,
+    playCardAnimated,
+    selectCard,
+    selectTargetState,
+    endTurn,
+    closeNewspaper,
+    executeAITurn,
+    confirmNewCards,
+    setGameState,
+    saveGame,
+    loadGame,
+    getSaveInfo,
+    registerParanormalSighting,
+  } = useGameState();
   const audio = useAudioContext();
   const { animatePlayCard, isAnimating } = useCardAnimation();
   const { discoverCard, playCard: recordCardPlay } = useCardCollection();
@@ -481,7 +497,8 @@ const Index = () => {
       const MAX_ENTRIES = 12;
       return merged.length > MAX_ENTRIES ? merged.slice(merged.length - MAX_ENTRIES) : merged;
     });
-  }, []);
+    registerParanormalSighting(entry.metadata?.source ?? undefined);
+  }, [registerParanormalSighting]);
 
   // Handle AI turns
   useEffect(() => {
@@ -1977,6 +1994,7 @@ const Index = () => {
           truth={gameState.truth}
           comboTruthDelta={gameState.comboTruthDeltaThisRound}
           sightings={paranormalSightings}
+          agendaIssue={gameState.agendaIssue}
           onClose={handleCloseNewspaper}
         />
       )}


### PR DESCRIPTION
## Summary
- add a rotating agenda issue configuration with themed quips, verb overlays, and weighting rules
- thread agenda issues through game state, selection, logging, and paranormal sighting tracking so progress messages stay flavorful
- synchronize the newspaper generator and UI with the active agenda issue for issue-aware headlines and tags

## Testing
- npm run lint *(fails: repository already contains many pre-existing lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68d74d87a3bc83208760408270802f23