### PR TITLE
Normalize interface scale percentage persistence

### DIFF
--- a/src/components/game/Options.tsx
+++ b/src/components/game/Options.tsx
@@ -13,6 +13,7 @@ import { COMBO_DEFINITIONS, DEFAULT_COMBO_SETTINGS } from '@/game/combo.config';
 import { formatComboReward, getComboSettings, setComboSettings } from '@/game/comboEngine';
 import type { ComboCategory, ComboSettings } from '@/game/combo.types';
 import { Badge } from '@/components/ui/badge';
+import { DEFAULT_UI_SCALE, coerceUiScale, parseUiScale } from '@/lib/ui-scale';
 import {
   Select,
   SelectContent,
@@ -92,14 +93,6 @@ interface OptionsProps {
   onSaveGame?: () => boolean;
 }
 
-const clampUiScale = (value: unknown): number => {
-  if (typeof value !== 'number' || Number.isNaN(value)) {
-    return 1;
-  }
-
-  return Math.min(1.5, Math.max(0.75, value));
-};
-
 interface GameSettings {
   masterVolume: number;
   musicVolume: number;
@@ -152,7 +145,7 @@ const Options = ({ onClose, onBackToMainMenu, onSaveGame }: OptionsProps) => {
       drawMode: 'standard',
       uiTheme,
       paranormalEffectsEnabled: true,
-      uiScale: 1,
+      uiScale: DEFAULT_UI_SCALE,
     };
 
     const stored = typeof localStorage !== 'undefined'
@@ -168,7 +161,7 @@ const Options = ({ onClose, onBackToMainMenu, onSaveGame }: OptionsProps) => {
           ...baseSettings,
           ...rest,
           difficulty: difficultyLabel,
-          uiScale: clampUiScale(rest?.uiScale ?? baseSettings.uiScale),
+          uiScale: parseUiScale(rest?.uiScale, baseSettings.uiScale),
         };
 
         if (typeof document !== 'undefined') {
@@ -327,7 +320,7 @@ const Options = ({ onClose, onBackToMainMenu, onSaveGame }: OptionsProps) => {
   const updateSettings = (newSettings: Partial<GameSettings>) => {
     const normalizedSettings: Partial<GameSettings> = { ...newSettings };
     if (typeof newSettings.uiScale === 'number') {
-      normalizedSettings.uiScale = clampUiScale(newSettings.uiScale);
+      normalizedSettings.uiScale = coerceUiScale(newSettings.uiScale);
     }
 
     if (typeof newSettings.masterVolume === 'number') {
@@ -400,7 +393,7 @@ const Options = ({ onClose, onBackToMainMenu, onSaveGame }: OptionsProps) => {
       drawMode: 'standard',
       uiTheme: 'tabloid_bw',
       paranormalEffectsEnabled: true,
-      uiScale: 1,
+      uiScale: DEFAULT_UI_SCALE,
     };
 
     const defaultCombos = setComboSettings({

--- a/src/lib/ui-scale.ts
+++ b/src/lib/ui-scale.ts
@@ -1,0 +1,28 @@
+export const DEFAULT_UI_SCALE = 1;
+export const MIN_UI_SCALE = 0.75;
+export const MAX_UI_SCALE = 1.5;
+
+const normalizeUiScale = (value: number): number => {
+  return Math.min(MAX_UI_SCALE, Math.max(MIN_UI_SCALE, value));
+};
+
+export const coerceUiScale = (value: number): number => {
+  const normalizedValue = value > 10 ? value / 100 : value;
+  return normalizeUiScale(normalizedValue);
+};
+
+export const parseUiScale = (value: unknown, fallback = DEFAULT_UI_SCALE): number => {
+  if (typeof value !== 'number' || Number.isNaN(value)) {
+    return fallback;
+  }
+
+  return coerceUiScale(value);
+};
+
+export const tryParseUiScale = (value: unknown): number | null => {
+  if (typeof value !== 'number' || Number.isNaN(value)) {
+    return null;
+  }
+
+  return coerceUiScale(value);
+};

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -2,16 +2,9 @@ import { createRoot } from 'react-dom/client';
 import App from './App.tsx';
 import './index.css';
 import { initializeExpansions } from '@/data/expansions/state';
+import { tryParseUiScale } from '@/lib/ui-scale';
 
 const SETTINGS_STORAGE_KEY = 'gameSettings';
-
-const clampUiScale = (value: unknown): number | null => {
-  if (typeof value !== 'number' || Number.isNaN(value)) {
-    return null;
-  }
-
-  return Math.min(1.5, Math.max(0.75, value));
-};
 
 const initializeUiScaleFromStorage = () => {
   if (typeof window === 'undefined' || typeof document === 'undefined') {
@@ -25,9 +18,9 @@ const initializeUiScaleFromStorage = () => {
 
   try {
     const parsed = JSON.parse(stored) as { uiScale?: unknown } | null;
-    const clamped = clampUiScale(parsed?.uiScale);
-    if (typeof clamped === 'number') {
-      document.documentElement.style.setProperty('--ui-scale', clamped.toString());
+    const normalized = tryParseUiScale(parsed?.uiScale);
+    if (typeof normalized === 'number') {
+      document.documentElement.style.setProperty('--ui-scale', normalized.toString());
     }
   } catch (error) {
     console.warn('[UI] Failed to parse stored UI scale', error);


### PR DESCRIPTION
## Summary
- add shared helpers to normalize interface scale values and treat stored percentages as 100%
- update options and bootstrap flow to use the shared normalization and keep 100% as the standard scale

## Testing
- npm run lint *(fails: existing lint violations in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68db90a643bc8320bd9bc41a1cda9222