### PR TITLE
Tighten particle effect completion timing

### DIFF
--- a/src/components/effects/ParticleSystem.tsx
+++ b/src/components/effects/ParticleSystem.tsx
@@ -47,6 +47,7 @@ export const ParticleSystem: React.FC<ParticleSystemProps> = ({
   const animationRef = useRef<number>();
   const particlesRef = useRef<Particle[]>([]);
   const startTimeRef = useRef<number>();
+  const effectDurationRef = useRef<number>();
 
   useEffect(() => {
     if (!active) return;
@@ -71,6 +72,9 @@ export const ParticleSystem: React.FC<ParticleSystemProps> = ({
     
     particlesRef.current = particles;
     startTimeRef.current = Date.now();
+    effectDurationRef.current = particles.length
+      ? particles.reduce((max, particle) => Math.max(max, particle.maxLife), 0) * (1000 / 60)
+      : undefined;
 
     const animate = () => {
       ctx.clearRect(0, 0, canvas.width, canvas.height);
@@ -85,10 +89,14 @@ export const ParticleSystem: React.FC<ParticleSystemProps> = ({
         return particle.life > 0;
       });
 
-      // Continue animation if particles exist and not too much time has passed
-      if (particlesRef.current.length > 0 && elapsed < 3000) {
+      const hasLivingParticles = particlesRef.current.length > 0;
+      const expectedDuration = effectDurationRef.current ?? 0;
+      const exceededExpectedDuration = expectedDuration > 0 && elapsed >= expectedDuration + 120;
+
+      if (hasLivingParticles && !exceededExpectedDuration) {
         animationRef.current = requestAnimationFrame(animate);
       } else {
+        animationRef.current = undefined;
         onComplete?.();
       }
     };


### PR DESCRIPTION
## Summary
- compute an expected particle effect duration from the emitted particles and drop the hard 3 second cutoff
- stop the animation loop as soon as particles expire and clear the frame handle so onComplete fires promptly

## Testing
- npm run lint *(fails: pre-existing lint errors across unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68da580e30048320a7d3a5d981c4ba74