### PR TITLE
Add in-briefing dev tools for error, audio, and hotspot QA

### DIFF
--- a/src/assets/audio/sfxManifest.ts
+++ b/src/assets/audio/sfxManifest.ts
@@ -1,0 +1,24 @@
+import { UFO_ELVIS_SFX, CRYPTID_RUMBLE_SFX, RADIO_STATIC_SFX } from './paranormalSfx';
+
+export const SFX_MANIFEST = {
+  cardPlay: '/audio/card-play.mp3',
+  flash: '/audio/card-play.mp3',
+  cardDraw: '/audio/card-draw.mp3',
+  stateCapture: '/audio/state-capture.mp3',
+  turnEnd: '/audio/turn-end.mp3',
+  newspaper: '/audio/newspaper.mp3',
+  victory: '/audio/victory.mp3',
+  defeat: '/audio/defeat.mp3',
+  hover: '/audio/hover.mp3',
+  click: '/audio/click.mp3',
+  typewriter: '/audio/typewriter.mp3',
+  lightClick: '/audio/click.mp3',
+  error: '/audio/click.mp3',
+  'ufo-elvis': UFO_ELVIS_SFX,
+  'cryptid-rumble': CRYPTID_RUMBLE_SFX,
+  'radio-static': RADIO_STATIC_SFX,
+} as const;
+
+export type SfxKey = keyof typeof SFX_MANIFEST;
+
+export const SFX_KEYS = Object.keys(SFX_MANIFEST) as SfxKey[];

--- a/src/components/dev/AudioQAControls.tsx
+++ b/src/components/dev/AudioQAControls.tsx
@@ -1,0 +1,138 @@
+import { useMemo, useState } from 'react';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Slider } from '@/components/ui/slider';
+import { ScrollArea } from '@/components/ui/scroll-area';
+import { Label } from '@/components/ui/label';
+import { useAudioContext } from '@/contexts/AudioContext';
+import { AudioGeneratorComponent } from './AudioGenerator';
+import { SFX_KEYS } from '@/assets/audio/sfxManifest';
+
+const sliderValue = (value: number) => Math.round(value * 100);
+
+const toNormalized = (value: number) => Math.max(0, Math.min(1, value / 100));
+
+const AudioQAControls = () => {
+  const audio = useAudioContext();
+  const [selectedSfx, setSelectedSfx] = useState<string>(SFX_KEYS[0] ?? 'click');
+
+  const sfxKeys = useMemo(() => [...SFX_KEYS].sort((a, b) => a.localeCompare(b)), []);
+  const { config, availableTracks } = audio;
+
+  const handlePlaySelected = () => {
+    audio.playSFX(selectedSfx);
+  };
+
+  return (
+    <Card>
+      <CardHeader className="space-y-2 border-b border-gray-800 bg-gray-900/60">
+        <div className="flex items-center justify-between">
+          <CardTitle className="text-base font-semibold text-white">
+            Audio QA Controls
+          </CardTitle>
+          <Badge variant="outline" className="uppercase tracking-wide text-[11px] border-sky-500/40 text-sky-200">
+            Sound lab
+          </Badge>
+        </div>
+        <p className="text-xs text-slate-400">
+          Audition SFX, validate music routing, and generate placeholder assets without leaving the briefing.
+        </p>
+      </CardHeader>
+      <CardContent className="space-y-6">
+        <section className="space-y-3">
+          <div className="flex items-center justify-between">
+            <h4 className="text-sm font-semibold text-slate-200">Sound Effect Palette</h4>
+            <div className="flex gap-2">
+              <Button size="sm" variant="secondary" onClick={audio.testSFX}>
+                Random test
+              </Button>
+              <Button size="sm" onClick={handlePlaySelected}>
+                Play {selectedSfx}
+              </Button>
+            </div>
+          </div>
+          <ScrollArea className="h-36 rounded border border-gray-800 bg-gray-950/60">
+            <div className="divide-y divide-gray-900">
+              {sfxKeys.map(key => (
+                <button
+                  key={key}
+                  type="button"
+                  onClick={() => {
+                    setSelectedSfx(key);
+                    audio.playSFX(key);
+                  }}
+                  className={`flex w-full items-center justify-between px-3 py-2 text-sm transition hover:bg-gray-900/80 focus:outline-none focus-visible:bg-gray-900/80 ${
+                    selectedSfx === key ? 'bg-gray-900/80 text-emerald-200' : 'text-slate-300'
+                  }`}
+                >
+                  <span className="font-mono text-xs uppercase tracking-wide">{key}</span>
+                  <Badge variant="outline" className="text-[10px] border-gray-700">
+                    Tap to audition
+                  </Badge>
+                </button>
+              ))}
+            </div>
+          </ScrollArea>
+        </section>
+
+        <section className="space-y-4">
+          <h4 className="text-sm font-semibold text-slate-200">Mix Levels</h4>
+          <div className="space-y-3">
+            <div>
+              <Label className="text-xs text-slate-400">Master Volume: {sliderValue(config.volume)}%</Label>
+              <Slider
+                value={[sliderValue(config.volume)]}
+                onValueChange={([value]) => audio.setVolume(toNormalized(value))}
+                max={100}
+                min={0}
+                step={1}
+                className="mt-2"
+              />
+            </div>
+            <div>
+              <Label className="text-xs text-slate-400">Music Bus: {sliderValue(config.musicVolume)}%</Label>
+              <Slider
+                value={[sliderValue(config.musicVolume)]}
+                onValueChange={([value]) => audio.setMusicVolume(toNormalized(value))}
+                max={100}
+                min={0}
+                step={1}
+                className="mt-2"
+              />
+            </div>
+            <div>
+              <Label className="text-xs text-slate-400">SFX Bus: {sliderValue(config.sfxVolume)}%</Label>
+              <Slider
+                value={[sliderValue(config.sfxVolume)]}
+                onValueChange={([value]) => audio.setSfxVolume(toNormalized(value))}
+                max={100}
+                min={0}
+                step={1}
+                className="mt-2"
+              />
+            </div>
+          </div>
+        </section>
+
+        <section className="space-y-2">
+          <h4 className="text-sm font-semibold text-slate-200">Loaded Music Sets</h4>
+          <div className="grid gap-2 text-xs text-slate-300">
+            {Object.entries(availableTracks).map(([key, tracks]) => (
+              <div key={key} className="flex items-center justify-between rounded border border-gray-800 bg-gray-950/60 px-3 py-2">
+                <span className="font-mono uppercase tracking-wide">{key}</span>
+                <span>{tracks.length} track{tracks.length === 1 ? '' : 's'}</span>
+              </div>
+            ))}
+          </div>
+        </section>
+
+        <section>
+          <AudioGeneratorComponent />
+        </section>
+      </CardContent>
+    </Card>
+  );
+};
+
+export default AudioQAControls;

--- a/src/components/dev/ErrorLogPanel.tsx
+++ b/src/components/dev/ErrorLogPanel.tsx
@@ -1,0 +1,144 @@
+import { Fragment, useMemo } from 'react';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { ScrollArea } from '@/components/ui/scroll-area';
+import { useErrorSummary, type GameError } from './useErrorSummary';
+
+const ERROR_ACCENTS: Record<GameError['type'], string> = {
+  audio: 'text-sky-300 border-sky-500/30 bg-sky-500/10',
+  network: 'text-amber-300 border-amber-500/30 bg-amber-500/10',
+  state: 'text-purple-300 border-purple-500/30 bg-purple-500/10',
+  ui: 'text-emerald-300 border-emerald-500/30 bg-emerald-500/10',
+  critical: 'text-rose-300 border-rose-500/50 bg-rose-500/10',
+};
+
+const formatTimestamp = (timestamp: number): string => {
+  return new Date(timestamp).toLocaleTimeString([], {
+    hour: '2-digit',
+    minute: '2-digit',
+    second: '2-digit',
+  });
+};
+
+const formatContext = (context: GameError['context']): string | null => {
+  if (!context) {
+    return null;
+  }
+
+  try {
+    if (typeof context === 'string') {
+      return context;
+    }
+
+    return JSON.stringify(context, null, 2);
+  } catch (error) {
+    console.error('Failed to stringify error context', error);
+    return null;
+  }
+};
+
+const renderSummaryBadges = (byType: Record<string, number>) => {
+  const entries = Object.entries(byType);
+  if (entries.length === 0) {
+    return (
+      <Badge variant="outline" className="border-gray-700 text-gray-400">
+        No categorized errors yet
+      </Badge>
+    );
+  }
+
+  return entries.map(([type, count]) => (
+    <Badge
+      key={type}
+      variant="outline"
+      className={`uppercase tracking-wide text-[11px] border ${ERROR_ACCENTS[type as GameError['type']] ?? 'border-gray-700 text-gray-300'}`}
+    >
+      {type}: {count}
+    </Badge>
+  ));
+};
+
+interface ErrorLogPanelProps {
+  className?: string;
+}
+
+const ErrorLogPanel = ({ className }: ErrorLogPanelProps) => {
+  const { total, byType, recent, clearErrors, lastUpdated } = useErrorSummary(4000);
+
+  const hasErrors = total > 0;
+
+  const recentErrors = useMemo(
+    () => [...recent].sort((a, b) => b.timestamp - a.timestamp),
+    [recent],
+  );
+
+  return (
+    <Card className={className}>
+      <CardHeader className="space-y-2 border-b border-gray-800 bg-gray-900/60">
+        <div className="flex items-center justify-between">
+          <CardTitle className="text-base font-semibold text-white">
+            Runtime Error Monitor
+          </CardTitle>
+          <Badge variant="outline" className="uppercase tracking-wide text-[11px] border-emerald-500/40 text-emerald-200">
+            Live feed
+          </Badge>
+        </div>
+        <div className="flex items-center justify-between text-xs text-slate-400">
+          <span>Total captured: {total}</span>
+          <span>Updated: {formatTimestamp(lastUpdated)}</span>
+        </div>
+        <div className="flex flex-wrap gap-2 text-xs">
+          {renderSummaryBadges(byType)}
+        </div>
+      </CardHeader>
+      <CardContent className="p-0">
+        {hasErrors ? (
+          <ScrollArea className="max-h-72">
+            <div className="divide-y divide-gray-800">
+              {recentErrors.map(error => {
+                const context = formatContext(error.context);
+                return (
+                  <Fragment key={`${error.timestamp}-${error.code}`}>
+                    <div className="p-4 space-y-2">
+                      <div className="flex items-center justify-between">
+                        <div className="flex items-center gap-2">
+                          <Badge
+                            variant="outline"
+                            className={`border ${ERROR_ACCENTS[error.type]} uppercase tracking-wide text-[10px]`}
+                          >
+                            {error.type}
+                          </Badge>
+                          <span className="text-xs font-mono text-slate-400">{error.code}</span>
+                        </div>
+                        <span className="text-[11px] text-slate-500 font-mono">{formatTimestamp(error.timestamp)}</span>
+                      </div>
+                      <p className="text-sm text-slate-200 leading-relaxed">{error.message}</p>
+                      {context && (
+                        <pre className="rounded bg-gray-900/70 border border-gray-800 p-2 text-[11px] text-slate-400 overflow-x-auto">
+                          {context}
+                        </pre>
+                      )}
+                    </div>
+                  </Fragment>
+                );
+              })}
+            </div>
+          </ScrollArea>
+        ) : (
+          <div className="p-6 text-center text-sm text-slate-400">
+            No runtime issues captured yet. Trigger actions in briefing to populate this log.
+          </div>
+        )}
+        <div className="border-t border-gray-800 p-4 flex items-center justify-between bg-gray-900/40">
+          <span className="text-xs text-slate-500">Keeping the last 10 errors from the centralized handler.</span>
+          <Button variant="outline" size="sm" onClick={clearErrors} disabled={!hasErrors}>
+            Clear log
+          </Button>
+        </div>
+      </CardContent>
+    </Card>
+  );
+};
+
+export default ErrorLogPanel;

--- a/src/components/dev/HotspotInspector.tsx
+++ b/src/components/dev/HotspotInspector.tsx
@@ -1,0 +1,124 @@
+import { useMemo } from 'react';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { ScrollArea } from '@/components/ui/scroll-area';
+import { type ActiveParanormalHotspot } from '@/hooks/gameStateTypes';
+import { VisualEffectsCoordinator } from '@/utils/visualEffects';
+
+interface HotspotInspectorProps {
+  hotspots?: Record<string, ActiveParanormalHotspot>;
+  onTriggerEvent?: (eventId: string) => void;
+}
+
+const resolvePosition = (stateAbbreviation: string | undefined) => {
+  if (!stateAbbreviation) {
+    return VisualEffectsCoordinator.getScreenCenter();
+  }
+
+  const element = document.querySelector<HTMLElement>(`[data-state-id="${stateAbbreviation.toUpperCase()}"]`);
+  return element
+    ? VisualEffectsCoordinator.getElementCenter(element)
+    : VisualEffectsCoordinator.getScreenCenter();
+};
+
+const HotspotInspector = ({ hotspots, onTriggerEvent }: HotspotInspectorProps) => {
+  const entries = useMemo(() => {
+    if (!hotspots) {
+      return [] as ActiveParanormalHotspot[];
+    }
+
+    return Object.values(hotspots).sort((a, b) => b.createdOnTurn - a.createdOnTurn);
+  }, [hotspots]);
+
+  const triggerVisuals = (hotspot: ActiveParanormalHotspot) => {
+    const position = resolvePosition(hotspot.stateAbbreviation);
+    VisualEffectsCoordinator.triggerParanormalHotspot({
+      position,
+      stateId: hotspot.stateId,
+      stateName: hotspot.stateName,
+      label: hotspot.label,
+      icon: hotspot.icon,
+      source: hotspot.source,
+      defenseBoost: hotspot.defenseBoost,
+      truthReward: hotspot.truthReward,
+    });
+  };
+
+  return (
+    <Card>
+      <CardHeader className="space-y-2 border-b border-gray-800 bg-gray-900/60">
+        <div className="flex items-center justify-between">
+          <CardTitle className="text-base font-semibold text-white">
+            Paranormal Hotspots
+          </CardTitle>
+          <Badge variant="outline" className="uppercase tracking-wide text-[11px] border-amber-500/40 text-amber-200">
+            Live map
+          </Badge>
+        </div>
+        <p className="text-xs text-slate-400">
+          Inspect and manually trigger active anomaly effects to validate overlays, audio, and event wiring.
+        </p>
+      </CardHeader>
+      <CardContent className="p-0">
+        {entries.length === 0 ? (
+          <div className="p-6 text-center text-sm text-slate-400">
+            No active hotspots detected. Fire an event that spawns anomalies to populate this panel.
+          </div>
+        ) : (
+          <ScrollArea className="max-h-72">
+            <div className="divide-y divide-gray-800">
+              {entries.map(hotspot => (
+                <div key={hotspot.id} className="p-4 space-y-3">
+                  <div className="flex items-center justify-between">
+                    <div className="flex items-center gap-2">
+                      <Badge variant="outline" className="text-[12px] border-emerald-500/40 text-emerald-200">
+                        {hotspot.stateAbbreviation}
+                      </Badge>
+                      <h4 className="text-sm font-semibold text-slate-200">
+                        {hotspot.icon ?? '👻'} {hotspot.label}
+                      </h4>
+                    </div>
+                    <span className="text-[11px] text-slate-500 font-mono">
+                      Turn {hotspot.createdOnTurn}
+                    </span>
+                  </div>
+                  <div className="grid gap-2 text-xs text-slate-300 sm:grid-cols-2">
+                    <div className="rounded border border-gray-800 bg-gray-950/60 px-3 py-2">
+                      <span className="block font-semibold text-[11px] uppercase tracking-wide text-slate-400">Defense bonus</span>
+                      <span className="text-sm text-slate-200">+{hotspot.defenseBoost}</span>
+                    </div>
+                    <div className="rounded border border-gray-800 bg-gray-950/60 px-3 py-2">
+                      <span className="block font-semibold text-[11px] uppercase tracking-wide text-slate-400">Truth reward</span>
+                      <span className="text-sm text-slate-200">+{hotspot.truthReward}%</span>
+                    </div>
+                    <div className="rounded border border-gray-800 bg-gray-950/60 px-3 py-2">
+                      <span className="block font-semibold text-[11px] uppercase tracking-wide text-slate-400">Source</span>
+                      <span className="text-sm text-slate-200">{hotspot.source}</span>
+                    </div>
+                    <div className="rounded border border-gray-800 bg-gray-950/60 px-3 py-2">
+                      <span className="block font-semibold text-[11px] uppercase tracking-wide text-slate-400">Expires</span>
+                      <span className="text-sm text-slate-200">Turn {hotspot.expiresOnTurn}</span>
+                    </div>
+                  </div>
+                  <div className="flex flex-wrap gap-2">
+                    <Button size="sm" variant="secondary" onClick={() => triggerVisuals(hotspot)}>
+                      Trigger visuals
+                    </Button>
+                    {onTriggerEvent && hotspot.eventId && (
+                      <Button size="sm" variant="outline" onClick={() => onTriggerEvent(hotspot.eventId)}>
+                        Trigger source event
+                      </Button>
+                    )}
+                  </div>
+                </div>
+              ))}
+            </div>
+          </ScrollArea>
+        )}
+      </CardContent>
+    </Card>
+  );
+};
+
+export default HotspotInspector;

--- a/src/components/dev/useErrorSummary.ts
+++ b/src/components/dev/useErrorSummary.ts
@@ -1,0 +1,68 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { errorHandler, type GameError } from '@/utils/errorHandler';
+
+interface ErrorSummaryState {
+  total: number;
+  byType: Record<string, number>;
+  recent: GameError[];
+}
+
+interface UseErrorSummaryResult extends ErrorSummaryState {
+  lastUpdated: number;
+  clearErrors: () => void;
+  refresh: () => void;
+}
+
+const createSummary = (): ErrorSummaryState => {
+  const summary = errorHandler.getErrorSummary();
+  return {
+    total: summary.total,
+    byType: { ...summary.byType },
+    recent: [...summary.recent],
+  };
+};
+
+export const useErrorSummary = (pollIntervalMs: number = 4000): UseErrorSummaryResult => {
+  const [summary, setSummary] = useState<ErrorSummaryState>(() => createSummary());
+  const [lastUpdated, setLastUpdated] = useState<number>(() => Date.now());
+  const intervalRef = useRef<ReturnType<typeof setInterval>>();
+
+  const refresh = useCallback(() => {
+    setSummary(createSummary());
+    setLastUpdated(Date.now());
+  }, []);
+
+  const clearErrors = useCallback(() => {
+    errorHandler.clearErrors();
+    refresh();
+  }, [refresh]);
+
+  useEffect(() => {
+    refresh();
+
+    intervalRef.current = setInterval(() => {
+      refresh();
+    }, pollIntervalMs);
+
+    return () => {
+      if (intervalRef.current) {
+        clearInterval(intervalRef.current);
+      }
+    };
+  }, [pollIntervalMs, refresh]);
+
+  const memoizedSummary = useMemo(() => ({
+    total: summary.total,
+    byType: summary.byType,
+    recent: summary.recent,
+  }), [summary]);
+
+  return {
+    ...memoizedSummary,
+    lastUpdated,
+    clearErrors,
+    refresh,
+  };
+};
+
+export type { GameError } from '@/utils/errorHandler';

--- a/src/hooks/useAudio.ts
+++ b/src/hooks/useAudio.ts
@@ -1,9 +1,5 @@
 import { useState, useRef, useCallback, useEffect } from 'react';
-import {
-  UFO_ELVIS_SFX,
-  CRYPTID_RUMBLE_SFX,
-  RADIO_STATIC_SFX,
-} from '../assets/audio/paranormalSfx';
+import { SFX_MANIFEST } from '@/assets/audio/sfxManifest';
 
 interface AudioConfig {
   volume: number;
@@ -403,29 +399,9 @@ export const useAudio = () => {
     loadMusicTracks();
 
     // Create sound effects with fallback handling - use existing files for paranormal effects
-    const existingSfxFiles = {
-      cardPlay: '/audio/card-play.mp3',
-      flash: '/audio/card-play.mp3',
-      cardDraw: '/audio/card-draw.mp3',
-      stateCapture: '/audio/state-capture.mp3',
-      turnEnd: '/audio/turn-end.mp3',
-      newspaper: '/audio/newspaper.mp3',
-      victory: '/audio/victory.mp3',
-      defeat: '/audio/defeat.mp3',
-      hover: '/audio/hover.mp3',
-      click: '/audio/click.mp3',
-      typewriter: '/audio/typewriter.mp3',
-      lightClick: '/audio/click.mp3', // Reuse click sound
-      error: '/audio/click.mp3', // Fallback for error sound
-      // Paranormal effects
-      'ufo-elvis': UFO_ELVIS_SFX,
-      'cryptid-rumble': CRYPTID_RUMBLE_SFX,
-      'radio-static': RADIO_STATIC_SFX
-    };
-
     // Load SFX asynchronously with error handling
     const loadSFX = async () => {
-      const loadPromises = Object.entries(existingSfxFiles).map(async ([key, src]) => {
+      const loadPromises = Object.entries(SFX_MANIFEST).map(async ([key, src]) => {
         const audio = await loadAudioTrack(src);
         if (audio) {
           const baseSfxVolume = config.muted ? 0 : config.volume * config.sfxVolume;

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -1850,6 +1850,7 @@ const Index = () => {
         onClose={() => setShowBalancing(false)}
         logEntries={gameState.log}
         initialView={balancingInitialView}
+        paranormalHotspots={gameState.paranormalHotspots}
       />
     );
   }


### PR DESCRIPTION
## Summary
- centralize the sound-effect manifest and expose audio QA controls with volume sliders and generator access inside the briefing tools
- add a polling error summary hook plus a runtime error log panel to surface issues in the dev tool tab
- expose EventViewer controls, add a paranormal hotspot inspector, and integrate the new panels into the dev tools layout

## Testing
- npm run lint *(fails: repository has hundreds of pre-existing lint errors unrelated to this change)*

------
https://chatgpt.com/codex/tasks/task_e_68daff30dedc8320bff86e6e488068cd