### PR TITLE
Ensure combo tests import unmocked card resolution

### DIFF
--- a/src/game/__tests__/comboAndStateEffects.test.ts
+++ b/src/game/__tests__/comboAndStateEffects.test.ts
@@ -3,7 +3,7 @@ import type { GameState } from '@/hooks/gameStateTypes';
 import type { AIDifficulty } from '@/data/aiStrategy';
 import { createDefaultCombinationEffects, STATE_COMBINATIONS, aggregateStateCombinationEffects, calculateDynamicIpBonus, applyStateCombinationCostModifiers, applyDefenseBonusToStates } from '@/data/stateCombinations';
 import type { TurnPlay } from '@/game/combo.types';
-import { resolveCardMVP } from '@/systems/cardResolution';
+import { resolveCardMVP } from '@/systems/cardResolution.actual';
 import type { GameCard } from '@/rules/mvp';
 import { applyComboRewards, evaluateCombos, setComboSettings } from '@/game/comboEngine';
 import { DEFAULT_COMBO_SETTINGS } from '@/game/combo.config';

--- a/src/systems/cardResolution.actual.ts
+++ b/src/systems/cardResolution.actual.ts
@@ -1,0 +1,1 @@
+export * from './cardResolution?actual';


### PR DESCRIPTION
## Summary
- update the combo/state integration tests to import the real card resolution logic
- add a dedicated re-export that bypasses Bun's module mock cache so coverage runs see the actual implementation

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68db7cc7e82c8320a3440b0e7618bdc1