### PR TITLE
Document and test swing tax catch-up flow

### DIFF
--- a/DESIGN_DOC_MVP.md
+++ b/DESIGN_DOC_MVP.md
@@ -98,11 +98,14 @@ Hver stat har en forhåndsdefinert Defense (f.eks. 2–5).
 
 Start of Turn
 
-
-
 Inntekt: Få +5 IP + +1 IP per stat du kontrollerer.
 
-
+- Reserver over 40 IP utløser vedlikehold: trekk `floor((IP - 40) / 10)` fra inntekten (aldri under 0).
+- Catch-up-modul: sammenlign egne og motstanders ressurser (`Δip` og `Δstates`).
+  - Ingen endring mens `Δip ≤ 10` og `Δstates ≤ 1`.
+  - Hver *fulle* 5 IP over 10-grensen gir ±1 justering.
+  - Hver ekstra stat over grensen gir ±1.
+  - Summen klippes til maks ±4 før den legges til (positivt når du ligger bak, negativt når du leder).
 
 Trekk: Trekk opp til 5 kort på hånd (fyll opp).
 

--- a/docs/TECHNICAL_README.md
+++ b/docs/TECHNICAL_README.md
@@ -20,7 +20,19 @@ The MVP design defines a duel between the Truth Seekers and the Government, each
 - **Victory checks:** `winCheck` confirms state, Truth, and IP victory thresholds after every turn wrap-up, matching the MVP specification but using 95%/5% Truth buffers for runtime tuning.【F:src/mvp/engine.ts†L367-L395】【F:DESIGN_DOC_MVP.md†L55-L63】
 
 ### Catch-up swing math
-`computeTurnIpIncome` now layers a swing-tax/catch-up module on top of the existing reserve maintenance. The routine compares the active player's reserves and state holdings to their opponent and scores two separate gaps: IP and controlled states. Gaps within the grace window (≤10 IP or ≤1 state) are ignored. Every additional 5 IP of lead beyond that window adds 1 swing tax, while every extra controlled state beyond the grace adds another point. Trailing players receive the same magnitude as a positive catch-up bonus. The combined modifier is capped at 4 IP in either direction before being applied to the base income of `5 + controlledStates`. This keeps small leads untouched, taxes runaway economies, and gives the underdog up to +4 IP when significantly behind.【F:src/mvp/engine.ts†L56-L114】
+`computeTurnIpIncome` now layers a swing-tax/catch-up module on top of the existing reserve maintenance. The routine compares the active player's reserves and state holdings to their opponent and scores two separate gaps: IP and controlled states. Full steps beyond the grace windows generate modifiers according to the piecewise formula
+
+```
+swingTax   = clamp₀⁴( floor(max(Δip - 10, 0) / 5) + max(Δstates - 1, 0) )
+catchUp    = clamp₀⁴( floor(max(-Δip - 10, 0) / 5) + max(-Δstates - 1, 0) )
+netIncome  = max(0, 5 + controlledStates - swingTax + catchUp)
+```
+
+where `Δip = playerIp - opponentIp` and `Δstates = playerStates - opponentStates`. This keeps small leads untouched, taxes runaway economies by up to 4 IP per turn, and grants the same ceiling as a comeback bonus when significantly behind.【F:src/mvp/engine.ts†L56-L207】
+
+#### FAQ: Why did my income swing this turn?
+- **You were ahead:** A positive `Δip` or `Δstates` beyond the grace windows triggers a swing tax. The log entry spells out the lead size so the reason is transparent.【F:src/mvp/engine.ts†L213-L272】
+- **You were behind:** Large deficits flip the same magnitude into a catch-up bonus, letting the underdog earn up to +4 IP until parity is restored.【F:src/mvp/engine.ts†L213-L272】
 
 ## MVP card schema
 MVP cards belong to the Truth or Government factions and are typed as ATTACK, MEDIA, or ZONE with rarities from common to legendary. The baseline design restricts each type to a concise whitelist of effect keys and ties costs to a rarity table.【F:DESIGN_DOC_MVP.md†L25-L178】【F:src/rules/mvp.ts†L1-L60】 The runtime validator codifies the schema:

--- a/src/mvp/__tests__/engine.income.test.ts
+++ b/src/mvp/__tests__/engine.income.test.ts
@@ -4,6 +4,7 @@ import {
   DEFAULT_IP_MAINTENANCE,
   DEFAULT_CATCH_UP_SETTINGS,
   computeTurnIpIncome,
+  evaluateCatchUpAdjustments,
   startTurn,
 } from '@/mvp/engine';
 import type { GameState, PlayerState } from '@/mvp/validator';
@@ -33,6 +34,25 @@ const makeState = (currentPlayer: PlayerState, opponentIp = 0): GameState => ({
   playsThisTurn: 0,
   turnPlays: [],
   log: [],
+});
+
+describe('evaluateCatchUpAdjustments', () => {
+  it('ignores small gaps within the grace windows', () => {
+    const result = evaluateCatchUpAdjustments(8, 1);
+    expect(result).toEqual({ swingTax: 0, catchUpBonus: 0, ipGap: 8, stateGap: 1 });
+  });
+
+  it('applies swing tax in steps and respects the cap', () => {
+    const bigLead = evaluateCatchUpAdjustments(35, 4);
+    expect(bigLead.swingTax).toBe(DEFAULT_CATCH_UP_SETTINGS.maxModifier);
+    expect(bigLead.catchUpBonus).toBe(0);
+  });
+
+  it('awards catch-up bonuses symmetrically for large deficits', () => {
+    const trailer = evaluateCatchUpAdjustments(-28, -3);
+    expect(trailer.catchUpBonus).toBe(DEFAULT_CATCH_UP_SETTINGS.maxModifier);
+    expect(trailer.swingTax).toBe(0);
+  });
 });
 
 describe('computeTurnIpIncome', () => {

--- a/src/mvp/engine.ts
+++ b/src/mvp/engine.ts
@@ -99,6 +99,18 @@ export interface CatchUpEvaluation {
   stateGap: number;
 }
 
+/**
+ * Computes turn income modifiers for the swing-tax / catch-up system.
+ *
+ * Let `Δip = playerIp - opponentIp` and `Δstates = playerStates - opponentStates`.
+ * We ignore small advantages within the configured grace windows. For IP this means
+ * no modifier while `Δip <= graceIp`. Every *full* `ipStep` beyond the grace adds
+ * 1 point of swing tax (or bonus when trailing). State leads follow the same logic:
+ * no change while `Δstates <= graceStates`, then +1 per extra controlled state.
+ *
+ * The resulting modifier is capped symmetrically by `maxModifier`, yielding a final
+ * income of `5 + controlledStates - swingTax + catchUpBonus`.
+ */
 export const evaluateCatchUpAdjustments = (
   ipGap: number,
   stateGap: number,


### PR DESCRIPTION
## Summary
- document the swing-tax / catch-up formula in the technical and player-facing rules
- add explicit unit tests for evaluateCatchUpAdjustments and clarify the engine helpers with inline docs
- ensure turn logs continue to explain swing tax and catch-up adjustments for players and AI planners

## Testing
- bun test

------
https://chatgpt.com/codex/tasks/task_e_68da27f1a05c83209a03e16c75778c2d