### PR TITLE
Add shared news metadata fields across cards and events

### DIFF
--- a/src/components/game/Newspaper.tsx
+++ b/src/components/game/Newspaper.tsx
@@ -4,6 +4,7 @@ import { Button } from '@/components/ui/button';
 import { X } from 'lucide-react';
 import type { GameCard } from '@/rules/mvp';
 import type { GameEvent } from '@/data/eventDatabase';
+import type { NewsArticle } from '@/types';
 import { formatComboReward, getLastComboSummary } from '@/game/comboEngine';
 
 interface PlayedCard {
@@ -21,17 +22,6 @@ interface NewspaperProps {
 interface NewspaperData {
   mastheads: string[];
   ads: string[];
-}
-
-interface Article {
-  id: string;
-  title: string;
-  headline: string;
-  content: string;
-  image: string;
-  isEvent: boolean;
-  isCard?: boolean;
-  player?: 'human' | 'ai';
 }
 
 const Newspaper = ({ events, playedCards, faction, onClose }: NewspaperProps) => {
@@ -101,7 +91,7 @@ const Newspaper = ({ events, playedCards, faction, onClose }: NewspaperProps) =>
   }, [newspaperData]);
 
   // Generate card articles with tabloid-style headlines
-  const generateCardArticle = (card: GameCard, player: 'human' | 'ai'): Article => {
+  const generateCardArticle = (card: GameCard, player: 'human' | 'ai'): NewsArticle => {
     const tabloidHeadlines = [
       `"${card.name}" SHOCKS NATION`,
       `EXCLUSIVE: ${card.name.toUpperCase()} LEAKED!`,
@@ -137,7 +127,9 @@ const Newspaper = ({ events, playedCards, faction, onClose }: NewspaperProps) =>
       title: card.name,
       headline,
       content: `${tabloidContent} ${editorialComments[Math.floor(Math.random() * editorialComments.length)]}`,
-      image: '/placeholder-card.png', // Default since cards don't have images in the type
+      image: card.artId ?? '/placeholder-card.png',
+      imageCredit: card.artAttribution,
+      tags: card.artTags && card.artTags.length > 0 ? [...card.artTags] : [],
       isCard: true,
       isEvent: false,
       player
@@ -188,7 +180,7 @@ const Newspaper = ({ events, playedCards, faction, onClose }: NewspaperProps) =>
   };
 
   // Convert events to articles with red styling for events
-  const eventArticles: Article[] = events.map(event => {
+  const eventArticles: NewsArticle[] = events.map(event => {
     const impact = formatEventImpact(event);
     const baseHeadline = event.headline || event.title;
 
@@ -197,12 +189,14 @@ const Newspaper = ({ events, playedCards, faction, onClose }: NewspaperProps) =>
       title: event.title,
       headline: impact ? `${baseHeadline} (${impact})` : baseHeadline,
       content: event.content,
-      image: '/placeholder-event.png',
+      image: event.image ?? '/placeholder-event.png',
+      imageCredit: event.imageCredit,
+      tags: event.tags && event.tags.length > 0 ? [...event.tags] : [],
       isEvent: true
     };
   });
 
-  const allArticles: Article[] = [...cardArticles, ...eventArticles];
+  const allArticles: NewsArticle[] = [...cardArticles, ...eventArticles];
 
   // Get random ads from newspaper data
   const getRandomAds = (count: number) => {
@@ -402,15 +396,22 @@ const Newspaper = ({ events, playedCards, faction, onClose }: NewspaperProps) =>
                 </h2>
                 
                 {article.image && (
-                  <div className="w-full h-32 mb-3 border-2 border-newspaper-border overflow-hidden">
-                    <img 
-                      src={article.image} 
-                      alt={article.title}
-                      className="w-full h-full object-cover"
-                      onError={(e) => {
-                        e.currentTarget.src = '/placeholder-card.png';
-                      }}
-                    />
+                  <div className="mb-3">
+                    <div className="w-full h-32 border-2 border-newspaper-border overflow-hidden">
+                      <img
+                        src={article.image}
+                        alt={article.title}
+                        className="w-full h-full object-cover"
+                        onError={(e) => {
+                          e.currentTarget.src = '/placeholder-card.png';
+                        }}
+                      />
+                    </div>
+                    {article.imageCredit ? (
+                      <p className="mt-1 text-[10px] font-serif italic text-newspaper-text/60">
+                        Image: {article.imageCredit}
+                      </p>
+                    ) : null}
                   </div>
                 )}
                 

--- a/src/data/cardDatabase.ts
+++ b/src/data/cardDatabase.ts
@@ -32,7 +32,25 @@ function ensureMvpCard(raw: GameCard, tag: SourceTag): GameCard {
     console.warn(`[CARD DATABASE][${tag}] ${card.id}: ${validation.errors.join('; ')}`);
   }
 
-  return card;
+  const normalizedArtTags = Array.isArray(card.artTags)
+    ? card.artTags
+        .map(tag => `${tag}`.trim())
+        .filter((tag): tag is string => tag.length > 0)
+    : [];
+  const normalizedArtId =
+    typeof card.artId === 'string' && card.artId.trim().length > 0 ? card.artId.trim() : undefined;
+  const normalizedAttribution =
+    typeof card.artAttribution === 'string' && card.artAttribution.trim().length > 0
+      ? card.artAttribution.trim()
+      : undefined;
+
+  return {
+    ...card,
+    artId: normalizedArtId,
+    artAttribution: normalizedAttribution,
+    artPolicy: card.artPolicy === 'manual' ? 'manual' : 'autofill',
+    artTags: normalizedArtTags,
+  } satisfies GameCard;
 }
 
 const FALLBACK_CARDS_RAW: GameCard[] = [

--- a/src/data/eventDatabase.ts
+++ b/src/data/eventDatabase.ts
@@ -27,6 +27,9 @@ export interface GameEvent {
   type: 'conspiracy' | 'government' | 'truth' | 'random' | 'crisis' | 'opportunity' | 'capture';
   faction?: 'truth' | 'government' | 'neutral';
   rarity: 'common' | 'uncommon' | 'rare' | 'legendary';
+  tags?: string[];
+  image?: string;
+  imageCredit?: string;
   effects?: {
     truth?: number;
     ip?: number;
@@ -2818,11 +2821,26 @@ export class EventManager {
         }
         const conditionalChance = event.weight / totalWeight;
         const triggerChance = this.baseEventChance * conditionalChance;
+        const normalizedTags = Array.isArray(event.tags)
+          ? event.tags
+              .map(tag => `${tag}`.trim())
+              .filter((tag): tag is string => tag.length > 0)
+          : [];
+        const normalizedImage = typeof event.image === 'string' && event.image.trim().length > 0
+          ? event.image
+          : undefined;
+        const normalizedImageCredit =
+          typeof event.imageCredit === 'string' && event.imageCredit.trim().length > 0
+            ? event.imageCredit.trim()
+            : undefined;
         return {
           ...event,
+          tags: normalizedTags,
+          image: normalizedImage,
+          imageCredit: normalizedImageCredit,
           conditionalChance,
           triggerChance,
-        };
+        } satisfies GameEvent;
       }
     }
 
@@ -2830,11 +2848,26 @@ export class EventManager {
     const fallback = availableEvents[0];
     const conditionalChance = fallback.weight / totalWeight;
     const triggerChance = this.baseEventChance * conditionalChance;
+    const normalizedTags = Array.isArray(fallback.tags)
+      ? fallback.tags
+          .map(tag => `${tag}`.trim())
+          .filter((tag): tag is string => tag.length > 0)
+      : [];
+    const normalizedImage = typeof fallback.image === 'string' && fallback.image.trim().length > 0
+      ? fallback.image
+      : undefined;
+    const normalizedImageCredit =
+      typeof fallback.imageCredit === 'string' && fallback.imageCredit.trim().length > 0
+        ? fallback.imageCredit.trim()
+        : undefined;
     return {
       ...fallback,
+      tags: normalizedTags,
+      image: normalizedImage,
+      imageCredit: normalizedImageCredit,
       conditionalChance,
       triggerChance,
-    };
+    } satisfies GameEvent;
   }
 
   getBaseEventChance(): number {

--- a/src/rules/mvp.ts
+++ b/src/rules/mvp.ts
@@ -46,6 +46,10 @@ export interface GameCard {
   effects?: CardEffects;
   target?: CardTarget;
   extId?: string;
+  artId?: string;
+  artPolicy?: 'manual' | 'autofill';
+  artTags?: string[];
+  artAttribution?: string;
 }
 
 export const MVP_COST_TABLE: Record<MVPCardType, Record<Rarity, number>> = {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,1 +1,2 @@
-export type { GameCard as Card } from '@/rules/mvp';
+export type { GameCard, GameCard as Card } from '@/rules/mvp';
+export type { NewsArticle } from './news';

--- a/src/types/news.ts
+++ b/src/types/news.ts
@@ -1,0 +1,12 @@
+export interface NewsArticle {
+  id: string;
+  title: string;
+  headline: string;
+  content: string;
+  isEvent: boolean;
+  image?: string;
+  imageCredit?: string;
+  tags?: string[];
+  isCard?: boolean;
+  player?: 'human' | 'ai';
+}


### PR DESCRIPTION
## Summary
- add optional art metadata to `GameCard` and normalize cards to default `artPolicy`
- introduce a shared `NewsArticle` type and refit the newspaper UI to consume card/event tags and image credits
- extend `GameEvent` with media metadata and normalize the event manager output

## Testing
- npm run lint *(fails: pre-existing lint issues in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68dba9b9c9c48320b1fb186dda8cab97