### PR TITLE
Track and surface state event bonuses in tooltips

### DIFF
--- a/src/components/game/EnhancedUSAMap.tsx
+++ b/src/components/game/EnhancedUSAMap.tsx
@@ -8,6 +8,7 @@ import { geoAlbersUsa, geoPath } from 'd3-geo';
 import { AlertTriangle, Target, Shield } from 'lucide-react';
 import { VisualEffectsCoordinator } from '@/utils/visualEffects';
 import { areParanormalEffectsEnabled } from '@/state/settings';
+import type { StateEventBonusSummary } from '@/hooks/gameStateTypes';
 
 
 interface EnhancedState {
@@ -40,6 +41,7 @@ interface EnhancedState {
     turnsRemaining: number;
     source: 'truth' | 'government' | 'neutral';
   };
+  stateEventBonus?: StateEventBonusSummary;
 }
 
 interface PlayedCard {
@@ -746,6 +748,34 @@ const EnhancedUSAMap: React.FC<EnhancedUSAMapProps> = ({
                 <div className="text-sm font-bold text-foreground mb-1">Control</div>
                 <div className="text-sm font-mono bg-card/60 border border-border/40 p-2 rounded shadow-sm opacity-95">
                   <span className="font-bold text-foreground">{stateInfo.occupierLabel}</span>
+                </div>
+              </div>
+            )}
+
+            {stateInfo.stateEventBonus && (
+              <div className="pt-2 border-t border-border">
+                <div className="flex items-center gap-2 text-sm font-bold text-foreground mb-1">
+                  <span>🗞️</span>
+                  <span>{stateInfo.stateEventBonus.label}</span>
+                </div>
+                <div className="space-y-2 text-xs font-mono bg-amber-500/10 border border-amber-500/40 p-3 rounded shadow-sm">
+                  {stateInfo.stateEventBonus.description && (
+                    <div className="text-muted-foreground leading-snug">
+                      {stateInfo.stateEventBonus.description}
+                    </div>
+                  )}
+                  {stateInfo.stateEventBonus.effectSummary?.length ? (
+                    <ul className="list-disc pl-4 space-y-1 text-foreground/90">
+                      {stateInfo.stateEventBonus.effectSummary.map((effect, index) => (
+                        <li key={`${stateInfo.id}-event-effect-${index}`}>{effect}</li>
+                      ))}
+                    </ul>
+                  ) : (
+                    <div className="text-muted-foreground">Bonus active</div>
+                  )}
+                  <div className="text-[11px] uppercase tracking-wide text-muted-foreground/80">
+                    Turn {stateInfo.stateEventBonus.triggeredOnTurn} · {stateInfo.stateEventBonus.faction.toUpperCase()}
+                  </div>
                 </div>
               </div>
             )}

--- a/src/hooks/gameStateTypes.ts
+++ b/src/hooks/gameStateTypes.ts
@@ -69,6 +69,7 @@ export interface GameState {
     occupierIcon?: string | null;
     occupierUpdatedAt?: number;
     paranormalHotspot?: StateParanormalHotspot;
+    stateEventBonus?: StateEventBonusSummary;
   }>;
   currentEvents: GameEvent[];
   eventManager?: EventManager;
@@ -104,6 +105,17 @@ export interface GameState {
   truthBelow20Streak: number;
   timeBasedGoalCounters: Record<string, number>;
   paranormalHotspots: Record<string, ActiveParanormalHotspot>;
+}
+
+export interface StateEventBonusSummary {
+  source: 'state-event';
+  eventId: string;
+  label: string;
+  description?: string;
+  triggeredOnTurn: number;
+  faction: 'truth' | 'government';
+  effects?: NonNullable<GameEvent['effects']>;
+  effectSummary?: string[];
 }
 
 export interface ActiveParanormalHotspot {

--- a/src/hooks/useStateEvents.ts
+++ b/src/hooks/useStateEvents.ts
@@ -2,11 +2,13 @@ import { useState, useCallback } from 'react';
 import { EventManager, GameEvent } from '@/data/eventDatabase';
 import { useToast } from '@/hooks/use-toast';
 import { VisualEffectsCoordinator } from '@/utils/visualEffects';
+import type { GameState } from './gameStateTypes';
 
 export interface StateEventTrigger {
   stateId: string;
   event: GameEvent;
-  capturingFaction: string;
+  capturingFaction: 'truth' | 'government';
+  triggeredOnTurn: number;
 }
 
 export const useStateEvents = () => {
@@ -15,12 +17,12 @@ export const useStateEvents = () => {
 
   const triggerStateEvent = useCallback((
     stateId: string, 
-    capturingFaction: string, 
-    gameState: any,
+    capturingFaction: 'truth' | 'government',
+    gameState: Pick<GameState, 'states' | 'turn'>,
     statePosition?: { x: number; y: number }
   ) => {
     const event = eventManager.selectStateEvent(stateId, capturingFaction, gameState);
-    
+
     if (!event) return null;
 
     // Get state name for display
@@ -42,8 +44,9 @@ export const useStateEvents = () => {
     return {
       stateId,
       event,
-      capturingFaction
-    } as StateEventTrigger;
+      capturingFaction,
+      triggeredOnTurn: typeof gameState.turn === 'number' ? Math.max(1, gameState.turn) : 1,
+    } satisfies StateEventTrigger;
   }, [eventManager, toast]);
 
   const triggerContestedStateEffects = useCallback((


### PR DESCRIPTION
## Summary
- add a structured state-event bonus summary to state entries and persist it through save/load
- apply captured state-event effects to the game state while logging each trigger and storing the resulting summary
- surface the captured state-event bonus information in the EnhancedUSAMap tooltip alongside existing bonus sections

## Testing
- npm run lint *(fails: existing lint violations across unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68d987a92dc08320a90cdddf111b0a44