### PR TITLE
Track captured states through card resolution

### DIFF
--- a/src/hooks/gameStateTypes.ts
+++ b/src/hooks/gameStateTypes.ts
@@ -17,6 +17,7 @@ export interface CardPlayRecord {
   ipDelta: number;
   aiIpDelta: number;
   capturedStates: string[];
+  capturedStateIds: string[];
   damageDealt: number;
   round: number;
   turn: number;

--- a/src/systems/cardResolution.ts
+++ b/src/systems/cardResolution.ts
@@ -72,6 +72,7 @@ export interface CardPlayResolution {
   states: StateForResolution[];
   controlledStates: string[];
   aiControlledStates: string[];
+  capturedStateIds: string[];
   targetState: string | null;
   selectedCard: string | null;
   logEntries: string[];
@@ -286,6 +287,7 @@ export function resolveCardMVP(
   const nextControlledStates = new Set(gameState.controlledStates);
   const nextAiControlledStates = new Set(gameState.aiControlledStates ?? []);
   let capturedCount = 0;
+  const capturedStateIds: string[] = [];
   let nextTargetState: string | null = actor === 'human' && card.type === 'ZONE' ? targetState : null;
   const resolvedHotspots: string[] = [];
   let truthBonusFromHotspots = 0;
@@ -320,6 +322,7 @@ export function resolveCardMVP(
 
     if (previousOwner !== 'player' && owner === 'player') {
       capturedCount += 1;
+      capturedStateIds.push(state.id);
       setStateOccupation(state, gameState.faction, { id: card.id, name: card.name }, false);
       logEntries.push(`🚨 ${card.name} captured ${state.name}!`);
       if (targetStateId === state.id) {
@@ -327,6 +330,7 @@ export function resolveCardMVP(
       }
     } else if (previousOwner !== 'ai' && owner === 'ai') {
       const aiFaction = gameState.faction === 'truth' ? 'government' : 'truth';
+      capturedStateIds.push(state.id);
       setStateOccupation(state, aiFaction, { id: card.id, name: card.name }, false);
       logEntries.push(`⚠️ ${card.name} seized ${state.name} for the enemy!`);
       if (targetStateId === state.id) {
@@ -403,6 +407,7 @@ export function resolveCardMVP(
     states: adjustedStates,
     controlledStates: Array.from(nextControlledStates),
     aiControlledStates: Array.from(nextAiControlledStates),
+    capturedStateIds,
     targetState: actor === 'human' ? nextTargetState : (gameState as any).targetState,
     selectedCard: null,
     logEntries,


### PR DESCRIPTION
## Summary
- include captured state IDs in card resolution results and metadata
- store captured IDs in play history records and turn play metadata for later consumers
- trigger state events for each captured state during player and AI card resolution

## Testing
- npm run lint *(fails: existing lint issues across unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68d97b092a3483209a35f1854fe6ffbc