### PR TITLE
Adjust US map faction styling

### DIFF
--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -2303,6 +2303,7 @@ const Index = () => {
                 selectedZoneCard={gameState.selectedCard}
                 selectedState={gameState.targetState}
                 audio={audio}
+                playerFaction={gameState.faction}
               />
             </div>
           </div>


### PR DESCRIPTION
## Summary
- add a playerFaction prop to EnhancedUSAMap and map state owners to truth/government factions
- update tooltip badge and map styling to use faction-based colors and classes
- pass the current faction to the map component from the game page

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68da802f62c8832091425c0c3b880f62