### PR TITLE
Default Player Hub to Field Intel tab when intel is available

### DIFF
--- a/src/components/game/StateIntelBoard.module.css
+++ b/src/components/game/StateIntelBoard.module.css
@@ -1,0 +1,333 @@
+.board {
+  position: relative;
+  display: grid;
+  grid-template-columns: minmax(240px, 0.8fr) minmax(220px, 0.8fr) minmax(300px, 1.4fr);
+  gap: 1.75rem;
+  height: 100%;
+  padding: 1.75rem;
+  background: radial-gradient(circle at top left, rgba(220, 38, 38, 0.06), transparent 55%),
+    radial-gradient(circle at bottom right, rgba(14, 116, 144, 0.08), transparent 50%),
+    linear-gradient(120deg, rgba(15, 23, 42, 0.9), rgba(15, 23, 42, 0.75));
+  border-radius: 1.25rem;
+  overflow: hidden;
+}
+
+.ringLine,
+.diagonalLine {
+  position: absolute;
+  pointer-events: none;
+  inset: 0;
+  opacity: 0.25;
+}
+
+.ringLine::before {
+  content: '';
+  position: absolute;
+  width: 420px;
+  height: 420px;
+  top: -140px;
+  right: -160px;
+  border: 1px dashed rgba(248, 113, 113, 0.35);
+  border-radius: 50%;
+}
+
+.diagonalLine::before {
+  content: '';
+  position: absolute;
+  width: 140%;
+  height: 2px;
+  background: linear-gradient(90deg, rgba(248, 113, 113, 0.55), transparent);
+  top: 16%;
+  left: -20%;
+  transform: rotate(-8deg);
+}
+
+.sectionHeader {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: 0.7rem;
+  text-transform: uppercase;
+  letter-spacing: 0.35em;
+  color: rgba(226, 232, 240, 0.85);
+  margin-bottom: 0.75rem;
+}
+
+.summaryCard {
+  position: relative;
+  padding: 1.5rem;
+  border-radius: 1rem;
+  background: linear-gradient(135deg, rgba(15, 118, 110, 0.22), rgba(15, 23, 42, 0.85));
+  border: 1px solid rgba(16, 185, 129, 0.35);
+  box-shadow: 0 25px 60px rgba(6, 78, 59, 0.25);
+  color: #ccfbf1;
+  overflow: hidden;
+}
+
+.summaryCard::after {
+  content: '';
+  position: absolute;
+  inset: 12px;
+  border: 1px dashed rgba(16, 185, 129, 0.2);
+  border-radius: 0.9rem;
+  pointer-events: none;
+}
+
+.summaryGrid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 1rem;
+  margin-bottom: 1.25rem;
+}
+
+.summaryStat {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  padding: 0.85rem;
+  background: rgba(15, 23, 42, 0.45);
+  border-radius: 0.75rem;
+  border: 1px solid rgba(20, 184, 166, 0.25);
+  box-shadow: inset 0 0 18px rgba(16, 185, 129, 0.15);
+}
+
+.summaryStat strong {
+  font-size: 1.9rem;
+  font-family: 'Space Grotesk', sans-serif;
+  line-height: 1.1;
+}
+
+.summaryStat span:last-child {
+  font-size: 0.7rem;
+  font-family: 'IBM Plex Mono', monospace;
+  letter-spacing: 0.25em;
+  text-transform: uppercase;
+  color: rgba(203, 213, 225, 0.75);
+}
+
+.summaryFooter {
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: 0.75rem;
+  letter-spacing: 0.25em;
+  color: rgba(203, 213, 225, 0.7);
+}
+
+.contestedColumn {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  padding: 1.5rem 1.25rem;
+  border-radius: 1rem;
+  background: linear-gradient(140deg, rgba(248, 250, 252, 0.9), rgba(226, 232, 240, 0.85));
+  border: 1px solid rgba(71, 85, 105, 0.2);
+  box-shadow: 0 20px 45px rgba(15, 23, 42, 0.25);
+  color: #0f172a;
+  overflow: hidden;
+}
+
+.contestedList {
+  display: grid;
+  gap: 1rem;
+  overflow: auto;
+  padding-right: 0.25rem;
+}
+
+.contestedCard {
+  position: relative;
+  padding: 1rem;
+  background: #f8fafc;
+  border-radius: 0.75rem;
+  border: 1px solid rgba(148, 163, 184, 0.4);
+  box-shadow: 0 12px 28px rgba(15, 23, 42, 0.18);
+}
+
+.contestedCard .tape,
+.emptyBoard .tape {
+  position: absolute;
+  top: -18px;
+  left: 50%;
+  transform: translateX(-50%) rotate(-6deg);
+  width: 110px;
+  height: 26px;
+  background: linear-gradient(135deg, rgba(253, 224, 71, 0.85), rgba(254, 243, 199, 0.8));
+  border-radius: 6px;
+  box-shadow: 0 14px 22px rgba(15, 23, 42, 0.4);
+  opacity: 0.85;
+  pointer-events: none;
+}
+
+.contestedMeta {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0.75rem;
+  margin-top: 1rem;
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: 0.75rem;
+  color: #1e293b;
+}
+
+.contestedMeta dt {
+  text-transform: uppercase;
+  letter-spacing: 0.18em;
+  color: rgba(71, 85, 105, 0.85);
+}
+
+.contestedMeta dd {
+  margin-top: 0.25rem;
+  font-weight: 600;
+}
+
+.placeholderCard {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 1.5rem 1rem;
+  border: 2px dashed rgba(148, 163, 184, 0.35);
+  border-radius: 0.75rem;
+  color: rgba(71, 85, 105, 0.8);
+  background: rgba(241, 245, 249, 0.6);
+  text-align: center;
+  font-family: 'IBM Plex Mono', monospace;
+}
+
+.eventsPanel {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  padding: 1.5rem;
+  background: linear-gradient(135deg, rgba(248, 113, 113, 0.14), rgba(15, 23, 42, 0.85));
+  border-radius: 1rem;
+  border: 1px solid rgba(248, 113, 113, 0.35);
+  box-shadow: 0 25px 60px rgba(127, 29, 29, 0.35);
+  overflow: hidden;
+}
+
+.eventsScroll {
+  height: 100%;
+  padding-right: 0.5rem;
+}
+
+.eventStack {
+  position: relative;
+  display: grid;
+  gap: 1.5rem;
+  padding-right: 0.75rem;
+  padding-bottom: 0.5rem;
+}
+
+.eventCard {
+  position: relative;
+  padding: 1.25rem 1.5rem 1.5rem;
+  border-radius: 0.85rem;
+  background: #fef3c7;
+  color: #1f2937;
+  border: 1px solid rgba(120, 53, 15, 0.35);
+  box-shadow: 0 28px 50px rgba(15, 23, 42, 0.35);
+  transform: rotate(var(--rotation, -2deg));
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.eventCard::before {
+  content: '';
+  position: absolute;
+  top: -24px;
+  left: 50%;
+  transform: translateX(-50%) rotate(calc(var(--rotation, 0deg) / 2));
+  width: 140px;
+  height: 32px;
+  background: linear-gradient(135deg, rgba(253, 230, 138, 0.9), rgba(251, 191, 36, 0.75));
+  border-radius: 6px;
+  box-shadow: 0 18px 26px rgba(15, 23, 42, 0.4);
+  mix-blend-mode: multiply;
+  opacity: 0.9;
+}
+
+.eventCard:hover {
+  transform: rotate(var(--rotation, -2deg)) scale(1.02);
+  box-shadow: 0 35px 68px rgba(15, 23, 42, 0.45);
+}
+
+.thread {
+  position: absolute;
+  top: -28px;
+  left: -44px;
+  width: calc(100% + 120px);
+  height: 2px;
+  background: linear-gradient(90deg, rgba(248, 113, 113, 0.95), rgba(248, 113, 113, 0.15));
+  transform: rotate(var(--thread-angle, -6deg));
+  transform-origin: left center;
+  opacity: 0.75;
+  pointer-events: none;
+}
+
+.eventHeader {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 1rem;
+}
+
+.effectList {
+  margin-top: 1.25rem;
+  padding-left: 1.25rem;
+  display: grid;
+  gap: 0.35rem;
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: 0.75rem;
+  color: #4b5563;
+}
+
+.eventFooter {
+  margin-top: 1.75rem;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: 0.7rem;
+  color: rgba(71, 85, 105, 0.8);
+}
+
+.emptyBoard {
+  position: relative;
+  padding: 2rem 1.5rem;
+  border-radius: 0.85rem;
+  border: 2px dashed rgba(148, 163, 184, 0.35);
+  background: rgba(248, 250, 252, 0.85);
+  color: #1f2937;
+  display: grid;
+  gap: 0.75rem;
+  text-align: center;
+  box-shadow: 0 20px 40px rgba(15, 23, 42, 0.25);
+}
+
+.emptyBoard p:last-of-type {
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: 0.75rem;
+  letter-spacing: 0.16em;
+}
+
+@media (max-width: 1280px) {
+  .board {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    grid-template-rows: auto auto;
+  }
+
+  .eventsPanel {
+    grid-column: span 2;
+  }
+}
+
+@media (max-width: 900px) {
+  .board {
+    grid-template-columns: minmax(0, 1fr);
+    grid-auto-rows: auto;
+    padding: 1.25rem;
+  }
+
+  .eventsPanel {
+    grid-column: span 1;
+  }
+}

--- a/src/components/game/StateIntelBoard.tsx
+++ b/src/components/game/StateIntelBoard.tsx
@@ -1,0 +1,195 @@
+import { type CSSProperties } from 'react';
+import { AlertTriangle, Shield, Target, Activity } from 'lucide-react';
+import { Badge } from '@/components/ui/badge';
+import { ScrollArea } from '@/components/ui/scroll-area';
+import { cn } from '@/lib/utils';
+import styles from './StateIntelBoard.module.css';
+import type { PlayerStateIntel } from './PlayerHubOverlay';
+
+interface StateIntelBoardProps {
+  intel?: PlayerStateIntel;
+}
+
+const ownerLabels: Record<PlayerStateIntel['states'][number]['owner'], string> = {
+  player: 'Operative Control',
+  ai: 'Opposition Control',
+  neutral: 'Unaligned',
+};
+
+const ownerBadgeStyles: Record<PlayerStateIntel['states'][number]['owner'], string> = {
+  player: 'bg-emerald-500/20 text-emerald-100 border border-emerald-400/40',
+  ai: 'bg-rose-500/20 text-rose-100 border border-rose-400/40',
+  neutral: 'bg-slate-500/20 text-slate-200 border border-slate-400/30',
+};
+
+const factionBadgeStyles: Record<'truth' | 'government', string> = {
+  truth: 'bg-sky-500/20 text-sky-100 border border-sky-400/40',
+  government: 'bg-amber-500/20 text-amber-100 border border-amber-400/40',
+};
+
+const rotations = [-2.8, -0.6, 1.6, -1.2, 2.4];
+const threadAngles = [-6, 3, -2, 4];
+
+const StateIntelBoard = ({ intel }: StateIntelBoardProps) => {
+  const totals = intel?.totals ?? { player: 0, ai: 0, neutral: 0, contested: 0 };
+  const contestedStates = (intel?.states ?? []).filter(state => state.contested).slice(0, 5);
+  const recentEvents = intel?.recentEvents ?? [];
+  const hasEvents = recentEvents.length > 0;
+
+  return (
+    <div className={styles.board}>
+      <div className={styles.ringLine} aria-hidden />
+      <div className={styles.diagonalLine} aria-hidden />
+
+      <section className={styles.summaryCard}>
+        <header className={styles.sectionHeader}>
+          <Activity className="h-4 w-4" />
+          <span>Command Overview</span>
+        </header>
+        <div className={styles.summaryGrid}>
+          <div className={styles.summaryStat}>
+            <Badge className="border border-emerald-400/50 bg-emerald-500/20 text-emerald-100">Player</Badge>
+            <strong>{totals.player}</strong>
+            <span>Strongholds</span>
+          </div>
+          <div className={styles.summaryStat}>
+            <Badge className="border border-rose-400/50 bg-rose-500/20 text-rose-100">AI</Badge>
+            <strong>{totals.ai}</strong>
+            <span>Occupied States</span>
+          </div>
+          <div className={styles.summaryStat}>
+            <Badge className="border border-slate-400/50 bg-slate-500/20 text-slate-100">Neutral</Badge>
+            <strong>{totals.neutral}</strong>
+            <span>In Flux</span>
+          </div>
+          <div className={styles.summaryStat}>
+            <Badge className="border border-amber-400/60 bg-amber-500/20 text-amber-100">Contested</Badge>
+            <strong>{totals.contested}</strong>
+            <span>Hot Zones</span>
+          </div>
+        </div>
+        <footer className={styles.summaryFooter}>
+          Turn {intel?.generatedAtTurn ?? '—'} &middot; Round {intel?.round ?? '—'}
+        </footer>
+      </section>
+
+      <section className={styles.contestedColumn}>
+        <header className={styles.sectionHeader}>
+          <Target className="h-4 w-4" />
+          <span>Active Hot Zones</span>
+        </header>
+        <div className={styles.contestedList}>
+          {contestedStates.length > 0 ? (
+            contestedStates.map(state => (
+              <div key={state.id} className={styles.contestedCard}>
+                <span className={styles.tape} aria-hidden />
+                <div className="flex items-center justify-between">
+                  <p className="font-mono text-xs uppercase tracking-[0.32em] text-slate-600">
+                    {state.abbreviation}
+                  </p>
+                  <Badge className={cn('font-mono text-[10px] uppercase tracking-[0.32em]', ownerBadgeStyles[state.owner])}>
+                    {ownerLabels[state.owner]}
+                  </Badge>
+                </div>
+                <h3 className="mt-2 font-serif text-lg text-slate-900">{state.name}</h3>
+                <dl className={styles.contestedMeta}>
+                  <div>
+                    <dt>Pressure</dt>
+                    <dd>
+                      <span className="text-rose-500">{state.pressureAi}</span>
+                      <span className="mx-1 text-slate-500">vs</span>
+                      <span className="text-emerald-500">{state.pressurePlayer}</span>
+                    </dd>
+                  </div>
+                  <div>
+                    <dt>Defense</dt>
+                    <dd>{state.defense}</dd>
+                  </div>
+                </dl>
+              </div>
+            ))
+          ) : (
+            <div className={styles.placeholderCard}>
+              <Shield className="h-5 w-5 text-slate-500" />
+              <p>No contested regions logged.</p>
+            </div>
+          )}
+        </div>
+      </section>
+
+      <section className={styles.eventsPanel}>
+        <header className={styles.sectionHeader}>
+          <AlertTriangle className="h-4 w-4" />
+          <span>Incident Board</span>
+        </header>
+        <ScrollArea className={styles.eventsScroll}>
+          <div className={styles.eventStack}>
+            {hasEvents ? (
+              recentEvents.map((entry, index) => {
+                const rotation = rotations[index % rotations.length];
+                const threadAngle = threadAngles[index % threadAngles.length];
+                const style = {
+                  '--rotation': `${rotation}deg`,
+                  '--thread-angle': `${threadAngle}deg`,
+                } as CSSProperties;
+                return (
+                  <article key={`${entry.stateId}-${entry.event.eventId}-${index}`} className={styles.eventCard} style={style}>
+                    <span className={styles.thread} aria-hidden />
+                    <header className={styles.eventHeader}>
+                      <div>
+                        <p className="font-mono text-[10px] uppercase tracking-[0.4em] text-slate-500">
+                          {entry.abbreviation} &bull; Turn {entry.event.triggeredOnTurn}
+                        </p>
+                        <h3 className="text-xl font-serif text-slate-900">{entry.event.label}</h3>
+                      </div>
+                      <Badge
+                        className={cn(
+                          'font-mono text-[10px] uppercase tracking-[0.32em]',
+                          factionBadgeStyles[entry.event.faction],
+                        )}
+                      >
+                        {entry.event.faction === 'truth' ? 'Truth Ops' : 'Government Ops'}
+                      </Badge>
+                    </header>
+                    {entry.event.description && (
+                      <p className="mt-3 text-sm leading-relaxed text-slate-700">
+                        {entry.event.description}
+                      </p>
+                    )}
+                    {Array.isArray(entry.event.effectSummary) && entry.event.effectSummary.length > 0 && (
+                      <ul className={styles.effectList}>
+                        {entry.event.effectSummary.map((summary, idx) => (
+                          <li key={idx}>
+                            <span className="text-slate-600">{summary}</span>
+                          </li>
+                        ))}
+                      </ul>
+                    )}
+                    <footer className={styles.eventFooter}>
+                      <span className="font-mono text-xs uppercase tracking-[0.32em] text-slate-500">
+                        {entry.stateName}
+                      </span>
+                      <span className="text-xs text-slate-500">
+                        Defense {entry.defense} · Pressure Δ {entry.pressurePlayer - entry.pressureAi}
+                      </span>
+                    </footer>
+                  </article>
+                );
+              })
+            ) : (
+              <div className={styles.emptyBoard}>
+                <span className={styles.tape} aria-hidden />
+                <p className="font-serif text-lg text-slate-900">No field events recorded yet.</p>
+                <p className="text-sm text-slate-600">
+                  Run operations to generate intel—reports will be pinned here with full dossiers.
+                </p>
+              </div>
+            )}
+          </div>
+        </ScrollArea>
+      </section>
+    </div>
+  );
+};
+
+export default StateIntelBoard;


### PR DESCRIPTION
## Summary
- default the Player Hub overlay to the Field Intel tab when recent intel has been gathered and no press issues are available
- keep other hub behavior unchanged so players still land on the press archive when issues exist

## Testing
- npm run lint *(fails: existing lint violations in unrelated files)*
- npm run build


------
https://chatgpt.com/codex/tasks/task_e_68da462a85cc8320bdf57d78f69380ff