### PR TITLE
Tighten responsive padding and grid spacing

### DIFF
--- a/src/components/game/TabloidNewspaperV2.tsx
+++ b/src/components/game/TabloidNewspaperV2.tsx
@@ -722,7 +722,7 @@ const TabloidNewspaperV2 = ({
             </div>
           </section>
 
-          <div className="grid gap-6 lg:grid-cols-3">
+          <div className="grid gap-4 lg:gap-5 lg:grid-cols-3">
             <article className="lg:col-span-2 space-y-4 rounded-md border border-newspaper-border bg-white/80 p-6 shadow-sm">
               <div className="flex flex-wrap items-center justify-between gap-3 text-xs font-semibold uppercase tracking-wide text-newspaper-text/70">
                 <span className="rounded-full border border-newspaper-border px-2 py-1">{heroTypeLabel}</span>

--- a/src/components/layout/ResponsiveLayout.tsx
+++ b/src/components/layout/ResponsiveLayout.tsx
@@ -37,10 +37,10 @@ export default function ResponsiveLayout({ masthead, leftPane, rightPane }: Prop
             paddingRight: "var(--safe-right)",
           }}
         >
-          <div className="app-scroll h-full p-2 sm:p-4 md:p-6">
+          <div className="app-scroll h-full p-2 sm:p-3 lg:p-4">
             <div
               className={clsx(
-                "grid h-full min-h-0 gap-4",
+                "grid h-full min-h-0 gap-3",
                 "grid-cols-1",
                 hasRightPane && "lg:grid-cols-[1fr_420px] xl:grid-cols-[1fr_480px]"
               )}


### PR DESCRIPTION
## Summary
- adjust the app shell scroll container padding and layout gap for better spacing across breakpoints
- reduce the TabloidNewspaperV2 grid spacing to maintain balance on smaller screens

## Testing
- npm run dev -- --host 0.0.0.0 --port 4173


------
https://chatgpt.com/codex/tasks/task_e_68daa1ef6c2883208251f9ef4e399436