### PR TITLE
Align card faction colors with theme tokens

### DIFF
--- a/src/lib/cardUi.ts
+++ b/src/lib/cardUi.ts
@@ -27,8 +27,13 @@ export const normalizeCardType = (type?: GameCard['type']): 'ATTACK' | 'MEDIA' |
   return 'MEDIA';
 };
 
+const FACTION_VAR_MAP: Record<NormalizedFaction, string> = {
+  truth: 'var(--pt-truth)',
+  government: 'var(--pt-gov)',
+};
+
 export const getFactionVar = (faction?: GameCard['faction']): string => {
-  return `var(--pt-${normalizeFaction(faction)})`;
+  return FACTION_VAR_MAP[normalizeFaction(faction)];
 };
 
 export const getFactionLabel = (faction?: GameCard['faction']): string => {


### PR DESCRIPTION
## Summary
- map normalized factions to explicit theme token variables for faction backgrounds
- ensure BaseCard continues to render government cards with the red label background via var(--pt-gov)

## Testing
- npm run lint *(fails: existing lint errors across unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68da86bdfadc8320b65f414b25ac4d9b