### PR TITLE
Add CardImage contain mode for newspaper hero

### DIFF
--- a/src/components/game/CardImage.test.tsx
+++ b/src/components/game/CardImage.test.tsx
@@ -1,0 +1,77 @@
+import { describe, expect, it } from 'bun:test';
+import React from 'react';
+import TestRenderer from 'react-test-renderer';
+import '@/test/setupLocalStorage';
+import CardImage from './CardImage';
+
+const renderCardImage = (props: React.ComponentProps<typeof CardImage>) => {
+  let renderer: TestRenderer.ReactTestRenderer;
+
+  TestRenderer.act(() => {
+    renderer = TestRenderer.create(<CardImage {...props} />);
+  });
+
+  return renderer!;
+};
+
+const findSkeletonNode = (renderer: TestRenderer.ReactTestRenderer) => {
+  return renderer.root.find(
+    node =>
+      node.type === 'div' &&
+      typeof node.props.className === 'string' &&
+      node.props.className.includes('animate-pulse'),
+  );
+};
+
+describe('CardImage fit modes', () => {
+  it('uses object-cover by default', () => {
+    const renderer = renderCardImage({ cardId: 'alpha-strike' });
+
+    const container = renderer.root.findByType('div');
+    const image = renderer.root.findByType('img');
+    const skeleton = findSkeletonNode(renderer);
+
+    expect(container.props.className).toContain('relative overflow-hidden');
+    expect(container.props.className).not.toContain('bg-muted/20');
+    expect(image.props.className).toContain('object-cover');
+    expect(image.props.className).not.toContain('object-contain');
+    expect(skeleton.props.className).toContain('bg-muted/20');
+
+    renderer.unmount();
+  });
+
+  it('enables containment mode to avoid cropping', () => {
+    const renderer = renderCardImage({ cardId: 'beta-signal', fit: 'contain' });
+
+    const container = renderer.root.findByType('div');
+    const image = renderer.root.findByType('img');
+    const skeleton = findSkeletonNode(renderer);
+
+    expect(container.props.className).toContain('bg-muted/20');
+    expect(image.props.className).toContain('object-contain');
+    expect(image.props.className).not.toContain('object-cover');
+    expect(skeleton.props.className).toContain('bg-muted/30');
+
+    renderer.unmount();
+  });
+
+  it('preserves custom sizing classes for varied aspect ratios', () => {
+    const aspectClasses = ['aspect-square', 'aspect-[63/88]', 'aspect-video'];
+
+    aspectClasses.forEach((aspectClass, index) => {
+      const renderer = renderCardImage({
+        cardId: `gamma-${index}`,
+        fit: 'contain',
+        className: `${aspectClass} w-full`,
+      });
+
+      const container = renderer.root.findByType('div');
+      expect(container.props.className).toContain(aspectClass);
+
+      const skeleton = findSkeletonNode(renderer);
+      expect(skeleton.props.className).toContain('absolute inset-0');
+
+      renderer.unmount();
+    });
+  });
+});

--- a/src/components/game/CardImage.tsx
+++ b/src/components/game/CardImage.tsx
@@ -1,12 +1,14 @@
 import React, { useEffect, useState } from 'react';
+import { cn } from '@/lib/utils';
 import { isExtensionCard, getCardExtensionInfo } from '@/data/extensionIntegration';
 
 interface CardImageProps {
   cardId: string;
   className?: string;
+  fit?: 'cover' | 'contain';
 }
 
-const CardImage: React.FC<CardImageProps> = ({ cardId, className = '' }) => {
+const CardImage: React.FC<CardImageProps> = ({ cardId, className = '', fit = 'cover' }) => {
   const [imageError, setImageError] = useState(false);
   const [imageLoaded, setImageLoaded] = useState(false);
   const [imageExtension, setImageExtension] = useState<'jpg' | 'png'>('jpg');
@@ -76,18 +78,34 @@ const CardImage: React.FC<CardImageProps> = ({ cardId, className = '' }) => {
     setImageLoaded(true);
   };
 
+  const containerClassName = cn(
+    'relative overflow-hidden',
+    fit === 'contain' && 'bg-muted/20',
+    className,
+  );
+
+  const loadingClassName = cn(
+    'absolute inset-0 flex items-center justify-center text-xs text-muted-foreground animate-pulse',
+    fit === 'contain' ? 'bg-muted/30' : 'bg-muted/20',
+  );
+
+  const imageClassName = cn(
+    'h-full w-full',
+    fit === 'contain' ? 'object-contain' : 'object-cover',
+  );
+
   return (
-    <div className={`relative overflow-hidden ${className}`}>
+    <div className={containerClassName}>
       {!imageLoaded && (
-        <div className="absolute inset-0 bg-muted/20 flex items-center justify-center text-xs text-muted-foreground animate-pulse">
+        <div className={loadingClassName}>
           Loading...
         </div>
       )}
-      
+
       <img
         src={imagePath}
         alt={`Card art for ${cardId}`}
-        className="w-full h-full object-cover"
+        className={imageClassName}
         onLoad={handleImageLoad}
         onError={handleImageError}
       />

--- a/src/components/game/TabloidNewspaperV2.tsx
+++ b/src/components/game/TabloidNewspaperV2.tsx
@@ -764,9 +764,13 @@ const TabloidNewspaperV2 = ({
               ) : null}
               <div className="relative overflow-hidden rounded-md border border-newspaper-border bg-newspaper-header/20">
                 {heroArticle?.cardId ? (
-                  <CardImage cardId={heroArticle.cardId} className="h-52 w-full object-cover" />
+                  <CardImage
+                    cardId={heroArticle.cardId}
+                    fit="contain"
+                    className="w-full aspect-[63/88] max-h-80"
+                  />
                 ) : (
-                  <div className="flex h-52 items-center justify-center text-sm font-semibold uppercase tracking-wide text-newspaper-text/60">
+                  <div className="flex aspect-[63/88] w-full max-h-80 items-center justify-center text-sm font-semibold uppercase tracking-wide text-newspaper-text/60">
                     Archival footage pending clearance.
                   </div>
                 )}

--- a/src/test/setupLocalStorage.ts
+++ b/src/test/setupLocalStorage.ts
@@ -1,0 +1,17 @@
+const storageMock = {
+  getItem: () => null,
+  setItem: () => undefined,
+  removeItem: () => undefined,
+  clear: () => undefined,
+  key: () => null,
+  length: 0,
+};
+
+if (typeof globalThis.localStorage === 'undefined') {
+  Object.defineProperty(globalThis, 'localStorage', {
+    value: storageMock,
+    writable: true,
+  });
+}
+
+export {};


### PR DESCRIPTION
## Summary
- add a containment fit option to `CardImage` with neutral background handling and updated skeleton styling
- use the new containment mode from the newspaper hero card slot and adopt a card-friendly aspect ratio container
- add targeted tests (with a localStorage test shim) to cover fit modes and varied sizing classes

## Testing
- bun test src/components/game/CardImage.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68da61da8aa4832085864f8c17f3ab28