### PR TITLE
Ensure initGame sets human as current player

### DIFF
--- a/src/hooks/__tests__/useGameState.aiTurnConcurrency.test.ts
+++ b/src/hooks/__tests__/useGameState.aiTurnConcurrency.test.ts
@@ -231,6 +231,7 @@ describe('useGameState AI turn scheduling', () => {
     const postRestartState = hook.result.current?.gameState;
     expect(postRestartState?.turn).toBe(1);
     expect(postRestartState?.phase).toBe('action');
+    expect(postRestartState?.currentPlayer).toBe('human');
     expect(postRestartState?.aiTurnInProgress).toBe(false);
 
     expect(timersWithDelay(1000)).toHaveLength(0);
@@ -240,6 +241,7 @@ describe('useGameState AI turn scheduling', () => {
     const finalState = hook.result.current?.gameState;
     expect(finalState?.turn).toBe(1);
     expect(finalState?.phase).toBe('action');
+    expect(finalState?.currentPlayer).toBe('human');
     expect(finalState?.aiTurnInProgress).toBe(false);
     expect(timersWithDelay(1000)).toHaveLength(0);
   });

--- a/src/hooks/useGameState.ts
+++ b/src/hooks/useGameState.ts
@@ -1260,6 +1260,7 @@ export const useGameState = (aiDifficultyOverride?: AIDifficulty) => {
       truth: startingTruth,
       ip: startingIP,
       aiIP: aiStartingIP,
+      currentPlayer: 'human',
       hand: startingHand,
       deck: remainingDeck,
       aiHand: aiStartingHand,


### PR DESCRIPTION
## Summary
- ensure initGame explicitly resets the current player to human when starting a new game
- assert via the AI turn concurrency test that initGame overrides a previous AI current player

## Testing
- bun test src/hooks/__tests__/useGameState.aiTurnConcurrency.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68dac7fbb5f88320a75c6b3e4ef941a0