### PR TITLE
Load stored distribution settings during expansion init

### DIFF
--- a/src/data/expansions/state.ts
+++ b/src/data/expansions/state.ts
@@ -7,6 +7,12 @@ import {
 } from './index';
 import type { MixMode } from '@/lib/decks/expansions';
 import { loadPrefs, savePrefs } from '@/lib/persist';
+import {
+  DEFAULT_DISTRIBUTION_SETTINGS,
+  loadDistributionSettingsFromStorage,
+  sanitizeDistributionSettings,
+  weightedDistribution,
+} from '../weightedCardDistribution';
 
 type StoredPrefs = {
   mode?: MixMode;
@@ -146,5 +152,9 @@ export const initializeExpansions = async (): Promise<void> => {
   );
 
   rebuildEnabledMap();
+  const storedDistribution = loadDistributionSettingsFromStorage();
+  const distributionSettings =
+    storedDistribution ?? sanitizeDistributionSettings(DEFAULT_DISTRIBUTION_SETTINGS);
+  weightedDistribution.updateSettings(distributionSettings);
   await ensureCardsLoaded();
 };


### PR DESCRIPTION
## Summary
- add shared helpers in weightedCardDistribution to sanitize and persist distribution settings
- hydrate the weighted distribution singleton during expansion initialization using persisted settings
- update the distribution settings hook to reuse the shared helpers for loading and saving

## Testing
- npm run lint *(fails: existing lint violations in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68da51c3519c83208c3dabf1b160e20d