### PR TITLE
Ensure fallback capture events are recorded

### DIFF
--- a/src/data/eventDatabase.ts
+++ b/src/data/eventDatabase.ts
@@ -2998,7 +2998,19 @@ export class EventManager {
       return true;
     });
 
-    if (!availableEvents.length) return null;
+    if (!availableEvents.length) {
+      const fallbackEvent = this.createFallbackStateEvent(
+        stateId,
+        capturingFaction,
+        gameState
+      );
+      const eventKey = `${stateId}_${fallbackEvent.id}`;
+      if (!this.eventHistory.includes(eventKey)) {
+        this.eventHistory.push(eventKey);
+      }
+
+      return fallbackEvent;
+    }
 
     // Select weighted random event
     const totalWeight = availableEvents.reduce((sum, event) => sum + event.weight, 0);

--- a/src/hooks/__tests__/useGameState.aiTurnConcurrency.test.ts
+++ b/src/hooks/__tests__/useGameState.aiTurnConcurrency.test.ts
@@ -138,8 +138,9 @@ describe('useGameState AI turn scheduling', () => {
     globalThis.setTimeout = originalSetTimeout;
     globalThis.clearTimeout = originalClearTimeout;
     timers.clear();
-    // eslint-disable-next-line @typescript-eslint/no-dynamic-delete
-    delete (globalThis as Partial<typeof globalThis>).localStorage;
+    if (!Reflect.deleteProperty(globalThis as Record<string, unknown>, 'localStorage')) {
+      (globalThis as Partial<typeof globalThis>).localStorage = undefined;
+    }
   });
 
   it('runs a single AI completion timeout and does not skip the human turn', async () => {

--- a/src/hooks/__tests__/useGameState.rehydration.test.ts
+++ b/src/hooks/__tests__/useGameState.rehydration.test.ts
@@ -249,8 +249,9 @@ describe('useGameState save rehydration', () => {
 
   afterEach(() => {
     Math.random = originalRandom;
-    // eslint-disable-next-line @typescript-eslint/no-dynamic-delete
-    delete (globalThis as Partial<typeof globalThis>).localStorage;
+    if (!Reflect.deleteProperty(globalThis as Record<string, unknown>, 'localStorage')) {
+      (globalThis as Partial<typeof globalThis>).localStorage = undefined;
+    }
   });
 
   afterAll(() => {


### PR DESCRIPTION
## Summary
- ensure fallback state events are generated and recorded when no state-specific events are available
- update state event tests to use a shared mock event manager and resilient localStorage cleanup
- align related tests to avoid localStorage deletion errors during teardown

## Testing
- bun test

------
https://chatgpt.com/codex/tasks/task_e_68da6b31e5708320937dac032294ea58