### PR TITLE
Normalize card target resolution for zone plays

### DIFF
--- a/src/game/__tests__/comboAndStateEffects.test.ts
+++ b/src/game/__tests__/comboAndStateEffects.test.ts
@@ -245,6 +245,44 @@ describe('combo and state synergy integration', () => {
     expect(target?.pressure).toBe(1);
   });
 
+  it('normalizes zone card targets before applying pressure', () => {
+    const state = buildBaseGameState();
+    state.stateCombinationEffects = { ...createDefaultCombinationEffects(), incomingPressureReduction: 1 };
+    state.controlledStates = ['NV'];
+    state.states = [{
+      id: '32',
+      name: 'Nevada',
+      abbreviation: 'NV',
+      baseIP: 2,
+      baseDefense: 2,
+      defense: 2,
+      comboDefenseBonus: 0,
+      pressure: 0,
+      pressurePlayer: 0,
+      pressureAi: 0,
+      contested: false,
+      owner: 'player' as const,
+      specialBonus: undefined,
+      bonusValue: undefined,
+      paranormalHotspot: undefined,
+    }];
+
+    const zoneCard: GameCard = {
+      id: 'zone-pressure',
+      name: 'Siege Column',
+      type: 'ZONE',
+      faction: 'government',
+      cost: 3,
+      effects: { pressureDelta: 2 },
+      target: { scope: 'state', count: 1 },
+    };
+
+    const result = resolveCardMVP(state, zoneCard, 'nv', 'ai');
+    const target = result.states.find(entry => entry.abbreviation === 'NV');
+    expect(target?.pressureAi).toBe(1);
+    expect(target?.pressure).toBe(1);
+  });
+
   it('reapplies defense bonuses to controlled states after card resolution', () => {
     const state = buildBaseGameState();
     state.stateCombinationEffects = { ...createDefaultCombinationEffects(), stateDefenseBonus: 1 };

--- a/src/systems/cardResolution.ts
+++ b/src/systems/cardResolution.ts
@@ -88,6 +88,11 @@ const AI_ID: PlayerId = 'P2';
 
 export type CardActor = 'human' | 'ai';
 
+/**
+ * Resolves a target string to a state id, matching case-insensitively against
+ * known identifiers. If no match is found we fall back to the trimmed input so
+ * downstream logic can decide how to handle the value.
+ */
 const resolveTargetStateId = (
   snapshot: GameSnapshot,
   target?: string | null,
@@ -96,14 +101,23 @@ const resolveTargetStateId = (
     return undefined;
   }
 
-  const match = snapshot.states.find(
-    state =>
-      state.id === target ||
-      state.abbreviation === target ||
-      state.name === target,
-  );
+  const trimmedTarget = target.trim();
+  if (!trimmedTarget) {
+    return undefined;
+  }
 
-  return match?.id;
+  const normalizedTarget = trimmedTarget.toLowerCase();
+
+  const normalize = (value: string) => value.trim().toLowerCase();
+
+  const match = snapshot.states.find(state => {
+    const candidates = [state.id, state.abbreviation, state.name].filter(
+      Boolean,
+    ) as string[];
+    return candidates.some(candidate => normalize(candidate) === normalizedTarget);
+  });
+
+  return match ? match.id : trimmedTarget;
 };
 
 const buildStateLookups = (states: StateForResolution[]) => {


### PR DESCRIPTION
## Summary
- normalize card target identifiers before matching against known states and fall back to the trimmed target id when no match exists
- document the case-insensitive resolution behavior in the targeting helper
- add a regression test covering lowercase zone card targets to ensure pressure is applied correctly

## Testing
- npm test -- --runTestsByPath src/game/__tests__/comboAndStateEffects.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68da7be652448320819d28596d22a22f