### PR TITLE
Add state-themed round bonuses and events system

### DIFF
--- a/src/components/game/EnhancedUSAMap.tsx
+++ b/src/components/game/EnhancedUSAMap.tsx
@@ -8,7 +8,11 @@ import { geoAlbersUsa, geoPath } from 'd3-geo';
 import { AlertTriangle, Target, Shield } from 'lucide-react';
 import { VisualEffectsCoordinator } from '@/utils/visualEffects';
 import { areParanormalEffectsEnabled } from '@/state/settings';
-import type { StateEventBonusSummary } from '@/hooks/gameStateTypes';
+import type {
+  ActiveStateBonus,
+  StateEventBonusSummary,
+  StateRoundEventLogEntry,
+} from '@/hooks/gameStateTypes';
 
 
 interface EnhancedState {
@@ -43,6 +47,8 @@ interface EnhancedState {
   };
   stateEventBonus?: StateEventBonusSummary;
   stateEventHistory?: StateEventBonusSummary[];
+  activeStateBonus?: ActiveStateBonus | null;
+  roundEvents?: StateRoundEventLogEntry[];
 }
 
 interface PlayedCard {
@@ -770,6 +776,107 @@ const EnhancedUSAMap: React.FC<EnhancedUSAMapProps> = ({
                 </div>
               </div>
             )}
+
+            {stateInfo.activeStateBonus && (
+              <div className="pt-2 border-t border-border">
+                <div className="flex items-center gap-2 text-sm font-bold text-foreground mb-1">
+                  <span>{stateInfo.activeStateBonus.icon ?? '⭐️'}</span>
+                  <span>{stateInfo.activeStateBonus.label}</span>
+                </div>
+                <div className="space-y-2 text-xs font-mono bg-emerald-500/10 border border-emerald-500/40 p-3 rounded shadow-sm">
+                  <div className="text-sm font-semibold text-foreground">
+                    {stateInfo.activeStateBonus.headline}
+                  </div>
+                  {stateInfo.activeStateBonus.subhead && (
+                    <div className="text-muted-foreground leading-snug">
+                      {stateInfo.activeStateBonus.subhead}
+                    </div>
+                  )}
+                  <div className="text-muted-foreground leading-snug">
+                    {stateInfo.activeStateBonus.summary}
+                  </div>
+                  <div className="grid grid-cols-2 gap-2 text-muted-foreground">
+                    {typeof stateInfo.activeStateBonus.truthDelta === 'number' && stateInfo.activeStateBonus.truthDelta !== 0 && (
+                      <span>
+                        Truth {stateInfo.activeStateBonus.truthDelta > 0 ? '+' : ''}
+                        {stateInfo.activeStateBonus.truthDelta}
+                      </span>
+                    )}
+                    {typeof stateInfo.activeStateBonus.ipDelta === 'number' && stateInfo.activeStateBonus.ipDelta !== 0 && (
+                      <span>
+                        IP {stateInfo.activeStateBonus.ipDelta > 0 ? '+' : ''}
+                        {stateInfo.activeStateBonus.ipDelta}
+                      </span>
+                    )}
+                    {typeof stateInfo.activeStateBonus.pressureDelta === 'number'
+                      && stateInfo.activeStateBonus.pressureDelta !== 0 && (
+                        <span>
+                          Pressure {stateInfo.activeStateBonus.pressureDelta > 0 ? '+' : ''}
+                          {stateInfo.activeStateBonus.pressureDelta}
+                        </span>
+                      )}
+                    {(!stateInfo.activeStateBonus.truthDelta
+                      && !stateInfo.activeStateBonus.ipDelta
+                      && !stateInfo.activeStateBonus.pressureDelta) && (
+                        <span className="col-span-2 text-muted-foreground/80">Passive influence active</span>
+                      )}
+                  </div>
+                  <div className="text-[11px] uppercase tracking-wide text-muted-foreground/80">
+                    Round {stateInfo.activeStateBonus.round}
+                  </div>
+                </div>
+              </div>
+            )}
+
+            {stateInfo.roundEvents?.length ? (
+              <div className="pt-2 border-t border-border">
+                <div className="flex items-center gap-2 text-sm font-bold text-foreground mb-1">
+                  <span>🗞️</span>
+                  <span>Current Anomalies</span>
+                </div>
+                <div className="space-y-2 text-xs font-mono bg-sky-500/10 border border-sky-500/40 p-3 rounded shadow-sm">
+                  {stateInfo.roundEvents.map(event => (
+                    <div
+                      key={`${stateInfo.id}-round-event-${event.id}`}
+                      className="rounded border border-sky-500/30 bg-background/80 p-2 shadow-sm"
+                    >
+                      <div className="flex items-center gap-2 text-sm font-semibold text-foreground">
+                        <span>{event.icon ?? '⚡'}</span>
+                        <span className="truncate">{event.headline}</span>
+                      </div>
+                      {event.subhead && (
+                        <div className="text-[11px] text-muted-foreground/80 mt-1">
+                          {event.subhead}
+                        </div>
+                      )}
+                      <div className="text-muted-foreground leading-snug mt-1">
+                        {event.summary}
+                      </div>
+                      <div className="flex flex-wrap gap-2 pt-1 text-[11px] text-muted-foreground/90">
+                        {typeof event.truthDelta === 'number' && event.truthDelta !== 0 && (
+                          <span className="rounded border border-sky-500/40 px-2 py-0.5">
+                            Truth {event.truthDelta > 0 ? '+' : ''}{event.truthDelta}
+                          </span>
+                        )}
+                        {typeof event.ipDelta === 'number' && event.ipDelta !== 0 && (
+                          <span className="rounded border border-sky-500/40 px-2 py-0.5">
+                            IP {event.ipDelta > 0 ? '+' : ''}{event.ipDelta}
+                          </span>
+                        )}
+                        {typeof event.pressureDelta === 'number' && event.pressureDelta !== 0 && (
+                          <span className="rounded border border-sky-500/40 px-2 py-0.5">
+                            Pressure {event.pressureDelta > 0 ? '+' : ''}{event.pressureDelta}
+                          </span>
+                        )}
+                        <span className="ml-auto text-[10px] uppercase tracking-wide text-muted-foreground/70">
+                          Round {event.round}
+                        </span>
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              </div>
+            ) : null}
 
             {stateInfo.stateEventBonus && (
               <div className="pt-2 border-t border-border">

--- a/src/data/stateThemedPools.ts
+++ b/src/data/stateThemedPools.ts
@@ -1,0 +1,427 @@
+import type { StateData } from '@/data/usaStates';
+
+export interface StateTag {
+  id: string;
+  label: string;
+  description?: string;
+  /**
+   * States included in this tag. Accepts either abbreviations (preferred) or
+   * the canonical FIPS identifiers used in {@link StateData.id}.
+   */
+  states: string[];
+}
+
+export interface ThemedEffect {
+  id: string;
+  label: string;
+  headline: string;
+  subhead?: string;
+  summary: string;
+  weight: number;
+  icon?: string;
+  tone?: string;
+  effect: {
+    truthDelta?: number;
+    ipDelta?: number;
+    pressureDelta?: number;
+  };
+}
+
+export interface StateThemedPool {
+  tag: StateTag;
+  bonuses: ThemedEffect[];
+  events: ThemedEffect[];
+}
+
+const createEffect = (effect: ThemedEffect): ThemedEffect => ({
+  ...effect,
+  weight: Math.max(1, Math.round(effect.weight)),
+  effect: {
+    truthDelta: effect.effect.truthDelta ?? 0,
+    ipDelta: effect.effect.ipDelta ?? 0,
+    pressureDelta: effect.effect.pressureDelta ?? 0,
+  },
+});
+
+export const STATE_THEMED_POOLS: StateThemedPool[] = [
+  {
+    tag: {
+      id: 'wy_plains_radar',
+      label: 'Cheyenne Listening Range',
+      description: 'Signals bounce off silent missile fields and wide-open skies.',
+      states: ['WY', '56'],
+    },
+    bonuses: [
+      createEffect({
+        id: 'wy_bonus_black_helicopter_subsidy',
+        label: 'Black Helicopter Fuel Subsidy',
+        headline: 'FEDS TOP OFF UNMARKED HELICOPTERS OVER PRAIRIE',
+        subhead: 'Witnesses hear midnight refuels; “contrails smell like diesel truth.”',
+        summary: 'Unlogged tankers hover in at dusk, topping off the clandestine fleet and leaving behind “truth fumes.”',
+        icon: '🚁',
+        weight: 3,
+        effect: { truthDelta: 4, ipDelta: 1 },
+      }),
+      createEffect({
+        id: 'wy_bonus_bigfoot_cattle_congress',
+        label: 'Bigfoot Cattle Congress',
+        headline: 'SASQUATCH UNIONIZES WYOMING CATTLE',
+        subhead: 'Hoofprints spell out “LISTEN” in Morse under a blood moon.',
+        summary: 'Ranchers wake to bovine picket lines patrolled by shaggy silhouettes whispering classified coordinates.',
+        icon: '🦶',
+        weight: 2,
+        effect: { truthDelta: 2, pressureDelta: 1 },
+      }),
+      createEffect({
+        id: 'wy_bonus_tourist_roadside_psychics',
+        label: 'Roadside Psychic Convoy',
+        headline: 'FORTUNE TELLERS SET UP MIRAGE CHECKPOINTS',
+        subhead: 'Drivers report tarot inspections before entering missile alley.',
+        summary: 'A caravan of neon campers performs aura screenings and leaks sanitized intel to any operative brave enough to stop.',
+        icon: '🔮',
+        weight: 1,
+        effect: { ipDelta: 2 },
+      }),
+    ],
+    events: [
+      createEffect({
+        id: 'wy_event_thunder_basement',
+        label: 'Thunder Basement Rumble',
+        headline: 'CHEYENNE HEARS DRUMBEAT BENEATH MAIN STREET',
+        subhead: 'Seismographs register “classified rhythm.”',
+        summary: 'Locals swear the silo complex below town is hosting a rave for remote viewers. Everyone feels strangely patriotic.',
+        icon: '🥁',
+        weight: 4,
+        effect: { truthDelta: 3, ipDelta: -1 },
+      }),
+      createEffect({
+        id: 'wy_event_skygrid_blackout',
+        label: 'Skygrid Blackout',
+        headline: 'NORTHERN SKY BLINKS LIKE GLITCHING SPREADSHEET',
+        subhead: 'Astronomers kicked out of their own observatories by men in polite suits.',
+        summary: 'Constellations flicker, spelling out coordinates to anyone tuned to the right AM frequency. Some agents get there first.',
+        icon: '🛰️',
+        weight: 2,
+        effect: { truthDelta: 1, pressureDelta: 2 },
+      }),
+      createEffect({
+        id: 'wy_event_dusty_clone_convoy',
+        label: 'Dusty Clone Convoy',
+        headline: 'IDENTICAL RANCHERS DRIVE IDENTICAL TRUCKS SOUTH',
+        subhead: 'License plates all read “TRUSTME.”',
+        summary: 'Convoy passes midnight checkpoints and waves forged credentials. Their windows are down. They chant classified slogans.',
+        icon: '🚚',
+        weight: 1,
+        effect: { ipDelta: 2 },
+      }),
+    ],
+  },
+  {
+    tag: {
+      id: 'nd_oilfield_rift',
+      label: 'Bakken Riftline',
+      description: 'Fracking rigs hum in harmony with buried satellite dishes.',
+      states: ['ND', '38'],
+    },
+    bonuses: [
+      createEffect({
+        id: 'nd_bonus_glow_derrick',
+        label: 'Glow-in-the-Dark Derrick Crews',
+        headline: 'RIG WORKERS REPORT “NIGHT-SHIFT AURAS”',
+        subhead: 'Company doctors prescribe sunglasses after midnight.',
+        summary: 'Entire crews start emitting faint chartreuse light and hearing coded numbers in the drilling vibrations. Productivity soars.',
+        icon: '🌌',
+        weight: 2,
+        effect: { truthDelta: 3 },
+      }),
+      createEffect({
+        id: 'nd_bonus_fracked_memory',
+        label: 'Fracked Memory Seep',
+        headline: 'GROUNDWATER STARTS REMEMBERING PASSWORDS',
+        subhead: 'Tap opens, secrets spill out between ice cubes.',
+        summary: 'Kitchen faucets now mutter login credentials for long-deleted agency accounts. Quick listeners bank the intel.',
+        icon: '💧',
+        weight: 3,
+        effect: { ipDelta: 2 },
+      }),
+      createEffect({
+        id: 'nd_bonus_satellite_seed_rain',
+        label: 'Satellite Seed Rain',
+        headline: 'MICROCHIP “HAIL” COATS FIELDS',
+        subhead: 'Farmers scoop glittering pellets into mason jars marked CLASSIFIED.',
+        summary: 'Debris from a decommissioned spy satellite sprinkles firmware shards over the prairie, boosting surveillance yields.',
+        icon: '🌾',
+        weight: 1,
+        effect: { truthDelta: 1, ipDelta: 1 },
+      }),
+    ],
+    events: [
+      createEffect({
+        id: 'nd_event_pipeline_echo',
+        label: 'Pipeline Echo Choir',
+        headline: 'VALVES HUM “WE KNOW WHAT YOU DID”',
+        subhead: 'Engineers admit pipeline is whispering agency roll call.',
+        summary: 'The Bakken mainline begins singing through the night, naming every operative who ever tapped the crude supply.',
+        icon: '🎶',
+        weight: 3,
+        effect: { truthDelta: 2 },
+      }),
+      createEffect({
+        id: 'nd_event_frozen_drone_yard',
+        label: 'Frozen Drone Yard',
+        headline: 'HUNDREDS OF DRONES FREEZE MID-TAKEOFF',
+        subhead: 'They hover, frostbitten, pointing toward a single warehouse.',
+        summary: 'A winter microburst flash-freezes classified deliveries. Whoever thaws them first gets the manifests.',
+        icon: '🧊',
+        weight: 2,
+        effect: { ipDelta: 2 },
+      }),
+      createEffect({
+        id: 'nd_event_williston_time_loop',
+        label: 'Williston Time Loop',
+        headline: 'DINER CLOCKS RUN BACKWARDS FOR ONE SHIFT',
+        subhead: 'Customers finish coffee before ordering.',
+        summary: 'Analysts exploit the loop to re-run the same intel drop three times. Skeptics wake up already convinced.',
+        icon: '⏱️',
+        weight: 1,
+        effect: { truthDelta: 1, pressureDelta: 1 },
+      }),
+    ],
+  },
+  {
+    tag: {
+      id: 'florida_strange_current',
+      label: 'Florida Manifold',
+      description: 'Humidity thick with conspiracies, oranges, and interdimensional tourists.',
+      states: ['FL', '12'],
+    },
+    bonuses: [
+      createEffect({
+        id: 'fl_bonus_airboat_numbers',
+        label: 'Airboat Number Stations',
+        headline: 'EVERGLADES TOUR GUIDE BROADCASTS PRIME NUMBERS',
+        subhead: 'Gators nod knowingly.',
+        summary: 'Night rides now include coded instructions piped through static-laced loudspeakers, synced with swamp fireflies.',
+        icon: '🐊',
+        weight: 2,
+        effect: { truthDelta: 2, ipDelta: 1 },
+      }),
+      createEffect({
+        id: 'fl_bonus_motel_oracle',
+        label: 'Motel Oracle Loyalty Card',
+        headline: 'EXIT-7 MOTEL CLERK TELLS FUTURE, TAKES CASH',
+        subhead: 'He stamps every card “DO NOT TRUST ROOM 213.”',
+        summary: 'Check-in ritual unlocks glimpses of next week’s cover-up. Management swears he just “reads people well.”',
+        icon: '🗝️',
+        weight: 3,
+        effect: { ipDelta: 3 },
+      }),
+      createEffect({
+        id: 'fl_bonus_tourist_ufo_ferry',
+        label: 'Tourist UFO Ferry',
+        headline: 'PANHANDLE FERRY CROSSES TRIANGLE IN 12 MINUTES',
+        subhead: 'Passengers disembark with matching sunburn sigils.',
+        summary: 'Ferry route slices through a geometry glitch, catapulting operatives ahead of schedule and straight into soft targets.',
+        icon: '🛸',
+        weight: 1,
+        effect: { truthDelta: 1, pressureDelta: 1 },
+      }),
+    ],
+    events: [
+      createEffect({
+        id: 'fl_event_reptilian_press_conference',
+        label: 'Reptilian Press Conference',
+        headline: 'STATE CAPITOL MICROPHONES HISS IN REPTO-SPEAK',
+        subhead: 'Officials insist it was “humid feedback.”',
+        summary: 'Televised briefing devolves into forked-tongue revelations. Viewers at home rewind the stream until the feed mysteriously burns out.',
+        icon: '🦎',
+        weight: 3,
+        effect: { truthDelta: 4, ipDelta: -1 },
+      }),
+      createEffect({
+        id: 'fl_event_themepark_blackout',
+        label: 'Theme Park Blackout',
+        headline: 'MASCOTS FREEZE, EYES GLOW BLUE',
+        subhead: 'Families escorted away by polite agents.',
+        summary: 'Animatronics lock into perfect salute, projecting classified coordinates on the nearest rollercoaster. Queue lines cheer.',
+        icon: '🎢',
+        weight: 2,
+        effect: { ipDelta: 2 },
+      }),
+      createEffect({
+        id: 'fl_event_citrus_psychic_bloom',
+        label: 'Citrus Psychic Bloom',
+        headline: 'ORANGE GROVES BLOSSOM WITH WIFI SIGNALS',
+        subhead: 'Phones auto-connect to network named “THE TRUTH”.',
+        summary: 'Harvest teams record impossible, hyper-clear dreams after squeezing the crop. Rival networks scramble to jam the orchard.',
+        icon: '🍊',
+        weight: 1,
+        effect: { truthDelta: 2, pressureDelta: 1 },
+      }),
+    ],
+  },
+  {
+    tag: {
+      id: 'nv_neon_occult',
+      label: 'Nevada Neon Occult',
+      description: 'Desert casinos, secret runways, and retro-future radio towers.',
+      states: ['NV', '32'],
+    },
+    bonuses: [
+      createEffect({
+        id: 'nv_bonus_slot_machine_divination',
+        label: 'Slot Machine Divination',
+        headline: 'JACKPOTS SPELL OUT AGENCY CALL SIGNS',
+        subhead: 'Security tapes mysteriously loop over the reveal.',
+        summary: 'High rollers pull triple oracle-7s and walk away with more intel than chips. Pit bosses shrug and comp the truth drinks.',
+        icon: '🎰',
+        weight: 3,
+        effect: { truthDelta: 2, ipDelta: 1 },
+      }),
+      createEffect({
+        id: 'nv_bonus_desert_zeppelin_drop',
+        label: 'Desert Zeppelin Drop',
+        headline: 'BLIMP RAINS POLYGRAPH BALLOONS',
+        subhead: 'Every balloon labeled “JUST BREATHE HONESTLY.”',
+        summary: 'Night sky fills with helium truth orbs gently landing on suburban lawns. Each contains a working interrogation rig.',
+        icon: '🎈',
+        weight: 2,
+        effect: { truthDelta: 3 },
+      }),
+      createEffect({
+        id: 'nv_bonus_area51_clearance_sale',
+        label: 'Area 51 Clearance Sale',
+        headline: 'SURPLUS HANGAR HOLDS “CLASSIFIED GARAGE SALE”',
+        subhead: 'Handwritten sign: “NO PHOTOS, NO REFUNDS, NO MEN-IN-BLACK.”',
+        summary: 'Retired engineers dump prototypes at discount rates. Savvy operatives snag cloaking blankets and EMP-resistant clipboards.',
+        icon: '🛸',
+        weight: 1,
+        effect: { ipDelta: 3 },
+      }),
+    ],
+    events: [
+      createEffect({
+        id: 'nv_event_mirrorstorm',
+        label: 'Strip Mirrorstorm',
+        headline: 'CASINO MIRRORS REFLECT ALTERNATE TIMELINE',
+        subhead: 'Tourists watch themselves lose at secret operations.',
+        summary: 'Reflections show tomorrow’s scandals in real time. Surveillance teams scramble to photograph the future before it blinks out.',
+        icon: '🪞',
+        weight: 3,
+        effect: { truthDelta: 3 },
+      }),
+      createEffect({
+        id: 'nv_event_coyote_oracle',
+        label: 'Coyote Oracle Broadcast',
+        headline: 'PACK OF COYOTES HOWLS ENCRYPTED WEBSITES',
+        subhead: 'Ham radios across the desert light up with login prompts.',
+        summary: 'Animals gather at mile marker 51 and chant root passwords in perfect chorus. Agency field teams race to transcribe.',
+        icon: '🐺',
+        weight: 2,
+        effect: { ipDelta: 2 },
+      }),
+      createEffect({
+        id: 'nv_event_phantom_table_games',
+        label: 'Phantom Table Games',
+        headline: 'DEALERS SERVE INVISIBLE HIGH ROLLERS',
+        subhead: 'Chips float, drinks empty, secrets leak.',
+        summary: 'Roulette wheels spin themselves, landing on coordinates only insiders recognize. Winners leave dossiers in their wake.',
+        icon: '🃏',
+        weight: 1,
+        effect: { truthDelta: 1, pressureDelta: 1 },
+      }),
+    ],
+  },
+  {
+    tag: {
+      id: 'nj_megacorridor',
+      label: 'Jersey Megacorridor',
+      description: 'Rest-stop gossip pipelines and pharmaceutical hush money.',
+      states: ['NJ', '34'],
+    },
+    bonuses: [
+      createEffect({
+        id: 'nj_bonus_turnpike_cb_rally',
+        label: 'Turnpike CB Rally',
+        headline: 'TRUCKERS JAM CHANNEL 19 WITH REDACTED RECIPES',
+        subhead: 'Every ingredient is a project codename.',
+        summary: 'Rest stop parking lots hum with rigs swapping hush-hush intelligence disguised as slow-cooker gossip.',
+        icon: '📻',
+        weight: 3,
+        effect: { truthDelta: 2, ipDelta: 1 },
+      }),
+      createEffect({
+        id: 'nj_bonus_pharma_samples',
+        label: 'Pharma Sample Overflow',
+        headline: 'REPS DUMP UNLABELED CASES AT WAREHOUSE B',
+        subhead: 'Everything stamped “FOR QUIET DISTRIBUTION ONLY.”',
+        summary: 'Overstock shipments contain morale boosters and memory serums. Operatives requisition pallets before the audit hits.',
+        icon: '💊',
+        weight: 2,
+        effect: { ipDelta: 3 },
+      }),
+      createEffect({
+        id: 'nj_bonus_pine_barrens_signal',
+        label: 'Pine Barrens Signal Fire',
+        headline: 'BLUE FLAMES SPELL OUT ROUTING NUMBERS',
+        subhead: 'Campers roast marshmallows, memorize offshore accounts.',
+        summary: 'Night hikers watch will-o’-wisps render clandestine bank transfers in the treetops. Treasury teams take frantic notes.',
+        icon: '🔥',
+        weight: 1,
+        effect: { truthDelta: 1, pressureDelta: 1 },
+      }),
+    ],
+    events: [
+      createEffect({
+        id: 'nj_event_turnpike_time_fog',
+        label: 'Turnpike Time Fog',
+        headline: 'EXIT 12 COVERED IN CLOCK-STOPPING MIST',
+        subhead: 'Commuters arrive before they leave; toll booths confused.',
+        summary: 'A luminescent fog halts time for twelve precious minutes. Operatives reposition surveillance vans under the cover of reversed traffic.',
+        icon: '🌫️',
+        weight: 3,
+        effect: { truthDelta: 2 },
+      }),
+      createEffect({
+        id: 'nj_event_reststop_flashmob',
+        label: 'Rest-Stop Flash Mob Briefing',
+        headline: 'JANITORS BREAK INTO CHOREOGRAPHED LEAK',
+        subhead: 'Routine mop bucket drill reveals black-budget line items.',
+        summary: 'Every employee at Molly Pitcher rest stop freezes, then performs a perfect interpretive whistleblower routine. Drivers applaud, record, upload.',
+        icon: '🧹',
+        weight: 2,
+        effect: { truthDelta: 1, ipDelta: 2 },
+      }),
+      createEffect({
+        id: 'nj_event_gwb_lightcode',
+        label: 'Bridge Lightcode Cascade',
+        headline: 'GEORGE WASHINGTON BRIDGE BLINKS BINARY',
+        subhead: 'Port Authority swears it was a “patriotic test pattern.”',
+        summary: 'An 8-bit aurora pulses across the Hudson, uploading clearance keys to anyone stuck in traffic with a dashcam.',
+        icon: '🌉',
+        weight: 1,
+        effect: { pressureDelta: 2 },
+      }),
+    ],
+  },
+];
+
+export const STATE_TAG_LOOKUP: Record<string, StateThemedPool> = STATE_THEMED_POOLS.reduce(
+  (acc, pool) => {
+    for (const stateId of pool.tag.states) {
+      const normalized = stateId.trim().toUpperCase();
+      acc[normalized] = pool;
+    }
+    return acc;
+  },
+  {} as Record<string, StateThemedPool>,
+);
+
+export const resolvePoolForState = (state: Pick<StateData, 'abbreviation' | 'id'>): StateThemedPool | null => {
+  const byAbbreviation = STATE_TAG_LOOKUP[state.abbreviation.toUpperCase()];
+  if (byAbbreviation) {
+    return byAbbreviation;
+  }
+  const byId = STATE_TAG_LOOKUP[String(state.id).toUpperCase()];
+  return byId ?? null;
+};

--- a/src/game/__tests__/stateBonuses.test.ts
+++ b/src/game/__tests__/stateBonuses.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, test } from 'bun:test';
+import { assignStateBonuses, computeRoundSeed } from '../stateBonuses';
+
+describe('stateBonuses deterministic selection', () => {
+  const mockStates = [
+    { id: '56', abbreviation: 'WY', name: 'Wyoming' },
+    { id: '38', abbreviation: 'ND', name: 'North Dakota' },
+    { id: '12', abbreviation: 'Florida', name: 'Florida' },
+    { id: '32', abbreviation: 'NV', name: 'Nevada' },
+  ];
+
+  test('assignments stay stable for identical seed/round', () => {
+    const baseSeed = computeRoundSeed(123456789, 1);
+    const resultA = assignStateBonuses({
+      states: mockStates,
+      baseSeed,
+      round: 5,
+      playerFaction: 'truth',
+    });
+    const resultB = assignStateBonuses({
+      states: mockStates,
+      baseSeed,
+      round: 5,
+      playerFaction: 'truth',
+    });
+
+    expect(resultA.debug.seed).toBe(resultB.debug.seed);
+    expect(resultA.bonuses).toEqual(resultB.bonuses);
+    expect(resultA.roundEvents).toEqual(resultB.roundEvents);
+    expect(resultA.pressureAdjustments).toEqual(resultB.pressureAdjustments);
+  });
+
+  test('different rounds produce different roll signatures', () => {
+    const baseSeed = 987654321;
+    const roundFive = assignStateBonuses({
+      states: mockStates,
+      baseSeed,
+      round: 5,
+      playerFaction: 'truth',
+    });
+    const roundSix = assignStateBonuses({
+      states: mockStates,
+      baseSeed,
+      round: 6,
+      playerFaction: 'truth',
+    });
+
+    expect(roundFive.debug.seed).not.toBe(roundSix.debug.seed);
+  });
+
+  test('event chance can be disabled entirely', () => {
+    const result = assignStateBonuses({
+      states: mockStates,
+      baseSeed: 42,
+      round: 3,
+      playerFaction: 'truth',
+      eventChance: 0,
+    });
+
+    for (const events of Object.values(result.roundEvents)) {
+      expect(events.length).toBe(0);
+    }
+    expect(result.newspaperEvents.length).toBe(0);
+  });
+});

--- a/src/game/stateBonuses.ts
+++ b/src/game/stateBonuses.ts
@@ -1,0 +1,278 @@
+import type { GameEvent } from '@/data/eventDatabase';
+import { resolvePoolForState, type ThemedEffect } from '@/data/stateThemedPools';
+import type { ActiveStateBonus, StateRoundEventLogEntry } from '@/hooks/gameStateTypes';
+
+const LCG_A = 1664525;
+const LCG_C = 1013904223;
+const UINT32_MAX = 0xffffffff;
+
+const clamp = (value: number, min: number, max: number): number => {
+  if (!Number.isFinite(value)) return 0;
+  return Math.max(min, Math.min(max, Math.trunc(value)));
+};
+
+const EFFECT_LIMITS = {
+  truth: { min: -8, max: 8 },
+  ip: { min: -5, max: 5 },
+  pressure: { min: -3, max: 3 },
+} as const;
+
+export class StateRoundRNG {
+  private state: number;
+
+  constructor(seed: number) {
+    this.state = seed >>> 0 || 0x1f123bb5;
+  }
+
+  nextInt(): number {
+    this.state = (Math.imul(this.state, LCG_A) + LCG_C) >>> 0;
+    return this.state;
+  }
+
+  nextFloat(): number {
+    return this.nextInt() / UINT32_MAX;
+  }
+
+  pickWeighted<T>(items: Array<{ weight: number; value: T }>): T | null {
+    if (!items.length) {
+      return null;
+    }
+    const total = items.reduce((sum, item) => sum + Math.max(0, item.weight), 0);
+    if (total <= 0) {
+      return items[0]?.value ?? null;
+    }
+    const roll = this.nextFloat() * total;
+    let cursor = 0;
+    for (const item of items) {
+      const weight = Math.max(0, item.weight);
+      cursor += weight;
+      if (roll <= cursor) {
+        return item.value;
+      }
+    }
+    return items[items.length - 1]?.value ?? null;
+  }
+
+  chance(probability: number): boolean {
+    if (probability <= 0) return false;
+    if (probability >= 1) return true;
+    return this.nextFloat() < probability;
+  }
+}
+
+export const STATE_EVENT_CHANCE = 0.35;
+
+export const computeRoundSeed = (baseSeed: number, round: number): number => {
+  const normalizedBase = baseSeed >>> 0;
+  const normalizedRound = Math.max(1, round) >>> 0;
+  const mixed = Math.imul(normalizedRound ^ 0x9e3779b9, 0x7f4a7c15) ^ normalizedBase;
+  const hashed = Math.imul(mixed ^ 0xa511e9b3, 0x632be5ab) >>> 0;
+  return hashed || 0x9b9773e5;
+};
+
+interface AssignStateBonusesOptions {
+  states: Array<{
+    id: string;
+    abbreviation: string;
+    name: string;
+  }>;
+  baseSeed: number;
+  round: number;
+  playerFaction: 'truth' | 'government';
+  eventChance?: number;
+}
+
+export interface AssignStateBonusesResult {
+  bonuses: Record<string, ActiveStateBonus>;
+  roundEvents: Record<string, StateRoundEventLogEntry[]>;
+  logs: string[];
+  truthDelta: number;
+  ipDelta: number;
+  pressureAdjustments: Record<string, number>;
+  newspaperEvents: GameEvent[];
+  debug: {
+    seed: number;
+    rolls: Array<{ state: string; bonusId: string | null; eventId: string | null }>;
+  };
+}
+
+const toBonus = (
+  themed: ThemedEffect,
+  state: AssignStateBonusesOptions['states'][number],
+  round: number,
+): ActiveStateBonus => {
+  return {
+    source: 'state-themed',
+    id: themed.id,
+    stateId: state.id,
+    stateName: state.name,
+    stateAbbreviation: state.abbreviation,
+    round,
+    label: themed.label,
+    summary: themed.summary,
+    headline: themed.headline,
+    subhead: themed.subhead,
+    icon: themed.icon,
+    truthDelta: clamp(themed.effect.truthDelta ?? 0, EFFECT_LIMITS.truth.min, EFFECT_LIMITS.truth.max),
+    ipDelta: clamp(themed.effect.ipDelta ?? 0, EFFECT_LIMITS.ip.min, EFFECT_LIMITS.ip.max),
+    pressureDelta: clamp(
+      themed.effect.pressureDelta ?? 0,
+      EFFECT_LIMITS.pressure.min,
+      EFFECT_LIMITS.pressure.max,
+    ),
+  } satisfies ActiveStateBonus;
+};
+
+const toRoundEvent = (
+  themed: ThemedEffect,
+  state: AssignStateBonusesOptions['states'][number],
+  round: number,
+): StateRoundEventLogEntry => {
+  return {
+    source: 'state-themed',
+    id: themed.id,
+    stateId: state.id,
+    stateName: state.name,
+    stateAbbreviation: state.abbreviation,
+    round,
+    headline: themed.headline,
+    summary: themed.summary,
+    subhead: themed.subhead,
+    icon: themed.icon,
+    truthDelta: clamp(themed.effect.truthDelta ?? 0, EFFECT_LIMITS.truth.min, EFFECT_LIMITS.truth.max),
+    ipDelta: clamp(themed.effect.ipDelta ?? 0, EFFECT_LIMITS.ip.min, EFFECT_LIMITS.ip.max),
+    pressureDelta: clamp(
+      themed.effect.pressureDelta ?? 0,
+      EFFECT_LIMITS.pressure.min,
+      EFFECT_LIMITS.pressure.max,
+    ),
+  } satisfies StateRoundEventLogEntry;
+};
+
+const toGameEvent = (
+  themed: ThemedEffect,
+  state: AssignStateBonusesOptions['states'][number],
+  round: number,
+  probability: number,
+): GameEvent => {
+  const truthDelta = clamp(themed.effect.truthDelta ?? 0, EFFECT_LIMITS.truth.min, EFFECT_LIMITS.truth.max);
+  const ipDelta = clamp(themed.effect.ipDelta ?? 0, EFFECT_LIMITS.ip.min, EFFECT_LIMITS.ip.max);
+  const pressureDelta = clamp(
+    themed.effect.pressureDelta ?? 0,
+    EFFECT_LIMITS.pressure.min,
+    EFFECT_LIMITS.pressure.max,
+  );
+
+  const effects: NonNullable<GameEvent['effects']> = {};
+  let hasEffect = false;
+  if (truthDelta) {
+    effects.truth = truthDelta;
+    hasEffect = true;
+  }
+  if (ipDelta) {
+    effects.ip = ipDelta;
+    hasEffect = true;
+  }
+  if (pressureDelta) {
+    effects.stateEffects = {
+      stateId: state.abbreviation,
+      pressure: pressureDelta,
+    };
+    hasEffect = true;
+  }
+
+  return {
+    id: `state-themed:${state.abbreviation}:${themed.id}:${round}`,
+    title: themed.label,
+    headline: themed.headline,
+    content: themed.summary,
+    type: 'conspiracy',
+    rarity: 'uncommon',
+    faction: 'truth',
+    ...(hasEffect ? { effects } : {}),
+    weight: Math.max(1, themed.weight),
+    flavorText: themed.subhead,
+    triggerChance: probability,
+    conditionalChance: Math.min(1, probability / Math.max(1, themed.weight)),
+  } satisfies GameEvent;
+};
+
+export const assignStateBonuses = (
+  options: AssignStateBonusesOptions,
+): AssignStateBonusesResult => {
+  const seed = computeRoundSeed(options.baseSeed, options.round);
+  const rng = new StateRoundRNG(seed);
+  const bonuses: Record<string, ActiveStateBonus> = {};
+  const roundEvents: Record<string, StateRoundEventLogEntry[]> = {};
+  const logs: string[] = [];
+  const newspaperEvents: GameEvent[] = [];
+  const pressureAdjustments: Record<string, number> = {};
+  const rolls: Array<{ state: string; bonusId: string | null; eventId: string | null }> = [];
+
+  let truthDelta = 0;
+  let ipDelta = 0;
+
+  const sortedStates = [...options.states].sort((a, b) => a.abbreviation.localeCompare(b.abbreviation));
+  const eventChance = options.eventChance ?? STATE_EVENT_CHANCE;
+
+  for (const state of sortedStates) {
+    const pool = resolvePoolForState({ id: state.id, abbreviation: state.abbreviation });
+    if (!pool) {
+      rolls.push({ state: state.abbreviation, bonusId: null, eventId: null });
+      continue;
+    }
+
+    const bonus = rng.pickWeighted(pool.bonuses.map(entry => ({ weight: entry.weight, value: entry }))) ?? null;
+    const bonusRecord = bonus ? toBonus(bonus, state, options.round) : null;
+
+    let selectedEvent: ThemedEffect | null = null;
+    if (rng.chance(eventChance)) {
+      selectedEvent = rng.pickWeighted(pool.events.map(entry => ({ weight: entry.weight, value: entry }))) ?? null;
+    }
+
+    rolls.push({
+      state: state.abbreviation,
+      bonusId: bonusRecord?.id ?? null,
+      eventId: selectedEvent?.id ?? null,
+    });
+
+    if (bonusRecord) {
+      bonuses[state.abbreviation] = bonusRecord;
+      truthDelta += bonusRecord.truthDelta ?? 0;
+      ipDelta += bonusRecord.ipDelta ?? 0;
+      if (bonusRecord.pressureDelta) {
+        pressureAdjustments[state.abbreviation] =
+          (pressureAdjustments[state.abbreviation] ?? 0) + bonusRecord.pressureDelta;
+      }
+      const icon = bonusRecord.icon ?? '⭐️';
+      logs.push(`${icon} ${state.name} activates ${bonusRecord.label}`);
+    }
+
+    if (selectedEvent) {
+      const eventEntry = toRoundEvent(selectedEvent, state, options.round);
+      roundEvents[state.abbreviation] = [...(roundEvents[state.abbreviation] ?? []), eventEntry];
+      truthDelta += eventEntry.truthDelta ?? 0;
+      ipDelta += eventEntry.ipDelta ?? 0;
+      if (eventEntry.pressureDelta) {
+        pressureAdjustments[state.abbreviation] =
+          (pressureAdjustments[state.abbreviation] ?? 0) + eventEntry.pressureDelta;
+      }
+      logs.push(`${eventEntry.icon ?? '🗞️'} ${state.name} reports: ${eventEntry.headline}`);
+      newspaperEvents.push(toGameEvent(selectedEvent, state, options.round, eventChance));
+    }
+  }
+
+  return {
+    bonuses,
+    roundEvents,
+    logs,
+    truthDelta,
+    ipDelta,
+    pressureAdjustments,
+    newspaperEvents,
+    debug: {
+      seed,
+      rolls,
+    },
+  } satisfies AssignStateBonusesResult;
+};

--- a/src/hooks/gameStateTypes.ts
+++ b/src/hooks/gameStateTypes.ts
@@ -71,6 +71,8 @@ export interface GameState {
     paranormalHotspot?: StateParanormalHotspot;
     stateEventBonus?: StateEventBonusSummary;
     stateEventHistory: StateEventBonusSummary[];
+    activeStateBonus?: ActiveStateBonus | null;
+    roundEvents: StateRoundEventLogEntry[];
   }>;
   currentEvents: GameEvent[];
   pendingEditionEvents: GameEvent[];
@@ -107,6 +109,9 @@ export interface GameState {
   truthBelow20Streak: number;
   timeBasedGoalCounters: Record<string, number>;
   paranormalHotspots: Record<string, ActiveParanormalHotspot>;
+  stateRoundSeed: number;
+  lastStateBonusRound: number;
+  stateRoundEvents: Record<string, StateRoundEventLogEntry[]>;
 }
 
 export interface StateEventBonusSummary {
@@ -118,6 +123,39 @@ export interface StateEventBonusSummary {
   faction: 'truth' | 'government';
   effects?: NonNullable<GameEvent['effects']>;
   effectSummary?: string[];
+}
+
+export interface ActiveStateBonus {
+  source: 'state-themed';
+  id: string;
+  stateId: string;
+  stateName: string;
+  stateAbbreviation: string;
+  round: number;
+  label: string;
+  summary: string;
+  headline: string;
+  subhead?: string;
+  icon?: string;
+  truthDelta?: number;
+  ipDelta?: number;
+  pressureDelta?: number;
+}
+
+export interface StateRoundEventLogEntry {
+  source: 'state-themed';
+  id: string;
+  stateId: string;
+  stateName: string;
+  stateAbbreviation: string;
+  round: number;
+  headline: string;
+  summary: string;
+  subhead?: string;
+  icon?: string;
+  truthDelta?: number;
+  ipDelta?: number;
+  pressureDelta?: number;
 }
 
 export interface ActiveParanormalHotspot {


### PR DESCRIPTION
## Summary
- add Weekly World News-inspired state pools for bonuses and surprise events
- assign deterministic state bonuses each round, apply their effects, and surface them in the game log and newspaper feed
- render active bonuses/events in the state inspector and cover the selector logic with deterministic tests

## Testing
- bun test

------
https://chatgpt.com/codex/tasks/task_e_68db9a414ca48320b0db1436679e193f