### PR TITLE
Add hotspot visuals and narrative feedback

### DIFF
--- a/src/components/effects/ParanormalHotspotOverlay.tsx
+++ b/src/components/effects/ParanormalHotspotOverlay.tsx
@@ -1,0 +1,77 @@
+import React, { useEffect } from 'react';
+import clsx from 'clsx';
+
+interface ParanormalHotspotOverlayProps {
+  x: number;
+  y: number;
+  icon: string;
+  label: string;
+  stateName: string;
+  source: 'truth' | 'government' | 'neutral';
+  defenseBoost: number;
+  truthReward: number;
+  onComplete?: () => void;
+}
+
+const SOURCE_STYLES: Record<ParanormalHotspotOverlayProps['source'], string> = {
+  truth: 'border-sky-400/70 bg-sky-500/20 text-sky-50',
+  government: 'border-rose-400/70 bg-rose-500/20 text-rose-50',
+  neutral: 'border-purple-400/70 bg-purple-500/20 text-purple-50',
+};
+
+const ParanormalHotspotOverlay: React.FC<ParanormalHotspotOverlayProps> = ({
+  x,
+  y,
+  icon,
+  label,
+  stateName,
+  source,
+  defenseBoost,
+  truthReward,
+  onComplete,
+}) => {
+  useEffect(() => {
+    const timeout = window.setTimeout(() => {
+      onComplete?.();
+    }, 3200);
+
+    return () => window.clearTimeout(timeout);
+  }, [onComplete]);
+
+  return (
+    <div
+      className="absolute pointer-events-none"
+      style={{ transform: `translate(-50%, -50%) translate(${x}px, ${y}px)` }}
+    >
+      <div
+        className={clsx(
+          'min-w-[220px] max-w-xs rounded-2xl border px-4 py-3 shadow-[0_0_35px_rgba(147,51,234,0.35)] backdrop-blur-xl',
+          'bg-gradient-to-br from-black/70 via-black/60 to-black/70 ring-1 ring-white/10',
+          'animate-[pulse_3s_ease-in-out_infinite]',
+          SOURCE_STYLES[source],
+        )}
+      >
+        <div className="flex items-center gap-3 text-lg font-extrabold tracking-wide">
+          <span aria-hidden="true" className="text-2xl">
+            {icon}
+          </span>
+          <span className="uppercase drop-shadow-[0_0_6px_rgba(255,255,255,0.35)]">{label}</span>
+        </div>
+        <div className="mt-1 text-[11px] uppercase tracking-[0.2em] text-white/60">{stateName}</div>
+        <div className="mt-3 grid grid-cols-2 gap-2 text-[12px] font-mono">
+          <div className="rounded border border-white/10 bg-black/30 px-2 py-1 text-white/80">
+            DEF +{defenseBoost}
+          </div>
+          <div className="rounded border border-white/10 bg-black/30 px-2 py-1 text-white/80">
+            TRUTH ±{truthReward}%
+          </div>
+        </div>
+        <div className="mt-2 text-[10px] uppercase tracking-[0.2em] text-white/50">
+          Source: {source.toUpperCase()}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default ParanormalHotspotOverlay;

--- a/src/components/game/TabloidNewspaperV2.tsx
+++ b/src/components/game/TabloidNewspaperV2.tsx
@@ -32,19 +32,22 @@ const FALLBACK_DATA: NewspaperData = {
 const SIGHTING_LABELS: Record<ParanormalSighting['category'], string> = {
   synergy: 'Synergy Spike',
   'truth-meltdown': 'Broadcast Hijack',
-  cryptid: 'Cryptid Alert'
+  cryptid: 'Cryptid Alert',
+  hotspot: 'Hotspot Alert'
 };
 
 const SIGHTING_ICONS: Record<ParanormalSighting['category'], string> = {
   synergy: '🛰️',
   'truth-meltdown': '📡',
-  cryptid: '🦶'
+  cryptid: '🦶',
+  hotspot: '👻'
 };
 
 const SIGHTING_BADGE_VARIANTS: Record<ParanormalSighting['category'], string> = {
   synergy: 'border-indigo-500 text-indigo-500',
   'truth-meltdown': 'border-rose-500 text-rose-500',
-  cryptid: 'border-emerald-500 text-emerald-500'
+  cryptid: 'border-emerald-500 text-emerald-500',
+  hotspot: 'border-purple-500 text-purple-500'
 };
 
 const formatSightingTime = (timestamp: number) => {
@@ -865,6 +868,30 @@ const TabloidNewspaperV2 = ({
                     {activeSighting.metadata?.setList?.length ? (
                       <div className="rounded border border-dashed border-newspaper-border/60 bg-white/60 p-2 text-[10px] uppercase tracking-wide text-newspaper-text/70">
                         {activeSighting.metadata.setList.join(' • ')}
+                      </div>
+                    ) : null}
+                    {activeSighting.category === 'hotspot' ? (
+                      <div className="grid grid-cols-2 gap-2 text-[11px] uppercase tracking-wide text-newspaper-text/70">
+                        {typeof activeSighting.metadata?.defenseBoost === 'number' ? (
+                          <span>DEF +{activeSighting.metadata.defenseBoost}</span>
+                        ) : null}
+                        {typeof activeSighting.metadata?.truthReward === 'number' ? (
+                          <span>TRUTH ±{activeSighting.metadata.truthReward}%</span>
+                        ) : null}
+                        {activeSighting.metadata?.source ? (
+                          <span>Source {activeSighting.metadata.source.toUpperCase()}</span>
+                        ) : null}
+                        {typeof activeSighting.metadata?.turnsRemaining === 'number' ? (
+                          <span>Turns Left {Math.max(0, activeSighting.metadata.turnsRemaining)}</span>
+                        ) : null}
+                        {activeSighting.metadata?.outcome ? (
+                          <span className="col-span-2">
+                            Status {activeSighting.metadata.outcome.toUpperCase()}
+                            {typeof activeSighting.metadata.truthDelta === 'number' && activeSighting.metadata.truthDelta !== 0
+                              ? ` (${activeSighting.metadata.truthDelta > 0 ? '+' : ''}${activeSighting.metadata.truthDelta}% Truth)`
+                              : ''}
+                          </span>
+                        ) : null}
                       </div>
                     ) : null}
                   </div>

--- a/src/types/paranormal.ts
+++ b/src/types/paranormal.ts
@@ -1,4 +1,4 @@
-export type SightingCategory = 'synergy' | 'truth-meltdown' | 'cryptid';
+export type SightingCategory = 'synergy' | 'truth-meltdown' | 'cryptid' | 'hotspot';
 
 export interface ParanormalSightingMetadata {
   setList?: string[];
@@ -11,6 +11,13 @@ export interface ParanormalSightingMetadata {
   bonusIP?: number;
   reducedMotion?: boolean;
   source?: 'truth' | 'government';
+  defenseBoost?: number;
+  truthReward?: number;
+  duration?: number;
+  turnsRemaining?: number;
+  hotspotId?: string;
+  outcome?: 'active' | 'captured' | 'expired';
+  truthDelta?: number;
 }
 
 export interface ParanormalSighting {

--- a/src/utils/visualEffects.ts
+++ b/src/utils/visualEffects.ts
@@ -156,6 +156,24 @@ export class VisualEffectsCoordinator {
     }));
   }
 
+  static triggerParanormalHotspot(detail: {
+    position: EffectPosition;
+    stateId: string;
+    stateName: string;
+    label: string;
+    icon?: string;
+    source: 'truth' | 'government' | 'neutral';
+    defenseBoost: number;
+    truthReward: number;
+  }): void {
+    window.dispatchEvent(new CustomEvent('paranormalHotspot', {
+      detail: {
+        ...detail,
+        position: { ...detail.position }
+      }
+    }));
+  }
+
   // Helper to get element center position
   static getElementCenter(element: Element): EffectPosition {
     const rect = element.getBoundingClientRect();


### PR DESCRIPTION
## Summary
- add a dedicated hotspot overlay and trigger it from the US map when paranormal events ignite, including audio/particle cues
- extend the game log processing to convert hotspot spawn, capture, and expiry messages into tabloid sightings with richer metadata
- update the newspaper layout and paranormal sighting schema to surface hotspot stats alongside a new icon set

## Testing
- npm run lint *(fails: pre-existing type errors in unrelated utility and tooling files)*

------
https://chatgpt.com/codex/tasks/task_e_68d79090c76483209043c1698ed71229