### PR TITLE
Adjust Tabloid newspaper modal width and padding

### DIFF
--- a/src/components/game/TabloidNewspaperV2.tsx
+++ b/src/components/game/TabloidNewspaperV2.tsx
@@ -663,7 +663,7 @@ const TabloidNewspaperV2 = ({
 
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 p-4">
-      <UICard className="ink-smudge relative flex h-full max-h-[90vh] w-full max-w-6xl flex-col overflow-hidden border-4 border-newspaper-border bg-newspaper-bg text-newspaper-text shadow-2xl">
+      <UICard className="ink-smudge relative flex h-full max-h-[90vh] w-full max-w-[min(95vw,1280px)] flex-col overflow-hidden border-4 border-newspaper-border bg-newspaper-bg text-newspaper-text shadow-2xl">
         <header className="relative border-b-4 border-double border-newspaper-border bg-newspaper-header/90 px-6 py-5">
           {breakingStamp ? (
             <div className="stamp stamp--breaking absolute left-6 top-4">{breakingStamp}</div>
@@ -695,7 +695,7 @@ const TabloidNewspaperV2 = ({
           </div>
         </header>
 
-        <div className="flex-1 overflow-y-auto px-6 py-6">
+        <div className="flex-1 overflow-y-auto px-4 py-5 sm:px-6 sm:py-6 xl:px-5 xl:py-5">
           <section className="mb-6 rounded-md border border-newspaper-border bg-white/70 px-4 py-3 text-sm text-newspaper-text shadow-sm">
             <div className="flex flex-wrap items-center justify-between gap-3">
               <div className="flex items-center gap-3">


### PR DESCRIPTION
## Summary
- increase the Tabloid newspaper modal's max width so the layout can use more of the viewport without scrolling
- tweak the scrollable area's padding with responsive values to give the content slightly more room on large screens

## Testing
- npm run dev -- --host 0.0.0.0 --port 4173


------
https://chatgpt.com/codex/tasks/task_e_68da91904c548320b3a72046d8a60b0d