### PR TITLE
Balance truth and government card swings

### DIFF
--- a/src/data/core/government-batch-1.ts
+++ b/src/data/core/government-batch-1.ts
@@ -76,7 +76,7 @@ export const governmentBatch1: GameCard[] = [
     "rarity": "rare",
     "cost": 5,
     "effects": {
-      "truthDelta": -3
+      "truthDelta": -2
     },
     "flavor": "Tonight's top story was approved at noon."
   },
@@ -178,7 +178,7 @@ export const governmentBatch1: GameCard[] = [
     "rarity": "rare",
     "cost": 5,
     "effects": {
-      "truthDelta": -3
+      "truthDelta": -2
     },
     "flavor": "Your regularly scheduled reality will return shortly."
   },
@@ -320,7 +320,7 @@ export const governmentBatch1: GameCard[] = [
     "rarity": "rare",
     "cost": 5,
     "effects": {
-      "truthDelta": -3
+      "truthDelta": -2
     },
     "flavor": "The smoke alarm is for show."
   },
@@ -625,7 +625,7 @@ export const governmentBatch1: GameCard[] = [
     "rarity": "legendary",
     "cost": 6,
     "effects": {
-      "truthDelta": -4
+      "truthDelta": -3
     },
     "flavor": "Minutes not taken. Decisions irreversible."
   },
@@ -637,7 +637,7 @@ export const governmentBatch1: GameCard[] = [
     "rarity": "rare",
     "cost": 5,
     "effects": {
-      "truthDelta": -3
+      "truthDelta": -2
     },
     "flavor": "It's not a cover-up if it's a comforter."
   }

--- a/src/data/core/truth-batch-1.ts
+++ b/src/data/core/truth-batch-1.ts
@@ -33,7 +33,7 @@ export const truthBatch1: GameCard[] = [
     "rarity": "rare",
     "cost": 5,
     "effects": {
-      "truthDelta": 3
+      "truthDelta": 4
     },
     "flavor": "Sponsored by Doomsday Beans™."
   },
@@ -45,7 +45,7 @@ export const truthBatch1: GameCard[] = [
     "rarity": "uncommon",
     "cost": 4,
     "effects": {
-      "truthDelta": 2
+      "truthDelta": 3
     },
     "flavor": "His platform: windows with no curtains."
   },
@@ -121,7 +121,7 @@ export const truthBatch1: GameCard[] = [
     "rarity": "rare",
     "cost": 5,
     "effects": {
-      "truthDelta": 3
+      "truthDelta": 4
     },
     "flavor": "Ink smudges reveal more than black bars."
   },
@@ -133,7 +133,7 @@ export const truthBatch1: GameCard[] = [
     "rarity": "rare",
     "cost": 5,
     "effects": {
-      "truthDelta": 3
+      "truthDelta": 4
     },
     "flavor": "Chat: 'first!'"
   },
@@ -212,7 +212,7 @@ export const truthBatch1: GameCard[] = [
     "rarity": "rare",
     "cost": 5,
     "effects": {
-      "truthDelta": 3
+      "truthDelta": 4
     },
     "flavor": "Historic handshake, very furry."
   },
@@ -224,7 +224,7 @@ export const truthBatch1: GameCard[] = [
     "rarity": "rare",
     "cost": 5,
     "effects": {
-      "truthDelta": 3
+      "truthDelta": 5
     },
     "flavor": "Thank you, interstellar much."
   },
@@ -536,7 +536,7 @@ export const truthBatch1: GameCard[] = [
     "rarity": "uncommon",
     "cost": 4,
     "effects": {
-      "truthDelta": 2
+      "truthDelta": 3
     },
     "flavor": "Neighborhood eyes beat satellite spies."
   },
@@ -560,7 +560,7 @@ export const truthBatch1: GameCard[] = [
     "rarity": "rare",
     "cost": 5,
     "effects": {
-      "truthDelta": 3
+      "truthDelta": 4
     },
     "flavor": "Invisible hands hold your hand."
   },
@@ -572,7 +572,7 @@ export const truthBatch1: GameCard[] = [
     "rarity": "uncommon",
     "cost": 4,
     "effects": {
-      "truthDelta": 2
+      "truthDelta": 3
     },
     "flavor": "Broadcast jammed by cosmic drizzle."
   },
@@ -584,7 +584,7 @@ export const truthBatch1: GameCard[] = [
     "rarity": "rare",
     "cost": 5,
     "effects": {
-      "truthDelta": 3
+      "truthDelta": 4
     },
     "flavor": "Many eyes, fewer lies."
   },
@@ -596,7 +596,7 @@ export const truthBatch1: GameCard[] = [
     "rarity": "uncommon",
     "cost": 4,
     "effects": {
-      "truthDelta": 2
+      "truthDelta": 3
     },
     "flavor": "Coupons clipped from reality."
   },
@@ -620,7 +620,7 @@ export const truthBatch1: GameCard[] = [
     "rarity": "rare",
     "cost": 5,
     "effects": {
-      "truthDelta": 3
+      "truthDelta": 4
     },
     "flavor": "All shook up… and tuned in."
   },
@@ -632,7 +632,7 @@ export const truthBatch1: GameCard[] = [
     "rarity": "legendary",
     "cost": 6,
     "effects": {
-      "truthDelta": 4
+      "truthDelta": 5
     },
     "flavor": "Running for Senate (again)."
   }

--- a/src/hooks/__tests__/useGameState.eventEffects.test.ts
+++ b/src/hooks/__tests__/useGameState.eventEffects.test.ts
@@ -1,5 +1,5 @@
 import React from 'react';
-import { describe, expect, it, beforeEach, afterEach, mock } from 'bun:test';
+import { describe, expect, it, beforeEach, afterEach, afterAll, mock } from 'bun:test';
 import TestRenderer, { act } from 'react-test-renderer';
 
 mock.module('@/hooks/comboAdapter', () => ({
@@ -179,6 +179,10 @@ describe('useGameState event effects', () => {
     resetMockEvents();
     // eslint-disable-next-line @typescript-eslint/no-dynamic-delete
     delete (globalThis as Partial<typeof globalThis>).localStorage;
+  });
+
+  afterAll(() => {
+    mock.restore();
   });
 
   it('applies truth, IP, and state modifiers from event effects', async () => {


### PR DESCRIPTION
## Summary
- increase truthDelta on high-rarity truth MEDIA cards and select uncommons to reward expensive plays
- soften the harshest negative truth swings on key government media cards
- isolate combo evaluation tests from shared mocks to keep the suite stable

## Testing
- bun test

------
https://chatgpt.com/codex/tasks/task_e_68d977555724832085de735572d2a51b