### PR TITLE
Add intel archive persistence and hub evidence panel

### DIFF
--- a/src/components/game/EvidenceArchivePanel.tsx
+++ b/src/components/game/EvidenceArchivePanel.tsx
@@ -1,0 +1,250 @@
+import { useMemo, useState } from 'react';
+import clsx from 'clsx';
+import { Archive, Filter, Flag, Layers, MapPin, Trash2 } from 'lucide-react';
+import { Card } from '@/components/ui/card';
+import { ScrollArea } from '@/components/ui/scroll-area';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
+import { Button } from '@/components/ui/button';
+import type { IntelArchiveEntry } from '@/hooks/useIntelArchive';
+
+interface EvidenceArchivePanelProps {
+  entries: IntelArchiveEntry[];
+  onDelete: (id: string) => void;
+  onClear?: () => void;
+  className?: string;
+}
+
+const FILTER_ALL = 'all';
+
+const formatTurnLabel = (turn: number, round: number): string => {
+  if (!Number.isFinite(turn) || !Number.isFinite(round)) {
+    return 'Unknown turn';
+  }
+  return `Round ${round}, Turn ${turn}`;
+};
+
+const EvidenceArchivePanel = ({ entries, onDelete, onClear, className }: EvidenceArchivePanelProps) => {
+  const [stateFilter, setStateFilter] = useState<string>(FILTER_ALL);
+  const [factionFilter, setFactionFilter] = useState<string>(FILTER_ALL);
+  const [typeFilter, setTypeFilter] = useState<string>(FILTER_ALL);
+
+  const { stateOptions, factionOptions, typeOptions, filteredEntries } = useMemo(() => {
+    const states = new Map<string, string>();
+    const factions = new Map<string, string>();
+    const types = new Map<string, string>();
+
+    const normalizedEntries = [...entries].sort((a, b) => b.savedAt - a.savedAt);
+
+    normalizedEntries.forEach(entry => {
+      const stateKey = entry.stateId ?? entry.stateAbbreviation ?? entry.stateName ?? entry.id;
+      const stateLabel = entry.stateName
+        ? `${entry.stateName}${entry.stateAbbreviation ? ` (${entry.stateAbbreviation})` : ''}`
+        : stateKey;
+      if (stateKey) {
+        states.set(stateKey, stateLabel);
+      }
+      const factionKey = entry.faction;
+      if (factionKey) {
+        factions.set(factionKey, factionKey === 'truth' ? 'Truth Network' : factionKey === 'government' ? 'Government' : 'Unknown');
+      }
+      const eventType = entry.eventType ?? 'unknown';
+      types.set(eventType, eventType.charAt(0).toUpperCase() + eventType.slice(1));
+    });
+
+    const filtered = normalizedEntries.filter(entry => {
+      const stateKey = entry.stateId ?? entry.stateAbbreviation ?? entry.stateName ?? entry.id;
+      const matchesState = stateFilter === FILTER_ALL || stateKey === stateFilter;
+      const matchesFaction = factionFilter === FILTER_ALL || entry.faction === factionFilter;
+      const matchesType = typeFilter === FILTER_ALL || (entry.eventType ?? 'unknown') === typeFilter;
+      return matchesState && matchesFaction && matchesType;
+    });
+
+    return {
+      stateOptions: Array.from(states.entries()),
+      factionOptions: Array.from(factions.entries()),
+      typeOptions: Array.from(types.entries()),
+      filteredEntries: filtered,
+    };
+  }, [entries, factionFilter, stateFilter, typeFilter]);
+
+  const hasEntries = entries.length > 0;
+  const hasFilteredResults = filteredEntries.length > 0;
+
+  return (
+    <div className={clsx('flex h-full flex-col', className)}>
+      <div className="relative mb-4 flex flex-wrap items-center justify-between gap-4 rounded-lg border border-emerald-500/30 bg-emerald-500/10 px-4 py-3">
+        <div>
+          <p className="font-mono text-xs uppercase tracking-[0.32em] text-emerald-200/80">Intel Archive</p>
+          <h3 className="font-mono text-lg font-semibold uppercase tracking-[0.2em] text-emerald-100">Evidence Locker</h3>
+        </div>
+        <Archive className="h-6 w-6 text-emerald-300" aria-hidden />
+      </div>
+
+      {hasEntries ? (
+        <>
+          <Card className="mb-4 border border-emerald-500/30 bg-slate-950/80 p-4">
+            <div className="mb-3 flex items-center gap-2 text-emerald-200/80">
+              <Filter className="h-4 w-4" aria-hidden />
+              <span className="font-mono text-[11px] uppercase tracking-[0.3em]">Filter Findings</span>
+            </div>
+            <div className="grid gap-3 md:grid-cols-3">
+              <div>
+                <label className="mb-1 block text-xs font-semibold uppercase tracking-[0.24em] text-emerald-200/70">
+                  State
+                </label>
+                <Select value={stateFilter} onValueChange={setStateFilter}>
+                  <SelectTrigger className="border-emerald-500/40 bg-emerald-500/5 text-emerald-100">
+                    <SelectValue placeholder="All" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value={FILTER_ALL}>All States</SelectItem>
+                    {stateOptions.map(([value, label]) => (
+                      <SelectItem key={value} value={value}>
+                        {label}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+              <div>
+                <label className="mb-1 block text-xs font-semibold uppercase tracking-[0.24em] text-emerald-200/70">
+                  Faction
+                </label>
+                <Select value={factionFilter} onValueChange={setFactionFilter}>
+                  <SelectTrigger className="border-emerald-500/40 bg-emerald-500/5 text-emerald-100">
+                    <SelectValue placeholder="All" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value={FILTER_ALL}>All Factions</SelectItem>
+                    {factionOptions.map(([value, label]) => (
+                      <SelectItem key={value} value={value}>
+                        {label}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+              <div>
+                <label className="mb-1 block text-xs font-semibold uppercase tracking-[0.24em] text-emerald-200/70">
+                  Event Type
+                </label>
+                <Select value={typeFilter} onValueChange={setTypeFilter}>
+                  <SelectTrigger className="border-emerald-500/40 bg-emerald-500/5 text-emerald-100">
+                    <SelectValue placeholder="All" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value={FILTER_ALL}>All Types</SelectItem>
+                    {typeOptions.map(([value, label]) => (
+                      <SelectItem key={value} value={value}>
+                        {label}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+            </div>
+            {onClear && (
+              <div className="mt-4 flex justify-end">
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  className="text-emerald-200/70 hover:text-emerald-100"
+                  onClick={onClear}
+                >
+                  <Trash2 className="mr-1 h-4 w-4" aria-hidden />
+                  Clear Archive
+                </Button>
+              </div>
+            )}
+          </Card>
+
+          {hasFilteredResults ? (
+            <ScrollArea className="flex-1 pr-2">
+              <div className="space-y-3 pb-4">
+                {filteredEntries.map(entry => (
+                  <Card
+                    key={entry.id}
+                    className="relative overflow-hidden border border-emerald-500/30 bg-slate-950/85 p-4"
+                  >
+                    <div className="pointer-events-none absolute inset-0 opacity-20 bg-[radial-gradient(circle_at_top,_rgba(16,185,129,0.35),_transparent_65%)]" />
+                    <div className="relative flex flex-col gap-3">
+                      <div className="flex flex-wrap items-center justify-between gap-2">
+                        <div>
+                          <p className="font-mono text-[11px] uppercase tracking-[0.3em] text-emerald-300/70">
+                            {formatTurnLabel(entry.triggeredOnTurn, entry.round)}
+                          </p>
+                          <h4 className="font-mono text-lg font-semibold uppercase tracking-[0.18em] text-emerald-100">
+                            {entry.eventLabel}
+                          </h4>
+                        </div>
+                        <Button
+                          variant="ghost"
+                          size="sm"
+                          className="text-emerald-200/70 hover:text-emerald-100"
+                          onClick={() => onDelete(entry.id)}
+                        >
+                          <Trash2 className="mr-1 h-4 w-4" aria-hidden />
+                          Remove
+                        </Button>
+                      </div>
+                      <div className="grid gap-3 text-sm text-emerald-100/80 md:grid-cols-3">
+                        <div className="flex items-center gap-2">
+                          <MapPin className="h-4 w-4 text-emerald-300" aria-hidden />
+                          <span>
+                            {entry.stateName ?? entry.stateAbbreviation ?? entry.stateId}
+                            {entry.stateAbbreviation && entry.stateName ? ` (${entry.stateAbbreviation})` : ''}
+                          </span>
+                        </div>
+                        <div className="flex items-center gap-2">
+                          <Flag className="h-4 w-4 text-emerald-300" aria-hidden />
+                          <span className="capitalize">{entry.faction}</span>
+                        </div>
+                        <div className="flex items-center gap-2">
+                          <Layers className="h-4 w-4 text-emerald-300" aria-hidden />
+                          <span className="capitalize">{entry.eventType ?? 'Unknown'}</span>
+                        </div>
+                      </div>
+                      <p className="text-sm leading-relaxed text-emerald-100/80 whitespace-pre-wrap">
+                        {entry.loreText}
+                      </p>
+                      {entry.effectSummary && entry.effectSummary.length > 0 && (
+                        <div className="flex flex-wrap gap-2 text-[11px] font-mono uppercase tracking-[0.24em] text-emerald-200/70">
+                          {entry.effectSummary.map(effect => (
+                            <span
+                              key={effect}
+                              className="rounded border border-emerald-500/40 bg-emerald-500/10 px-2 py-1"
+                            >
+                              {effect}
+                            </span>
+                          ))}
+                        </div>
+                      )}
+                    </div>
+                  </Card>
+                ))}
+              </div>
+            </ScrollArea>
+          ) : (
+            <Card className="flex flex-1 flex-col items-center justify-center border border-dashed border-emerald-500/40 bg-emerald-500/5 p-8 text-center">
+              <MapPin className="mb-3 h-10 w-10 text-emerald-300/70" aria-hidden />
+              <h4 className="font-mono text-sm uppercase tracking-[0.28em] text-emerald-200/70">No matches</h4>
+              <p className="mt-2 max-w-sm text-sm text-emerald-100/70">
+                Adjust the filters to surface archived state intel from previous operations.
+              </p>
+            </Card>
+          )}
+        </>
+      ) : (
+        <Card className="flex flex-1 flex-col items-center justify-center border border-dashed border-emerald-500/40 bg-emerald-500/5 p-8 text-center">
+          <Archive className="mb-3 h-10 w-10 text-emerald-300/70" aria-hidden />
+          <h4 className="font-mono text-sm uppercase tracking-[0.28em] text-emerald-200/70">No evidence logged</h4>
+          <p className="mt-2 max-w-sm text-sm text-emerald-100/70">
+            Complete a match to catalogue intelligence reports from state events in your archive.
+          </p>
+        </Card>
+      )}
+    </div>
+  );
+};
+
+export default EvidenceArchivePanel;

--- a/src/components/game/PlayerHubOverlay.tsx
+++ b/src/components/game/PlayerHubOverlay.tsx
@@ -4,7 +4,7 @@ import { Card } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { Badge } from '@/components/ui/badge';
-import { Trophy, Library, GraduationCap, Newspaper, X, MapPin } from 'lucide-react';
+import { Trophy, Library, GraduationCap, Newspaper, X, MapPin, FileSearch2 } from 'lucide-react';
 import { AchievementsSection } from './AchievementPanel';
 import { CardCollectionContent } from './CardCollection';
 import { TutorialSection } from './TutorialOverlay';
@@ -13,6 +13,8 @@ import type { ArchivedEdition } from '@/hooks/usePressArchive';
 import StateIntelBoard from './StateIntelBoard';
 import PlayerHubMapView from './PlayerHubMapView';
 import type { StateEventBonusSummary } from '@/hooks/gameStateTypes';
+import EvidenceArchivePanel from './EvidenceArchivePanel';
+import type { IntelArchiveEntry } from '@/hooks/useIntelArchive';
 import '@/styles/playerHub.css';
 
 interface PlayerHubOverlayProps {
@@ -22,6 +24,9 @@ interface PlayerHubOverlayProps {
   onOpenEdition: (issue: ArchivedEdition) => void;
   onDeleteEdition: (id: string) => void;
   stateIntel?: PlayerStateIntel;
+  intelArchive: IntelArchiveEntry[];
+  onDeleteIntel: (id: string) => void;
+  onClearIntel?: () => void;
   faction: 'truth' | 'government';
 }
 
@@ -72,7 +77,7 @@ export interface PlayerStateIntel {
   }>;
 }
 
-type HubTab = 'achievements' | 'cards' | 'tutorials' | 'press' | 'intel';
+type HubTab = 'achievements' | 'cards' | 'tutorials' | 'press' | 'evidence' | 'intel';
 
 const PlayerHubOverlay = ({
   onClose,
@@ -81,11 +86,18 @@ const PlayerHubOverlay = ({
   onOpenEdition,
   onDeleteEdition,
   stateIntel,
+  intelArchive,
+  onDeleteIntel,
+  onClearIntel,
   faction,
 }: PlayerHubOverlayProps) => {
   const [activeTab, setActiveTab] = useState<HubTab>(() => {
     if (pressIssues.length > 0) {
       return 'press';
+    }
+
+    if (intelArchive.length > 0) {
+      return 'evidence';
     }
 
     if (stateIntel && stateIntel.recentEvents.length > 0) {
@@ -191,7 +203,7 @@ const PlayerHubOverlay = ({
           <div className="relative px-6 pt-6">
             <TabsList
               className={clsx(
-                'player-hub-tablist grid w-full grid-cols-5 gap-2 rounded-lg border p-1 backdrop-blur',
+                'player-hub-tablist grid w-full grid-cols-6 gap-2 rounded-lg border p-1 backdrop-blur',
                 isTruth
                   ? 'border-rose-900/40 bg-[rgba(255,255,255,0.86)] shadow-[inset_0_15px_40px_rgba(124,45,18,0.12)]'
                   : 'border-emerald-500/20 bg-slate-900/70',
@@ -244,6 +256,18 @@ const PlayerHubOverlay = ({
               >
                 <Newspaper className="h-4 w-4" />
                 Press Archive
+              </TabsTrigger>
+              <TabsTrigger
+                value="evidence"
+                className={clsx(
+                  'flex items-center justify-center gap-2 rounded-md border border-transparent px-3 py-2 text-[11px] font-semibold uppercase tracking-[0.32em] transition',
+                  isTruth
+                    ? 'text-stone-500 data-[state=active]:border-rose-900/60 data-[state=active]:bg-amber-100/90 data-[state=active]:text-rose-900 data-[state=active]:shadow-[inset_0_4px_18px_rgba(124,45,18,0.18)]'
+                    : 'text-slate-400 data-[state=active]:border-emerald-400/60 data-[state=active]:bg-emerald-500/15 data-[state=active]:text-emerald-200',
+                )}
+              >
+                <FileSearch2 className="h-4 w-4" />
+                Evidence
               </TabsTrigger>
               <TabsTrigger
                 value="intel"
@@ -308,6 +332,14 @@ const PlayerHubOverlay = ({
                   issues={pressIssues}
                   onOpen={onOpenEdition}
                   onDelete={onDeleteEdition}
+                  className="h-full"
+                />
+              </TabsContent>
+              <TabsContent value="evidence" className="relative h-full overflow-hidden p-6 focus-visible:outline-none">
+                <EvidenceArchivePanel
+                  entries={intelArchive}
+                  onDelete={onDeleteIntel}
+                  onClear={onClearIntel}
                   className="h-full"
                 />
               </TabsContent>

--- a/src/hooks/useIntelArchive.ts
+++ b/src/hooks/useIntelArchive.ts
@@ -1,0 +1,176 @@
+import { useCallback, useEffect, useState } from 'react';
+import type { GameEvent } from '@/data/eventDatabase';
+
+export interface IntelArchiveEntry {
+  id: string;
+  savedAt: number;
+  stateId: string;
+  stateName?: string;
+  stateAbbreviation?: string;
+  stateOwner: 'player' | 'ai' | 'neutral';
+  contested: boolean;
+  faction: 'truth' | 'government' | 'neutral';
+  eventId: string;
+  eventLabel: string;
+  eventType: GameEvent['type'] | 'unknown';
+  triggeredOnTurn: number;
+  round: number;
+  loreText: string;
+  effectSummary?: string[];
+}
+
+export type IntelArchiveDraft = Omit<IntelArchiveEntry, 'id' | 'savedAt'> & {
+  id?: string;
+  savedAt?: number;
+};
+
+const STORAGE_KEY = 'shadowgov-intel-archive';
+const MAX_ENTRIES = 36;
+
+const normalizeEntry = (entry: Partial<IntelArchiveEntry>): IntelArchiveEntry | null => {
+  if (!entry) {
+    return null;
+  }
+
+  const stateId = typeof entry.stateId === 'string' && entry.stateId.trim().length > 0
+    ? entry.stateId.trim()
+    : entry.stateAbbreviation ?? entry.stateName;
+  const eventId = typeof entry.eventId === 'string' && entry.eventId.trim().length > 0
+    ? entry.eventId.trim()
+    : undefined;
+  const eventLabel = typeof entry.eventLabel === 'string' && entry.eventLabel.trim().length > 0
+    ? entry.eventLabel.trim()
+    : undefined;
+  const loreText = typeof entry.loreText === 'string' && entry.loreText.trim().length > 0
+    ? entry.loreText.trim()
+    : undefined;
+  const triggeredOnTurn = typeof entry.triggeredOnTurn === 'number' && Number.isFinite(entry.triggeredOnTurn)
+    ? entry.triggeredOnTurn
+    : undefined;
+  const round = typeof entry.round === 'number' && Number.isFinite(entry.round)
+    ? entry.round
+    : undefined;
+
+  if (!stateId || !eventId || !eventLabel || !loreText || !triggeredOnTurn || !round) {
+    return null;
+  }
+
+  const faction = entry.faction === 'government' || entry.faction === 'truth'
+    ? entry.faction
+    : 'neutral';
+  const owner = entry.stateOwner === 'player' || entry.stateOwner === 'ai'
+    ? entry.stateOwner
+    : 'neutral';
+  const eventType = entry.eventType ?? 'unknown';
+
+  const id = typeof entry.id === 'string' && entry.id.trim().length > 0
+    ? entry.id.trim()
+    : `${stateId}-${eventId}-${triggeredOnTurn}`;
+
+  return {
+    id,
+    savedAt: typeof entry.savedAt === 'number' && Number.isFinite(entry.savedAt)
+      ? entry.savedAt
+      : Date.now(),
+    stateId,
+    stateName: entry.stateName ?? undefined,
+    stateAbbreviation: entry.stateAbbreviation ?? undefined,
+    stateOwner: owner,
+    contested: Boolean(entry.contested),
+    faction,
+    eventId,
+    eventLabel,
+    eventType,
+    triggeredOnTurn,
+    round,
+    loreText,
+    effectSummary: Array.isArray(entry.effectSummary) && entry.effectSummary.length > 0
+      ? entry.effectSummary.map(String)
+      : undefined,
+  } satisfies IntelArchiveEntry;
+};
+
+export const useIntelArchive = () => {
+  const [entries, setEntries] = useState<IntelArchiveEntry[]>([]);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') {
+      return;
+    }
+
+    try {
+      const stored = window.localStorage.getItem(STORAGE_KEY);
+      if (!stored) {
+        return;
+      }
+      const parsed = JSON.parse(stored) as Array<Partial<IntelArchiveEntry>> | null;
+      if (!Array.isArray(parsed)) {
+        return;
+      }
+      const normalized = parsed
+        .map(normalizeEntry)
+        .filter((entry): entry is IntelArchiveEntry => entry !== null)
+        .sort((a, b) => b.savedAt - a.savedAt);
+      setEntries(normalized.slice(0, MAX_ENTRIES));
+    } catch (error) {
+      console.warn('Failed to load intel archive', error);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') {
+      return;
+    }
+
+    try {
+      const payload = JSON.stringify(entries);
+      window.localStorage.setItem(STORAGE_KEY, payload);
+    } catch (error) {
+      console.warn('Failed to persist intel archive', error);
+    }
+  }, [entries]);
+
+  const archiveIntelEvents = useCallback((records: IntelArchiveDraft | IntelArchiveDraft[]) => {
+    const payload = Array.isArray(records) ? records : [records];
+    setEntries(prev => {
+      const existing = [...prev];
+      const now = Date.now();
+
+      payload.forEach(record => {
+        const normalized = normalizeEntry({
+          ...record,
+          savedAt: record.savedAt ?? now,
+        });
+        if (!normalized) {
+          return;
+        }
+        const index = existing.findIndex(entry => entry.id === normalized.id);
+        if (index >= 0) {
+          existing[index] = normalized;
+        } else {
+          existing.unshift(normalized);
+        }
+      });
+
+      existing.sort((a, b) => b.savedAt - a.savedAt);
+      return existing.slice(0, MAX_ENTRIES);
+    });
+  }, []);
+
+  const removeIntelFromArchive = useCallback((id: string) => {
+    setEntries(prev => prev.filter(entry => entry.id !== id));
+  }, []);
+
+  const clearArchive = useCallback(() => {
+    setEntries([]);
+  }, []);
+
+  return {
+    entries,
+    archiveIntelEvents,
+    removeIntelFromArchive,
+    clearArchive,
+  };
+};
+
+export default useIntelArchive;


### PR DESCRIPTION
## Summary
- add a reusable useIntelArchive hook to persist recovered state intel to local storage
- capture game-over state event history in the index page and feed it into the Player Hub overlay
- introduce an EvidenceArchivePanel tab for filtering and browsing archived state findings

## Testing
- npm run lint *(fails: existing repository lint issues)*

------
https://chatgpt.com/codex/tasks/task_e_68db62f7fc1c8320977341eb81e637e3