### PR TITLE
Restore data-card-id attribute in EnhancedGameHand

### DIFF
--- a/src/components/game/EnhancedGameHand.tsx
+++ b/src/components/game/EnhancedGameHand.tsx
@@ -179,6 +179,7 @@ const EnhancedGameHand: React.FC<EnhancedGameHandProps> = ({
                   disabled && 'cursor-default'
                 )}
                 style={{ animationDelay: `${index * 0.03}s` }}
+                data-card-id={card.id}
                 onClick={(e) => {
                   e.preventDefault();
                   audio.playSFX('click');


### PR DESCRIPTION
## Summary
- ensure EnhancedGameHand card buttons expose the data-card-id attribute so animation hooks can find them again

## Testing
- npm run lint *(fails: existing lint errors unrelated to this change)*

------
https://chatgpt.com/codex/tasks/task_e_68dad6ee8704832099447d9ffd10fab5