### PR TITLE
Add final edition press archive experience

### DIFF
--- a/src/components/effects/ParanormalHotspotOverlay.tsx
+++ b/src/components/effects/ParanormalHotspotOverlay.tsx
@@ -1,0 +1,77 @@
+import React, { useEffect } from 'react';
+import clsx from 'clsx';
+
+interface ParanormalHotspotOverlayProps {
+  x: number;
+  y: number;
+  icon: string;
+  label: string;
+  stateName: string;
+  source: 'truth' | 'government' | 'neutral';
+  defenseBoost: number;
+  truthReward: number;
+  onComplete?: () => void;
+}
+
+const SOURCE_STYLES: Record<ParanormalHotspotOverlayProps['source'], string> = {
+  truth: 'border-sky-400/70 bg-sky-500/20 text-sky-50',
+  government: 'border-rose-400/70 bg-rose-500/20 text-rose-50',
+  neutral: 'border-purple-400/70 bg-purple-500/20 text-purple-50',
+};
+
+const ParanormalHotspotOverlay: React.FC<ParanormalHotspotOverlayProps> = ({
+  x,
+  y,
+  icon,
+  label,
+  stateName,
+  source,
+  defenseBoost,
+  truthReward,
+  onComplete,
+}) => {
+  useEffect(() => {
+    const timeout = window.setTimeout(() => {
+      onComplete?.();
+    }, 3200);
+
+    return () => window.clearTimeout(timeout);
+  }, [onComplete]);
+
+  return (
+    <div
+      className="absolute pointer-events-none"
+      style={{ transform: `translate(-50%, -50%) translate(${x}px, ${y}px)` }}
+    >
+      <div
+        className={clsx(
+          'min-w-[220px] max-w-xs rounded-2xl border px-4 py-3 shadow-[0_0_35px_rgba(147,51,234,0.35)] backdrop-blur-xl',
+          'bg-gradient-to-br from-black/70 via-black/60 to-black/70 ring-1 ring-white/10',
+          'animate-[pulse_3s_ease-in-out_infinite]',
+          SOURCE_STYLES[source],
+        )}
+      >
+        <div className="flex items-center gap-3 text-lg font-extrabold tracking-wide">
+          <span aria-hidden="true" className="text-2xl">
+            {icon}
+          </span>
+          <span className="uppercase drop-shadow-[0_0_6px_rgba(255,255,255,0.35)]">{label}</span>
+        </div>
+        <div className="mt-1 text-[11px] uppercase tracking-[0.2em] text-white/60">{stateName}</div>
+        <div className="mt-3 grid grid-cols-2 gap-2 text-[12px] font-mono">
+          <div className="rounded border border-white/10 bg-black/30 px-2 py-1 text-white/80">
+            DEF +{defenseBoost}
+          </div>
+          <div className="rounded border border-white/10 bg-black/30 px-2 py-1 text-white/80">
+            TRUTH ±{truthReward}%
+          </div>
+        </div>
+        <div className="mt-2 text-[10px] uppercase tracking-[0.2em] text-white/50">
+          Source: {source.toUpperCase()}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default ParanormalHotspotOverlay;

--- a/src/components/effects/TabloidVictoryScreen.tsx
+++ b/src/components/effects/TabloidVictoryScreen.tsx
@@ -1,727 +1,125 @@
-import React, { useEffect, useState } from 'react';
+import { useState } from 'react';
 import { Card } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
-import { X } from 'lucide-react';
+import { X, Newspaper, Trophy, Sparkles } from 'lucide-react';
 import EndCredits from '@/components/game/EndCredits';
-
-type ImpactType = 'capture' | 'truth' | 'ip' | 'damage' | 'support';
-
-interface AgendaSummary {
-  title: string;
-  headline: string;
-  operationName: string;
-  issueTheme: string;
-  pullQuote?: string;
-  artCue?: {
-    icon?: string;
-    alt?: string;
-  };
-  faction: 'truth' | 'government' | 'both';
-  progress: number;
-  target: number;
-  completed: boolean;
-  revealed: boolean;
-}
-
-interface MVPDetails {
-  cardId: string;
-  cardName: string;
-  player: 'human' | 'ai';
-  faction: 'truth' | 'government';
-  truthDelta: number;
-  ipDelta: number;
-  aiIpDelta: number;
-  capturedStates: string[];
-  damageDealt: number;
-  round: number;
-  turn: number;
-  impactType: ImpactType;
-  impactValue: number;
-  impactLabel: string;
-  highlight: string;
-}
+import FinalEditionLayout from '@/components/game/FinalEditionLayout';
+import type { GameOverReport } from '@/types/finalEdition';
+import { getVictoryConditionLabel } from '@/utils/finalEdition';
 
 interface TabloidVictoryScreenProps {
   isVisible: boolean;
-  isVictory: boolean;
-  victoryType: 'states' | 'ip' | 'truth' | 'agenda' | null;
+  report: GameOverReport | null;
   playerFaction: 'truth' | 'government';
-  gameStats: {
-    rounds: number;
-    roundNumber?: number;
-    finalTruth: number;
-    playerIP: number;
-    aiIP: number;
-    playerStates: number;
-    aiStates: number;
-    mvp?: MVPDetails;
-    playerSecretAgenda?: AgendaSummary;
-    aiSecretAgenda?: AgendaSummary;
-  };
+  victoryType: 'states' | 'ip' | 'truth' | 'agenda' | null;
   onClose: () => void;
   onMainMenu: () => void;
+  onViewFinalEdition: () => void;
+  onArchive?: () => void;
+  isArchived?: boolean;
 }
 
-const TabloidVictoryScreen = ({ 
-  isVisible, 
-  isVictory, 
-  victoryType, 
-  playerFaction, 
-  gameStats, 
+const TabloidVictoryScreen = ({
+  isVisible,
+  report,
+  playerFaction,
+  victoryType,
   onClose,
-  onMainMenu 
+  onMainMenu,
+  onViewFinalEdition,
+  onArchive,
+  isArchived = false,
 }: TabloidVictoryScreenProps) => {
-  const [glitching, setGlitching] = useState(false);
-  const [confetti, setConfetti] = useState<Array<{ id: number; x: number; y: number; delay: number }>>([]);
   const [showCredits, setShowCredits] = useState(false);
 
-  useEffect(() => {
-    if (isVisible) {
-      // Generate confetti particles
-      const particles = Array.from({ length: 40 }, (_, i) => ({
-        id: i,
-        x: Math.random() * 100,
-        y: Math.random() * 100,
-        delay: Math.random() * 2000
-      }));
-      setConfetti(particles);
-
-      // Glitch effect
-      const shouldGlitch = Math.random() < 0.2;
-      if (shouldGlitch) {
-        setGlitching(true);
-        setTimeout(() => setGlitching(false), 1500);
-      }
-    }
-  }, [isVisible]);
-
-  if (!isVisible) return null;
-
-  const completedRounds = Math.max(0, Math.floor(gameStats.rounds ?? 0));
-  const displayRoundNumber = gameStats.roundNumber && gameStats.roundNumber > 0
-    ? gameStats.roundNumber
-    : Math.max(1, completedRounds || 1);
-  const battleDescriptor = playerFaction === 'government' ? 'information warfare' : 'awakening operations';
-  const roundSummaryFragment = completedRounds === 0
-    ? 'before the first full round could even conclude'
-    : `after ${completedRounds} full round${completedRounds === 1 ? '' : 's'} of intense ${battleDescriptor}`;
-
-  const formatSignedNumber = (value: number) => {
-    const rounded = Math.round(value);
-    if (rounded > 0) return `+${rounded}`;
-    if (rounded < 0) return `${rounded}`;
-    return '0';
-  };
-
-  const formatPercent = (value: number) => {
-    const rounded = Math.round(value);
-    if (rounded > 0) return `+${rounded}%`;
-    if (rounded < 0) return `${rounded}%`;
-    return '0%';
-  };
-
-  const formatImpactValue = (mvp: MVPDetails): string => {
-    switch (mvp.impactType) {
-      case 'capture':
-        return `${mvp.impactValue} state${mvp.impactValue === 1 ? '' : 's'}`;
-      case 'truth':
-        return `${formatPercent(mvp.impactValue)}`;
-      case 'ip':
-        return `${formatSignedNumber(mvp.impactValue)} IP swing`;
-      case 'damage':
-        return `${Math.round(mvp.impactValue)} damage`; 
-      case 'support':
-      default:
-        return 'Momentum play';
-    }
-  };
-
-  const formatAgendaProgress = (agenda: AgendaSummary): string => {
-    return agenda.target > 0 ? `${agenda.progress}/${agenda.target}` : `${agenda.progress}`;
-  };
-
-  const getMvpStatLines = (mvp: MVPDetails): string[] => {
-    const lines: string[] = [];
-    if (mvp.truthDelta !== 0) {
-      lines.push(`Truth delta: ${formatPercent(mvp.truthDelta)}`);
-    }
-
-    const operativeIp = mvp.player === 'human' ? mvp.ipDelta : mvp.aiIpDelta;
-    const opponentIp = mvp.player === 'human' ? mvp.aiIpDelta : mvp.ipDelta;
-    if (operativeIp !== 0 || opponentIp !== 0) {
-      const segments: string[] = [];
-      if (operativeIp !== 0) {
-        segments.push(`${mvp.player === 'human' ? 'Operative' : 'AI'} IP ${formatSignedNumber(operativeIp)}`);
-      }
-      if (opponentIp !== 0) {
-        segments.push(`${mvp.player === 'human' ? 'AI' : 'Operative'} IP ${formatSignedNumber(opponentIp)}`);
-      }
-      if (segments.length) {
-        lines.push(segments.join(' | '));
-      }
-    }
-
-    if (mvp.damageDealt > 0) {
-      lines.push(`Damage dealt: ${Math.round(mvp.damageDealt)}`);
-    }
-
-    if (mvp.capturedStates.length > 0) {
-      lines.push(`Captured: ${mvp.capturedStates.join(', ')}`);
-    }
-
-    return lines.slice(0, 3);
-  };
-
-  const buildMvpHeadline = (mvp: MVPDetails): string => {
-    const loudName = mvp.cardName.toUpperCase();
-    switch (mvp.impactType) {
-      case 'capture':
-        return `${loudName} SWEEPS ${mvp.impactValue} STATE${mvp.impactValue === 1 ? '' : 'S'}!`;
-      case 'truth':
-        return `${loudName} ${mvp.faction === 'truth' ? 'IGNITES' : 'SUPPRESSES'} TRUTH ${formatPercent(mvp.impactValue)}!`;
-      case 'ip':
-        return `${loudName} CHANNELS ${formatSignedNumber(mvp.impactValue)} IP POWER SURGE!`;
-      case 'damage':
-        return `${loudName} CRIPPLES OPPOSITION WITH ${Math.round(mvp.impactValue)} DAMAGE!`;
-      case 'support':
-      default:
-        return `${loudName} NAMED OPERATION MVP IN CLUTCH MANEUVER!`;
-    }
-  };
-
-  const generateHeadlines = () => {
-    const headlines: string[] = [];
-    
-    if (isVictory) {
-      // Faction-aware victory headlines
-      if (playerFaction === 'government') {
-        switch (victoryType) {
-          case 'truth':
-            headlines.push(`TRUTH SUPPRESSED! Disinformation Triumph at ${gameStats.finalTruth}%!`);
-            headlines.push(`PUBLIC REMAINS CALM — BECAUSE THEY HAVE NO IDEA.`);
-            break;
-          case 'states':
-            headlines.push(`STABILITY OPERATIONS COMPLETE! ${gameStats.playerStates} States Secured!`);
-            headlines.push(`HOMELAND DEFENSE GRID ACTIVATED — Citizens Sleep Soundly!`);
-            break;
-          case 'ip':
-            headlines.push(`OPERATIONAL FUNDING MAXIMIZED! Network Power: ${gameStats.playerIP} IP!`);
-            headlines.push(`SHADOW BUDGET APPROVED — Pentagon Takes Notes!`);
-            break;
-          case 'agenda': {
-            const mission = gameStats.playerSecretAgenda?.operationName ?? gameStats.playerSecretAgenda?.headline ?? 'CLASSIFIED MISSION';
-            headlines.push(`CLASSIFIED MISSION SUCCESS! Operation: ${mission}!`);
-            headlines.push(`MEN IN BLACK CELEBRATE — With Decaf Coffee!`);
-            break;
-          }
-        }
-      } else {
-        switch (victoryType) {
-          case 'truth':
-            headlines.push(`DISCLOSURE EVENT! Public Awakening Reaches ${gameStats.finalTruth}%!`);
-            headlines.push(`EYES OPEN: OFFICIALS BAFFLED, COFFEE SPILLS.`);
-            break;
-          case 'states':
-            headlines.push(`LIBERATION COMPLETE! ${gameStats.playerStates} States Awakened!`);
-            headlines.push(`TRUTH NETWORK SPREADS — Tinfoil Sales Soar!`);
-            break;
-          case 'ip':
-            headlines.push(`RESISTANCE FUNDING PEAKS! Network Power: ${gameStats.playerIP} IP!`);
-            headlines.push(`GRASSROOTS REVOLUTION — Aliens Take Notice!`);
-            break;
-          case 'agenda': {
-            const mission = gameStats.playerSecretAgenda?.headline ?? gameStats.playerSecretAgenda?.operationName ?? 'TRUTH MISSION';
-            headlines.push(`TRUTH MISSION ACCOMPLISHED! Operation: ${mission}!`);
-            headlines.push(`WHISTLEBLOWERS UNITE — Reality TV Show Imminent!`);
-            break;
-          }
-        }
-      }
-    } else {
-      const aiAgendaTitle = (() => {
-        if (!gameStats.aiSecretAgenda) {
-          return undefined;
-        }
-        if (gameStats.aiSecretAgenda.revealed || gameStats.aiSecretAgenda.completed) {
-          return gameStats.aiSecretAgenda.title;
-        }
-        return 'Classified Operation';
-      })();
-
-      if (victoryType === 'agenda' && aiAgendaTitle) {
-        if (playerFaction === 'government') {
-          headlines.push(`TRUTH OPERATION "${aiAgendaTitle.toUpperCase()}" TOPPLES COVER STORY!`);
-          headlines.push(`CITIZENS DEMAND RECEIPTS — AND THEY HAVE THEM.`);
-        } else {
-          headlines.push(`DEEP STATE OPERATION "${aiAgendaTitle.toUpperCase()}" EXECUTED FLAWLESSLY!`);
-          headlines.push(`BLACK BUDGET PARTY — INVITATION DENIED.`);
-        }
-      } else if (playerFaction === 'government') {
-        headlines.push(`TRUTH RUNS RAMPANT! Cover Story In Tatters.`);
-        headlines.push(`LOCAL MAN (YOU) DISCOVERS CONSEQUENCES.`);
-      } else {
-        headlines.push(`NARRATIVE LOCKDOWN! Resistance Memes Not Enough.`);
-        headlines.push(`SHEEP REMAIN ASLEEP — BIG BROTHER SMILES.`);
-      }
-    }
-
-    // Universal headlines with faction flavor
-    headlines.push(`Round ${displayRoundNumber} ${isVictory ? 'Triumph' : 'Disaster'}: ${gameStats.playerStates}-${gameStats.aiStates} State Split!`);
-    if (gameStats.mvp) {
-      headlines.push(buildMvpHeadline(gameStats.mvp));
-    }
-    headlines.push(`Florida Man ${getRandomFloridaAntic()} During Final Count!`);
-
-    return headlines.slice(0, 4);
-  };
-
-  const getRandomFloridaAntic = () => {
-    const antics = [
-      "Builds Time Machine",
-      "Adopts Alien Pet",
-      "Declares War on Gravity",
-      "Opens Dimension Portal",
-      "Marries Pizza Slice",
-      "Becomes Cryptid Mayor"
-    ];
-    return antics[Math.floor(Math.random() * antics.length)];
-  };
-
-  const getFakeAds = () => {
-    const govAds = [
-      "Reptile Thermos™ — keeps coffee hot, blood cold.",
-      "Time-Travel Insurance — covered yesterday.",
-      "Official Denial Training — \"Nothing to see here!\"",
-      "Memory Foam Pillows — now with selective amnesia!"
-    ];
-    
-    const truthAds = [
-      "Anonymous Leak Platform — 'We come in peace, mostly'.",
-      "Psychic Wi-Fi — 6G Chakra Plan.",
-      "Tinfoil Hat Boutique — Fashion meets Function!",
-      "Abductee Singles Hotline — 'Probed and ready to mingle!'"
-    ];
-    
-    const universal = [
-      "Bat Boy Marries Vending Machine — RSVP now!",
-      "Florida Man Life Coach — \"Embrace the Chaos!\""
-    ];
-    
-    const factionAds = playerFaction === 'government' ? govAds : truthAds;
-    return [...factionAds.slice(0, 1), ...universal.slice(0, 1)];
-  };
-
-  const getConspiracyTheory = () => {
-    if (isVictory) {
-      return playerFaction === 'truth' 
-        ? "The simulation is cracking! We're breaking through the matrix!"
-        : "Order from chaos achieved. The plan proceeds as foretold.";
-    } else {
-      return playerFaction === 'truth'
-        ? "They got us this time, but the truth seeds are planted..."
-        : "Even the best operations sometimes require... recalibration.";
-    }
-  };
-
-  const headlines = generateHeadlines();
-  const fakeAds = getFakeAds();
-  const { playerStates, aiStates } = gameStats;
-  
-  const factionColors = playerFaction === 'government' 
-    ? 'border-government-blue bg-government-blue/5' 
-    : 'border-truth-red bg-truth-red/5';
-  
-  const factionBadge = playerFaction === 'government' 
-    ? '🦎 OPERATIONAL UPDATE' 
-    : '👁️ DISCLOSURE UPDATE';
-  
-  const networkLabel = playerFaction === 'government' 
-    ? 'Operative Network' 
-    : 'Resistance Network';
-  
-  const truthMeterLabel = playerFaction === 'government' 
-    ? 'Suppression Index' 
-    : 'Awakening Index';
-  
-  const statesLabel = playerFaction === 'government' 
-    ? 'Stability Ops' 
-    : 'Liberated States';
+  if (!isVisible || !report) {
+    return null;
+  }
 
   if (showCredits) {
     return (
       <EndCredits
-        isVisible={showCredits}
+        isVisible
         playerFaction={playerFaction}
-        onClose={() => {
-          setShowCredits(false);
-          onMainMenu();
-        }}
+        onClose={() => setShowCredits(false)}
       />
     );
   }
 
+  const isVictory = report.winner === report.playerFaction;
+  const bannerLabel = report.winner === 'draw'
+    ? 'Stalemate'
+    : isVictory
+      ? 'Victory'
+      : 'Defeat';
+  const victoryDetail = victoryType
+    ? getVictoryConditionLabel(victoryType).toUpperCase()
+    : report.victoryType
+      ? getVictoryConditionLabel(report.victoryType).toUpperCase()
+      : 'FINAL REPORT';
+
   return (
-    <div 
-      className="fixed inset-0 bg-slate-900/70 flex items-center justify-center z-50 animate-fade-in"
-      role="dialog"
-      aria-label={isVictory ? "Victory - Extra Edition" : "Defeat - Extra Edition"}
-      tabIndex={0}
-      onKeyDown={(e) => {
-        if (e.key === 'Escape') {
-          e.preventDefault(); // Prevent closing with ESC - must use buttons
-        }
-      }}
-    >
-      {/* Confetti */}
-      {isVictory && confetti.map(particle => (
-        <div
-          key={particle.id}
-          className="absolute w-2 h-2 bg-truth-red animate-[confetti_3s_ease-out_infinite]"
-          style={{
-            left: `${particle.x}%`,
-            top: `${particle.y}%`,
-            animationDelay: `${particle.delay}ms`
-          }}
-        />
-      ))}
-
-      <Card className="bg-newspaper-bg text-newspaper-text p-0 max-w-6xl max-h-[95vh] overflow-y-auto border-4 border-newspaper-border transform animate-[newspaper-spin_0.8s_ease-out] shadow-2xl font-serif"
-        onClick={(e) => e.stopPropagation()}>
-        {/* Newspaper Header */}
-        <div className="bg-newspaper-header p-4 sm:p-6 border-b-8 border-newspaper-border relative">
-          {/* Faction Badge */}
-          <div className="absolute top-2 left-2 bg-newspaper-accent text-white px-2 py-1 text-xs font-bold rounded transform -rotate-2">
-            {factionBadge}
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-slate-950/85 p-6">
+      <div className="absolute inset-0 bg-[radial-gradient(circle_at_top,_rgba(16,185,129,0.25),_transparent_60%)]" aria-hidden />
+      <Card className="relative z-10 flex max-h-[92vh] w-full max-w-5xl flex-col overflow-hidden border border-emerald-500/40 bg-slate-950/95 shadow-[0_0_65px_rgba(16,185,129,0.25)]">
+        <div className="flex items-start justify-between gap-4 border-b border-emerald-500/20 bg-slate-950/90 px-6 py-4">
+          <div>
+            <p className="font-mono text-xs uppercase tracking-[0.32em] text-emerald-300/80">{victoryDetail}</p>
+            <h2 className="mt-1 flex items-center gap-2 text-2xl font-semibold text-emerald-100">
+              {isVictory ? <Trophy className="h-5 w-5 text-emerald-300" /> : <Sparkles className="h-5 w-5 text-emerald-300" />}
+              {bannerLabel}
+            </h2>
           </div>
-          
-          {/* Masthead */}
-          <div className="text-center mb-4">
-            <div className="text-xs font-bold tracking-widest mb-1 opacity-60">ESTABLISHED 1947 • CIRCULATION: CLASSIFIED</div>
-            <h1 className="text-3xl sm:text-5xl font-black tracking-tighter font-serif mb-1">
-              THE WEEKLY PARANOID NEWS
-            </h1>
-            <div className="flex flex-col sm:flex-row justify-between items-center text-xs font-bold border-t border-b border-newspaper-border py-1 gap-1">
-              <span>Vol. 77, No. {displayRoundNumber}</span>
-              <span>{new Date().toLocaleDateString('en-US', { weekday: 'long', year: 'numeric', month: 'long', day: 'numeric' })}</span>
-              <span>Price: YOUR SOUL</span>
-            </div>
-          </div>
-          
-          {/* Main Headline */}
-          <div className="text-center py-4 border-y-4 border-newspaper-border bg-newspaper-bg/50">
-            <div className={`text-5xl sm:text-7xl font-black tracking-tight font-serif leading-none ${
-              isVictory ? 'text-newspaper-accent' : 'text-red-600'
-            } ${glitching ? 'animate-pulse text-truth-red' : ''}`}>
-              {isVictory ? 'VICTORY!' : 'DEFEAT!'}
-            </div>
-            <div className="text-lg sm:text-2xl font-bold mt-2 tracking-wide">
-              {isVictory 
-                ? playerFaction === 'government' ? 'SHADOW OPERATIVE SUCCEEDS' : 'DISCLOSURE EVENT CONFIRMED'
-                : playerFaction === 'government' ? 'OPERATION COMPROMISED' : 'NARRATIVE LOCKDOWN ACTIVATED'
-              }
-            </div>
-          </div>
-          
+          <Button
+            variant="ghost"
+            size="icon"
+            className="text-emerald-200 hover:text-emerald-100"
+            onClick={onClose}
+            aria-label="Close victory report"
+          >
+            <X className="h-5 w-5" />
+          </Button>
         </div>
 
-        <div className="p-4 sm:p-6">
-          <div className="grid grid-cols-1 lg:grid-cols-4 gap-6">
-            {/* Main Article */}
-            <div className="lg:col-span-3">
-              {headlines.map((headline, index) => (
-                <article key={index} className={`${index === 0 ? 'mb-6' : 'mb-4'} ${index > 0 ? 'border-t border-newspaper-border pt-4' : ''}`}>
-                  <h2 className={`font-black font-serif leading-tight mb-2 ${
-                    index === 0 ? 'text-3xl' : index === 1 ? 'text-xl' : 'text-lg'
-                  }`}>
-                    {headline}
-                  </h2>
-                   {index === 0 && (
-                     <div className="sm:columns-2 gap-6 text-sm leading-relaxed text-justify">
-                       <p className="mb-3">
-                         <span className="float-left text-4xl sm:text-6xl font-black leading-none mr-2 mt-1">{isVictory ? 'I' : 'I'}</span>
-                         n a {isVictory ? 'stunning victory that has shocked the intelligence community' : 'devastating defeat that will echo through classified corridors'}, 
-                        the {playerFaction === 'truth' ? 'Truth Seekers resistance movement' : 'Government shadow operations'} have {isVictory ? 'emerged triumphant' : 'suffered catastrophic losses'}
-                        {` ${roundSummaryFragment}.`}
-                       </p>
-                       <p className="mb-3">
-                         {playerFaction === 'government' 
-                           ? `Classified sources from within the Pentagon report ${isVictory ? 'successful narrative control' : 'containment breach'} as the national ${truthMeterLabel.toLowerCase()} reached ${gameStats.finalTruth}%. Agency analysts confirm that operational networks have ${isVictory ? 'maintained strategic dominance' : 'suffered critical exposure'} across key territories.`
-                           : `Underground sources from the resistance network report ${isVictory ? 'breakthrough awakening events' : 'suppression protocols activated'} as the national ${truthMeterLabel.toLowerCase()} reached ${gameStats.finalTruth}%. Independent analysts confirm that truth distribution networks have ${isVictory ? 'achieved critical mass' : 'encountered systematic shutdown'} across liberated zones.`
-                         }
-                       </p>
-                       <p className="mb-3">
-                         "This changes everything," whispered a high-ranking {playerFaction === 'government' ? 'operative' : 'truth seeker'} who requested anonymity while adjusting their {playerFaction === 'government' ? 'security clearance badge' : 'tin foil hat'}. 
-                         "The {playerFaction === 'government' ? 'operational parameters' : 'simulation matrix'} have been permanently altered. We're not in Kansas anymore."
-                       </p>
-                       <p>
-                         Emergency sessions have been called at locations that officially don't exist, while citizens remain blissfully unaware that their reality 
-                         has been fundamentally {isVictory ? 'secured' : 'compromised'} during their morning coffee.
-                       </p>
-                     </div>
-                   )}
-                  {index === 1 && (
-                    <div className="flex gap-4">
-                      <div className="flex-1">
-                        <div className="w-full h-20 bg-newspaper-header border border-newspaper-border flex items-center justify-center text-xs font-bold mb-2">
-                          📸 CLASSIFIED SURVEILLANCE PHOTO
-                        </div>
-                        <p className="text-sm leading-relaxed text-justify">
-                          Exclusive footage captured by our network of citizen journalists reveals the exact moment when 
-                          the balance of power shifted. Government sources neither confirm nor deny the authenticity of these images.
-                        </p>
-                      </div>
-                    </div>
-                  )}
-                  {index > 1 && (
-                    <p className="text-sm opacity-80 italic">
-                      Developing story... More classified details on page 7 (if you have proper clearance level).
-                    </p>
-                  )}
-                </article>
-              ))}
-            </div>
-
-            {/* Sidebar */}
-            <div className="space-y-4">
-              {/* Final Intel Report */}
-              <div className={`bg-newspaper-header/50 p-4 border-2 ${isVictory ? factionColors.split(' ')[0] : 'border-red-500'}`}>
-                <h3 className="text-lg font-black text-center mb-3 font-serif border-b border-newspaper-border pb-2">
-                  📊 FINAL INTEL REPORT
-                </h3>
-                <div className="space-y-1 text-sm">
-                  <div className="flex justify-between border-b border-newspaper-border/30 py-1">
-                    <span className="font-bold">OPERATION STATUS:</span>
-                    <span className={`font-black ${isVictory ? 'text-newspaper-accent' : 'text-red-600'}`}>
-                      {isVictory ? 'SUCCESS' : 'COMPROMISED'}
-                    </span>
-                  </div>
-                  <div className="flex justify-between border-b border-newspaper-border/30 py-1">
-                    <span>Full Rounds:</span>
-                    <span className="font-bold">{completedRounds}</span>
-                  </div>
-                  <div className="flex justify-between border-b border-newspaper-border/30 py-1">
-                    <span>{truthMeterLabel}:</span>
-                    <span className="font-bold">{gameStats.finalTruth}%</span>
-                  </div>
-                  <div className="flex justify-between border-b border-newspaper-border/30 py-1">
-                    <span>{networkLabel}:</span>
-                    <span className="font-bold">{gameStats.playerIP} IP</span>
-                  </div>
-                  <div className="flex justify-between border-b border-newspaper-border/30 py-1">
-                    <span>Enemy Network:</span>
-                    <span className="font-bold">{gameStats.aiIP} IP</span>
-                  </div>
-                  <div className="flex justify-between py-1">
-                    <span>{statesLabel}:</span>
-                    <span className="font-bold">{playerStates} vs {aiStates}</span>
-                  </div>
-                  {gameStats.mvp && (
-                    <div className="border-t border-newspaper-border pt-2 mt-2 text-left">
-                      <div className="text-xs font-bold opacity-80 text-center">
-                        {playerFaction === 'government' ? 'ASSET OF THE MATCH' : 'TRUTH MVP'}
-                      </div>
-                      <div className={`font-black text-sm text-center ${playerFaction === 'government' ? 'text-government-blue' : 'text-truth-red'}`}>
-                        {gameStats.mvp.cardName}
-                      </div>
-                      <div className="text-xs font-bold uppercase tracking-wide text-black/70 mt-1 text-center">
-                        {gameStats.mvp.impactLabel}: {formatImpactValue(gameStats.mvp)}
-                      </div>
-                      <div className="text-xs italic mt-2 text-black/70 text-justify">
-                        {gameStats.mvp.highlight}
-                      </div>
-                      <div className="mt-2 space-y-1 text-[10px] uppercase tracking-wide text-black/60">
-                        <div className="flex justify-between">
-                          <span>Round</span>
-                          <span>{(gameStats.mvp.round && gameStats.mvp.round > 0) ? gameStats.mvp.round : displayRoundNumber}</span>
-                        </div>
-                        <div className="flex justify-between">
-                          <span>Turn</span>
-                          <span>{(gameStats.mvp.turn && gameStats.mvp.turn > 0) ? gameStats.mvp.turn : 1}</span>
-                        </div>
-                        <div className="flex justify-between">
-                          <span>Operative</span>
-                          <span>{gameStats.mvp.player === 'human' ? 'Player' : 'AI Strategist'}</span>
-                        </div>
-                        {getMvpStatLines(gameStats.mvp).map((line, index) => (
-                          <div
-                            key={index}
-                            className="text-left normal-case tracking-normal text-black/70 first-letter:uppercase"
-                          >
-                            {line}
-                          </div>
-                        ))}
-                      </div>
-                    </div>
-                  )}
-                  {(gameStats.playerSecretAgenda || gameStats.aiSecretAgenda) && (
-                    <div className="border-t border-newspaper-border pt-2 mt-2 text-center space-y-3">
-                      <div className="text-xs font-bold opacity-80">SECRET OPERATIONS</div>
-                      {gameStats.playerSecretAgenda && (
-                        <div className="space-y-1 text-xs">
-                          <div className="text-[11px] uppercase tracking-wide opacity-70">Player Objective</div>
-                          {gameStats.playerSecretAgenda.artCue?.icon && (
-                            <div className="flex justify-center">
-                              <img
-                                src={gameStats.playerSecretAgenda.artCue.icon}
-                                alt={gameStats.playerSecretAgenda.artCue.alt ?? 'Objective accent'}
-                                className="h-10 w-10 mx-auto opacity-80"
-                                loading="lazy"
-                              />
-                            </div>
-                          )}
-                          <div className={`font-bold text-sm ${gameStats.playerSecretAgenda.completed ? 'text-newspaper-accent' : 'text-red-600'}`}>
-                            {gameStats.playerSecretAgenda.headline || gameStats.playerSecretAgenda.title}
-                          </div>
-                          <div className="text-[11px] uppercase tracking-wide opacity-70">
-                            Operation: {gameStats.playerSecretAgenda.operationName}
-                          </div>
-                          <div className="text-[11px] uppercase tracking-wide opacity-70">
-                            Theme: {gameStats.playerSecretAgenda.issueTheme}
-                          </div>
-                          {gameStats.playerSecretAgenda.pullQuote && (
-                            <div className="italic opacity-80">
-                              “{gameStats.playerSecretAgenda.pullQuote.replace(/^"|"$/g, '')}”
-                            </div>
-                          )}
-                          <div className="text-xs font-bold">
-                            {gameStats.playerSecretAgenda.completed ? '✓ PASSED' : '✗ FAILED'} ({formatAgendaProgress(gameStats.playerSecretAgenda)})
-                          </div>
-                        </div>
-                      )}
-                      {gameStats.aiSecretAgenda && (
-                        <div className="space-y-1 text-xs">
-                          <div className="text-[11px] uppercase tracking-wide opacity-70">AI Objective</div>
-                          {(gameStats.aiSecretAgenda.revealed || gameStats.aiSecretAgenda.completed) && gameStats.aiSecretAgenda.artCue?.icon && (
-                            <div className="flex justify-center">
-                              <img
-                                src={gameStats.aiSecretAgenda.artCue.icon}
-                                alt={gameStats.aiSecretAgenda.artCue.alt ?? 'Objective accent'}
-                                className="h-10 w-10 mx-auto opacity-80"
-                                loading="lazy"
-                              />
-                            </div>
-                          )}
-                          <div className={`font-bold text-sm ${gameStats.aiSecretAgenda.completed ? 'text-newspaper-accent' : 'text-red-600'}`}>
-                            {(gameStats.aiSecretAgenda.revealed || gameStats.aiSecretAgenda.completed)
-                              ? (gameStats.aiSecretAgenda.headline || gameStats.aiSecretAgenda.title)
-                              : 'CLASSIFIED OPERATION'}
-                          </div>
-                          {(gameStats.aiSecretAgenda.revealed || gameStats.aiSecretAgenda.completed) && (
-                            <>
-                              <div className="text-[11px] uppercase tracking-wide opacity-70">
-                                Operation: {gameStats.aiSecretAgenda.operationName}
-                              </div>
-                              <div className="text-[11px] uppercase tracking-wide opacity-70">
-                                Theme: {gameStats.aiSecretAgenda.issueTheme}
-                              </div>
-                              {gameStats.aiSecretAgenda.pullQuote && (
-                                <div className="italic opacity-80">
-                                  “{gameStats.aiSecretAgenda.pullQuote.replace(/^"|"$/g, '')}”
-                                </div>
-                              )}
-                            </>
-                          )}
-                          <div className="text-xs font-bold">
-                            {gameStats.aiSecretAgenda.completed ? '✓ PASSED' : '✗ FAILED'} ({formatAgendaProgress(gameStats.aiSecretAgenda)})
-                          </div>
-                        </div>
-                      )}
-                    </div>
-                  )}
-                </div>
-              </div>
-
-              {/* Weather & Classified Ads */}
-              <div className="bg-newspaper-header/30 p-3 border border-newspaper-border">
-                <h4 className="font-black text-sm text-center mb-2 border-b border-newspaper-border pb-1">
-                  TODAY'S WEATHER
-                </h4>
-                <div className="text-xs text-center">
-                  <div>🌫️ Fog of War: Heavy</div>
-                  <div>🔍 Visibility: Classified</div>
-                  <div>🎭 Chance of Deception: 99%</div>
-                </div>
-              </div>
-
-              <div className="space-y-2">
-                <h4 className="font-black text-sm text-center border-b border-newspaper-border pb-1">
-                  📢 CLASSIFIED MARKETPLACE
-                </h4>
-                {fakeAds.map((ad, index) => (
-                  <div key={index} className="bg-newspaper-header/20 p-2 text-xs text-center border border-newspaper-border/50">
-                    {ad}
-                  </div>
-                ))}
-              </div>
-
-              {/* Conspiracy Corner */}
-              <div className="bg-truth-red/10 p-3 border-2 border-truth-red/40">
-                <h4 className="font-black text-sm text-center mb-2 text-truth-red border-b border-truth-red/30 pb-1">
-                  🔻 DEEP STATE UPDATE
-                </h4>
-                <div className="text-xs italic text-center leading-relaxed">
-                  {getConspiracyTheory()}
-                </div>
-              </div>
-
-              {/* Stock Market Ticker */}
-              <div className="bg-newspaper-header/30 p-2 border border-newspaper-border">
-                <h4 className="font-black text-xs text-center mb-1">📈 SHADOW MARKETS</h4>
-                <div className="text-xs space-y-1">
-                  <div className="flex justify-between">
-                    <span>Aluminum Foil:</span>
-                    <span className="text-green-600">↗ +420%</span>
-                  </div>
-                  <div className="flex justify-between">
-                    <span>Trust Index:</span>
-                    <span className="text-red-600">↘ -{100 - gameStats.finalTruth}%</span>
-                  </div>
-                  <div className="flex justify-between">
-                    <span>Paranoia Futures:</span>
-                    <span className="text-green-600">↗ +∞%</span>
-                  </div>
-                </div>
-              </div>
-            </div>
-          </div>
+        <div className="flex-1 overflow-y-auto px-6 py-6">
+          <FinalEditionLayout report={report} />
         </div>
 
-        {/* Footer */}
-        <div className="bg-newspaper-header border-t-4 border-newspaper-border p-4">
-          <div className="flex justify-between items-center text-xs text-newspaper-bg border-b border-newspaper-border pb-2 mb-3">
-            <div>© 2024 The Weekly Paranoid News</div>
-            <div>All Rights Reserved Under Alien Treaty 4B7</div>
-            <div>Printed on Recycled Surveillance Reports</div>
-          </div>
-          <div className="text-center">
-            <div className="text-xs mb-4 italic text-newspaper-bg/80">
-              "Remember: They're Watching, But So Are We" • Established When Truth Mattered
-            </div>
-            <div className="flex gap-4 justify-center">
+        <div className="flex flex-wrap items-center justify-between gap-3 border-t border-emerald-500/20 bg-slate-950/90 px-6 py-4">
+          <div className="flex flex-wrap items-center gap-2">
+            <Button
+              onClick={onViewFinalEdition}
+              className="bg-emerald-500/20 text-emerald-100 hover:bg-emerald-500/30"
+            >
+              <Newspaper className="mr-2 h-4 w-4" />
+              Read Final Newspaper
+            </Button>
+            {onArchive && (
               <Button
-                onClick={(e) => {
-                  e.stopPropagation();
-                  onMainMenu();
-                }}
+                onClick={onArchive}
+                disabled={isArchived}
                 variant="outline"
-                className="font-bold text-lg px-8 py-3 bg-newspaper-bg hover:bg-newspaper-bg/90 text-newspaper-text border-2 border-newspaper-border shadow-lg transform hover:scale-105 transition-all"
+                className="border-emerald-500/40 text-emerald-200 hover:bg-emerald-500/10 disabled:opacity-60"
               >
-                📰 Return to Main Menu
+                {isArchived ? 'Archived' : 'Archive to Player Hub'}
               </Button>
-              <Button
-                onClick={(e) => {
-                  e.stopPropagation();
-                  setShowCredits(true);
-                }}
-                className={`font-bold text-lg px-8 py-3 ${
-                  isVictory 
-                    ? 'bg-newspaper-accent hover:bg-newspaper-accent/80 text-white' 
-                    : 'bg-red-600 hover:bg-red-700 text-white'
-                } border-2 border-newspaper-border shadow-lg transform hover:scale-105 transition-all`}
-              >
-                🎬 End Credits
-              </Button>
-            </div>
+            )}
+          </div>
+          <div className="flex flex-wrap items-center gap-2">
+            <Button
+              variant="ghost"
+              className="text-emerald-200 hover:text-emerald-100"
+              onClick={() => setShowCredits(true)}
+            >
+              Roll Credits
+            </Button>
+            <Button
+              variant="secondary"
+              className="bg-emerald-500/20 text-emerald-100 hover:bg-emerald-500/30"
+              onClick={onMainMenu}
+            >
+              Return to Menu
+            </Button>
           </div>
         </div>
       </Card>

--- a/src/components/game/ExtraEditionNewspaper.tsx
+++ b/src/components/game/ExtraEditionNewspaper.tsx
@@ -1,447 +1,55 @@
-import React, { useState, useEffect } from 'react';
 import { Card } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
-import { X } from 'lucide-react';
-
-type ImpactType = 'capture' | 'truth' | 'ip' | 'damage' | 'support';
-
-interface AgendaSummary {
-  title: string;
-  headline: string;
-  operationName: string;
-  issueTheme: string;
-  pullQuote?: string;
-  artCue?: {
-    icon?: string;
-    alt?: string;
-  };
-  faction: 'truth' | 'government' | 'both';
-  progress: number;
-  target: number;
-  completed: boolean;
-  revealed: boolean;
-}
-
-interface MVPDetails {
-  cardId: string;
-  cardName: string;
-  player: 'human' | 'ai';
-  faction: 'truth' | 'government';
-  truthDelta: number;
-  ipDelta: number;
-  aiIpDelta: number;
-  capturedStates: string[];
-  damageDealt: number;
-  round: number;
-  turn: number;
-  impactType: ImpactType;
-  impactValue: number;
-  impactLabel: string;
-  highlight: string;
-}
-
-interface GameOverReport {
-  winner: "government" | "truth" | "draw";
-  rounds: number;
-  finalTruth: number;
-  ipPlayer: number;
-  ipAI: number;
-  statesGov: number;
-  statesTruth: number;
-  playerSecretAgenda?: AgendaSummary;
-  aiSecretAgenda?: AgendaSummary;
-  topPlays?: string[];
-  legendaryUsed?: string[];
-  funniestEvent?: string;
-  mvp?: MVPDetails | null;
-  durationSec?: number;
-}
+import { X, Archive } from 'lucide-react';
+import FinalEditionLayout from '@/components/game/FinalEditionLayout';
+import type { GameOverReport } from '@/types/finalEdition';
 
 interface ExtraEditionNewspaperProps {
   report: GameOverReport;
   onClose: () => void;
+  onArchive?: () => void;
+  isArchived?: boolean;
 }
 
-const formatSignedNumber = (value: number) => {
-  const rounded = Math.round(value);
-  if (rounded > 0) return `+${rounded}`;
-  if (rounded < 0) return `${rounded}`;
-  return '0';
-};
-
-const formatPercent = (value: number) => {
-  const rounded = Math.round(value);
-  if (rounded > 0) return `+${rounded}%`;
-  if (rounded < 0) return `${rounded}%`;
-  return '0%';
-};
-
-const formatAgendaProgress = (agenda: AgendaSummary): string => {
-  return agenda.target > 0 ? `${agenda.progress}/${agenda.target}` : `${agenda.progress}`;
-};
-
-const describeMvpImpact = (mvp: MVPDetails): string => {
-  switch (mvp.impactType) {
-    case 'capture':
-      return `Captured ${mvp.impactValue} state${mvp.impactValue === 1 ? '' : 's'}`;
-    case 'truth':
-      return `Shifted truth ${formatPercent(mvp.impactValue)}`;
-    case 'ip':
-      return `Swung IP ${formatSignedNumber(mvp.impactValue)}`;
-    case 'damage':
-      return `Dealt ${Math.round(mvp.impactValue)} damage`;
-    case 'support':
-    default:
-      return 'Clutch momentum play';
-  }
-};
-
-const summarizeMvpStats = (mvp: MVPDetails): string[] => {
-  const lines: string[] = [];
-  if (mvp.truthDelta !== 0) {
-    lines.push(`Truth delta: ${formatPercent(mvp.truthDelta)}`);
-  }
-
-  const operativeIp = mvp.player === 'human' ? mvp.ipDelta : mvp.aiIpDelta;
-  const opponentIp = mvp.player === 'human' ? mvp.aiIpDelta : mvp.ipDelta;
-  if (operativeIp !== 0 || opponentIp !== 0) {
-    const segments: string[] = [];
-    if (operativeIp !== 0) {
-      segments.push(`${mvp.player === 'human' ? 'Operative' : 'AI'} IP ${formatSignedNumber(operativeIp)}`);
-    }
-    if (opponentIp !== 0) {
-      segments.push(`${mvp.player === 'human' ? 'AI' : 'Operative'} IP ${formatSignedNumber(opponentIp)}`);
-    }
-    if (segments.length) {
-      lines.push(segments.join(' | '));
-    }
-  }
-
-  if (mvp.damageDealt > 0) {
-    lines.push(`Damage dealt: ${Math.round(mvp.damageDealt)}`);
-  }
-
-  if (mvp.capturedStates.length > 0) {
-    lines.push(`Captured: ${mvp.capturedStates.join(', ')}`);
-  }
-
-  return lines;
-};
-
-const ExtraEditionNewspaper = ({ report, onClose }: ExtraEditionNewspaperProps) => {
-  const [glitching, setGlitching] = useState(false);
-
-  // Glitch effect on masthead
-  useEffect(() => {
-    const shouldGlitch = Math.random() < 0.15;
-    if (shouldGlitch) {
-      setGlitching(true);
-      setTimeout(() => setGlitching(false), 1500);
-    }
-  }, []);
-
-  // Generate headlines based on winner
-  const generateHeadlines = () => {
-    const {
-      winner,
-      finalTruth,
-      statesGov,
-      statesTruth,
-      rounds,
-      legendaryUsed,
-      mvp,
-      playerSecretAgenda,
-      aiSecretAgenda,
-    } = report;
-    const headlines: string[] = [];
-
-    if (winner === "truth") {
-      headlines.push(`SHEEPLE AWAKE! Truth Hits ${finalTruth}% — Government in Disarray!`);
-      headlines.push(`Bat Boy Endorses New Regime; Ratings Soar!`);
-      if (finalTruth >= 95) headlines.push(`Elvira Declares Victory: 'Leaks Never Sleep!'`);
-      if (statesTruth >= 10) headlines.push(`Corn Empire Falls; Popcorn Prices Plunge!`);
-    } else if (winner === "government") {
-      headlines.push(`ORDER RESTORED! Narrative Lockdown at ${finalTruth}%`);
-      headlines.push(`Men in Black Erase All Evidence; Nothing to See Here`);
-      if (statesGov >= 10) headlines.push(`Containment Complete: ${statesGov} States Secured`);
-      headlines.push(`Candy Confiscation Act Passes — Kids Furious`);
-    } else {
-      headlines.push(`STALEMATE! Round ${rounds} Ends in Confusion`);
-      headlines.push(`Both Sides Claim Victory; Reality Unclear`);
-    }
-
-    if (playerSecretAgenda?.completed) {
-      const factionLabel = playerSecretAgenda.faction === 'government' ? 'Government' : 'Truth';
-      const agendaHeadline = playerSecretAgenda.headline || playerSecretAgenda.title;
-      headlines.push(`${factionLabel.toUpperCase()} SECRET AGENDA COMPLETE: ${agendaHeadline}!`);
-    } else if (aiSecretAgenda?.completed) {
-      const factionLabel = aiSecretAgenda.faction === 'government' ? 'Government' : 'Truth';
-      const agendaHeadline = aiSecretAgenda.headline || aiSecretAgenda.title;
-      headlines.push(`${factionLabel.toUpperCase()} SHADOW PLAN "${agendaHeadline.toUpperCase()}" SUCCEEDS!`);
-    }
-
-    // Add universal headlines
-    headlines.push(`Round ${rounds} Shock: ${statesGov}-${statesTruth} State Split`);
-    if (legendaryUsed && legendaryUsed.length > 0) {
-      headlines.push(`Legendary Play of the Night: ${legendaryUsed[0]}`);
-    }
-    if (mvp) {
-      headlines.push(`MVP ${mvp.cardName}: ${describeMvpImpact(mvp)}`);
-    }
-    headlines.push(`Florida Man ${getRandomFloridaAntic()} During Count — Officials Shrug`);
-
-    return headlines.slice(0, 4); // Take first 4
-  };
-
-  const getRandomFloridaAntic = () => {
-    const antics = [
-      "Wrestles Alligator",
-      "Steals Ice Cream Truck",
-      "Builds UFO Landing Pad",
-      "Marries Pet Iguana",
-      "Declares Independence",
-      "Opens Portal to Ohio"
-    ];
-    return antics[Math.floor(Math.random() * antics.length)];
-  };
-
-  const getFakeAds = () => [
-    "Buy 2 Tinfoil Hats, Get 3rd Free!",
-    "Pastor Rex Miracle Tape — Sees Through Redactions!",
-    "Crystal Wi-Fi Chakras — Boosts Truth Meter!",
-    "Area 51 Tours — Family Discount (Bring Snacks)"
-  ].slice(0, 2);
-
-  const headlines = generateHeadlines();
-  const fakeAds = getFakeAds();
-
+const ExtraEditionNewspaper = ({ report, onClose, onArchive, isArchived = false }: ExtraEditionNewspaperProps) => {
   return (
-    <div 
-      className="fixed inset-0 bg-black/90 flex items-center justify-center z-50 animate-fade-in cursor-pointer"
-      onClick={onClose}
-      role="dialog"
-      aria-label="Game Over — Extra Edition"
-      tabIndex={0}
-      onKeyDown={(e) => {
-        if (e.key === 'Escape' || e.key === 'Enter' || e.key === ' ') {
-          onClose();
-        }
-      }}
-    >
-      <Card className="bg-newspaper-bg text-newspaper-text p-8 max-w-4xl max-h-[90vh] overflow-y-auto border-8 border-truth-red transform animate-[newspaper-spin_0.8s_ease-out] shadow-2xl">
-        {/* Header */}
-        <div className="text-center border-b-4 border-newspaper-text pb-6 mb-6">
-          <h1 className={`text-6xl font-black tracking-wider mb-2 ${glitching ? 'animate-pulse text-truth-red' : ''}`}>
-            EXTRA EDITION
-          </h1>
-          <div className="text-lg font-mono opacity-80">
-            THE PARANOID TIMES • FINAL REPORT • {new Date().toLocaleDateString()}
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-slate-950/90 p-6">
+      <div className="absolute inset-0 bg-[radial-gradient(circle_at_center,_rgba(56,189,248,0.15),_transparent_60%)]" aria-hidden />
+      <Card className="relative z-10 flex max-h-[92vh] w-full max-w-5xl flex-col overflow-hidden border border-emerald-500/40 bg-slate-950/95 shadow-[0_0_65px_rgba(56,189,248,0.25)]">
+        <div className="flex items-center justify-between gap-4 border-b border-emerald-500/20 bg-slate-950/90 px-6 py-4">
+          <div>
+            <p className="font-mono text-xs uppercase tracking-[0.32em] text-emerald-300/80">Extra Edition</p>
+            <h2 className="mt-1 text-2xl font-semibold text-emerald-100">Breakdown of Final Operations</h2>
           </div>
           <Button
             variant="ghost"
-            size="sm"
-            onClick={(e) => {
-              e.stopPropagation();
-              onClose();
-            }}
-            className="absolute top-4 right-4 text-newspaper-text hover:text-truth-red"
+            size="icon"
+            className="text-emerald-200 hover:text-emerald-100"
+            onClick={onClose}
+            aria-label="Close extra edition"
           >
-            <X className="w-6 h-6" />
+            <X className="h-5 w-5" />
           </Button>
         </div>
 
-        <div className="grid grid-cols-3 gap-8">
-          {/* Main Headlines */}
-          <div className="col-span-2 space-y-6">
-            {headlines.map((headline, index) => (
-              <article key={index} className={`${index === 0 ? 'text-2xl font-black' : 'text-lg font-bold'} mb-4`}>
-                <h2 className="mb-2 leading-tight">{headline}</h2>
-                {index === 0 && (
-                  <div className="text-sm font-normal opacity-80 leading-relaxed">
-                    <p>
-                      In a shocking turn of events, the {report.winner === 'draw' ? 'battle ended in complete chaos' : `${report.winner === 'government' ? 'Government' : 'Truth Seekers'} have emerged victorious`} after {report.rounds} intense rounds of shadow operations.
-                    </p>
-                    <p className="mt-2">
-                      Sources close to the situation report unprecedented levels of {report.winner === 'truth' ? 'awakening' : 'containment'} across the continental United States.
-                    </p>
-                  </div>
-                )}
-                {index > 0 && (
-                  <div className="w-full h-16 bg-gray-300 flex items-center justify-center text-xs opacity-60 mt-2">
-                    📰 [Classified Photo]
-                  </div>
-                )}
-              </article>
-            ))}
-          </div>
-
-          {/* Sidebar */}
-          <div className="space-y-6">
-            {/* Box Score */}
-            <div className="bg-black/20 p-4 rounded">
-              <h3 className="text-lg font-bold mb-3 text-truth-red text-center">📊 FINAL SCORE</h3>
-              <div className="space-y-2 text-sm font-mono">
-                <div className="flex justify-between">
-                  <span>Rounds:</span>
-                  <span className="font-bold">{report.rounds}</span>
-                </div>
-                <div className="flex justify-between">
-                  <span>Final Truth:</span>
-                  <span className="font-bold">{report.finalTruth}%</span>
-                </div>
-                <div className="flex justify-between">
-                  <span>States:</span>
-                  <span className="font-bold">Gov {report.statesGov} — Truth {report.statesTruth}</span>
-                </div>
-                <div className="flex justify-between">
-                  <span>Player IP:</span>
-                  <span className="font-bold">{report.ipPlayer}</span>
-                </div>
-                <div className="flex justify-between">
-                  <span>AI IP:</span>
-                  <span className="font-bold">{report.ipAI}</span>
-                </div>
-                {report.mvp && (
-                  <div className="border-t border-newspaper-text/20 pt-2 mt-2 space-y-1">
-                    <div className="text-center">
-                      <div className="text-xs opacity-80">OPERATION MVP</div>
-                      <div className={`font-bold ${report.mvp.faction === 'government' ? 'text-government-blue' : 'text-truth-red'}`}>
-                        {report.mvp.cardName}
-                      </div>
-                      <div className="text-[11px] uppercase tracking-wide opacity-80">
-                        {report.mvp.impactLabel}: {describeMvpImpact(report.mvp)}
-                      </div>
-                    </div>
-                    <div className="text-xs italic text-center text-newspaper-text/80">
-                      {report.mvp.highlight}
-                    </div>
-                    <div className="grid grid-cols-2 gap-1 text-[10px] uppercase tracking-wide text-newspaper-text/70">
-                      <span>Round {report.mvp.round && report.mvp.round > 0 ? report.mvp.round : report.rounds}</span>
-                      <span className="text-right">Turn {report.mvp.turn && report.mvp.turn > 0 ? report.mvp.turn : 1}</span>
-                    </div>
-                    {summarizeMvpStats(report.mvp).map((line, index) => (
-                      <div key={index} className="text-[10px] text-newspaper-text/70">
-                        {line}
-                      </div>
-                    ))}
-                  </div>
-                )}
-                {(report.playerSecretAgenda || report.aiSecretAgenda) && (
-                  <div className="border-t border-newspaper-text/20 pt-2 mt-2 space-y-3">
-                    <div className="text-center text-xs opacity-80">SECRET OPERATIONS</div>
-                    {report.playerSecretAgenda && (
-                      <div className="text-xs space-y-1 text-center">
-                        <div className="uppercase tracking-wide opacity-70">Player Objective</div>
-                        {report.playerSecretAgenda.artCue?.icon && (
-                          <div className="flex justify-center">
-                            <img
-                              src={report.playerSecretAgenda.artCue.icon}
-                              alt={report.playerSecretAgenda.artCue.alt ?? 'Objective accent'}
-                              className="h-10 w-10 mx-auto opacity-80"
-                              loading="lazy"
-                            />
-                          </div>
-                        )}
-                        <div className={`font-bold text-sm ${report.playerSecretAgenda.completed ? 'text-green-400' : 'text-red-400'}`}>
-                          {report.playerSecretAgenda.headline || report.playerSecretAgenda.title}
-                        </div>
-                        <div className="text-[11px] uppercase tracking-wider opacity-70">
-                          Operation: {report.playerSecretAgenda.operationName}
-                        </div>
-                        <div className="text-[11px] uppercase tracking-wider opacity-70">
-                          Issue Theme: {report.playerSecretAgenda.issueTheme}
-                        </div>
-                        {report.playerSecretAgenda.pullQuote && (
-                          <div className="italic opacity-80">
-                            “{report.playerSecretAgenda.pullQuote.replace(/^"|"$/g, '')}”
-                          </div>
-                        )}
-                        <div>
-                          {report.playerSecretAgenda.completed ? '✅ SUCCESS' : '❌ FAILED'} ({formatAgendaProgress(report.playerSecretAgenda)})
-                        </div>
-                      </div>
-                    )}
-                    {report.aiSecretAgenda && (
-                      <div className="text-xs space-y-1 text-center">
-                        <div className="uppercase tracking-wide opacity-70">AI Objective</div>
-                        {(report.aiSecretAgenda.revealed || report.aiSecretAgenda.completed) && report.aiSecretAgenda.artCue?.icon && (
-                          <div className="flex justify-center">
-                            <img
-                              src={report.aiSecretAgenda.artCue.icon}
-                              alt={report.aiSecretAgenda.artCue.alt ?? 'Objective accent'}
-                              className="h-10 w-10 mx-auto opacity-80"
-                              loading="lazy"
-                            />
-                          </div>
-                        )}
-                        <div className={`font-bold text-sm ${report.aiSecretAgenda.completed ? 'text-green-400' : 'text-red-400'}`}>
-                          {(report.aiSecretAgenda.revealed || report.aiSecretAgenda.completed)
-                            ? (report.aiSecretAgenda.headline || report.aiSecretAgenda.title)
-                            : 'CLASSIFIED OPERATION'}
-                        </div>
-                        {(report.aiSecretAgenda.revealed || report.aiSecretAgenda.completed) && (
-                          <>
-                            <div className="text-[11px] uppercase tracking-wider opacity-70">
-                              Operation: {report.aiSecretAgenda.operationName}
-                            </div>
-                            <div className="text-[11px] uppercase tracking-wider opacity-70">
-                              Issue Theme: {report.aiSecretAgenda.issueTheme}
-                            </div>
-                            {report.aiSecretAgenda.pullQuote && (
-                              <div className="italic opacity-80">
-                                “{report.aiSecretAgenda.pullQuote.replace(/^"|"$/g, '')}”
-                              </div>
-                            )}
-                          </>
-                        )}
-                        <div>
-                          {report.aiSecretAgenda.completed ? '✅ SUCCESS' : '❌ FAILED'} ({formatAgendaProgress(report.aiSecretAgenda)})
-                        </div>
-                      </div>
-                    )}
-                  </div>
-                )}
-              </div>
-            </div>
-
-            {/* Fake Ads */}
-            <div className="space-y-4">
-              <h3 className="text-lg font-bold text-center text-government-blue">📢 CLASSIFIED ADS</h3>
-              {fakeAds.map((ad, index) => (
-                <div key={index} className="bg-government-blue/10 p-3 rounded text-center text-sm border border-government-blue/30">
-                  {ad}
-                </div>
-              ))}
-            </div>
-
-            {/* Conspiracy Corner */}
-            <div className="bg-truth-red/10 p-4 rounded border border-truth-red/30">
-              <h3 className="text-lg font-bold mb-2 text-truth-red text-center">🕵️ CONSPIRACY CORNER</h3>
-              <div className="text-sm italic text-center">
-                {report.winner === 'truth' 
-                  ? "The lizard people have been exposed! Democracy is saved!"
-                  : report.winner === 'government'
-                  ? "Nothing to see here, citizen. Move along."
-                  : "Both sides are controlled by Big Pretzel. Wake up!"}
-              </div>
-            </div>
-          </div>
+        <div className="flex-1 overflow-y-auto px-6 py-6">
+          <FinalEditionLayout report={report} />
         </div>
 
-        {/* Footer */}
-        <div className="border-t-4 border-newspaper-text pt-6 mt-8 text-center">
-          <div className="text-sm opacity-60 mb-4">
-            © 2024 The Paranoid Times • All Conspiracies Reserved • "Trust No One (Except Us)"
+        <div className="flex flex-wrap items-center justify-between gap-3 border-t border-emerald-500/20 bg-slate-950/90 px-6 py-4">
+          <div className="text-xs font-mono uppercase tracking-[0.32em] text-emerald-200/70">
+            Vol. Final • {new Date(report.recordedAt).toLocaleString()}
           </div>
-          <Button
-            onClick={(e) => {
-              e.stopPropagation();
-              onClose();
-            }}
-            className="bg-truth-red hover:bg-truth-red/80 text-white font-bold text-lg px-8 py-3"
-          >
-            Return to Main Menu
-          </Button>
+          {onArchive && (
+            <Button
+              onClick={onArchive}
+              disabled={isArchived}
+              className="bg-emerald-500/20 text-emerald-100 hover:bg-emerald-500/30 disabled:opacity-60"
+            >
+              <Archive className="mr-2 h-4 w-4" />
+              {isArchived ? 'Already Archived' : 'Archive to Player Hub'}
+            </Button>
+          )}
         </div>
       </Card>
     </div>

--- a/src/components/game/FinalEditionLayout.tsx
+++ b/src/components/game/FinalEditionLayout.tsx
@@ -1,0 +1,253 @@
+import { Badge } from '@/components/ui/badge';
+import type { GameOverReport, FinalEditionEventHighlight, MVPReport } from '@/types/finalEdition';
+import {
+  getFactionDisplayName,
+  getOppositionDisplayName,
+  getOutcomeSummary,
+  getPlayerOutcomeLabel,
+  getVictoryConditionLabel,
+} from '@/utils/finalEdition';
+
+interface FinalEditionLayoutProps {
+  report: GameOverReport;
+}
+
+const formatVictoryHeadline = (report: GameOverReport): string => {
+  if (report.winner === 'draw') {
+    return 'DEADLOCK! BOTH SIDES CLAIM VICTORY';
+  }
+  if (report.winner === 'truth') {
+    return report.victoryType === 'truth'
+      ? 'TRUTH SURGE SHATTERS COVER-UP'
+      : report.victoryType === 'states'
+        ? 'DISCLOSURE FORCES SWEEP ACROSS THE MAP'
+        : report.victoryType === 'ip'
+          ? 'TRUTH OPERATIVES FLOOD THE AIRWAVES'
+          : 'SECRET AGENDA EXPOSED TO THE WORLD';
+  }
+  return report.victoryType === 'truth'
+    ? 'NARRATIVE LOCKDOWN SUPPRESSES TRUTH'
+    : report.victoryType === 'states'
+      ? 'GOVERNMENT RECAPTURES THE HEARTLAND'
+      : report.victoryType === 'ip'
+        ? 'COUNTER-NARRATIVE BLITZ OUTSPENDS RESISTANCE'
+        : 'SHADOW BUREAU EXECUTES CLASSIFIED PLAN';
+};
+
+const formatVictorySubhead = (report: GameOverReport): string => {
+  const rounds = report.rounds > 0 ? `${report.rounds} rounds` : 'a lightning opener';
+  const truth = `${Math.round(report.finalTruth)}% truth`; 
+  if (report.winner === 'draw') {
+    return `Stalemate declared after ${rounds}; truth settles at ${truth}.`;
+  }
+  const victor = report.winner === 'truth' ? 'Truth Network' : 'Shadow Government';
+  const method = report.victoryType === 'truth'
+    ? 'truth meter swing'
+    : report.victoryType === 'states'
+      ? 'territorial control'
+      : report.victoryType === 'ip'
+        ? 'broadcast dominance'
+        : 'covert agenda reveal';
+  return `${victor} closes the season via ${method} after ${rounds}; monitors register ${truth}.`;
+};
+
+const formatAgendaSummary = (agenda?: GameOverReport['playerSecretAgenda']) => {
+  if (!agenda) {
+    return null;
+  }
+  const status = agenda.completed ? 'Completed' : 'In Progress';
+  return `${agenda.headline || agenda.title} — ${status} (${agenda.progress}/${agenda.target})`;
+};
+
+const renderImpactBadges = (event: FinalEditionEventHighlight) => {
+  const segments: string[] = [];
+  if (event.truthDelta) {
+    const sign = event.truthDelta > 0 ? '+' : '';
+    segments.push(`${sign}${event.truthDelta} Truth`);
+  }
+  if (event.ipDelta) {
+    const sign = event.ipDelta > 0 ? '+' : '';
+    segments.push(`${sign}${event.ipDelta} IP`);
+  }
+  if (event.stateName) {
+    segments.push(event.stateName);
+  }
+  return segments.join(' · ');
+};
+
+const renderMvpPanel = (label: string, mvp?: MVPReport | null) => {
+  if (!mvp) {
+    return null;
+  }
+  return (
+    <div className="rounded-xl border border-slate-700/60 bg-slate-900/70 p-4">
+      <div className="flex items-center justify-between">
+        <h4 className="font-mono text-xs uppercase tracking-[0.32em] text-emerald-300/80">{label}</h4>
+        <Badge className="border-emerald-500/40 bg-emerald-500/10 text-emerald-200">{mvp.impactLabel}</Badge>
+      </div>
+      <h3 className="mt-2 text-xl font-semibold text-emerald-100">{mvp.cardName}</h3>
+      <p className="mt-1 text-sm text-emerald-100/80">{mvp.highlight}</p>
+      <div className="mt-3 grid gap-2 text-xs text-emerald-200/70 sm:grid-cols-2">
+        <div>Truth Delta: {Math.round(mvp.truthDelta)}%</div>
+        <div>IP Swing: {mvp.ipDelta >= 0 ? '+' : ''}{Math.round(mvp.ipDelta)}</div>
+        <div>States Captured: {mvp.capturedStates.length > 0 ? mvp.capturedStates.join(', ') : '—'}</div>
+        <div>Damage: {Math.round(mvp.damageDealt)}</div>
+      </div>
+    </div>
+  );
+};
+
+const FinalEditionLayout = ({ report }: FinalEditionLayoutProps) => {
+  const headline = formatVictoryHeadline(report);
+  const subhead = formatVictorySubhead(report);
+  const playerAgenda = formatAgendaSummary(report.playerSecretAgenda);
+  const aiAgenda = formatAgendaSummary(report.aiSecretAgenda);
+  const eventHighlights = report.topEvents.slice(0, 3);
+  const comboHighlights = report.comboHighlights.slice(0, 3);
+  const sightings = report.sightings.slice(-4);
+  const playerOutcome = getPlayerOutcomeLabel(report);
+  const victoryConditionLabel = getVictoryConditionLabel(report.victoryType);
+  const playerFactionLabel = getFactionDisplayName(report.playerFaction);
+  const oppositionLabel = getOppositionDisplayName(report.playerFaction);
+  const outcomeSummary = getOutcomeSummary(report);
+  const influenceSummary = `${playerFactionLabel} ${Math.round(report.ipPlayer)} · ${oppositionLabel} ${Math.round(report.ipAI)}`;
+
+  return (
+    <div className="flex flex-col gap-6">
+      <header className="rounded-2xl border border-emerald-500/30 bg-slate-950/90 p-6 shadow-[0_0_35px_rgba(16,185,129,0.2)]">
+        <div className="flex flex-wrap items-center justify-between gap-3">
+          <div className="font-mono text-xs uppercase tracking-[0.32em] text-emerald-300/80">
+            Final Edition • {new Date(report.recordedAt).toLocaleDateString()}
+          </div>
+          <div className="flex flex-wrap items-center gap-2">
+            {playerOutcome !== 'Stalemate' && (
+              <Badge className="border-emerald-500/40 bg-emerald-500/15 text-emerald-100">
+                {playerOutcome}
+              </Badge>
+            )}
+            <Badge className="border-emerald-500/40 bg-emerald-500/10 text-emerald-200">
+              {victoryConditionLabel}
+            </Badge>
+            <Badge className="border-emerald-500/40 bg-emerald-500/10 text-emerald-200">
+              {playerFactionLabel}
+            </Badge>
+          </div>
+        </div>
+        <h1 className="mt-3 text-3xl font-black tracking-tight text-emerald-100 sm:text-4xl">{headline}</h1>
+        <p className="mt-2 text-sm text-emerald-100/80">{subhead}</p>
+        <p className="mt-2 text-xs uppercase tracking-[0.28em] text-emerald-200/70">{outcomeSummary}</p>
+        <div className="mt-4 grid gap-3 text-xs uppercase tracking-[0.28em] text-emerald-200/70 sm:grid-cols-4">
+          <div className="rounded-lg border border-emerald-500/20 bg-emerald-500/10 p-3">
+            <div className="text-emerald-200/70">Rounds</div>
+            <div className="mt-1 text-emerald-100 text-lg font-semibold tracking-normal">{report.rounds > 0 ? report.rounds : '—'}</div>
+          </div>
+          <div className="rounded-lg border border-emerald-500/20 bg-emerald-500/10 p-3">
+            <div className="text-emerald-200/70">Truth Meter</div>
+            <div className="mt-1 text-emerald-100 text-lg font-semibold tracking-normal">{Math.round(report.finalTruth)}%</div>
+          </div>
+          <div className="rounded-lg border border-emerald-500/20 bg-emerald-500/10 p-3">
+            <div className="text-emerald-200/70">State Control</div>
+            <div className="mt-1 text-emerald-100 text-lg font-semibold tracking-normal">Truth {report.statesTruth} · Gov {report.statesGov}</div>
+          </div>
+          <div className="rounded-lg border border-emerald-500/20 bg-emerald-500/10 p-3">
+            <div className="text-emerald-200/70">Influence Points</div>
+            <div className="mt-1 text-emerald-100 text-lg font-semibold tracking-normal">{influenceSummary}</div>
+          </div>
+        </div>
+      </header>
+
+      <section className="grid gap-4 md:grid-cols-2">
+        {renderMvpPanel('MVP Play', report.mvp)}
+        {renderMvpPanel('Runner-Up', report.runnerUp)}
+      </section>
+
+      <section className="rounded-2xl border border-slate-700/50 bg-slate-950/80 p-5">
+        <div className="flex items-center justify-between">
+          <h2 className="font-mono text-sm uppercase tracking-[0.32em] text-emerald-200/80">Key Events</h2>
+          <Badge className="border-emerald-500/40 bg-emerald-500/10 text-emerald-200">{eventHighlights.length}</Badge>
+        </div>
+        <div className="mt-4 space-y-4">
+          {eventHighlights.map(event => (
+            <div key={event.id} className="rounded-lg border border-slate-700/40 bg-slate-900/70 p-4">
+              <div className="flex flex-wrap items-center justify-between gap-2">
+                <h3 className="text-lg font-semibold text-emerald-100">{event.headline}</h3>
+                <Badge variant="outline" className="border-emerald-500/40 text-emerald-200">
+                  {event.faction.toUpperCase()} · {event.rarity.toUpperCase()}
+                </Badge>
+              </div>
+              <p className="mt-2 text-sm text-emerald-100/80">{event.summary}</p>
+              {event.kicker && <p className="mt-2 text-xs italic text-emerald-200/70">{event.kicker}</p>}
+              <div className="mt-3 text-xs text-emerald-200/70">{renderImpactBadges(event)}</div>
+            </div>
+          ))}
+          {eventHighlights.length === 0 && (
+            <p className="text-sm text-emerald-100/70">No notable events logged this match.</p>
+          )}
+        </div>
+      </section>
+
+      <section className="grid gap-4 md:grid-cols-2">
+        <div className="rounded-2xl border border-slate-700/50 bg-slate-950/80 p-5">
+          <h2 className="font-mono text-sm uppercase tracking-[0.32em] text-emerald-200/80">Combo Highlights</h2>
+          <div className="mt-4 space-y-3">
+            {comboHighlights.map(combo => (
+              <div key={combo.id} className="rounded-lg border border-slate-700/40 bg-slate-900/70 p-3">
+                <div className="flex items-center justify-between">
+                  <h3 className="text-sm font-semibold text-emerald-100">{combo.name}</h3>
+                  <Badge variant="outline" className="border-emerald-500/40 text-emerald-200">{combo.rewardLabel}</Badge>
+                </div>
+                <p className="mt-1 text-xs text-emerald-200/70">Turn {combo.turn} · {combo.ownerLabel}</p>
+                {combo.description && <p className="mt-2 text-sm text-emerald-100/80">{combo.description}</p>}
+              </div>
+            ))}
+            {comboHighlights.length === 0 && (
+              <p className="text-sm text-emerald-100/70">No combo sequences documented.</p>
+            )}
+          </div>
+        </div>
+
+        <div className="rounded-2xl border border-slate-700/50 bg-slate-950/80 p-5">
+          <h2 className="font-mono text-sm uppercase tracking-[0.32em] text-emerald-200/80">Paranormal Sightings</h2>
+          <div className="mt-4 space-y-3">
+            {sightings.map(sighting => (
+              <div key={sighting.id} className="rounded-lg border border-slate-700/40 bg-slate-900/70 p-3">
+                <div className="flex items-center justify-between gap-2">
+                  <h3 className="text-sm font-semibold text-emerald-100">{sighting.headline}</h3>
+                  <Badge variant="outline" className="border-emerald-500/40 text-emerald-200">{sighting.category.toUpperCase()}</Badge>
+                </div>
+                <p className="mt-1 text-sm text-emerald-100/80">{sighting.subtext}</p>
+                {sighting.metadata?.stateName && (
+                  <p className="mt-1 text-xs text-emerald-200/70">{sighting.metadata.stateName}</p>
+                )}
+              </div>
+            ))}
+            {sightings.length === 0 && (
+              <p className="text-sm text-emerald-100/70">No anomalous activity logged for this run.</p>
+            )}
+          </div>
+        </div>
+      </section>
+
+      <section className="rounded-2xl border border-slate-700/50 bg-slate-950/80 p-5">
+        <h2 className="font-mono text-sm uppercase tracking-[0.32em] text-emerald-200/80">After-Action Notes</h2>
+        <div className="mt-3 flex flex-wrap gap-3 text-xs text-emerald-200/70">
+          {report.legendaryUsed.length > 0 ? (
+            <Badge variant="outline" className="border-emerald-500/40 text-emerald-200">
+              Legendary Deployments: {report.legendaryUsed.join(', ')}
+            </Badge>
+          ) : (
+            <Badge variant="outline" className="border-emerald-500/40 text-emerald-200">No legendary cards deployed</Badge>
+          )}
+          {playerAgenda && (
+            <Badge variant="outline" className="border-emerald-500/40 text-emerald-200">Operative Agenda: {playerAgenda}</Badge>
+          )}
+          {aiAgenda && (
+            <Badge variant="outline" className="border-emerald-500/40 text-emerald-200">Opposition Agenda: {aiAgenda}</Badge>
+          )}
+        </div>
+      </section>
+    </div>
+  );
+};
+
+export default FinalEditionLayout;

--- a/src/components/game/PlayerHubOverlay.tsx
+++ b/src/components/game/PlayerHubOverlay.tsx
@@ -3,20 +3,25 @@ import { Card } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { Badge } from '@/components/ui/badge';
-import { Trophy, Library, GraduationCap, X } from 'lucide-react';
+import { Trophy, Library, GraduationCap, Newspaper, X } from 'lucide-react';
 import { AchievementsSection } from './AchievementPanel';
 import { CardCollectionContent } from './CardCollection';
 import { TutorialSection } from './TutorialOverlay';
+import PressArchivePanel from './PressArchivePanel';
+import type { ArchivedEdition } from '@/hooks/usePressArchive';
 
 interface PlayerHubOverlayProps {
   onClose: () => void;
   onStartTutorial?: (sequenceId: string) => void;
+  pressIssues: ArchivedEdition[];
+  onOpenEdition: (issue: ArchivedEdition) => void;
+  onDeleteEdition: (id: string) => void;
 }
 
-type HubTab = 'achievements' | 'cards' | 'tutorials';
+type HubTab = 'achievements' | 'cards' | 'tutorials' | 'press';
 
-const PlayerHubOverlay = ({ onClose, onStartTutorial }: PlayerHubOverlayProps) => {
-  const [activeTab, setActiveTab] = useState<HubTab>('achievements');
+const PlayerHubOverlay = ({ onClose, onStartTutorial, pressIssues, onOpenEdition, onDeleteEdition }: PlayerHubOverlayProps) => {
+  const [activeTab, setActiveTab] = useState<HubTab>(pressIssues.length > 0 ? 'press' : 'achievements');
 
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/80 p-4">
@@ -61,7 +66,7 @@ const PlayerHubOverlay = ({ onClose, onStartTutorial }: PlayerHubOverlayProps) =
           className="relative flex flex-1 flex-col overflow-hidden"
         >
           <div className="relative px-6 pt-6">
-            <TabsList className="grid w-full grid-cols-3 gap-2 rounded-lg border border-emerald-500/20 bg-slate-900/70 p-1 backdrop-blur">
+            <TabsList className="grid w-full grid-cols-4 gap-2 rounded-lg border border-emerald-500/20 bg-slate-900/70 p-1 backdrop-blur">
               <TabsTrigger
                 value="achievements"
                 className="flex items-center justify-center gap-2 rounded-md border border-transparent px-3 py-2 text-[11px] font-semibold uppercase tracking-[0.32em] text-slate-400 transition data-[state=active]:border-emerald-400/60 data-[state=active]:bg-emerald-500/15 data-[state=active]:text-emerald-200"
@@ -82,6 +87,13 @@ const PlayerHubOverlay = ({ onClose, onStartTutorial }: PlayerHubOverlayProps) =
               >
                 <GraduationCap className="h-4 w-4" />
                 Shadow Academy
+              </TabsTrigger>
+              <TabsTrigger
+                value="press"
+                className="flex items-center justify-center gap-2 rounded-md border border-transparent px-3 py-2 text-[11px] font-semibold uppercase tracking-[0.32em] text-slate-400 transition data-[state=active]:border-emerald-400/60 data-[state=active]:bg-emerald-500/15 data-[state=active]:text-emerald-200"
+              >
+                <Newspaper className="h-4 w-4" />
+                Press Archive
               </TabsTrigger>
             </TabsList>
           </div>
@@ -109,6 +121,15 @@ const PlayerHubOverlay = ({ onClose, onStartTutorial }: PlayerHubOverlayProps) =
                   isActive={activeTab === 'tutorials'}
                   onStartTutorial={onStartTutorial}
                   onClose={onClose}
+                  className="h-full"
+                />
+              </TabsContent>
+
+              <TabsContent value="press" className="relative h-full overflow-hidden p-6 focus-visible:outline-none">
+                <PressArchivePanel
+                  issues={pressIssues}
+                  onOpen={onOpenEdition}
+                  onDelete={onDeleteEdition}
                   className="h-full"
                 />
               </TabsContent>

--- a/src/components/game/PressArchivePanel.tsx
+++ b/src/components/game/PressArchivePanel.tsx
@@ -1,0 +1,135 @@
+import { Activity, Clock, Newspaper, Target, Trash2, Trophy } from 'lucide-react';
+import clsx from 'clsx';
+import { Card } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { ScrollArea } from '@/components/ui/scroll-area';
+import type { ArchivedEdition } from '@/hooks/usePressArchive';
+import {
+  getFactionDisplayName,
+  getOppositionDisplayName,
+  getOutcomeSummary,
+  getPlayerOutcomeLabel,
+  getVictoryConditionLabel,
+} from '@/utils/finalEdition';
+
+interface PressArchivePanelProps {
+  issues: ArchivedEdition[];
+  onOpen: (issue: ArchivedEdition) => void;
+  onDelete: (id: string) => void;
+  className?: string;
+}
+
+const formatTimestamp = (timestamp: number): string => {
+  try {
+    return new Intl.DateTimeFormat(undefined, {
+      year: 'numeric',
+      month: 'short',
+      day: 'numeric',
+      hour: '2-digit',
+      minute: '2-digit',
+    }).format(new Date(timestamp));
+  } catch {
+    const date = new Date(timestamp);
+    return `${date.toLocaleDateString()} ${date.getHours().toString().padStart(2, '0')}:${date.getMinutes().toString().padStart(2, '0')}`;
+  }
+};
+
+const PressArchivePanel = ({ issues, onOpen, onDelete, className }: PressArchivePanelProps) => {
+  return (
+    <div className={clsx('flex h-full flex-col', className)}>
+      <div className="relative mb-4 flex items-center justify-between rounded-lg border border-emerald-500/30 bg-emerald-500/10 px-4 py-3">
+        <div>
+          <p className="font-mono text-xs uppercase tracking-[0.32em] text-emerald-200/80">Press Archive</p>
+          <h3 className="font-mono text-lg font-semibold uppercase tracking-[0.2em] text-emerald-100">Captured Editions</h3>
+        </div>
+        <Newspaper className="h-6 w-6 text-emerald-300" aria-hidden />
+      </div>
+
+      {issues.length === 0 ? (
+        <Card className="flex flex-1 flex-col items-center justify-center border border-dashed border-emerald-500/40 bg-emerald-500/5 p-8 text-center">
+          <Newspaper className="mb-3 h-10 w-10 text-emerald-300/70" aria-hidden />
+          <h4 className="font-mono text-sm uppercase tracking-[0.28em] text-emerald-200/70">No editions archived</h4>
+          <p className="mt-2 max-w-sm text-sm text-emerald-100/70">
+            Finish a match and press <span className="font-semibold">“Archive to Player Hub”</span> on the victory screen to preserve the final newspaper here.
+          </p>
+        </Card>
+      ) : (
+        <ScrollArea className="flex-1 pr-2">
+          <div className="space-y-3 pb-4">
+            {issues.map(issue => {
+              const { report } = issue;
+              const mvpName = report.mvp?.cardName ?? report.runnerUp?.cardName ?? 'Unsung Hero';
+              const playerOutcome = getPlayerOutcomeLabel(report);
+              const victoryLabel = getVictoryConditionLabel(report.victoryType);
+              const playerLabel = getFactionDisplayName(report.playerFaction);
+              const opponentLabel = getOppositionDisplayName(report.playerFaction);
+              const outcomeSummary = getOutcomeSummary(report);
+              return (
+                <Card
+                  key={issue.id}
+                  className="relative overflow-hidden border border-emerald-500/30 bg-slate-950/80 p-4 shadow-[0_0_25px_rgba(16,185,129,0.12)]"
+                >
+                  <div className="absolute inset-0 pointer-events-none opacity-20 bg-[radial-gradient(circle_at_top,_rgba(16,185,129,0.35),_transparent_60%)]" />
+                    <div className="relative flex flex-col gap-3">
+                      <div className="flex flex-col gap-1">
+                        <p className="font-mono text-[11px] uppercase tracking-[0.32em] text-emerald-300/70">{formatTimestamp(issue.savedAt)}</p>
+                        <h4 className="font-mono text-lg font-semibold uppercase tracking-[0.2em] text-emerald-100">
+                          {issue.title}
+                        </h4>
+                      </div>
+                      <div className="grid gap-3 text-sm text-emerald-100/80 md:grid-cols-2">
+                        <div className="flex items-center gap-2">
+                          <Clock className="h-4 w-4 text-emerald-300" aria-hidden />
+                          <span>
+                            {report.rounds > 0 ? `${report.rounds} rounds` : 'Opening Gambit'} · Truth {Math.round(report.finalTruth)}%
+                          </span>
+                        </div>
+                        <div className="flex items-center gap-2">
+                          <Trophy className="h-4 w-4 text-emerald-300" aria-hidden />
+                          <span>{mvpName}</span>
+                        </div>
+                        <div className="flex items-center gap-2">
+                          <Target className="h-4 w-4 text-emerald-300" aria-hidden />
+                          <span>{playerOutcome} · {victoryLabel}</span>
+                        </div>
+                        <div className="flex items-center gap-2">
+                          <Activity className="h-4 w-4 text-emerald-300" aria-hidden />
+                          <span>{playerLabel} {Math.round(report.ipPlayer)} · {opponentLabel} {Math.round(report.ipAI)}</span>
+                        </div>
+                        <div className="flex items-center gap-2 md:col-span-2">
+                          <span className="font-mono text-xs uppercase tracking-[0.28em] text-emerald-200/70">Legendary</span>
+                          <span>{report.legendaryUsed.length > 0 ? report.legendaryUsed.join(', ') : 'None reported'}</span>
+                        </div>
+                      </div>
+                      <p className="text-xs font-mono uppercase tracking-[0.28em] text-emerald-200/60">{outcomeSummary}</p>
+                      <div className="flex flex-wrap items-center gap-2">
+                        <Button
+                          variant="outline"
+                          size="sm"
+                          className="border-emerald-500/40 bg-emerald-500/10 text-emerald-100 hover:bg-emerald-500/20"
+                        onClick={() => onOpen(issue)}
+                      >
+                        Read Edition
+                      </Button>
+                      <Button
+                        variant="ghost"
+                        size="sm"
+                        className="text-emerald-200/70 hover:text-emerald-100"
+                        onClick={() => onDelete(issue.id)}
+                      >
+                        <Trash2 className="mr-1 h-4 w-4" aria-hidden />
+                        Remove
+                      </Button>
+                    </div>
+                  </div>
+                </Card>
+              );
+            })}
+          </div>
+        </ScrollArea>
+      )}
+    </div>
+  );
+};
+
+export default PressArchivePanel;

--- a/src/components/game/TabloidNewspaperV2.tsx
+++ b/src/components/game/TabloidNewspaperV2.tsx
@@ -32,19 +32,22 @@ const FALLBACK_DATA: NewspaperData = {
 const SIGHTING_LABELS: Record<ParanormalSighting['category'], string> = {
   synergy: 'Synergy Spike',
   'truth-meltdown': 'Broadcast Hijack',
-  cryptid: 'Cryptid Alert'
+  cryptid: 'Cryptid Alert',
+  hotspot: 'Hotspot Alert'
 };
 
 const SIGHTING_ICONS: Record<ParanormalSighting['category'], string> = {
   synergy: '🛰️',
   'truth-meltdown': '📡',
-  cryptid: '🦶'
+  cryptid: '🦶',
+  hotspot: '👻'
 };
 
 const SIGHTING_BADGE_VARIANTS: Record<ParanormalSighting['category'], string> = {
   synergy: 'border-indigo-500 text-indigo-500',
   'truth-meltdown': 'border-rose-500 text-rose-500',
-  cryptid: 'border-emerald-500 text-emerald-500'
+  cryptid: 'border-emerald-500 text-emerald-500',
+  hotspot: 'border-purple-500 text-purple-500'
 };
 
 const formatSightingTime = (timestamp: number) => {
@@ -865,6 +868,30 @@ const TabloidNewspaperV2 = ({
                     {activeSighting.metadata?.setList?.length ? (
                       <div className="rounded border border-dashed border-newspaper-border/60 bg-white/60 p-2 text-[10px] uppercase tracking-wide text-newspaper-text/70">
                         {activeSighting.metadata.setList.join(' • ')}
+                      </div>
+                    ) : null}
+                    {activeSighting.category === 'hotspot' ? (
+                      <div className="grid grid-cols-2 gap-2 text-[11px] uppercase tracking-wide text-newspaper-text/70">
+                        {typeof activeSighting.metadata?.defenseBoost === 'number' ? (
+                          <span>DEF +{activeSighting.metadata.defenseBoost}</span>
+                        ) : null}
+                        {typeof activeSighting.metadata?.truthReward === 'number' ? (
+                          <span>TRUTH ±{activeSighting.metadata.truthReward}%</span>
+                        ) : null}
+                        {activeSighting.metadata?.source ? (
+                          <span>Source {activeSighting.metadata.source.toUpperCase()}</span>
+                        ) : null}
+                        {typeof activeSighting.metadata?.turnsRemaining === 'number' ? (
+                          <span>Turns Left {Math.max(0, activeSighting.metadata.turnsRemaining)}</span>
+                        ) : null}
+                        {activeSighting.metadata?.outcome ? (
+                          <span className="col-span-2">
+                            Status {activeSighting.metadata.outcome.toUpperCase()}
+                            {typeof activeSighting.metadata.truthDelta === 'number' && activeSighting.metadata.truthDelta !== 0
+                              ? ` (${activeSighting.metadata.truthDelta > 0 ? '+' : ''}${activeSighting.metadata.truthDelta}% Truth)`
+                              : ''}
+                          </span>
+                        ) : null}
                       </div>
                     ) : null}
                   </div>

--- a/src/hooks/usePressArchive.ts
+++ b/src/hooks/usePressArchive.ts
@@ -1,0 +1,97 @@
+import { useCallback, useEffect, useState } from 'react';
+import type { GameOverReport } from '@/types/finalEdition';
+import { getFactionDisplayName, getVictoryConditionLabel } from '@/utils/finalEdition';
+
+export interface ArchivedEdition {
+  id: string;
+  savedAt: number;
+  title: string;
+  report: GameOverReport;
+}
+
+const STORAGE_KEY = 'shadowgov-press-archive';
+const MAX_ENTRIES = 12;
+
+const deriveTitle = (report: GameOverReport): string => {
+  const outcome = report.winner === 'draw'
+    ? 'Stalemate'
+    : `${getFactionDisplayName(report.winner)} Victory`;
+  const condition = getVictoryConditionLabel(report.victoryType);
+  const roundLabel = report.rounds > 0 ? `Round ${report.rounds}` : 'Prologue';
+  return `${outcome} · ${condition} · ${roundLabel}`;
+};
+
+export const usePressArchive = () => {
+  const [issues, setIssues] = useState<ArchivedEdition[]>([]);
+
+  useEffect(() => {
+    try {
+      const stored = localStorage.getItem(STORAGE_KEY);
+      if (!stored) {
+        return;
+      }
+      const parsed = JSON.parse(stored) as ArchivedEdition[] | null;
+      if (!Array.isArray(parsed)) {
+        return;
+      }
+      const normalized = parsed
+        .filter(entry => entry && entry.report)
+        .map(entry => ({
+          ...entry,
+          id: entry.id ?? `edition-${entry.report.recordedAt}`,
+          title: entry.title ?? deriveTitle(entry.report),
+          savedAt: entry.savedAt ?? entry.report.recordedAt ?? Date.now(),
+        }))
+        .sort((a, b) => (b.savedAt ?? b.report.recordedAt ?? 0) - (a.savedAt ?? a.report.recordedAt ?? 0));
+      setIssues(normalized);
+    } catch (error) {
+      console.warn('Failed to load press archive', error);
+    }
+  }, []);
+
+  useEffect(() => {
+    try {
+      const payload = JSON.stringify(issues);
+      localStorage.setItem(STORAGE_KEY, payload);
+    } catch (error) {
+      console.warn('Failed to persist press archive', error);
+    }
+  }, [issues]);
+
+  const archiveEdition = useCallback((report: GameOverReport) => {
+    setIssues(prev => {
+      const id = `edition-${report.recordedAt}`;
+      const title = deriveTitle(report);
+      const existingIndex = prev.findIndex(entry => entry.id === id);
+      const nextEntry: ArchivedEdition = {
+        id,
+        savedAt: Date.now(),
+        title,
+        report,
+      };
+
+      if (existingIndex >= 0) {
+        const copy = [...prev];
+        copy[existingIndex] = nextEntry;
+        return copy;
+      }
+
+      return [nextEntry, ...prev].slice(0, MAX_ENTRIES);
+    });
+  }, []);
+
+  const removeEditionFromArchive = useCallback((id: string) => {
+    setIssues(prev => prev.filter(entry => entry.id !== id));
+  }, []);
+
+  const clearArchive = useCallback(() => {
+    setIssues([]);
+  }, []);
+
+  return {
+    issues,
+    archiveEdition,
+    removeEditionFromArchive,
+    clearArchive,
+  };
+};

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState, useCallback } from 'react';
+import { useEffect, useState, useCallback, useMemo, useRef } from 'react';
 import clsx from 'clsx';
 import { Button } from '@/components/ui/button';
 import ResponsiveLayout from '@/components/layout/ResponsiveLayout';
@@ -41,66 +41,26 @@ import EnhancedNewspaper from '@/components/game/EnhancedNewspaper';
 import MinimizedHand from '@/components/game/MinimizedHand';
 import { VictoryConditions } from '@/components/game/VictoryConditions';
 import toast, { Toaster } from 'react-hot-toast';
-import type { CardPlayRecord } from '@/hooks/gameStateTypes';
+import type { ActiveParanormalHotspot, CardPlayRecord } from '@/hooks/gameStateTypes';
 import { getStateByAbbreviation, getStateById } from '@/data/usaStates';
 import type { ParanormalSighting } from '@/types/paranormal';
 import { areParanormalEffectsEnabled } from '@/state/settings';
 import type { GameCard } from '@/rules/mvp';
+import type { GameEvent } from '@/data/eventDatabase';
+import { formatComboReward, getLastComboSummary } from '@/game/comboEngine';
+import { usePressArchive } from '@/hooks/usePressArchive';
+import type {
+  AgendaSummary,
+  ImpactType,
+  MVPReport,
+  GameOverReport,
+  FinalEditionComboHighlight,
+  FinalEditionEventHighlight,
+} from '@/types/finalEdition';
 
 type ContextualEffectType = Parameters<typeof VisualEffectsCoordinator.triggerContextualEffect>[0];
 
-type ImpactType = 'capture' | 'truth' | 'ip' | 'damage' | 'support';
-
 type ObjectiveSectionId = 'victory' | 'secret-agenda';
-
-interface AgendaSummary {
-  title: string;
-  headline: string;
-  operationName: string;
-  issueTheme: string;
-  pullQuote?: string;
-  artCue?: {
-    icon?: string;
-    alt?: string;
-  };
-  faction: 'truth' | 'government' | 'both';
-  progress: number;
-  target: number;
-  completed: boolean;
-  revealed: boolean;
-}
-
-interface MVPReport {
-  cardId: string;
-  cardName: string;
-  player: 'human' | 'ai';
-  faction: 'truth' | 'government';
-  truthDelta: number;
-  ipDelta: number;
-  aiIpDelta: number;
-  capturedStates: string[];
-  damageDealt: number;
-  round: number;
-  turn: number;
-  impactType: ImpactType;
-  impactValue: number;
-  impactLabel: string;
-  highlight: string;
-}
-
-interface GameOverReport {
-  winner: 'government' | 'truth' | 'draw';
-  rounds: number;
-  finalTruth: number;
-  ipPlayer: number;
-  ipAI: number;
-  statesGov: number;
-  statesTruth: number;
-  playerSecretAgenda?: AgendaSummary;
-  aiSecretAgenda?: AgendaSummary;
-  mvp?: MVPReport | null;
-  legendaryUsed: string[];
-}
 
 interface EnrichedPlay {
   play: CardPlayRecord;
@@ -118,6 +78,24 @@ const SYNERGY_SIGHTING_TAGLINES = [
   'Combo uplink redlined at +{BONUS} IP before stabilizers kicked in.',
   'Witnesses report neon corkboard materializing with +{BONUS} IP scribbles.',
   'Analytics desk logged a phantom +{BONUS} IP surge and a chorus of high-fives.',
+];
+
+const HOTSPOT_SPAWN_TAGLINES = [
+  '{STATE} skies glow as defenses spike +{DEFENSE}. Command races for ±{TRUTH}% truth swing.',
+  'Field agents erect ecto-barriers in {STATE}. Whoever breaches first claims ±{TRUTH}% truth.',
+  'Spectral alarm: {STATE} grid hardens by +{DEFENSE}. News desk calls a hotspot scramble!',
+];
+
+const HOTSPOT_RESOLUTION_TAGLINES = [
+  '{STATE} anomaly captured—truth meter jolts {TRUTH_DELTA}%.',
+  'Task force secures {STATE} hotspot and rewrites the narrative {TRUTH_DELTA}% in their favor.',
+  'Hotspot lockdown lifted in {STATE}; truth sensors register {TRUTH_DELTA}% swing.',
+];
+
+const HOTSPOT_EXPIRE_TAGLINES = [
+  'Unstable portal in {STATE} flickers out before capture. Defenses normalize.',
+  '{STATE} anomaly dissipates quietly—no faction claims the truth swing.',
+  'Hotspot haze clears over {STATE}; analysts log a null capture.',
 ];
 
 const BROADCAST_SIGHTING_TAGLINES = [
@@ -152,6 +130,83 @@ const resolveStateName = (stateId: string): string => {
     return byAbbr.name;
   }
   return stateId;
+};
+
+const computeEventScore = (event: GameEvent): number => {
+  const effects = event.effects ?? {};
+  const truthMagnitude = Math.abs(effects.truth ?? 0) + Math.abs(effects.truthChange ?? 0);
+  const ipMagnitude = Math.abs(effects.ip ?? 0) + Math.abs(effects.ipChange ?? 0);
+  const defenseMagnitude = Math.abs(effects.defenseChange ?? 0) + Math.abs(effects.stateEffects?.defense ?? 0);
+  const rarityBoost = event.rarity === 'legendary'
+    ? 3
+    : event.rarity === 'rare'
+      ? 2
+      : event.rarity === 'uncommon'
+        ? 1
+        : 0;
+  return truthMagnitude * 2 + ipMagnitude * 1.5 + defenseMagnitude + rarityBoost;
+};
+
+const summarizeEventForFinalEdition = (event: GameEvent): FinalEditionEventHighlight => {
+  const headline = event.headline ?? event.title;
+  const effects = event.effects ?? {};
+  const truthDelta = (effects.truth ?? 0) + (effects.truthChange ?? 0);
+  const ipDelta = (effects.ip ?? 0) + (effects.ipChange ?? 0);
+  const stateName = effects.stateEffects?.stateId
+    ? resolveStateName(effects.stateEffects.stateId)
+    : undefined;
+
+  return {
+    id: event.id,
+    headline,
+    summary: event.content,
+    faction: event.faction ?? 'neutral',
+    rarity: event.rarity,
+    truthDelta,
+    ipDelta,
+    stateName,
+    kicker: event.flavorText ?? event.flavorTruth ?? event.flavorGov ?? undefined,
+  } satisfies FinalEditionEventHighlight;
+};
+
+const pickTopEvents = (events: GameEvent[], limit = 3): FinalEditionEventHighlight[] => {
+  return events
+    .map(event => ({ event, score: computeEventScore(event) }))
+    .sort((a, b) => b.score - a.score)
+    .slice(0, limit)
+    .map(entry => summarizeEventForFinalEdition(entry.event));
+};
+
+const resolveComboOwnerLabel = (owner: string | undefined): string => {
+  if (owner === 'P1') {
+    return 'Operative Team';
+  }
+  if (owner === 'P2') {
+    return 'Opposition Network';
+  }
+  return owner ?? 'Unknown Cell';
+};
+
+const buildComboHighlights = (
+  summary: ReturnType<typeof getLastComboSummary>,
+): FinalEditionComboHighlight[] => {
+  if (!summary || !summary.results || summary.results.length === 0) {
+    return [];
+  }
+
+  const ownerLabel = resolveComboOwnerLabel(summary.player);
+
+  return summary.results.map(result => {
+    const rewardLabel = formatComboReward(result.appliedReward).replace(/[()]/g, '').trim();
+    return {
+      id: result.definition.id,
+      name: result.definition.name ?? result.definition.id,
+      rewardLabel: rewardLabel.length > 0 ? rewardLabel : 'Momentum Bonus',
+      turn: summary.turn,
+      ownerLabel,
+      description: result.definition.description,
+    } satisfies FinalEditionComboHighlight;
+  });
 };
 
 const inferFactionFromRecord = (
@@ -378,63 +433,88 @@ const buildMvpReport = (candidate: EnrichedPlay, impactType: ImpactType, impactV
   };
 };
 
-const determineMVP = (
+const findTopCandidate = (
+  candidates: EnrichedPlay[],
+): { candidate: EnrichedPlay; impactType: ImpactType; impactValue: number } | null => {
+  if (candidates.length === 0) {
+    return null;
+  }
+
+  const captureMax = Math.max(...candidates.map(entry => entry.captureCount), 0);
+  if (captureMax > 0) {
+    const captureCandidates = candidates.filter(entry => entry.captureCount === captureMax);
+    const best = pickBestCandidate(captureCandidates, 'truthImpact', ['ipImpact', 'damageImpact']);
+    if (best) {
+      return { candidate: best, impactType: 'capture', impactValue: captureMax };
+    }
+  }
+
+  const truthMax = Math.max(...candidates.map(entry => entry.truthImpact), 0);
+  if (truthMax > 0) {
+    const truthCandidates = candidates.filter(entry => entry.truthImpact === truthMax);
+    const best = pickBestCandidate(truthCandidates, 'captureCount', ['ipImpact', 'damageImpact']);
+    if (best) {
+      return { candidate: best, impactType: 'truth', impactValue: truthMax };
+    }
+  }
+
+  const ipMax = Math.max(...candidates.map(entry => entry.ipImpact), 0);
+  if (ipMax > 0) {
+    const ipCandidates = candidates.filter(entry => entry.ipImpact === ipMax);
+    const best = pickBestCandidate(ipCandidates, 'captureCount', ['truthImpact', 'damageImpact']);
+    if (best) {
+      return { candidate: best, impactType: 'ip', impactValue: ipMax };
+    }
+  }
+
+  const damageMax = Math.max(...candidates.map(entry => entry.damageImpact), 0);
+  if (damageMax > 0) {
+    const damageCandidates = candidates.filter(entry => entry.damageImpact === damageMax);
+    const best = pickBestCandidate(damageCandidates, 'truthImpact', ['ipImpact', 'captureCount']);
+    if (best) {
+      return { candidate: best, impactType: 'damage', impactValue: damageMax };
+    }
+  }
+
+  const fallback = pickBestCandidate(candidates, 'captureCount', ['truthImpact', 'ipImpact', 'damageImpact']);
+  return fallback ? { candidate: fallback, impactType: 'support', impactValue: 0 } : null;
+};
+
+const determineTopPlays = (
   history: CardPlayRecord[],
   winner: 'truth' | 'government' | 'draw' | null,
   playerFaction: 'truth' | 'government',
-): MVPReport | null => {
+): { mvp: MVPReport | null; runnerUp: MVPReport | null } => {
   if (!winner || winner === 'draw' || history.length === 0) {
-    return null;
+    return { mvp: null, runnerUp: null };
   }
 
-  const enrichedPlays: EnrichedPlay[] = history.map(play => {
-    const faction = inferFactionFromRecord(play, playerFaction);
-    const metrics = computePlayMetrics(play, faction);
-    return { play, faction, ...metrics };
-  }).filter(entry => entry.faction === winner);
+  const enrichedPlays: EnrichedPlay[] = history
+    .map(play => {
+      const faction = inferFactionFromRecord(play, playerFaction);
+      const metrics = computePlayMetrics(play, faction);
+      return { play, faction, ...metrics };
+    })
+    .filter(entry => entry.faction === winner);
 
   if (enrichedPlays.length === 0) {
-    return null;
+    return { mvp: null, runnerUp: null };
   }
 
-  const captureMax = Math.max(...enrichedPlays.map(entry => entry.captureCount), 0);
-  if (captureMax > 0) {
-    const captureCandidates = enrichedPlays.filter(entry => entry.captureCount === captureMax);
-    const best = pickBestCandidate(captureCandidates, 'truthImpact', ['ipImpact', 'damageImpact']);
-    if (best) {
-      return buildMvpReport(best, 'capture', captureMax);
-    }
+  const primary = findTopCandidate(enrichedPlays);
+  if (!primary) {
+    return { mvp: null, runnerUp: null };
   }
 
-  const truthMax = Math.max(...enrichedPlays.map(entry => entry.truthImpact), 0);
-  if (truthMax > 0) {
-    const truthCandidates = enrichedPlays.filter(entry => entry.truthImpact === truthMax);
-    const best = pickBestCandidate(truthCandidates, 'captureCount', ['ipImpact', 'damageImpact']);
-    if (best) {
-      return buildMvpReport(best, 'truth', truthMax);
-    }
-  }
+  const mvp = buildMvpReport(primary.candidate, primary.impactType, primary.impactValue);
 
-  const ipMax = Math.max(...enrichedPlays.map(entry => entry.ipImpact), 0);
-  if (ipMax > 0) {
-    const ipCandidates = enrichedPlays.filter(entry => entry.ipImpact === ipMax);
-    const best = pickBestCandidate(ipCandidates, 'captureCount', ['truthImpact', 'damageImpact']);
-    if (best) {
-      return buildMvpReport(best, 'ip', ipMax);
-    }
-  }
+  const remaining = enrichedPlays.filter(entry => entry !== primary.candidate);
+  const secondary = findTopCandidate(remaining);
+  const runnerUp = secondary
+    ? buildMvpReport(secondary.candidate, secondary.impactType, secondary.impactValue)
+    : null;
 
-  const damageMax = Math.max(...enrichedPlays.map(entry => entry.damageImpact), 0);
-  if (damageMax > 0) {
-    const damageCandidates = enrichedPlays.filter(entry => entry.damageImpact === damageMax);
-    const best = pickBestCandidate(damageCandidates, 'truthImpact', ['ipImpact', 'captureCount']);
-    if (best) {
-      return buildMvpReport(best, 'damage', damageMax);
-    }
-  }
-
-  const fallback = pickBestCandidate(enrichedPlays, 'captureCount', ['truthImpact', 'ipImpact', 'damageImpact']);
-  return fallback ? buildMvpReport(fallback, 'support', 0) : null;
+  return { mvp, runnerUp };
 };
 
 const Index = () => {
@@ -456,11 +536,12 @@ const Index = () => {
     y?: number;
   } | null>(null);
   const [previousPhase, setPreviousPhase] = useState('');
-  const [hoveredCard, setHoveredCard] = useState<any>(null);
+  const [hoveredCard, setHoveredCard] = useState<GameCard | null>(null);
   const [victoryState, setVictoryState] = useState<{ isVictory: boolean; type: 'states' | 'ip' | 'truth' | 'agenda' | null }>({ isVictory: false, type: null });
   const [showOnboarding, setShowOnboarding] = useState(false);
   const [showInGameOptions, setShowInGameOptions] = useState(false);
-  const [gameOverReport, setGameOverReport] = useState<GameOverReport | null>(null);
+  const [finalEdition, setFinalEdition] = useState<GameOverReport | null>(null);
+  const [readingEdition, setReadingEdition] = useState<GameOverReport | null>(null);
   const [showExtraEdition, setShowExtraEdition] = useState(false);
   const [paranormalSightings, setParanormalSightings] = useState<ParanormalSighting[]>([]);
   const [inspectedPlayedCard, setInspectedPlayedCard] = useState<GameCard | null>(null);
@@ -490,6 +571,37 @@ const Index = () => {
   const { animatePlayCard, isAnimating } = useCardAnimation();
   const { discoverCard, playCard: recordCardPlay } = useCardCollection();
   const { checkSynergies, getActiveCombinations, getTotalBonusIP } = useSynergyDetection();
+  const { issues: pressArchive, archiveEdition, removeEditionFromArchive } = usePressArchive();
+
+  const isEditionArchived = useCallback(
+    (edition: GameOverReport | null) => {
+      if (!edition) {
+        return false;
+      }
+      const id = `edition-${edition.recordedAt}`;
+      return pressArchive.some(entry => entry.id === id);
+    },
+    [pressArchive],
+  );
+
+  const archiveEditionWithToast = useCallback(
+    (edition: GameOverReport | null) => {
+      if (!edition) {
+        return;
+      }
+      if (isEditionArchived(edition)) {
+        toast('Edition already in archive', {
+          style: { background: '#0f172a', color: '#bbf7d0', border: '1px solid #10b981' },
+        });
+        return;
+      }
+      archiveEdition(edition);
+      toast.success('Final newspaper archived to Player Hub', {
+        style: { background: '#0f172a', color: '#bbf7d0', border: '1px solid #10b981' },
+      });
+    },
+    [archiveEdition, isEditionArchived],
+  );
 
   const pushSighting = useCallback((entry: ParanormalSighting) => {
     setParanormalSightings(prev => {
@@ -499,6 +611,29 @@ const Index = () => {
     });
     registerParanormalSighting(entry.metadata?.source ?? undefined);
   }, [registerParanormalSighting]);
+
+  const hotspotHistoryRef = useRef<Record<string, ActiveParanormalHotspot>>({});
+  const activeHotspotByStateRef = useRef<Record<string, ActiveParanormalHotspot>>({});
+  const hotspotLogCursorRef = useRef<number>(0);
+  const hotspotLogInitializedRef = useRef<boolean>(false);
+
+  const stateLookupByName = useMemo(() => {
+    const lookup = new Map<string, (typeof gameState.states)[number]>();
+    gameState.states.forEach(state => {
+      lookup.set(state.name, state);
+      lookup.set(state.abbreviation, state);
+    });
+    return lookup;
+  }, [gameState.states]);
+
+  useEffect(() => {
+    const nextActive: Record<string, ActiveParanormalHotspot> = {};
+    Object.entries(gameState.paranormalHotspots ?? {}).forEach(([abbr, hotspot]) => {
+      nextActive[abbr] = hotspot;
+      hotspotHistoryRef.current[hotspot.id] = hotspot;
+    });
+    activeHotspotByStateRef.current = nextActive;
+  }, [gameState.paranormalHotspots]);
 
   // Handle AI turns
   useEffect(() => {
@@ -591,12 +726,16 @@ const Index = () => {
       setGameState(prev => ({ ...prev, isGameOver: true }));
 
       // Build game over report
-      const mvp = determineMVP(gameState.playHistory, winner, gameState.faction);
+      const { mvp, runnerUp } = determineTopPlays(gameState.playHistory, winner, gameState.faction);
       const legendaryUsed = Array.from(new Set(
         gameState.playHistory
           .filter(entry => entry.card.rarity === 'legendary')
           .map(entry => entry.card.name),
       ));
+      const topEvents = pickTopEvents(gameState.currentEvents ?? [], 4);
+      const comboSummary = getLastComboSummary();
+      const comboHighlights = buildComboHighlights(comboSummary);
+      const recordedAt = Date.now();
       const summarizeAgenda = (source?: typeof playerSecretAgenda) => {
         if (!source) {
           return undefined;
@@ -621,22 +760,41 @@ const Index = () => {
 
       const report: GameOverReport = {
         winner,
+        victoryType,
         rounds: gameState.round,
         finalTruth: Math.round(gameState.truth),
         ipPlayer: gameState.ip,
         ipAI: gameState.aiIP,
         statesGov: gameState.states.filter(s => s.owner === (gameState.faction === 'government' ? 'player' : 'ai')).length,
         statesTruth: gameState.states.filter(s => s.owner === (gameState.faction === 'truth' ? 'player' : 'ai')).length,
+        playerFaction: gameState.faction,
         playerSecretAgenda: summarizeAgenda(playerSecretAgenda),
         aiSecretAgenda: summarizeAgenda(aiSecretAgenda),
         mvp,
+        runnerUp,
         legendaryUsed,
+        topEvents,
+        comboHighlights,
+        sightings: [...paranormalSightings],
+        recordedAt,
       };
 
-      setGameOverReport(report);
+      setFinalEdition(report);
       setVictoryState({ isVictory: true, type: victoryType });
     }
-  }, [gameState.controlledStates.length, gameState.ip, gameState.aiIP, gameState.truth, gameState.secretAgenda?.completed, gameState.aiSecretAgenda?.completed, gameState.states, gameState.faction, gameState.isGameOver]);
+  }, [
+    gameState.controlledStates.length,
+    gameState.ip,
+    gameState.aiIP,
+    gameState.truth,
+    gameState.secretAgenda?.completed,
+    gameState.aiSecretAgenda?.completed,
+    gameState.states,
+    gameState.faction,
+    gameState.isGameOver,
+    gameState.currentEvents,
+    paranormalSightings,
+  ]);
 
   // Enhanced synergy detection with coordinated visual effects
   useEffect(() => {
@@ -899,6 +1057,199 @@ const Index = () => {
       window.removeEventListener('stateEvent', handleStateEventEffect as EventListener);
     };
   }, []);
+
+  useEffect(() => {
+    const logLength = gameState.log.length;
+
+    if (!areParanormalEffectsEnabled()) {
+      hotspotLogCursorRef.current = logLength;
+      hotspotLogInitializedRef.current = true;
+      return;
+    }
+
+    if (!hotspotLogInitializedRef.current) {
+      hotspotLogCursorRef.current = logLength;
+      hotspotLogInitializedRef.current = true;
+      return;
+    }
+
+    if (logLength <= hotspotLogCursorRef.current) {
+      hotspotLogCursorRef.current = logLength;
+      return;
+    }
+
+    const newEntries = gameState.log.slice(hotspotLogCursorRef.current);
+    hotspotLogCursorRef.current = logLength;
+
+    const pickTemplate = (templates: string[]): string => {
+      if (!templates.length) return '';
+      const index = Math.floor(Math.random() * templates.length);
+      return templates[index];
+    };
+
+    newEntries.forEach(entry => {
+      if (!entry.startsWith('👻') && !entry.startsWith('🕯️')) {
+        return;
+      }
+
+      const timestamp = Date.now();
+
+      if (entry.startsWith('👻 ') && entry.includes('erupts in')) {
+        const spawnMatch = entry.match(/^👻 (.+?) erupts in (.+?)!/);
+        if (!spawnMatch) {
+          return;
+        }
+
+        const [, label, stateName] = spawnMatch;
+        const stateRecord = stateLookupByName.get(stateName);
+        const abbreviation = stateRecord?.abbreviation;
+        const hotspot = abbreviation
+          ? activeHotspotByStateRef.current[abbreviation]
+          : Object.values(activeHotspotByStateRef.current).find(
+              candidate => candidate.stateName === stateName,
+            );
+
+        const defenseBoost = hotspot?.defenseBoost ?? (() => {
+          const match = entry.match(/Defense \+(\d+)/);
+          return match ? Number.parseInt(match[1], 10) : undefined;
+        })();
+        const truthReward = hotspot?.truthReward ?? (() => {
+          const match = entry.match(/±(\d+)%/);
+          return match ? Number.parseInt(match[1], 10) : undefined;
+        })();
+
+        const template = pickTemplate(HOTSPOT_SPAWN_TAGLINES);
+        const subtext = template
+          ? fillTemplate(template, {
+              STATE: stateName.toUpperCase(),
+              DEFENSE: defenseBoost ?? 0,
+              TRUTH: truthReward ?? 0,
+            })
+          : `Defense grid surges by +${defenseBoost ?? '?'} while ±${truthReward ?? '?'}% truth is up for grabs.`;
+
+        pushSighting({
+          id: `hotspot-${hotspot?.id ?? `${stateName}-${timestamp}`}`,
+          timestamp,
+          category: 'hotspot',
+          headline: `${hotspot?.icon ?? '👻'} ${label.toUpperCase()} IN ${stateName.toUpperCase()}`,
+          subtext,
+          location: stateName,
+          metadata: {
+            hotspotId: hotspot?.id,
+            stateId: stateRecord?.id ?? stateRecord?.abbreviation ?? stateName,
+            stateName,
+            source: hotspot?.source ?? 'neutral',
+            defenseBoost,
+            truthReward,
+            duration: hotspot?.duration,
+            turnsRemaining: hotspot ? Math.max(0, hotspot.expiresOnTurn - gameState.turn) : undefined,
+            outcome: 'active',
+          },
+        });
+        return;
+      }
+
+      if (entry.startsWith('👻 ') && entry.includes('resolved in')) {
+        const resolveMatch = entry.match(/^👻 (.+?) resolved in (.+?)!/);
+        if (!resolveMatch) {
+          return;
+        }
+
+        const [, label, stateName] = resolveMatch;
+        const truthMatch = entry.match(/Truth ([+-]?\d+)/);
+        const truthDelta = truthMatch ? Number.parseInt(truthMatch[1], 10) : 0;
+        const stateRecord = stateLookupByName.get(stateName);
+        const historyEntry = Object.values(hotspotHistoryRef.current).find(
+          hotspot => hotspot.label === label && hotspot.stateName === stateName,
+        );
+
+        const template = pickTemplate(HOTSPOT_RESOLUTION_TAGLINES);
+        const formattedDelta = `${truthDelta >= 0 ? '+' : ''}${truthDelta}`;
+        const subtext = template
+          ? fillTemplate(template, {
+              STATE: stateName.toUpperCase(),
+              TRUTH_DELTA: formattedDelta,
+            })
+          : truthDelta !== 0
+            ? `Truth ${formattedDelta}% swing recorded as the anomaly is secured.`
+            : 'Hotspot secured without shifting the truth meter.';
+
+        pushSighting({
+          id: `hotspot-${historyEntry?.id ?? `${stateName}-resolved-${timestamp}`}`,
+          timestamp,
+          category: 'hotspot',
+          headline: `${historyEntry?.icon ?? '👻'} ${label.toUpperCase()} CONTAINED`,
+          subtext,
+          location: stateName,
+          metadata: {
+            hotspotId: historyEntry?.id,
+            stateId: historyEntry?.stateId ?? stateRecord?.id ?? stateRecord?.abbreviation ?? stateName,
+            stateName,
+            source: historyEntry?.source ?? 'neutral',
+            defenseBoost: historyEntry?.defenseBoost,
+            truthReward: historyEntry?.truthReward,
+            outcome: 'captured',
+            truthDelta,
+          },
+        });
+
+        if (historyEntry) {
+          delete hotspotHistoryRef.current[historyEntry.id];
+        }
+
+        audio?.playSFX?.('cryptid-rumble');
+        return;
+      }
+
+      if (entry.startsWith('🕯️ ')) {
+        const expireMatch = entry.match(/^🕯️ (.+?) in (.+?) fizzles out\./);
+        if (!expireMatch) {
+          return;
+        }
+
+        const [, label, stateName] = expireMatch;
+        const stateRecord = stateLookupByName.get(stateName);
+        const historyEntry = Object.values(hotspotHistoryRef.current).find(
+          hotspot => hotspot.label === label && hotspot.stateName === stateName,
+        );
+
+        const template = pickTemplate(HOTSPOT_EXPIRE_TAGLINES);
+        const subtext = template
+          ? fillTemplate(template, { STATE: stateName.toUpperCase() })
+          : `Hotspot dissipates over ${stateName}; defenses return to baseline.`;
+
+        pushSighting({
+          id: `hotspot-${historyEntry?.id ?? `${stateName}-expired-${timestamp}`}`,
+          timestamp,
+          category: 'hotspot',
+          headline: `${historyEntry?.icon ?? '👻'} ${label.toUpperCase()} FADES`,
+          subtext,
+          location: stateName,
+          metadata: {
+            hotspotId: historyEntry?.id,
+            stateId: historyEntry?.stateId ?? stateRecord?.id ?? stateRecord?.abbreviation ?? stateName,
+            stateName,
+            source: historyEntry?.source ?? 'neutral',
+            defenseBoost: historyEntry?.defenseBoost,
+            truthReward: historyEntry?.truthReward,
+            outcome: 'expired',
+          },
+        });
+
+        if (historyEntry) {
+          delete hotspotHistoryRef.current[historyEntry.id];
+        }
+
+        audio?.playSFX?.('radio-static');
+      }
+    });
+  }, [
+    gameState.log,
+    gameState.turn,
+    stateLookupByName,
+    pushSighting,
+    audio,
+  ]);
 
   // Track cards being drawn to hand for collection discovery
   useEffect(() => {
@@ -1352,6 +1703,13 @@ const Index = () => {
           setShowPlayerHub(false);
           audio.playSFX('click');
         }}
+        pressIssues={pressArchive}
+        onOpenEdition={(issue) => {
+          setReadingEdition(issue.report);
+          setShowExtraEdition(true);
+          setShowPlayerHub(false);
+        }}
+        onDeleteEdition={(id) => removeEditionFromArchive(id)}
       />
     );
   }
@@ -1414,27 +1772,11 @@ const Index = () => {
   const handInteractionDisabled = isPlayerActionLocked || gameState.cardsPlayedThisTurn >= 3;
 
   const playerAgenda = gameState.secretAgenda;
-  const playerAgendaSummary = playerAgenda ? {
-    title: playerAgenda.title,
-    faction: playerAgenda.faction,
-    progress: playerAgenda.progress,
-    target: playerAgenda.target,
-    completed: playerAgenda.completed,
-    revealed: playerAgenda.revealed,
-  } : undefined;
   const aiControlledStates = gameState.states.filter(s => s.owner === 'ai').length;
   const aiAgenda = gameState.aiSecretAgenda;
   const aiObjectiveProgress = aiAgenda
     ? Math.min(100, (aiAgenda.progress / aiAgenda.target) * 100)
     : 0;
-  const aiAgendaSummary = aiAgenda ? {
-    title: aiAgenda.title,
-    faction: aiAgenda.faction,
-    progress: aiAgenda.progress,
-    target: aiAgenda.target,
-    completed: aiAgenda.completed,
-    revealed: aiAgenda.revealed,
-  } : undefined;
   const aiAssessment = gameState.aiStrategist?.getStrategicAssessment(gameState);
 
   const renderSecretAgendaPanel = (variant: 'overlay' | 'mobile') => {
@@ -1655,8 +1997,6 @@ const Index = () => {
     </div>
   );
 
-  const roundsCompleted = Math.max(0, gameState.round - 1);
-  const currentRoundNumber = Math.max(1, gameState.round);
 
   const mastheadButtonClass = "touch-target inline-flex items-center justify-center rounded-md border border-newspaper-border bg-newspaper-text px-3 text-sm font-semibold text-newspaper-bg shadow-sm transition hover:bg-newspaper-text/80 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-newspaper-border focus-visible:ring-offset-2 focus-visible:ring-offset-newspaper-bg";
   const statusBadgeClass = 'flex items-center gap-1 whitespace-nowrap rounded border border-newspaper-border bg-newspaper-text px-2 py-1 text-newspaper-bg shadow-sm';
@@ -1917,44 +2257,52 @@ const Index = () => {
 
       <TabloidVictoryScreen
         isVisible={victoryState.isVictory}
-        isVictory={gameState.faction === (gameOverReport?.winner || 'truth')}
-        victoryType={victoryState.type}
+        report={finalEdition}
         playerFaction={gameState.faction}
-        gameStats={{
-          rounds: roundsCompleted,
-          roundNumber: currentRoundNumber,
-          finalTruth: Math.round(gameState.truth),
-          playerIP: gameState.ip,
-          aiIP: gameState.aiIP,
-          playerStates: gameState.states.filter(s => s.owner === 'player').length,
-          aiStates: gameState.states.filter(s => s.owner === 'ai').length,
-          mvp: gameOverReport?.mvp ?? undefined,
-          playerSecretAgenda: playerAgendaSummary,
-          aiSecretAgenda: aiAgendaSummary
-        }}
+        victoryType={victoryState.type}
         onClose={() => {
           setVictoryState({ isVictory: false, type: null });
-          setGameOverReport(null);
+          setFinalEdition(null);
+          setReadingEdition(null);
           setShowMenu(true);
           setShowIntro(true);
         }}
         onMainMenu={() => {
           setVictoryState({ isVictory: false, type: null });
-          setGameOverReport(null);
+          setFinalEdition(null);
+          setReadingEdition(null);
+          setShowExtraEdition(false);
           setShowMenu(true);
           setShowIntro(true);
+          setGameState(prev => ({ ...prev, isGameOver: false }));
+          audio.playMusic('theme');
         }}
+        onViewFinalEdition={() => {
+          if (!finalEdition) return;
+          setReadingEdition(finalEdition);
+          setShowExtraEdition(true);
+        }}
+        onArchive={finalEdition ? () => archiveEditionWithToast(finalEdition) : undefined}
+        isArchived={isEditionArchived(finalEdition)}
       />
 
-      {showExtraEdition && gameOverReport && (
+      {showExtraEdition && readingEdition && (
         <ExtraEditionNewspaper
-          report={gameOverReport}
+          report={readingEdition}
+          isArchived={isEditionArchived(readingEdition)}
+          onArchive={() => archiveEditionWithToast(readingEdition)}
           onClose={() => {
             setShowExtraEdition(false);
-            setGameOverReport(null);
-            setShowMenu(true);
-            setGameState(prev => ({ ...prev, isGameOver: false }));
-            audio.playMusic('theme');
+            const closingActiveVictory = finalEdition && victoryState.isVictory && readingEdition.recordedAt === finalEdition.recordedAt;
+            setReadingEdition(null);
+            if (closingActiveVictory) {
+              setVictoryState({ isVictory: false, type: null });
+              setFinalEdition(null);
+              setShowMenu(true);
+              setShowIntro(true);
+              setGameState(prev => ({ ...prev, isGameOver: false }));
+              audio.playMusic('theme');
+            }
           }}
         />
       )}

--- a/src/types/finalEdition.ts
+++ b/src/types/finalEdition.ts
@@ -1,0 +1,82 @@
+import type { ParanormalSighting } from '@/types/paranormal';
+
+export type ImpactType = 'capture' | 'truth' | 'ip' | 'damage' | 'support';
+
+export interface AgendaSummary {
+  title: string;
+  headline: string;
+  operationName: string;
+  issueTheme: string;
+  pullQuote?: string;
+  artCue?: {
+    icon?: string;
+    alt?: string;
+  };
+  faction: 'truth' | 'government' | 'both';
+  progress: number;
+  target: number;
+  completed: boolean;
+  revealed: boolean;
+}
+
+export interface MVPReport {
+  cardId: string;
+  cardName: string;
+  player: 'human' | 'ai';
+  faction: 'truth' | 'government';
+  truthDelta: number;
+  ipDelta: number;
+  aiIpDelta: number;
+  capturedStates: string[];
+  damageDealt: number;
+  round: number;
+  turn: number;
+  impactType: ImpactType;
+  impactValue: number;
+  impactLabel: string;
+  highlight: string;
+}
+
+export interface FinalEditionEventHighlight {
+  id: string;
+  headline: string;
+  summary: string;
+  faction: 'truth' | 'government' | 'neutral';
+  rarity: 'common' | 'uncommon' | 'rare' | 'legendary';
+  truthDelta: number;
+  ipDelta: number;
+  stateName?: string;
+  kicker?: string;
+}
+
+export interface FinalEditionComboHighlight {
+  id: string;
+  name: string;
+  rewardLabel: string;
+  turn: number;
+  ownerLabel: string;
+  description?: string;
+}
+
+export interface FinalEditionReport {
+  winner: 'government' | 'truth' | 'draw';
+  victoryType: 'states' | 'ip' | 'truth' | 'agenda' | 'draw';
+  rounds: number;
+  finalTruth: number;
+  ipPlayer: number;
+  ipAI: number;
+  statesGov: number;
+  statesTruth: number;
+  playerFaction: 'truth' | 'government';
+  playerSecretAgenda?: AgendaSummary;
+  aiSecretAgenda?: AgendaSummary;
+  mvp?: MVPReport | null;
+  runnerUp?: MVPReport | null;
+  legendaryUsed: string[];
+  topEvents: FinalEditionEventHighlight[];
+  comboHighlights: FinalEditionComboHighlight[];
+  sightings: ParanormalSighting[];
+  recordedAt: number;
+}
+
+export type GameOverReport = FinalEditionReport;

--- a/src/types/paranormal.ts
+++ b/src/types/paranormal.ts
@@ -1,4 +1,4 @@
-export type SightingCategory = 'synergy' | 'truth-meltdown' | 'cryptid';
+export type SightingCategory = 'synergy' | 'truth-meltdown' | 'cryptid' | 'hotspot';
 
 export interface ParanormalSightingMetadata {
   setList?: string[];
@@ -11,6 +11,13 @@ export interface ParanormalSightingMetadata {
   bonusIP?: number;
   reducedMotion?: boolean;
   source?: 'truth' | 'government';
+  defenseBoost?: number;
+  truthReward?: number;
+  duration?: number;
+  turnsRemaining?: number;
+  hotspotId?: string;
+  outcome?: 'active' | 'captured' | 'expired';
+  truthDelta?: number;
 }
 
 export interface ParanormalSighting {

--- a/src/utils/finalEdition.ts
+++ b/src/utils/finalEdition.ts
@@ -1,0 +1,47 @@
+import type { GameOverReport } from '@/types/finalEdition';
+
+export const getFactionDisplayName = (faction: 'truth' | 'government'): string => {
+  return faction === 'truth' ? 'Truth Network' : 'Shadow Government';
+};
+
+export const getOppositionDisplayName = (playerFaction: 'truth' | 'government'): string => {
+  return getFactionDisplayName(playerFaction === 'truth' ? 'government' : 'truth');
+};
+
+export const getVictoryConditionLabel = (
+  victoryType: GameOverReport['victoryType'],
+): string => {
+  switch (victoryType) {
+    case 'truth':
+      return 'Truth Threshold';
+    case 'states':
+      return 'State Sweep';
+    case 'ip':
+      return 'IP Race';
+    case 'agenda':
+      return 'Secret Agenda';
+    case 'draw':
+    default:
+      return 'Final Edition';
+  }
+};
+
+export const getPlayerOutcomeLabel = (
+  report: GameOverReport,
+): 'Victory' | 'Defeat' | 'Stalemate' => {
+  if (report.winner === 'draw') {
+    return 'Stalemate';
+  }
+
+  return report.winner === report.playerFaction ? 'Victory' : 'Defeat';
+};
+
+export const getOutcomeSummary = (report: GameOverReport): string => {
+  if (report.winner === 'draw') {
+    return 'Stalemate';
+  }
+
+  const victorLabel = getFactionDisplayName(report.winner);
+  const condition = getVictoryConditionLabel(report.victoryType);
+  return `${victorLabel} · ${condition}`;
+};

--- a/src/utils/visualEffects.ts
+++ b/src/utils/visualEffects.ts
@@ -156,6 +156,24 @@ export class VisualEffectsCoordinator {
     }));
   }
 
+  static triggerParanormalHotspot(detail: {
+    position: EffectPosition;
+    stateId: string;
+    stateName: string;
+    label: string;
+    icon?: string;
+    source: 'truth' | 'government' | 'neutral';
+    defenseBoost: number;
+    truthReward: number;
+  }): void {
+    window.dispatchEvent(new CustomEvent('paranormalHotspot', {
+      detail: {
+        ...detail,
+        position: { ...detail.position }
+      }
+    }));
+  }
+
   // Helper to get element center position
   static getElementCenter(element: Element): EffectPosition {
     const rect = element.getBoundingClientRect();


### PR DESCRIPTION
## Summary
- replace the victory overlay and extra edition newspaper with a shared final edition layout that highlights MVPs, events, combos, and sightings
- extend the game-over report to capture runner-up plays, hotspot sightings, and combo summaries so the final edition has complete data and can be archived
- add a press archive backed by local storage with Player Hub browsing and controls to open or remove past editions

## Testing
- npm run lint *(fails: existing lint/type errors in project)*

------
https://chatgpt.com/codex/tasks/task_e_68d79090c76483209043c1698ed71229