### PR TITLE
Normalize captured state event lookup

### DIFF
--- a/src/hooks/useGameState.ts
+++ b/src/hooks/useGameState.ts
@@ -825,13 +825,18 @@ export const useGameState = (aiDifficultyOverride?: AIDifficulty) => {
           continue;
         }
 
-        const trigger = triggerStateEvent(stateId, capturingFaction, nextState);
+        const eventStateKey = resolvedState.abbreviation ?? stateId;
+        const trigger = triggerStateEvent(eventStateKey, capturingFaction, nextState);
         if (!trigger) {
           continue;
         }
 
         const statesArray = ensureWorkingStates();
-        const indexCandidates = [resolvedState.id, resolvedState.abbreviation, trigger.stateId];
+        const indexCandidates = [resolvedState.id, resolvedState.abbreviation];
+        if (!indexCandidates.includes(eventStateKey)) {
+          indexCandidates.push(eventStateKey);
+        }
+        indexCandidates.push(trigger.stateId);
         let stateIndex = -1;
         for (const candidate of indexCandidates) {
           stateIndex = findStateIndex(statesArray, candidate);


### PR DESCRIPTION
## Summary
- normalize the state key used when triggering captured state events to prefer abbreviations
- ensure captured state lookup candidates include both the id and abbreviation before adding the triggered key

## Testing
- not run (reason: manual verification requires in-game testing)


------
https://chatgpt.com/codex/tasks/task_e_68da2f1fda78832095fda5fd3ff20d77