### PR TITLE
Refine victory screen newspaper layout

### DIFF
--- a/src/components/effects/TabloidVictoryScreen.tsx
+++ b/src/components/effects/TabloidVictoryScreen.tsx
@@ -1,9 +1,9 @@
 import { useState } from 'react';
-import { Card } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
-import { X, Newspaper, Trophy, Sparkles } from 'lucide-react';
+import { Newspaper, Trophy, Sparkles } from 'lucide-react';
 import EndCredits from '@/components/game/EndCredits';
 import FinalEditionLayout from '@/components/game/FinalEditionLayout';
+import GameOverEditionLayout from '@/components/game/GameOverEditionLayout';
 import type { GameOverReport } from '@/types/finalEdition';
 import { getVictoryConditionLabel } from '@/utils/finalEdition';
 
@@ -57,72 +57,67 @@ const TabloidVictoryScreen = ({
     : report.victoryType
       ? getVictoryConditionLabel(report.victoryType).toUpperCase()
       : 'FINAL REPORT';
+  const editionDate = new Date(report.recordedAt).toLocaleDateString(undefined, {
+    month: 'long',
+    day: 'numeric',
+    year: 'numeric',
+  });
+  const tagline = [
+    report.rounds > 0 ? `${report.rounds} rounds` : 'Lightning opener',
+    `Truth ${Math.round(report.finalTruth)}%`,
+  ].join(' • ');
 
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-slate-950/85 p-6">
-      <div className="absolute inset-0 bg-[radial-gradient(circle_at_top,_rgba(16,185,129,0.25),_transparent_60%)]" aria-hidden />
-      <Card className="relative z-10 flex max-h-[92vh] w-full max-w-5xl flex-col overflow-hidden border border-emerald-500/40 bg-slate-950/95 shadow-[0_0_65px_rgba(16,185,129,0.25)]">
-        <div className="flex items-start justify-between gap-4 border-b border-emerald-500/20 bg-slate-950/90 px-6 py-4">
-          <div>
-            <p className="font-mono text-xs uppercase tracking-[0.32em] text-emerald-300/80">{victoryDetail}</p>
-            <h2 className="mt-1 flex items-center gap-2 text-2xl font-semibold text-emerald-100">
-              {isVictory ? <Trophy className="h-5 w-5 text-emerald-300" /> : <Sparkles className="h-5 w-5 text-emerald-300" />}
-              {bannerLabel}
-            </h2>
-          </div>
-          <Button
-            variant="ghost"
-            size="icon"
-            className="text-emerald-200 hover:text-emerald-100"
-            onClick={onClose}
-            aria-label="Close victory report"
-          >
-            <X className="h-5 w-5" />
-          </Button>
-        </div>
-
-        <div className="flex-1 overflow-y-auto px-6 py-6">
-          <FinalEditionLayout report={report} />
-        </div>
-
-        <div className="flex flex-wrap items-center justify-between gap-3 border-t border-emerald-500/20 bg-slate-950/90 px-6 py-4">
-          <div className="flex flex-wrap items-center gap-2">
-            <Button
-              onClick={onViewFinalEdition}
-              className="bg-emerald-500/20 text-emerald-100 hover:bg-emerald-500/30"
-            >
-              <Newspaper className="mr-2 h-4 w-4" />
-              Read Final Newspaper
-            </Button>
-            {onArchive && (
+      <GameOverEditionLayout
+        bannerLabel={bannerLabel}
+        bannerIcon={isVictory ? <Trophy className="h-6 w-6" /> : <Sparkles className="h-6 w-6" />}
+        kicker={victoryDetail}
+        metaLine={`Final Campaign Report • ${editionDate}`}
+        tagline={tagline}
+        onClose={onClose}
+        footer={(
+          <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+            <div className="flex flex-wrap justify-center gap-2 md:justify-start">
               <Button
-                onClick={onArchive}
-                disabled={isArchived}
-                variant="outline"
-                className="border-emerald-500/40 text-emerald-200 hover:bg-emerald-500/10 disabled:opacity-60"
+                onClick={onViewFinalEdition}
+                className="border border-newspaper-border bg-newspaper-bg/90 text-newspaper-text transition hover:bg-white/80 hover:text-newspaper-headline"
               >
-                {isArchived ? 'Archived' : 'Archive to Player Hub'}
+                <Newspaper className="mr-2 h-4 w-4" />
+                Read Final Newspaper
               </Button>
-            )}
+              {onArchive && (
+                <Button
+                  onClick={onArchive}
+                  disabled={isArchived}
+                  variant="outline"
+                  className="border border-dashed border-newspaper-border/70 bg-newspaper-bg/70 text-newspaper-text transition hover:bg-white/80 hover:text-newspaper-headline disabled:opacity-60"
+                >
+                  {isArchived ? 'Archived' : 'Archive to Player Hub'}
+                </Button>
+              )}
+            </div>
+            <div className="flex flex-wrap justify-center gap-2 md:justify-end">
+              <Button
+                variant="ghost"
+                className="text-newspaper-text/80 transition hover:text-newspaper-text"
+                onClick={() => setShowCredits(true)}
+              >
+                Roll Credits
+              </Button>
+              <Button
+                variant="secondary"
+                className="border border-newspaper-border bg-newspaper-bg/90 text-newspaper-text transition hover:bg-white/80 hover:text-newspaper-headline"
+                onClick={onMainMenu}
+              >
+                Return to Menu
+              </Button>
+            </div>
           </div>
-          <div className="flex flex-wrap items-center gap-2">
-            <Button
-              variant="ghost"
-              className="text-emerald-200 hover:text-emerald-100"
-              onClick={() => setShowCredits(true)}
-            >
-              Roll Credits
-            </Button>
-            <Button
-              variant="secondary"
-              className="bg-emerald-500/20 text-emerald-100 hover:bg-emerald-500/30"
-              onClick={onMainMenu}
-            >
-              Return to Menu
-            </Button>
-          </div>
-        </div>
-      </Card>
+        )}
+      >
+        <FinalEditionLayout report={report} />
+      </GameOverEditionLayout>
     </div>
   );
 };

--- a/src/components/game/GameOverEditionLayout.tsx
+++ b/src/components/game/GameOverEditionLayout.tsx
@@ -1,0 +1,77 @@
+import type { ReactNode } from 'react';
+import { X } from 'lucide-react';
+import { cn } from '@/lib/utils';
+
+interface GameOverEditionLayoutProps {
+  bannerLabel: string;
+  bannerIcon?: ReactNode;
+  kicker: string;
+  metaLine: string;
+  tagline?: string;
+  onClose: () => void;
+  children: ReactNode;
+  footer?: ReactNode;
+  className?: string;
+}
+
+const GameOverEditionLayout = ({
+  bannerLabel,
+  bannerIcon,
+  kicker,
+  metaLine,
+  tagline,
+  onClose,
+  children,
+  footer,
+  className,
+}: GameOverEditionLayoutProps) => {
+  return (
+    <div
+      className={cn(
+        'relative flex h-full max-h-[92vh] w-full max-w-5xl flex-col overflow-hidden rounded-[1.5rem] border-4 border-newspaper-border bg-newspaper-bg text-newspaper-text shadow-2xl before:absolute before:-inset-6 before:-z-10 before:rounded-[2rem] before:bg-[radial-gradient(circle_at_top,_rgba(16,185,129,0.28),_transparent_70%)] before:opacity-80 before:blur-xl before:content-[""] after:pointer-events-none after:absolute after:-inset-12 after:-z-20 after:rounded-[2.75rem] after:bg-[radial-gradient(circle,_rgba(16,185,129,0.18),_transparent_75%)] after:opacity-80 after:blur-[90px] after:content-[""]',
+        className,
+      )}
+    >
+      <header className="relative border-b-4 border-double border-newspaper-border bg-newspaper-header/95 px-6 py-6">
+        <button
+          type="button"
+          onClick={onClose}
+          aria-label="Close victory report"
+          className="absolute right-4 top-4 rounded-full border-2 border-newspaper-text/40 bg-newspaper-bg/40 p-1 text-newspaper-text transition hover:bg-newspaper-bg"
+        >
+          <X className="h-5 w-5" />
+        </button>
+        <div className="flex flex-col items-center gap-2 text-center">
+          <span className="text-[11px] font-semibold uppercase tracking-[0.6em] text-newspaper-text/60">
+            ShadowGov Press Bureau
+          </span>
+          <p className="text-xs font-semibold uppercase tracking-[0.35em] text-newspaper-text/70">{kicker}</p>
+          <div className="flex items-center gap-3">
+            {bannerIcon ? <span className="text-newspaper-headline">{bannerIcon}</span> : null}
+            <h2 className="text-3xl font-black uppercase tracking-[0.25em] text-newspaper-text sm:text-4xl">
+              {bannerLabel}
+            </h2>
+          </div>
+          <p className="text-[11px] font-semibold uppercase tracking-[0.35em] text-newspaper-text/60">{metaLine}</p>
+          {tagline ? (
+            <p className="text-[11px] font-semibold uppercase tracking-[0.32em] text-newspaper-text/50">{tagline}</p>
+          ) : null}
+        </div>
+      </header>
+
+      <main className="flex-1 overflow-y-auto bg-slate-950/95 px-6 py-6">
+        <div className="mx-auto max-w-4xl text-emerald-100">
+          {children}
+        </div>
+      </main>
+
+      {footer ? (
+        <footer className="border-t-4 border-newspaper-border bg-newspaper-header/95 px-6 py-5 text-newspaper-text">
+          {footer}
+        </footer>
+      ) : null}
+    </div>
+  );
+};
+
+export default GameOverEditionLayout;


### PR DESCRIPTION
## Summary
- replace the victory screen card wrapper with a reusable GameOverEditionLayout that borrows the Tabloid newspaper styling
- relocate the action buttons into a dedicated footer section and preserve the green aura with pseudo-element layers
- refresh the game over metadata to surface edition details alongside the final edition content

## Testing
- npm run lint *(fails: existing lint errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68da3fc8aa0c8320ba82c5f0190141bf