### PR TITLE
Enforce AI card play cap during automated turns

### DIFF
--- a/src/hooks/aiHelpers.ts
+++ b/src/hooks/aiHelpers.ts
@@ -250,6 +250,19 @@ export const applyAiCardPlay = (
   params: AiCardPlayParams,
   achievements: AchievementTracker,
 ): AiCardPlayResult => {
+  if (prev.cardsPlayedThisTurn >= 3) {
+    return {
+      nextState: {
+        ...prev,
+        log: [
+          ...prev.log,
+          'AI attempted to play an additional card but already reached the turn limit of 3.',
+        ],
+      },
+      failed: true,
+    };
+  }
+
   const { cardId, card: providedCard, targetState, reasoning, strategyDetails } = params;
   const resolvedCard = prev.aiHand.find(handCard => handCard.id === (providedCard?.id ?? cardId));
 
@@ -318,6 +331,7 @@ export const applyAiCardPlay = (
     turnPlays: [...prev.turnPlays, ...turnPlayEntries],
     log: logEntries,
     paranormalHotspots: updatedHotspots,
+    cardsPlayedThisTurn: prev.cardsPlayedThisTurn + 1,
   };
 
   return {

--- a/src/hooks/aiTurnActions.ts
+++ b/src/hooks/aiTurnActions.ts
@@ -29,6 +29,10 @@ export const processAiActions = async ({
       return { gameOver: true };
     }
 
+    if (latestBeforeAction.cardsPlayedThisTurn >= 3) {
+      return { gameOver: false };
+    }
+
     const action = actions[index];
     const detailEntries = [
       ...(index === 0 ? sequenceDetails : []),
@@ -50,6 +54,10 @@ export const processAiActions = async ({
     const latestAfterAction = await readLatestState();
     if (latestAfterAction.isGameOver) {
       return { gameOver: true };
+    }
+
+    if (latestAfterAction.cardsPlayedThisTurn >= 3) {
+      return { gameOver: false };
     }
 
     if (index < actions.length - 1) {


### PR DESCRIPTION
## Summary
- short-circuit AI card plays when the turn limit has already been reached
- increment the AI's cardsPlayedThisTurn counter after successful resolutions
- stop scheduling additional AI actions once the per-turn cap is hit

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d7d1562c6c832088afb3a836f79cc7