### PR TITLE
Fix truth delta handling for captured state events

### DIFF
--- a/src/hooks/useGameState.ts
+++ b/src/hooks/useGameState.ts
@@ -924,7 +924,13 @@ export const useGameState = (aiDifficultyOverride?: AIDifficulty) => {
         if (eventEffects && typeof eventEffects === 'object') {
           const truthDelta = (eventEffects.truth ?? 0) + (eventEffects.truthChange ?? 0);
           if (truthDelta) {
-            truth = applyTruthDelta(truth, truthDelta);
+            const truthMutation = { truth, log: [] as string[] };
+            const truthActor = capturingFaction === nextState.faction ? 'human' : 'ai';
+            applyTruthDelta(truthMutation, truthDelta, truthActor);
+            if (truthMutation.log.length > 0) {
+              eventLogs.push(...truthMutation.log);
+            }
+            truth = truthMutation.truth;
             truthChanged = true;
           }
 


### PR DESCRIPTION
## Summary
- ensure captured state events mutate truth using a TruthMutable wrapper and correct actor identifier
- append generated truth manipulation log messages to the event log buffer to preserve logging

## Testing
- not run (not available in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68da8ba5de0c83208e5e1fb837e9f6aa