### PR TITLE
Add rarity emoji mapping for rarity labels

### DIFF
--- a/src/lib/cardUi.ts
+++ b/src/lib/cardUi.ts
@@ -39,8 +39,17 @@ export const getRarityVar = (rarity?: GameCard['rarity']): string => {
   return `var(--pt-rarity-${normalizeRarity(rarity)})`;
 };
 
+export const RARITY_EMOJI: Record<NormalizedRarity, string> = {
+  common: '⚪',
+  uncommon: '🟢',
+  rare: '🔷',
+  legendary: '✨',
+};
+
 export const getRarityLabel = (rarity?: GameCard['rarity']): string => {
-  return normalizeRarity(rarity);
+  const normalized = normalizeRarity(rarity);
+  const emoji = RARITY_EMOJI[normalized];
+  return `${normalized} ${emoji}`.trim();
 };
 
 export const getFlavorText = (card: GameCard): string | undefined => {


### PR DESCRIPTION
## Summary
- add a shared rarity-to-emoji mapping for card UI helpers
- include the emoji in rarity labels so callers render text plus icon

## Testing
- npm run lint *(fails: existing lint errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68da7527bc148320abdf8e34325d1790