### PR TITLE
Add truth-themed styling for player hub overlay

### DIFF
--- a/src/components/game/PlayerHubOverlay.tsx
+++ b/src/components/game/PlayerHubOverlay.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import clsx from 'clsx';
 import { Card } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
@@ -11,6 +12,7 @@ import PressArchivePanel from './PressArchivePanel';
 import type { ArchivedEdition } from '@/hooks/usePressArchive';
 import StateIntelBoard from './StateIntelBoard';
 import type { StateEventBonusSummary } from '@/hooks/gameStateTypes';
+import '@/styles/playerHub.css';
 
 interface PlayerHubOverlayProps {
   onClose: () => void;
@@ -19,6 +21,7 @@ interface PlayerHubOverlayProps {
   onOpenEdition: (issue: ArchivedEdition) => void;
   onDeleteEdition: (id: string) => void;
   stateIntel?: PlayerStateIntel;
+  faction: 'truth' | 'government';
 }
 
 export interface PlayerStateIntel {
@@ -65,6 +68,7 @@ const PlayerHubOverlay = ({
   onOpenEdition,
   onDeleteEdition,
   stateIntel,
+  faction,
 }: PlayerHubOverlayProps) => {
   const [activeTab, setActiveTab] = useState<HubTab>(() => {
     if (pressIssues.length > 0) {
@@ -78,28 +82,74 @@ const PlayerHubOverlay = ({
     return 'achievements';
   });
 
+  const isTruth = faction === 'truth';
+
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/80 p-4">
-      <Card className="relative flex h-[90vh] w-full max-w-7xl flex-col overflow-hidden border border-emerald-500/30 bg-slate-950/95 text-slate-100 shadow-[0_0_80px_rgba(16,185,129,0.25)]">
-        <div className="pointer-events-none absolute inset-0">
-          <div className="absolute inset-0 opacity-60 bg-[radial-gradient(circle_at_top,_rgba(16,185,129,0.22),_transparent_55%)]" />
-          <div className="absolute inset-0 opacity-50 bg-[radial-gradient(circle_at_bottom,_rgba(56,189,248,0.18),_transparent_60%)]" />
-          <div
-            className="absolute inset-0 opacity-35 mix-blend-screen"
-            style={{ backgroundImage: 'linear-gradient(135deg, rgba(56,189,248,0.16), transparent 45%, rgba(16,185,129,0.12))' }}
-          />
+      <Card
+        className={clsx(
+          'player-hub-card relative flex h-[90vh] w-full max-w-7xl flex-col overflow-hidden',
+          isTruth
+            ? 'player-hub-truth border border-amber-900/40 bg-[rgba(252,245,232,0.97)] text-stone-900 shadow-[0_35px_120px_rgba(124,45,18,0.25)]'
+            : 'player-hub-government border border-emerald-500/30 bg-slate-950/95 text-slate-100 shadow-[0_0_80px_rgba(16,185,129,0.25)]',
+        )}
+      >
+        <div className="player-hub-background pointer-events-none absolute inset-0">
+          {isTruth ? (
+            <>
+              <div className="player-hub-truth__paper" />
+              <div className="player-hub-truth__grain" />
+              <div className="player-hub-truth__thread player-hub-truth__thread--one" />
+              <div className="player-hub-truth__thread player-hub-truth__thread--two" />
+              <div className="player-hub-truth__tape player-hub-truth__tape--one" />
+              <div className="player-hub-truth__tape player-hub-truth__tape--two" />
+            </>
+          ) : (
+            <>
+              <div className="absolute inset-0 bg-[radial-gradient(circle_at_top,_rgba(16,185,129,0.22),_transparent_55%)] opacity-60" />
+              <div className="absolute inset-0 bg-[radial-gradient(circle_at_bottom,_rgba(56,189,248,0.18),_transparent_60%)] opacity-50" />
+              <div
+                className="absolute inset-0 opacity-35 mix-blend-screen"
+                style={{ backgroundImage: 'linear-gradient(135deg, rgba(56,189,248,0.16), transparent 45%, rgba(16,185,129,0.12))' }}
+              />
+            </>
+          )}
         </div>
 
-        <div className="relative border-b border-emerald-500/20 bg-gradient-to-r from-emerald-900/40 via-slate-950 to-slate-950/90 px-6 py-5 backdrop-blur">
+        <div
+          className={clsx(
+            'player-hub-header relative border-b px-6 py-5 backdrop-blur',
+            isTruth
+              ? 'border-rose-900/40 bg-gradient-to-r from-amber-100 via-rose-50 to-amber-200/80 text-stone-900'
+              : 'border-emerald-500/20 bg-gradient-to-r from-emerald-900/40 via-slate-950 to-slate-950/90 text-emerald-100',
+          )}
+        >
           <div className="flex flex-wrap items-start justify-between gap-6">
             <div className="space-y-2">
-              <Badge className="border border-emerald-400/60 bg-emerald-500/15 font-mono text-[11px] uppercase tracking-[0.35em] text-emerald-200">
+              <Badge
+                className={clsx(
+                  'player-hub-badge border font-mono text-[11px] uppercase tracking-[0.35em]',
+                  isTruth
+                    ? 'border-rose-800/60 bg-rose-100/90 text-rose-900 shadow-[0_6px_18px_rgba(124,45,18,0.18)]'
+                    : 'border-emerald-400/60 bg-emerald-500/15 text-emerald-200',
+                )}
+              >
                 Operator Uplink
               </Badge>
-              <h2 className="font-mono text-2xl font-semibold uppercase tracking-[0.2em] text-emerald-100">
+              <h2
+                className={clsx(
+                  'font-mono text-2xl font-semibold uppercase tracking-[0.2em]',
+                  isTruth ? 'text-rose-900 drop-shadow-[0_1px_0_rgba(255,255,255,0.65)]' : 'text-emerald-100',
+                )}
+              >
                 AGENT DOSSIER HUB
               </h2>
-              <p className="max-w-2xl text-sm text-emerald-100/70">
+              <p
+                className={clsx(
+                  'max-w-2xl text-sm',
+                  isTruth ? 'text-stone-700' : 'text-emerald-100/70',
+                )}
+              >
                 Review your progress, browse unlocked cards, and continue your training across the network.
               </p>
             </div>
@@ -107,7 +157,12 @@ const PlayerHubOverlay = ({
               onClick={onClose}
               variant="outline"
               size="sm"
-              className="border-emerald-400/40 bg-emerald-500/10 text-emerald-200 transition hover:bg-emerald-500/20 hover:text-emerald-100"
+              className={clsx(
+                'player-hub-close-btn transition',
+                isTruth
+                  ? 'border-rose-800/40 bg-rose-100/70 text-rose-900 shadow-sm hover:bg-rose-200/80 hover:text-rose-900'
+                  : 'border-emerald-400/40 bg-emerald-500/10 text-emerald-200 hover:bg-emerald-500/20 hover:text-emerald-100',
+              )}
             >
               <X size={16} className="mr-1" />
               Close
@@ -121,38 +176,70 @@ const PlayerHubOverlay = ({
           className="relative flex flex-1 flex-col overflow-hidden"
         >
           <div className="relative px-6 pt-6">
-            <TabsList className="grid w-full grid-cols-5 gap-2 rounded-lg border border-emerald-500/20 bg-slate-900/70 p-1 backdrop-blur">
+            <TabsList
+              className={clsx(
+                'player-hub-tablist grid w-full grid-cols-5 gap-2 rounded-lg border p-1 backdrop-blur',
+                isTruth
+                  ? 'border-rose-900/40 bg-[rgba(255,255,255,0.86)] shadow-[inset_0_15px_40px_rgba(124,45,18,0.12)]'
+                  : 'border-emerald-500/20 bg-slate-900/70',
+              )}
+            >
               <TabsTrigger
                 value="achievements"
-                className="flex items-center justify-center gap-2 rounded-md border border-transparent px-3 py-2 text-[11px] font-semibold uppercase tracking-[0.32em] text-slate-400 transition data-[state=active]:border-emerald-400/60 data-[state=active]:bg-emerald-500/15 data-[state=active]:text-emerald-200"
+                className={clsx(
+                  'flex items-center justify-center gap-2 rounded-md border border-transparent px-3 py-2 text-[11px] font-semibold uppercase tracking-[0.32em] transition',
+                  isTruth
+                    ? 'text-stone-500 data-[state=active]:border-rose-900/60 data-[state=active]:bg-amber-100/90 data-[state=active]:text-rose-900 data-[state=active]:shadow-[inset_0_4px_18px_rgba(124,45,18,0.18)]'
+                    : 'text-slate-400 data-[state=active]:border-emerald-400/60 data-[state=active]:bg-emerald-500/15 data-[state=active]:text-emerald-200',
+                )}
               >
                 <Trophy className="h-4 w-4" />
                 Achievements
               </TabsTrigger>
               <TabsTrigger
                 value="cards"
-                className="flex items-center justify-center gap-2 rounded-md border border-transparent px-3 py-2 text-[11px] font-semibold uppercase tracking-[0.32em] text-slate-400 transition data-[state=active]:border-emerald-400/60 data-[state=active]:bg-emerald-500/15 data-[state=active]:text-emerald-200"
+                className={clsx(
+                  'flex items-center justify-center gap-2 rounded-md border border-transparent px-3 py-2 text-[11px] font-semibold uppercase tracking-[0.32em] transition',
+                  isTruth
+                    ? 'text-stone-500 data-[state=active]:border-rose-900/60 data-[state=active]:bg-amber-100/90 data-[state=active]:text-rose-900 data-[state=active]:shadow-[inset_0_4px_18px_rgba(124,45,18,0.18)]'
+                    : 'text-slate-400 data-[state=active]:border-emerald-400/60 data-[state=active]:bg-emerald-500/15 data-[state=active]:text-emerald-200',
+                )}
               >
                 <Library className="h-4 w-4" />
                 Card Collection
               </TabsTrigger>
               <TabsTrigger
                 value="tutorials"
-                className="flex items-center justify-center gap-2 rounded-md border border-transparent px-3 py-2 text-[11px] font-semibold uppercase tracking-[0.32em] text-slate-400 transition data-[state=active]:border-emerald-400/60 data-[state=active]:bg-emerald-500/15 data-[state=active]:text-emerald-200"
+                className={clsx(
+                  'flex items-center justify-center gap-2 rounded-md border border-transparent px-3 py-2 text-[11px] font-semibold uppercase tracking-[0.32em] transition',
+                  isTruth
+                    ? 'text-stone-500 data-[state=active]:border-rose-900/60 data-[state=active]:bg-amber-100/90 data-[state=active]:text-rose-900 data-[state=active]:shadow-[inset_0_4px_18px_rgba(124,45,18,0.18)]'
+                    : 'text-slate-400 data-[state=active]:border-emerald-400/60 data-[state=active]:bg-emerald-500/15 data-[state=active]:text-emerald-200',
+                )}
               >
                 <GraduationCap className="h-4 w-4" />
                 Shadow Academy
               </TabsTrigger>
               <TabsTrigger
                 value="press"
-                className="flex items-center justify-center gap-2 rounded-md border border-transparent px-3 py-2 text-[11px] font-semibold uppercase tracking-[0.32em] text-slate-400 transition data-[state=active]:border-emerald-400/60 data-[state=active]:bg-emerald-500/15 data-[state=active]:text-emerald-200"
+                className={clsx(
+                  'flex items-center justify-center gap-2 rounded-md border border-transparent px-3 py-2 text-[11px] font-semibold uppercase tracking-[0.32em] transition',
+                  isTruth
+                    ? 'text-stone-500 data-[state=active]:border-rose-900/60 data-[state=active]:bg-amber-100/90 data-[state=active]:text-rose-900 data-[state=active]:shadow-[inset_0_4px_18px_rgba(124,45,18,0.18)]'
+                    : 'text-slate-400 data-[state=active]:border-emerald-400/60 data-[state=active]:bg-emerald-500/15 data-[state=active]:text-emerald-200',
+                )}
               >
                 <Newspaper className="h-4 w-4" />
                 Press Archive
               </TabsTrigger>
               <TabsTrigger
                 value="intel"
-                className="flex items-center justify-center gap-2 rounded-md border border-transparent px-3 py-2 text-[11px] font-semibold uppercase tracking-[0.32em] text-slate-400 transition data-[state=active]:border-emerald-400/60 data-[state=active]:bg-emerald-500/15 data-[state=active]:text-emerald-200"
+                className={clsx(
+                  'flex items-center justify-center gap-2 rounded-md border border-transparent px-3 py-2 text-[11px] font-semibold uppercase tracking-[0.32em] transition',
+                  isTruth
+                    ? 'text-stone-500 data-[state=active]:border-rose-900/60 data-[state=active]:bg-amber-100/90 data-[state=active]:text-rose-900 data-[state=active]:shadow-[inset_0_4px_18px_rgba(124,45,18,0.18)]'
+                    : 'text-slate-400 data-[state=active]:border-emerald-400/60 data-[state=active]:bg-emerald-500/15 data-[state=active]:text-emerald-200',
+                )}
               >
                 <MapPin className="h-4 w-4" />
                 Field Intel
@@ -161,10 +248,26 @@ const PlayerHubOverlay = ({
           </div>
 
           <div className="relative flex-1 overflow-hidden px-6 pb-6 pt-4">
-            <div className="relative flex h-full flex-col overflow-hidden rounded-2xl border border-emerald-500/25 bg-slate-950/80 shadow-[0_0_45px_rgba(16,185,129,0.15)]">
+            <div
+              className={clsx(
+                'player-hub-panel relative flex h-full flex-col overflow-hidden rounded-2xl border',
+                isTruth
+                  ? 'border-rose-900/30 bg-[rgba(255,250,240,0.88)] shadow-[0_35px_80px_rgba(124,45,18,0.18)]'
+                  : 'border-emerald-500/25 bg-slate-950/80 shadow-[0_0_45px_rgba(16,185,129,0.15)]',
+              )}
+            >
               <div className="pointer-events-none absolute inset-0 opacity-45">
-                <div className="absolute inset-0 bg-[radial-gradient(circle_at_top,_rgba(16,185,129,0.18),_transparent_55%)]" />
-                <div className="absolute inset-0 bg-[linear-gradient(160deg,_rgba(56,189,248,0.12),_transparent_60%)]" />
+                {isTruth ? (
+                  <>
+                    <div className="absolute inset-0 bg-[radial-gradient(circle_at_top,_rgba(252,211,77,0.25),_transparent_60%)]" />
+                    <div className="absolute inset-0 bg-[linear-gradient(160deg,_rgba(244,114,182,0.18),_transparent_55%)]" />
+                  </>
+                ) : (
+                  <>
+                    <div className="absolute inset-0 bg-[radial-gradient(circle_at_top,_rgba(16,185,129,0.18),_transparent_55%)]" />
+                    <div className="absolute inset-0 bg-[linear-gradient(160deg,_rgba(56,189,248,0.12),_transparent_60%)]" />
+                  </>
+                )}
               </div>
 
               <TabsContent value="achievements" className="relative h-full overflow-hidden p-6 focus-visible:outline-none">

--- a/src/styles/playerHub.css
+++ b/src/styles/playerHub.css
@@ -1,0 +1,163 @@
+.player-hub-card {
+  position: relative;
+}
+
+.player-hub-card .player-hub-background {
+  pointer-events: none;
+}
+
+.player-hub-truth {
+  --player-hub-truth-paper: linear-gradient(135deg, rgba(255, 247, 231, 0.95), rgba(245, 228, 200, 0.85));
+  --player-hub-truth-paper-secondary: repeating-linear-gradient(
+    0deg,
+    rgba(255, 255, 255, 0.05) 0px,
+    rgba(255, 255, 255, 0.05) 4px,
+    rgba(233, 216, 166, 0.08) 4px,
+    rgba(233, 216, 166, 0.08) 8px
+  );
+  --player-hub-truth-fiber: repeating-linear-gradient(
+    115deg,
+    rgba(255, 255, 255, 0.15) 0px,
+    rgba(255, 255, 255, 0.15) 8px,
+    rgba(230, 214, 175, 0.12) 8px,
+    rgba(230, 214, 175, 0.12) 18px
+  );
+  --player-hub-truth-noise: url('data:image/svg+xml,%3Csvg xmlns="http://www.w3.org/2000/svg" width="120" height="120" viewBox="0 0 120 120"%3E%3Cg fill="none" fill-opacity="0.2"%3E%3Ccircle fill="%23d97706" cx="6" cy="6" r="1"/%3E%3Ccircle fill="%23facc15" cx="50" cy="30" r="1"/%3E%3Ccircle fill="%23f59e0b" cx="24" cy="84" r="1"/%3E%3Ccircle fill="%23ef4444" cx="90" cy="20" r="1"/%3E%3Ccircle fill="%23dc2626" cx="70" cy="100" r="1"/%3E%3Ccircle fill="%23f97316" cx="110" cy="60" r="1"/%3E%3C/g%3E%3C/svg%3E');
+}
+
+.player-hub-truth .player-hub-background > * {
+  pointer-events: none;
+}
+
+.player-hub-truth .player-hub-truth__paper {
+  position: absolute;
+  inset: 0;
+  background-image: var(--player-hub-truth-paper), var(--player-hub-truth-paper-secondary), var(--player-hub-truth-fiber);
+  background-blend-mode: multiply;
+  filter: saturate(1.02) contrast(1.05);
+}
+
+.player-hub-truth .player-hub-truth__grain {
+  position: absolute;
+  inset: 0;
+  background-image: var(--player-hub-truth-noise);
+  background-size: 120px 120px;
+  opacity: 0.28;
+  mix-blend-mode: multiply;
+}
+
+.player-hub-truth .player-hub-truth__thread {
+  position: absolute;
+  height: 3px;
+  border-radius: 999px;
+  background: linear-gradient(90deg, rgba(127, 29, 29, 0.75) 0%, rgba(220, 38, 38, 0.85) 45%, rgba(127, 29, 29, 0.75) 100%);
+  box-shadow: 0 0 14px rgba(185, 28, 28, 0.35);
+  opacity: 0.8;
+}
+
+.player-hub-truth .player-hub-truth__thread::before,
+.player-hub-truth .player-hub-truth__thread::after {
+  content: '';
+  position: absolute;
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+  background: radial-gradient(circle at 30% 30%, rgba(248, 113, 113, 0.85), rgba(127, 29, 29, 0.95));
+  border: 2px solid rgba(127, 29, 29, 0.6);
+  box-shadow: 0 4px 10px rgba(127, 29, 29, 0.4);
+}
+
+.player-hub-truth .player-hub-truth__thread::before {
+  left: -4px;
+  top: -5px;
+}
+
+.player-hub-truth .player-hub-truth__thread::after {
+  right: -4px;
+  top: -5px;
+}
+
+.player-hub-truth .player-hub-truth__thread--one {
+  top: 18%;
+  left: 6%;
+  width: 78%;
+  transform: rotate(-5deg);
+}
+
+.player-hub-truth .player-hub-truth__thread--two {
+  bottom: 24%;
+  right: 5%;
+  width: 72%;
+  transform: rotate(8deg);
+}
+
+.player-hub-truth .player-hub-truth__tape {
+  position: absolute;
+  width: 160px;
+  height: 48px;
+  border-radius: 6px;
+  background: linear-gradient(135deg, rgba(255, 243, 205, 0.9) 0%, rgba(255, 223, 148, 0.9) 50%, rgba(249, 210, 118, 0.85) 100%);
+  box-shadow: 0 18px 26px rgba(120, 53, 15, 0.22);
+  opacity: 0.78;
+  filter: saturate(1.1);
+}
+
+.player-hub-truth .player-hub-truth__tape::before {
+  content: '';
+  position: absolute;
+  inset: 10px 12px;
+  border-radius: 4px;
+  background: repeating-linear-gradient(
+    90deg,
+    rgba(255, 255, 255, 0.55) 0,
+    rgba(255, 255, 255, 0.55) 12px,
+    rgba(253, 230, 138, 0.4) 12px,
+    rgba(253, 230, 138, 0.4) 24px
+  );
+  opacity: 0.55;
+}
+
+.player-hub-truth .player-hub-truth__tape--one {
+  top: 18px;
+  left: 50%;
+  transform: translateX(-50%) rotate(-6deg);
+}
+
+.player-hub-truth .player-hub-truth__tape--two {
+  bottom: 26px;
+  right: 60px;
+  width: 130px;
+  transform: rotate(7deg);
+}
+
+.player-hub-truth .player-hub-tablist {
+  box-shadow: inset 0 20px 40px rgba(124, 45, 18, 0.08);
+}
+
+.player-hub-truth .player-hub-panel {
+  backdrop-filter: blur(6px);
+}
+
+.player-hub-truth .player-hub-header {
+  backdrop-filter: blur(8px);
+}
+
+.player-hub-truth .player-hub-badge {
+  letter-spacing: 0.32em;
+}
+
+.player-hub-truth .player-hub-close-btn {
+  font-weight: 600;
+}
+
+@media (max-width: 1024px) {
+  .player-hub-truth .player-hub-truth__thread--one,
+  .player-hub-truth .player-hub-truth__thread--two {
+    display: none;
+  }
+
+  .player-hub-truth .player-hub-truth__tape--one,
+  .player-hub-truth .player-hub-truth__tape--two {
+    opacity: 0.6;
+  }
+}


### PR DESCRIPTION
## Summary
- extend the player hub overlay so it knows the active faction and can shift between government and truth visual treatments
- introduce a textured truth theme with conspiracy board accents and palette-aware tab, badge, and button styles
- persist the player faction selection for menu access and pass the correct faction when opening the hub from either the menu or in-game controls

## Testing
- `bun test` *(fails: combo and state synergy integration expectations are currently out-of-date in src/game/__tests__/comboAndStateEffects.test.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68da4af2d8d083208432aef6ae455b25