### PR TITLE
Add played pile container for card animations

### DIFF
--- a/src/components/game/PlayedCardsDock.tsx
+++ b/src/components/game/PlayedCardsDock.tsx
@@ -14,6 +14,8 @@ const CardsInPlayCard = ({ card, onInspect }: { card: GameCard; onInspect?: (car
     type="button"
     onClick={() => onInspect?.(card)}
     className="group relative flex w-full items-center justify-center rounded-lg border border-transparent bg-transparent p-0 transition-transform duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-offset-yellow-200 focus-visible:ring-yellow-400"
+    data-played-card
+    data-played-card-id={card.id}
   >
     <span className="sr-only">View {card.name}</span>
     <BaseCard
@@ -33,29 +35,44 @@ interface SectionProps {
   emptyMessage: string;
   ariaLabel: string;
   onInspectCard?: (card: GameCard) => void;
+  containerId?: string;
 }
 
-const PlayedCardsSection: React.FC<SectionProps> = ({ title, toneClass, cards, emptyMessage, ariaLabel, onInspectCard }) => (
+const PlayedCardsSection: React.FC<SectionProps> = ({
+  title,
+  toneClass,
+  cards,
+  emptyMessage,
+  ariaLabel,
+  onInspectCard,
+  containerId
+}) => (
   <section
     aria-label={ariaLabel}
     className={cn('rounded-md p-3 text-black', toneClass)}
   >
     <h4 className="mb-2 text-[12px] font-extrabold uppercase tracking-[0.2em] text-black/70">{title}</h4>
-    {cards.length > 0 ? (
-      <div className="grid grid-cols-3 gap-2 place-items-start">
-        {cards.map((entry, index) => (
+    <div
+      id={containerId}
+      className={cn(
+        'relative min-h-[120px] w-full',
+        cards.length > 0 ? 'grid grid-cols-3 place-items-start gap-2' : 'flex'
+      )}
+    >
+      {cards.length > 0 ? (
+        cards.map((entry, index) => (
           <CardsInPlayCard
             key={`${entry.card.id}-${index}`}
             card={entry.card}
             onInspect={onInspectCard}
           />
-        ))}
-      </div>
-    ) : (
-      <div className="grid min-h-[120px] place-items-center rounded border border-dashed border-black/20 bg-white/40 p-4 text-center text-[11px] font-mono uppercase tracking-wide text-black/50">
-        {emptyMessage}
-      </div>
-    )}
+        ))
+      ) : (
+        <div className="grid min-h-[120px] w-full place-items-center rounded border border-dashed border-black/20 bg-white/40 p-4 text-center text-[11px] font-mono uppercase tracking-wide text-black/50">
+          {emptyMessage}
+        </div>
+      )}
+    </div>
   </section>
 );
 
@@ -84,6 +101,7 @@ const PlayedCardsDock: React.FC<PlayedCardsDockProps> = ({ playedCards, onInspec
           emptyMessage="No cards deployed this turn."
           toneClass="bg-[image:var(--halftone-blue)] bg-[length:8px_8px] bg-repeat bg-blue-50/40"
           onInspectCard={onInspectCard}
+          containerId="played-pile"
         />
       </div>
     </div>

--- a/src/hooks/useCardAnimation.ts
+++ b/src/hooks/useCardAnimation.ts
@@ -183,62 +183,48 @@ export const useCardAnimation = () => {
     const playedPile = document.getElementById('played-pile');
     if (!playedPile) return;
 
+    const playedCardElements = Array.from(playedPile.querySelectorAll<HTMLElement>('[data-played-card]'));
     const pileRect = playedPile.getBoundingClientRect();
-    const pileCards = playedPile.children.length;
-    const cardWidth = 200;
-    const cardHeight = 280;
-    const cols = 5;
-    
-    const col = pileCards % cols;
-    const row = Math.floor(pileCards / cols);
-    
-    const destRect: AnimationRect = {
-      x: pileRect.left + col * (cardWidth + 4),
-      y: pileRect.top + row * (cardHeight + 4),
-      width: cardWidth,
-      height: cardHeight
-    };
+
+    let targetCardId: string | undefined;
+    if (element.dataset.cardData) {
+      try {
+        const parsedData = JSON.parse(element.dataset.cardData) as Partial<GameCard>;
+        if (parsedData && typeof parsedData.id === 'string') {
+          targetCardId = parsedData.id;
+        }
+      } catch (error) {
+        // Ignore parsing errors and fall back to layout-based positioning
+      }
+    }
+
+    const targetElement = targetCardId
+      ? playedCardElements.find(el => el.getAttribute('data-played-card-id') === targetCardId)
+      : playedCardElements[playedCardElements.length - 1];
+
+    let destRect: AnimationRect;
+
+    if (targetElement) {
+      destRect = getBoundingRect(targetElement);
+    } else {
+      const cardWidth = 200;
+      const cardHeight = 280;
+      const cols = 5;
+
+      const pileCards = playedCardElements.length;
+      const col = pileCards % cols;
+      const row = Math.floor(pileCards / cols);
+
+      destRect = {
+        x: pileRect.left + col * (cardWidth + 4),
+        y: pileRect.top + row * (cardHeight + 4),
+        width: cardWidth,
+        height: cardHeight
+      };
+    }
 
     const currentRect = getBoundingRect(element);
     await tweenTransform(element, currentRect, destRect, { duration: 400 });
-
-    // Create permanent large played card element with full details
-    const playedCard = document.createElement('div');
-    playedCard.className = 'played-card bg-card border-2 border-border rounded-lg shadow-xl overflow-hidden transform hover:scale-105 transition-transform';
-    playedCard.style.width = `${cardWidth}px`;
-    playedCard.style.height = `${cardHeight}px`;
-    
-    // Enhanced played card with full details
-    const cardData = JSON.parse(element.dataset.cardData || '{}');
-    playedCard.innerHTML = `
-      <div class="relative h-full">
-        <div class="absolute top-2 right-2 w-8 h-8 rounded-full bg-primary text-primary-foreground flex items-center justify-center text-xs font-bold z-10">
-          ${cardData.cost || '?'}
-        </div>
-        <div class="p-3 pb-2 bg-gradient-to-r from-card to-card/80">
-          <h4 class="font-bold text-sm font-mono text-center">${cardData.name || 'Unknown'}</h4>
-        </div>
-        <div class="h-32 border-y overflow-hidden">
-          <img src="/lovable-uploads/e7c952a9-333a-4f6b-b1b5-f5aeb6c3d9c1.png" alt="Card art" class="w-full h-full object-cover" />
-        </div>
-        <div class="p-3 space-y-2">
-          <div class="flex justify-center">
-            <span class="text-xs font-mono px-2 py-1 bg-accent/20 border border-accent rounded">${cardData.type || 'UNKNOWN'}</span>
-          </div>
-          <div class="text-xs text-center font-medium min-h-8 flex items-center justify-center">
-            ${cardData.text || 'Effect unknown'}
-          </div>
-          <div class="text-xs italic text-muted-foreground text-center min-h-6 border-t border-border pt-2">
-            "${cardData.flavor ?? cardData.flavorGov ?? cardData.flavorTruth ?? 'No flavor text'}"
-          </div>
-          <div class="text-xs text-center font-bold text-primary">
-            DEPLOYED
-          </div>
-        </div>
-      </div>
-    `;
-    
-    playedPile.appendChild(playedCard);
   };
 
   const highlightState = (stateId?: string) => {


### PR DESCRIPTION
## Summary
- add a dedicated `played-pile` wrapper to the played cards dock so animation targets exist in the DOM
- mark played cards with stable data attributes and keep the container rendered even when empty
- update the fly-to-played-pile animation to align with the React-rendered cards instead of injecting manual DOM nodes

## Testing
- npm run lint *(fails: repository currently has pre-existing lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68dad84e269483209d0a10857a2f21dd