### PR TITLE
Add UI scale setting

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -8,6 +8,7 @@ All colors MUST be HSL.
 
 @layer base {
   :root {
+    --ui-scale: 1;
     --background: 44 43% 93%;
     --foreground: 222.2 84% 4.9%;
 
@@ -44,18 +45,18 @@ All colors MUST be HSL.
     --sidebar-primary-foreground: 0 0% 98%;
 
     /* Layout sizing tokens */
-    --hdr: clamp(64px, 11dvh, 112px);
-    --ftr: clamp(34px, 6dvh, 64px);
-    --gut: clamp(8px, 1.2vw, 16px);
+    --hdr: clamp(calc(64px * var(--ui-scale, 1)), calc(11dvh * var(--ui-scale, 1)), calc(112px * var(--ui-scale, 1)));
+    --ftr: clamp(calc(34px * var(--ui-scale, 1)), calc(6dvh * var(--ui-scale, 1)), calc(64px * var(--ui-scale, 1)));
+    --gut: clamp(calc(8px * var(--ui-scale, 1)), calc(1.2vw * var(--ui-scale, 1)), calc(16px * var(--ui-scale, 1)));
 
     --row-top: 58%;
     --row-bot: 42%;
 
     /* Typography scaling tokens */
-    --h1: clamp(28px, 6vh, 64px);
-    --h2: clamp(18px, 3.2vh, 40px);
-    --btn: clamp(14px, 2.6vh, 28px);
-    --cap: clamp(10px, 1.6vh, 13px);
+    --h1: clamp(calc(28px * var(--ui-scale, 1)), calc(6vh * var(--ui-scale, 1)), calc(64px * var(--ui-scale, 1)));
+    --h2: clamp(calc(18px * var(--ui-scale, 1)), calc(3.2vh * var(--ui-scale, 1)), calc(40px * var(--ui-scale, 1)));
+    --btn: clamp(calc(14px * var(--ui-scale, 1)), calc(2.6vh * var(--ui-scale, 1)), calc(28px * var(--ui-scale, 1)));
+    --cap: clamp(calc(10px * var(--ui-scale, 1)), calc(1.6vh * var(--ui-scale, 1)), calc(13px * var(--ui-scale, 1)));
 
     /* Tabloid newspaper theme tokens */
     --paper: hsl(44 43% 93%);
@@ -137,25 +138,29 @@ All colors MUST be HSL.
     --effect-evidence: #4444ff;
     --effect-news-ticker: #ff0066;
   }
+
+  html {
+    font-size: calc(16px * var(--ui-scale, 1));
+  }
   @media (max-height: 820px) {
     :root {
-      --hdr: clamp(52px, 9.5dvh, 88px);
-      --ftr: clamp(30px, 5.5dvh, 56px);
-      --gut: clamp(6px, 0.9vw, 12px);
+      --hdr: clamp(calc(52px * var(--ui-scale, 1)), calc(9.5dvh * var(--ui-scale, 1)), calc(88px * var(--ui-scale, 1)));
+      --ftr: clamp(calc(30px * var(--ui-scale, 1)), calc(5.5dvh * var(--ui-scale, 1)), calc(56px * var(--ui-scale, 1)));
+      --gut: clamp(calc(6px * var(--ui-scale, 1)), calc(0.9vw * var(--ui-scale, 1)), calc(12px * var(--ui-scale, 1)));
 
       --row-top: 54%;
       --row-bot: 46%;
 
-      --h1: clamp(24px, 5.2vh, 52px);
-      --h2: clamp(16px, 2.6vh, 34px);
-      --btn: clamp(12px, 2.2vh, 22px);
-      --cap: clamp(9px, 1.4vh, 12px);
+      --h1: clamp(calc(24px * var(--ui-scale, 1)), calc(5.2vh * var(--ui-scale, 1)), calc(52px * var(--ui-scale, 1)));
+      --h2: clamp(calc(16px * var(--ui-scale, 1)), calc(2.6vh * var(--ui-scale, 1)), calc(34px * var(--ui-scale, 1)));
+      --btn: clamp(calc(12px * var(--ui-scale, 1)), calc(2.2vh * var(--ui-scale, 1)), calc(22px * var(--ui-scale, 1)));
+      --cap: clamp(calc(9px * var(--ui-scale, 1)), calc(1.4vh * var(--ui-scale, 1)), calc(12px * var(--ui-scale, 1)));
     }
   }
 
   @media (max-width: 1400px) {
     :root {
-      --gut: clamp(6px, 0.8vw, 12px);
+      --gut: clamp(calc(6px * var(--ui-scale, 1)), calc(0.8vw * var(--ui-scale, 1)), calc(12px * var(--ui-scale, 1)));
     }
   }
 

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -3,6 +3,39 @@ import App from './App.tsx';
 import './index.css';
 import { initializeExpansions } from '@/data/expansions/state';
 
+const SETTINGS_STORAGE_KEY = 'gameSettings';
+
+const clampUiScale = (value: unknown): number | null => {
+  if (typeof value !== 'number' || Number.isNaN(value)) {
+    return null;
+  }
+
+  return Math.min(1.5, Math.max(0.75, value));
+};
+
+const initializeUiScaleFromStorage = () => {
+  if (typeof window === 'undefined' || typeof document === 'undefined') {
+    return;
+  }
+
+  const stored = window.localStorage?.getItem(SETTINGS_STORAGE_KEY);
+  if (!stored) {
+    return;
+  }
+
+  try {
+    const parsed = JSON.parse(stored) as { uiScale?: unknown } | null;
+    const clamped = clampUiScale(parsed?.uiScale);
+    if (typeof clamped === 'number') {
+      document.documentElement.style.setProperty('--ui-scale', clamped.toString());
+    }
+  } catch (error) {
+    console.warn('[UI] Failed to parse stored UI scale', error);
+  }
+};
+
+initializeUiScaleFromStorage();
+
 const rootElement = document.getElementById('root');
 if (!rootElement) {
   throw new Error('Root element not found');


### PR DESCRIPTION
## Summary
- add uiScale option to game settings with persistence and update flow
- bind interface scale slider and update css custom properties for layout tokens
- initialize stored ui scale before app render so startup respects saved preference

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68db8a95bfa483208845ef1b36efd67e