### PR TITLE
Fix onboarding overlay pointer events

### DIFF
--- a/src/components/game/InteractiveOnboarding.tsx
+++ b/src/components/game/InteractiveOnboarding.tsx
@@ -127,10 +127,10 @@ const InteractiveOnboarding = ({ isActive, onComplete, onSkip, gameState }: Inte
   return (
     <>
       {/* Overlay */}
-      <div className="fixed inset-0 bg-black/60 z-50 animate-fade-in">
+      <div className="fixed inset-0 bg-black/60 z-50 animate-fade-in pointer-events-none">
         {/* Onboarding Card */}
-        <div className="fixed bottom-4 left-1/2 transform -translate-x-1/2 z-60 animate-slide-in-right">
-          <Card className="p-6 max-w-md bg-newspaper-text text-newspaper-bg border-4 border-truth-red shadow-2xl">
+        <div className="fixed bottom-4 left-1/2 transform -translate-x-1/2 z-60 animate-slide-in-right pointer-events-auto">
+          <Card className="p-6 max-w-md bg-newspaper-text text-newspaper-bg border-4 border-truth-red shadow-2xl pointer-events-auto">
             {/* Header */}
             <div className="flex justify-between items-start mb-4">
               <div className="flex items-center gap-2">


### PR DESCRIPTION
## Summary
- disable pointer events on the onboarding backdrop so highlighted controls remain clickable
- re-enable pointer events on the tutorial card so the onboarding UI stays interactive

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dabee2290c8320b0479a7ee8b5525c