### PR TITLE
Add state event history tracking and display

### DIFF
--- a/src/components/game/EnhancedUSAMap.tsx
+++ b/src/components/game/EnhancedUSAMap.tsx
@@ -42,6 +42,7 @@ interface EnhancedState {
     source: 'truth' | 'government' | 'neutral';
   };
   stateEventBonus?: StateEventBonusSummary;
+  stateEventHistory?: StateEventBonusSummary[];
 }
 
 interface PlayedCard {
@@ -776,6 +777,27 @@ const EnhancedUSAMap: React.FC<EnhancedUSAMapProps> = ({
                   <div className="text-[11px] uppercase tracking-wide text-muted-foreground/80">
                     Turn {stateInfo.stateEventBonus.triggeredOnTurn} · {stateInfo.stateEventBonus.faction.toUpperCase()}
                   </div>
+                  {stateInfo.stateEventHistory?.length ? (
+                    <div className="mt-2 border-t border-amber-500/20 pt-2">
+                      <div className="text-[10px] uppercase tracking-wider text-muted-foreground/70">Event history</div>
+                      <ul className="mt-1 space-y-1 text-[11px] text-muted-foreground/90">
+                        {stateInfo.stateEventHistory
+                          .slice(-5)
+                          .reverse()
+                          .map((entry, index) => (
+                            <li
+                              key={`${stateInfo.id}-event-history-${entry.eventId}-${entry.triggeredOnTurn}-${index}`}
+                              className="flex items-center justify-between gap-2 rounded bg-amber-500/5 px-2 py-1"
+                            >
+                              <span className="truncate font-semibold text-foreground/90">{entry.label}</span>
+                              <span className="text-[10px] font-mono uppercase tracking-wide text-muted-foreground/70">
+                                Turn {entry.triggeredOnTurn} · {entry.faction.toUpperCase()}
+                              </span>
+                            </li>
+                          ))}
+                      </ul>
+                    </div>
+                  ) : null}
                 </div>
               </div>
             )}

--- a/src/hooks/aiHelpers.ts
+++ b/src/hooks/aiHelpers.ts
@@ -5,6 +5,7 @@ import type { TurnPlay } from '@/game/combo.types';
 import type { PlayerId } from '@/mvp/validator';
 
 import type { CardPlayRecord, GameState } from './gameStateTypes';
+import { mergeStateEventHistories } from './stateEventHistory';
 
 const CAPTURE_REGEX = /(captured|seized)\s+([^!]+)!/i;
 
@@ -344,12 +345,14 @@ export const applyAiCardPlay = (
     }
   }
 
+  const mergedStates = mergeStateEventHistories(prev.states, resolution.states);
+
   const nextState: GameState = {
     ...prev,
     ip: resolution.ip,
     aiIP: resolution.aiIP,
     truth: resolution.truth,
-    states: resolution.states,
+    states: mergedStates,
     controlledStates: resolution.controlledStates,
     aiControlledStates: resolution.aiControlledStates,
     targetState: resolution.targetState,

--- a/src/hooks/gameStateTypes.ts
+++ b/src/hooks/gameStateTypes.ts
@@ -70,6 +70,7 @@ export interface GameState {
     occupierUpdatedAt?: number;
     paranormalHotspot?: StateParanormalHotspot;
     stateEventBonus?: StateEventBonusSummary;
+    stateEventHistory: StateEventBonusSummary[];
   }>;
   currentEvents: GameEvent[];
   eventManager?: EventManager;

--- a/src/hooks/stateEventHistory.ts
+++ b/src/hooks/stateEventHistory.ts
@@ -1,0 +1,63 @@
+import type { GameState, StateEventBonusSummary } from './gameStateTypes';
+
+export const STATE_EVENT_HISTORY_LIMIT = 5;
+
+export const trimStateEventHistory = (
+  history: StateEventBonusSummary[],
+): StateEventBonusSummary[] => {
+  if (history.length <= STATE_EVENT_HISTORY_LIMIT) {
+    return history;
+  }
+
+  return history.slice(history.length - STATE_EVENT_HISTORY_LIMIT);
+};
+
+const buildHistoryLookupKey = (state: GameState['states'][number]): string[] => {
+  const keys = [] as string[];
+  if (typeof state.id === 'string') {
+    keys.push(state.id);
+  }
+  if (typeof state.abbreviation === 'string') {
+    keys.push(state.abbreviation);
+  }
+  return keys;
+};
+
+type StateWithOptionalHistory = Omit<GameState['states'][number], 'stateEventHistory'> & {
+  stateEventHistory?: StateEventBonusSummary[];
+  stateEventBonus?: StateEventBonusSummary;
+};
+
+export const mergeStateEventHistories = (
+  previous: GameState['states'],
+  next: StateWithOptionalHistory[],
+): GameState['states'] => {
+  const historyLookup = new Map<string, StateEventBonusSummary[]>();
+
+  for (const state of previous) {
+    const history = Array.isArray(state.stateEventHistory) ? state.stateEventHistory : [];
+    for (const key of buildHistoryLookupKey(state)) {
+      historyLookup.set(key, history);
+    }
+  }
+
+  return next.map(state => {
+    const existingHistory = Array.isArray(state.stateEventHistory)
+      ? state.stateEventHistory
+      : historyLookup.get(state.id) ?? historyLookup.get(state.abbreviation) ?? [];
+    const normalizedHistory = trimStateEventHistory([...existingHistory]);
+    const historyWithBonus =
+      normalizedHistory.length === 0 && state.stateEventBonus
+        ? trimStateEventHistory([...normalizedHistory, state.stateEventBonus])
+        : normalizedHistory;
+    const normalizedBonus = historyWithBonus.length > 0
+      ? historyWithBonus[historyWithBonus.length - 1]
+      : undefined;
+
+    return {
+      ...state,
+      stateEventHistory: historyWithBonus,
+      stateEventBonus: normalizedBonus,
+    } satisfies GameState['states'][number];
+  });
+};

--- a/src/systems/cardResolution.ts
+++ b/src/systems/cardResolution.ts
@@ -9,7 +9,7 @@ import {
   type StateCombinationEffects,
 } from '@/data/stateCombinations';
 import type { PlayerStats } from '@/data/achievementSystem';
-import type { StateParanormalHotspot } from '@/hooks/gameStateTypes';
+import type { StateEventBonusSummary, StateParanormalHotspot } from '@/hooks/gameStateTypes';
 
 type Faction = 'government' | 'truth';
 
@@ -48,6 +48,8 @@ export interface StateForResolution {
   occupierIcon?: string | null;
   occupierUpdatedAt?: number;
   paranormalHotspot?: StateParanormalHotspot;
+  stateEventBonus?: StateEventBonusSummary;
+  stateEventHistory?: StateEventBonusSummary[];
 }
 
 export interface GameSnapshot {


### PR DESCRIPTION
## Summary
- track per-state event history, merge it across game updates, and rehydrate saved games with normalized entries
- share state-event history helpers with AI resolutions and show the recent log on the EnhancedUSAMap tooltip
- extend event effect tests to cover sequential captures and ensure the mock event manager serves state events

## Testing
- bun test src/hooks/__tests__/useGameState.eventEffects.test.ts
- bunx tsc --noEmit

------
https://chatgpt.com/codex/tasks/task_e_68da42abd7708320ba738bbc6ac78e4d