### PR TITLE
feat: add asset resolver and autofill tooling

### DIFF
--- a/src/components/game/CardImage.tsx
+++ b/src/components/game/CardImage.tsx
@@ -1,6 +1,10 @@
-import React, { useEffect, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { cn } from '@/lib/utils';
 import { isExtensionCard, getCardExtensionInfo } from '@/data/extensionIntegration';
+import { getAllCardsSnapshot } from '@/data/cardDatabase';
+import type { ResolvedAsset } from '@/services/assets/types';
+import { resolveImage } from '@/services/assets/AssetResolver';
+import AutofillControls from '@/ui/devtools/AutofillControls';
 
 interface CardImageProps {
   cardId: string;
@@ -8,75 +12,125 @@ interface CardImageProps {
   fit?: 'cover' | 'contain';
 }
 
-const CardImage: React.FC<CardImageProps> = ({ cardId, className = '', fit = 'cover' }) => {
-  const [imageError, setImageError] = useState(false);
-  const [imageLoaded, setImageLoaded] = useState(false);
-  const [imageExtension, setImageExtension] = useState<'jpg' | 'png'>('jpg');
+const getFallbackImagePath = (cardId: string) => {
+  if (isExtensionCard(cardId)) {
+    const extensionInfo = getCardExtensionInfo(cardId);
 
-  // Check if this is an extension card with temp image
-  const getFallbackImagePath = () => {
-    // Primary: extension metadata
-    if (isExtensionCard(cardId)) {
-      const extensionInfo = getCardExtensionInfo(cardId);
-      
-      // CRYPTIDS extension temp image
-      if (extensionInfo?.id?.toLowerCase().includes('cryptids')) {
-        return '/lovable-uploads/c290a92b-014a-4427-8dd2-a78b76dd986e.png';
-      }
-      
-      // Halloween Spooktacular extension temp image  
-      if (extensionInfo?.id?.toLowerCase().includes('halloween_spooktacular')) {
-        return '/card-art/halloween_spooktacular-Temp-Image.png';
-      }
-    }
-
-    // Fallback: card id naming conventions for extensions
-    if (cardId.toLowerCase().startsWith('hallo-')) {
-      return '/card-art/halloween_spooktacular-Temp-Image.png';
-    }
-    
-    // CRYPTIDS cards have various prefixes like gov_, truth_ from the extension
-    if (cardId.toLowerCase().includes('bigfoot') || 
-        cardId.toLowerCase().includes('mothman') || 
-        cardId.toLowerCase().includes('chupacabra') ||
-        cardId.toLowerCase().includes('cryptid') ||
-        cardId.toLowerCase().includes('men_in_black') ||
-        cardId.toLowerCase().includes('area_51') ||
-        cardId.toLowerCase().includes('roswell')) {
+    if (extensionInfo?.id?.toLowerCase().includes('cryptids')) {
       return '/lovable-uploads/c290a92b-014a-4427-8dd2-a78b76dd986e.png';
     }
 
-    // Default PARANOID TIMES placeholder
-    return '/lovable-uploads/e7c952a9-333a-4f6b-b1b5-f5aeb6c3d9c1.png';
-  };
+    if (extensionInfo?.id?.toLowerCase().includes('halloween_spooktacular')) {
+      return '/card-art/halloween_spooktacular-Temp-Image.png';
+    }
+  }
 
-  const fallbackImagePath = getFallbackImagePath();
-  const imagePath = imageError
-    ? fallbackImagePath
-    : `/card-art/${cardId}.${imageExtension}`;
+  const lower = cardId.toLowerCase();
+
+  if (lower.startsWith('hallo-')) {
+    return '/card-art/halloween_spooktacular-Temp-Image.png';
+  }
+
+  if (
+    lower.includes('bigfoot') ||
+    lower.includes('mothman') ||
+    lower.includes('chupacabra') ||
+    lower.includes('cryptid') ||
+    lower.includes('men_in_black') ||
+    lower.includes('area_51') ||
+    lower.includes('roswell')
+  ) {
+    return '/lovable-uploads/c290a92b-014a-4427-8dd2-a78b76dd986e.png';
+  }
+
+  return '/lovable-uploads/e7c952a9-333a-4f6b-b1b5-f5aeb6c3d9c1.png';
+};
+
+const CardImage: React.FC<CardImageProps> = ({ cardId, className = '', fit = 'cover' }) => {
+  const card = useMemo(() => getAllCardsSnapshot().find(item => item.id === cardId), [cardId]);
+  const fallbackImagePath = useMemo(() => getFallbackImagePath(cardId), [cardId]);
+  const [asset, setAsset] = useState<ResolvedAsset | null>(null);
+  const [imageUrl, setImageUrl] = useState<string>(fallbackImagePath);
+  const [imageLoaded, setImageLoaded] = useState(false);
+  const [imageError, setImageError] = useState(false);
+  const [isResolving, setIsResolving] = useState(false);
+
+  const assetContext = useMemo(() => {
+    if (!card) return null;
+    return {
+      scope: 'card' as const,
+      card,
+      tags: card.artTags,
+      fallbackUrl: fallbackImagePath,
+    };
+  }, [card, fallbackImagePath]);
 
   useEffect(() => {
+    setImageUrl(fallbackImagePath);
+    setImageLoaded(false);
     setImageError(false);
-    setImageLoaded(false);
-    setImageExtension('jpg');
-  }, [cardId]);
+  }, [fallbackImagePath, cardId]);
 
-  const handleImageError = () => {
+  useEffect(() => {
+    if (!assetContext) {
+      setAsset(null);
+      setImageUrl(fallbackImagePath);
+      return;
+    }
+
+    let cancelled = false;
+    setIsResolving(true);
+
+    resolveImage(assetContext)
+      .then(result => {
+        if (cancelled) return;
+        setAsset(result);
+        if (result?.styledUrl) {
+          setImageUrl(result.styledUrl);
+        } else if (result?.url) {
+          setImageUrl(result.url);
+        } else {
+          setImageUrl(fallbackImagePath);
+        }
+      })
+      .catch(() => {
+        if (cancelled) return;
+        setAsset(null);
+        setImageUrl(fallbackImagePath);
+      })
+      .finally(() => {
+        if (!cancelled) {
+          setIsResolving(false);
+        }
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [assetContext, fallbackImagePath]);
+
+  const handleImageLoad = useCallback(() => {
+    setImageLoaded(true);
+  }, []);
+
+  const handleImageError = useCallback(() => {
     setImageLoaded(false);
 
-    if (!imageError && imageExtension === 'jpg') {
-      setImageExtension('png');
+    const metadata = asset?.metadata as Record<string, unknown> | undefined;
+    const fallbackFromMetadata =
+      typeof metadata?.['extensionFallback'] === 'string'
+        ? (metadata['extensionFallback'] as string)
+        : undefined;
+    if (fallbackFromMetadata && fallbackFromMetadata !== imageUrl) {
+      setImageUrl(fallbackFromMetadata);
       return;
     }
 
     if (!imageError) {
       setImageError(true);
+      setImageUrl(fallbackImagePath);
     }
-  };
-
-  const handleImageLoad = () => {
-    setImageLoaded(true);
-  };
+  }, [asset, fallbackImagePath, imageError, imageUrl]);
 
   const containerClassName = cn(
     'relative overflow-hidden',
@@ -94,21 +148,48 @@ const CardImage: React.FC<CardImageProps> = ({ cardId, className = '', fit = 'co
     fit === 'contain' ? 'object-contain' : 'object-cover',
   );
 
+  const handleResolved = useCallback(
+    (resolved: ResolvedAsset | null) => {
+      if (!resolved) return;
+      setAsset(resolved);
+      setImageLoaded(false);
+      setImageUrl(resolved.styledUrl ?? resolved.url);
+      setImageError(false);
+    },
+    [],
+  );
+
+  const showControls = assetContext && card?.artPolicy !== 'manual';
+
   return (
     <div className={containerClassName}>
-      {!imageLoaded && (
+      {(!imageLoaded || isResolving) && (
         <div className={loadingClassName}>
-          Loading...
+          {isResolving ? 'Resolving art…' : 'Loading...'}
         </div>
       )}
 
       <img
-        src={imagePath}
+        src={imageUrl}
         alt={`Card art for ${cardId}`}
         className={imageClassName}
         onLoad={handleImageLoad}
         onError={handleImageError}
       />
+
+      {asset?.credit && (
+        <div className="pointer-events-none absolute inset-x-0 bottom-0 bg-black/60 px-2 py-1 text-[10px] text-muted-foreground">
+          <span className="line-clamp-2">{asset.credit}</span>
+        </div>
+      )}
+
+      {showControls && assetContext && (
+        <div className="pointer-events-none absolute inset-x-1 bottom-1">
+          <div className="pointer-events-auto">
+            <AutofillControls context={assetContext} onResolved={handleResolved} className="mt-0 bg-background/95" />
+          </div>
+        </div>
+      )}
     </div>
   );
 };

--- a/src/components/game/EnhancedBalancingDashboard.tsx
+++ b/src/components/game/EnhancedBalancingDashboard.tsx
@@ -27,6 +27,7 @@ import ErrorLogPanel from '@/components/dev/ErrorLogPanel';
 import AudioQAControls from '@/components/dev/AudioQAControls';
 import HotspotInspector from '@/components/dev/HotspotInspector';
 import type { ActiveParanormalHotspot } from '@/hooks/gameStateTypes';
+import AssetAuditPanel from '@/ui/devtools/AssetAuditPanel';
 
 type HistogramBin = { label: string; count: number };
 
@@ -889,6 +890,7 @@ const EnhancedBalancingDashboard = ({
                 />
                 <div className="flex flex-col gap-6">
                   <ErrorLogPanel />
+                  <AssetAuditPanel />
                   <AudioQAControls />
                   <HotspotInspector
                     hotspots={paranormalHotspots}

--- a/src/components/game/TabloidNewspaperV2.tsx
+++ b/src/components/game/TabloidNewspaperV2.tsx
@@ -12,6 +12,8 @@ import { formatComboReward, getLastComboSummary } from '@/game/comboEngine';
 import { buildRoundContext, formatTruthDelta } from './tabloidRoundUtils';
 import { useAudioContext } from '@/contexts/AudioContext';
 import type { ParanormalSighting } from '@/types/paranormal';
+import { resolveImage } from '@/services/assets/AssetResolver';
+import { featureFlags } from '@/state/featureFlags';
 
 const GLITCH_OPTIONS = ['PAGE NOT FOUND', '░░░ERROR░░░', '▓▓▓SIGNAL LOST▓▓▓', '404 TRUTH NOT FOUND'];
 
@@ -183,6 +185,7 @@ const TabloidNewspaperV2 = ({
   const [data, setData] = useState<NewspaperData | null>(null);
   const [masthead, setMasthead] = useState('THE PARANOID TIMES');
   const [glitchText, setGlitchText] = useState<string | null>(null);
+  const [eventAssets, setEventAssets] = useState<Record<string, { url: string; credit?: string }>>({});
 
   const dataset = data ?? FALLBACK_DATA;
   const [issue, setIssue] = useState<NarrativeIssue | null>(null);
@@ -565,6 +568,14 @@ const TabloidNewspaperV2 = ({
   const heroTriggerChance = heroEvent?.triggerChance ?? null;
   const heroConditionalChance = heroEvent?.conditionalChance ?? null;
   const comboNarrative = issue?.comboArticle ?? null;
+  const heroEventAsset = useMemo(() => {
+    if (!heroEvent) return null;
+    const asset = eventAssets[heroEvent.id];
+    const url = asset?.url ?? heroEvent.image ?? null;
+    const credit = asset?.credit ?? heroEvent.imageCredit;
+    if (!url) return null;
+    return { url, credit };
+  }, [heroEvent, eventAssets]);
 
   const bylinePool = dataset.bylines && dataset.bylines.length ? dataset.bylines : FALLBACK_DATA.bylines;
   const sourcePool = dataset.sources && dataset.sources.length ? dataset.sources : FALLBACK_DATA.sources;
@@ -607,6 +618,65 @@ const TabloidNewspaperV2 = ({
       })),
     [events],
   );
+
+  const autofillEnabled = featureFlags.autofillCardArt;
+
+  useEffect(() => {
+    if (!autofillEnabled) {
+      return;
+    }
+
+    const pending = events.filter(event => {
+      if (eventAssets[event.id]) {
+        return false;
+      }
+      return !event.image || !event.imageCredit;
+    });
+
+    if (!pending.length) {
+      return;
+    }
+
+    let cancelled = false;
+
+    pending.forEach(event => {
+      const fallback = event.image ?? '/placeholder-event.png';
+      resolveImage({
+        scope: 'event',
+        event,
+        tags: event.tags,
+        fallbackUrl: fallback,
+      })
+        .then(result => {
+          if (cancelled) return;
+          if (!result) {
+            setEventAssets(prev => ({
+              ...prev,
+              [event.id]: { url: fallback, credit: event.imageCredit },
+            }));
+            return;
+          }
+          setEventAssets(prev => ({
+            ...prev,
+            [event.id]: {
+              url: result.styledUrl ?? result.url ?? fallback,
+              credit: result.credit ?? event.imageCredit,
+            },
+          }));
+        })
+        .catch(() => {
+          if (cancelled) return;
+          setEventAssets(prev => ({
+            ...prev,
+            [event.id]: { url: fallback, credit: event.imageCredit },
+          }));
+        });
+    });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [events, eventAssets, autofillEnabled]);
 
   const playerStorySummaries = useMemo(() => {
     const stories = issue?.playerArticles ?? [];
@@ -782,6 +852,22 @@ const TabloidNewspaperV2 = ({
                         fit="contain"
                         className="w-full aspect-[63/88] max-h-80"
                       />
+                    ) : heroEventAsset ? (
+                      <div className="relative aspect-[63/88] w-full max-h-80 overflow-hidden">
+                        <img
+                          src={heroEventAsset.url}
+                          alt={heroEvent?.title ?? 'Event art'}
+                          className="h-full w-full object-cover"
+                          onError={e => {
+                            e.currentTarget.src = '/placeholder-event.png';
+                          }}
+                        />
+                        {heroEventAsset.credit ? (
+                          <div className="absolute inset-x-0 bottom-0 bg-black/60 px-2 py-1 text-[10px] text-white/80">
+                            Image: {heroEventAsset.credit}
+                          </div>
+                        ) : null}
+                      </div>
                     ) : (
                       <div className="flex aspect-[63/88] w-full max-h-80 items-center justify-center text-sm font-semibold uppercase tracking-wide text-newspaper-text/60">
                         Archival footage pending clearance.
@@ -1032,6 +1118,30 @@ const TabloidNewspaperV2 = ({
                   <div className="space-y-3 text-sm text-secret-red/90">
                     {eventStories.slice(0, 3).map(story => (
                       <div key={story.id} className="border-b border-dashed border-newspaper-border/60 pb-2 last:border-0 last:pb-0">
+                        {(() => {
+                          const sourceEvent = events.find(event => event.id === story.id);
+                          const asset = eventAssets[story.id];
+                          const imageSrc = asset?.url ?? sourceEvent?.image;
+                          const credit = asset?.credit ?? sourceEvent?.imageCredit;
+                          if (!imageSrc) {
+                            return null;
+                          }
+                          return (
+                            <div className="mb-2 overflow-hidden rounded border border-secret-red/40">
+                              <img
+                                src={imageSrc}
+                                alt={story.headline}
+                                className="h-28 w-full object-cover"
+                                onError={e => {
+                                  e.currentTarget.src = '/placeholder-event.png';
+                                }}
+                              />
+                              {credit ? (
+                                <div className="bg-black/60 px-2 py-1 text-[10px] text-white/80">Image: {credit}</div>
+                              ) : null}
+                            </div>
+                          );
+                        })()}
                         <div className="text-[11px] font-semibold uppercase tracking-wide text-secret-red/80">{story.typeLabel}</div>
                         <p className="font-semibold leading-snug text-secret-red">{story.headline}</p>
                         <p className="text-xs italic text-secret-red/80">{story.subhead}</p>
@@ -1097,6 +1207,30 @@ const TabloidNewspaperV2 = ({
                       >
                         {story.summary}
                       </p>
+                      {!isCard && (() => {
+                        const sourceEvent = events.find(event => event.id === story.id);
+                        const asset = eventAssets[story.id];
+                        const imageSrc = asset?.url ?? sourceEvent?.image;
+                        const credit = asset?.credit ?? sourceEvent?.imageCredit;
+                        if (!imageSrc) {
+                          return null;
+                        }
+                        return (
+                          <div className="overflow-hidden rounded border border-secret-red/30">
+                            <img
+                              src={imageSrc}
+                              alt={story.headline}
+                              className="h-32 w-full object-cover"
+                              onError={e => {
+                                e.currentTarget.src = '/placeholder-event.png';
+                              }}
+                            />
+                            {credit ? (
+                              <div className="bg-black/60 px-2 py-1 text-[10px] text-white/80">Image: {credit}</div>
+                            ) : null}
+                          </div>
+                        );
+                      })()}
                       {!isCard && (formatChance(story.triggerChance) || formatChance(story.conditionalChance)) ? (
                         <div className="text-[10px] font-semibold uppercase tracking-wide text-secret-red/80">
                           {formatChance(story.triggerChance) ? (

--- a/src/services/assets/AssetResolver.ts
+++ b/src/services/assets/AssetResolver.ts
@@ -1,0 +1,231 @@
+import { featureFlags } from '@/state/featureFlags';
+import { buildQuery } from './QueryBuilder';
+import { rankCandidates } from './Ranker';
+import { runStylePipeline } from './StylePipeline';
+import { OfficialStore } from './providers/OfficialStore';
+import { PackStore } from './providers/PackStore';
+import { WikimediaProvider } from './providers/WikimediaProvider';
+import { assetManifest } from './storage/AssetManifest';
+import { CacheManager } from './storage/CacheManager';
+import { hash } from './storage/Hash';
+import { mergeCredit, normalizeCredit } from './storage/Credit';
+import type { AssetContext, AssetProvider, AssetScope, ManifestEntry, ResolvedAsset } from './types';
+
+const providers: AssetProvider[] = [OfficialStore, PackStore, WikimediaProvider].sort(
+  (a, b) => a.priority - b.priority,
+);
+
+type ProviderSnapshot = {
+  id: string;
+  url: string;
+  provider: string;
+  credit?: string;
+  license?: string;
+  tags?: string[];
+  locked?: boolean;
+  metadata?: Record<string, unknown>;
+  confidence?: number;
+};
+
+const providerCache = new CacheManager<ProviderSnapshot[]>('asset-provider-results');
+
+function manifestKey(context: AssetContext): string | null {
+  if (context.scope === 'card' && context.card) {
+    return `card:${context.card.id}`;
+  }
+  if (context.scope === 'event' && context.event) {
+    return `event:${context.event.id}`;
+  }
+  if (context.scope === 'article' && context.article) {
+    return `article:${context.article.id}`;
+  }
+  return null;
+}
+
+export function getManifestKey(context: AssetContext): string | null {
+  return manifestKey(context);
+}
+
+function manifestEntryToResolved(entry: ManifestEntry): ResolvedAsset {
+  return {
+    key: entry.key,
+    url: entry.url,
+    styledUrl: entry.styledUrl,
+    provider: entry.provider,
+    credit: entry.credit,
+    license: entry.license,
+    locked: entry.locked,
+    updatedAt: entry.updatedAt,
+    tags: entry.tags,
+    metadata: entry.metadata,
+  };
+}
+
+async function resolveWithProviders(context: AssetContext) {
+  const query = buildQuery(context);
+  const cacheKey = await hash(JSON.stringify(query));
+  const cached = providerCache.get(cacheKey);
+  if (cached && Array.isArray(cached)) {
+    return { query, providerSnapshots: cached };
+  }
+
+  const rankingContext = {
+    scope: context.scope,
+    desiredTags: query.includeTags,
+    licensePreference: query.licensePreference,
+    card: context.card,
+    event: context.event,
+    article: context.article,
+  };
+
+  const allCandidates = [];
+  for (const provider of providers) {
+    if (provider.shouldSkip(context)) {
+      continue;
+    }
+
+    const result = await provider.fetchAssets(query, context);
+    const ranked = rankCandidates(result.candidates, rankingContext);
+    allCandidates.push(
+      ...ranked.map(candidate => ({
+        candidate,
+        providerId: provider.id,
+      })),
+    );
+
+    if (ranked.some(candidate => candidate.locked)) {
+      break;
+    }
+  }
+
+  const providerSnapshots = allCandidates.map(({ candidate }) => ({
+    id: candidate.id,
+    url: candidate.url,
+    provider: candidate.provider,
+    credit: candidate.credit,
+    license: candidate.license,
+    tags: candidate.tags,
+    locked: candidate.locked,
+    metadata: candidate.metadata,
+    confidence: candidate.confidence,
+  }));
+
+  providerCache.set(cacheKey, providerSnapshots, 1000 * 60 * 30);
+
+  return { query, providerSnapshots };
+}
+
+interface ResolveOptions {
+  forceRefresh?: boolean;
+}
+
+export async function resolveImage(
+  context: AssetContext,
+  options: ResolveOptions = {},
+): Promise<ResolvedAsset | null> {
+  const key = manifestKey(context);
+  if (!key) {
+    return null;
+  }
+
+  if (!featureFlags.autofillCardArt && context.scope === 'card') {
+    const existing = assetManifest.getEntry(key);
+    return existing ? manifestEntryToResolved(existing) : null;
+  }
+
+  const existing = assetManifest.getEntry(key);
+  if (existing && existing.locked && !options.forceRefresh) {
+    return manifestEntryToResolved(existing);
+  }
+
+  if (existing && !options.forceRefresh) {
+    return manifestEntryToResolved(existing);
+  }
+
+  try {
+    const { providerSnapshots, query } = await resolveWithProviders(context);
+    if (providerSnapshots.length === 0) {
+      if (context.fallbackUrl) {
+        const entry: ManifestEntry = {
+          key,
+          scope: context.scope,
+          url: context.fallbackUrl,
+          styledUrl: context.fallbackUrl,
+          provider: 'fallback',
+          credit: undefined,
+          license: undefined,
+          locked: false,
+          tags: context.tags ?? [],
+          metadata: { query },
+          updatedAt: Date.now(),
+        };
+        assetManifest.upsert(entry);
+        return manifestEntryToResolved(entry);
+      }
+      return existing ? manifestEntryToResolved(existing) : null;
+    }
+
+    const bestCandidate = providerSnapshots.sort(
+      (a, b) => (b.confidence ?? 0) - (a.confidence ?? 0),
+    )[0];
+
+    if (!bestCandidate) {
+      return existing ? manifestEntryToResolved(existing) : null;
+    }
+
+    let styledUrl = bestCandidate.url;
+    try {
+      styledUrl = await runStylePipeline(bestCandidate.url);
+    } catch (error) {
+      console.warn('[AssetResolver] style pipeline failed, using original url', error);
+      styledUrl = bestCandidate.url;
+    }
+
+    const manifestEntry: ManifestEntry = {
+      key,
+      scope: context.scope,
+      url: bestCandidate.url,
+      styledUrl,
+      provider: bestCandidate.provider,
+      credit: normalizeCredit(
+        mergeCredit(existing?.credit, bestCandidate.credit ?? undefined) ?? bestCandidate.credit,
+      ),
+      license: bestCandidate.license,
+      locked: Boolean(bestCandidate.locked),
+      tags: bestCandidate.tags ?? context.tags ?? [],
+      metadata: { ...bestCandidate.metadata, query },
+      updatedAt: Date.now(),
+    };
+
+    assetManifest.upsert(manifestEntry);
+    return manifestEntryToResolved(manifestEntry);
+  } catch (error) {
+    console.warn('[AssetResolver] Failed to resolve image', error);
+    return existing ? manifestEntryToResolved(existing) : null;
+  }
+}
+
+export function subscribeToManifest(listener: (entries: ManifestEntry[]) => void) {
+  return assetManifest.subscribe(listener);
+}
+
+export function getManifestEntry(context: AssetContext): ManifestEntry | undefined {
+  const key = manifestKey(context);
+  return key ? assetManifest.getEntry(key) : undefined;
+}
+
+export function updateManifestCredit(context: AssetContext, credit?: string) {
+  const key = manifestKey(context);
+  if (!key) return;
+  assetManifest.updateCredit(key, credit);
+}
+
+export function toggleManifestLock(context: AssetContext, locked: boolean) {
+  const key = manifestKey(context);
+  if (!key) return;
+  assetManifest.toggleLock(key, locked);
+}
+
+export function clearManifest(scope?: AssetScope) {
+  assetManifest.clear(scope);
+}

--- a/src/services/assets/QueryBuilder.ts
+++ b/src/services/assets/QueryBuilder.ts
@@ -1,0 +1,56 @@
+import type { AssetContext, QueryPlan } from './types';
+
+const STOP_WORDS = new Set(['the', 'a', 'an', 'of', 'and', 'or']);
+
+function tokenize(text: string): string[] {
+  return text
+    .split(/[^a-z0-9]+/i)
+    .map(token => token.trim())
+    .filter(token => token.length > 1 && !STOP_WORDS.has(token.toLowerCase()));
+}
+
+export function buildQuery(context: AssetContext): QueryPlan {
+  const terms = new Set<string>();
+  const includeTags = new Set<string>();
+  const excludeTerms = new Set<string>(['logo', 'watermark']);
+  let licensePreference: QueryPlan['licensePreference'] = 'cc';
+
+  if (context.card) {
+    tokenize(context.card.name).forEach(term => terms.add(term));
+    if (context.card.faction) {
+      terms.add(`${context.card.faction} faction`);
+    }
+    if (context.card.type) {
+      terms.add(`${context.card.type.toLowerCase()} card art`);
+    }
+    (context.card.artTags ?? []).forEach(tag => includeTags.add(tag));
+    if (context.card.artPolicy === 'manual') {
+      licensePreference = 'any';
+    }
+  }
+
+  if (context.event) {
+    tokenize(context.event.title).forEach(term => terms.add(term));
+    tokenize(context.event.headline ?? '').forEach(term => terms.add(term));
+    (context.event.tags ?? []).forEach(tag => includeTags.add(tag));
+    licensePreference = 'public-domain';
+  }
+
+  if (context.article) {
+    tokenize(context.article.title).forEach(term => terms.add(term));
+    tokenize(context.article.headline).forEach(term => terms.add(term));
+    (context.article.tags ?? []).forEach(tag => includeTags.add(tag));
+  }
+
+  (context.tags ?? []).forEach(tag => includeTags.add(tag));
+
+  const cleanedTerms = Array.from(terms).slice(0, 12);
+  const cleanedTags = Array.from(includeTags).slice(0, 8);
+
+  return {
+    terms: cleanedTerms,
+    includeTags: cleanedTags,
+    excludeTerms: Array.from(excludeTerms),
+    licensePreference,
+  };
+}

--- a/src/services/assets/Ranker.ts
+++ b/src/services/assets/Ranker.ts
@@ -1,0 +1,60 @@
+import type { AssetCandidate, RankingContext } from './types';
+
+function scoreForLicense(candidate: AssetCandidate, preference: RankingContext['licensePreference']): number {
+  if (!candidate.license || !preference || preference === 'any') {
+    return 0;
+  }
+  const license = candidate.license.toLowerCase();
+  if (preference === 'public-domain') {
+    return license.includes('public') || license.includes('cc0') ? 12 : -10;
+  }
+  if (preference === 'cc') {
+    return license.includes('cc') ? 6 : -4;
+  }
+  return 0;
+}
+
+function scoreForTags(candidate: AssetCandidate, desiredTags: string[]): number {
+  if (!desiredTags.length) return 0;
+  const candidateTags = (candidate.tags ?? []).map(tag => tag.toLowerCase());
+  let score = 0;
+  for (const tag of desiredTags) {
+    if (candidateTags.includes(tag.toLowerCase())) {
+      score += 4;
+    }
+  }
+  return score;
+}
+
+function scoreForProvider(candidate: AssetCandidate): number {
+  if (candidate.provider === 'official') {
+    return 100;
+  }
+  if (candidate.provider === 'pack') {
+    return 75;
+  }
+  if (candidate.provider === 'wikimedia') {
+    return 10;
+  }
+  return 0;
+}
+
+export function rankCandidates(candidates: AssetCandidate[], context: RankingContext): AssetCandidate[] {
+  const scored = candidates.map(candidate => {
+    let score = candidate.confidence ?? 0;
+    score += scoreForProvider(candidate);
+    score += scoreForLicense(candidate, context.licensePreference);
+    score += scoreForTags(candidate, context.desiredTags);
+
+    if (candidate.locked) {
+      score += 200;
+    }
+
+    return {
+      ...candidate,
+      confidence: score,
+    } satisfies AssetCandidate;
+  });
+
+  return scored.sort((a, b) => (b.confidence ?? 0) - (a.confidence ?? 0));
+}

--- a/src/services/assets/StylePipeline.ts
+++ b/src/services/assets/StylePipeline.ts
@@ -1,0 +1,67 @@
+interface StylePipelineOptions {
+  width?: number;
+  height?: number;
+  saturation?: number;
+  contrast?: number;
+  brightness?: number;
+  grain?: number;
+}
+
+const DEFAULT_OPTIONS: Required<Omit<StylePipelineOptions, 'width' | 'height'>> = {
+  saturation: 1.1,
+  contrast: 1.05,
+  brightness: 1.05,
+  grain: 0.08,
+};
+
+async function loadImage(url: string): Promise<HTMLImageElement> {
+  return new Promise((resolve, reject) => {
+    const image = new Image();
+    image.crossOrigin = 'anonymous';
+    image.onload = () => resolve(image);
+    image.onerror = error => reject(error);
+    image.src = url;
+  });
+}
+
+function applyFilmGrain(ctx: CanvasRenderingContext2D, width: number, height: number, intensity: number) {
+  const imageData = ctx.getImageData(0, 0, width, height);
+  const data = imageData.data;
+  for (let i = 0; i < data.length; i += 4) {
+    const grain = (Math.random() - 0.5) * 255 * intensity;
+    data[i] = Math.min(255, Math.max(0, data[i] + grain));
+    data[i + 1] = Math.min(255, Math.max(0, data[i + 1] + grain));
+    data[i + 2] = Math.min(255, Math.max(0, data[i + 2] + grain));
+  }
+  ctx.putImageData(imageData, 0, 0);
+}
+
+export async function runStylePipeline(url: string, options: StylePipelineOptions = {}): Promise<string> {
+  if (typeof window === 'undefined') {
+    return url;
+  }
+
+  const image = await loadImage(url);
+  const width = options.width ?? image.width;
+  const height = options.height ?? image.height;
+  const canvas = document.createElement('canvas');
+  canvas.width = width;
+  canvas.height = height;
+  const ctx = canvas.getContext('2d');
+  if (!ctx) {
+    return url;
+  }
+
+  const saturation = options.saturation ?? DEFAULT_OPTIONS.saturation;
+  const contrast = options.contrast ?? DEFAULT_OPTIONS.contrast;
+  const brightness = options.brightness ?? DEFAULT_OPTIONS.brightness;
+  ctx.filter = `saturate(${saturation}) contrast(${contrast}) brightness(${brightness})`;
+  ctx.drawImage(image, 0, 0, width, height);
+
+  const grain = options.grain ?? DEFAULT_OPTIONS.grain;
+  if (grain > 0) {
+    applyFilmGrain(ctx, width, height, grain);
+  }
+
+  return canvas.toDataURL('image/png');
+}

--- a/src/services/assets/providers/OfficialStore.ts
+++ b/src/services/assets/providers/OfficialStore.ts
@@ -1,0 +1,52 @@
+import { getCardExtensionInfo } from '@/data/extensionIntegration';
+import type { AssetProvider, AssetProviderResult } from '../types';
+
+function inferExtension(cardId: string): string | null {
+  const info = getCardExtensionInfo(cardId);
+  if (info) {
+    return info.id;
+  }
+  if (cardId.toLowerCase().startsWith('hallo-')) {
+    return 'halloween_spooktacular';
+  }
+  return null;
+}
+
+function buildOfficialUrl(cardId: string, preferredExtension: 'jpg' | 'png'): string {
+  return `/card-art/${cardId}.${preferredExtension}`;
+}
+
+export const OfficialStore: AssetProvider = {
+  id: 'official',
+  priority: 0,
+  shouldSkip: context => context.scope !== 'card' || !context.card,
+  async fetchAssets(_query, context): Promise<AssetProviderResult> {
+    const card = context.card;
+    if (!card) {
+      return { candidates: [] };
+    }
+
+    const extension = inferExtension(card.id);
+    const isTemp = Boolean(extension) && card.artPolicy !== 'manual';
+
+    if (!card.artId && !isTemp) {
+      return { candidates: [] };
+    }
+
+    const idToUse = card.artId ?? card.id;
+
+    return {
+      candidates: [
+        {
+          id: `official-${idToUse}`,
+          url: buildOfficialUrl(idToUse, 'jpg'),
+          provider: 'official',
+          credit: card.artAttribution,
+          tags: card.artTags,
+          locked: card.artPolicy === 'manual',
+          metadata: { extensionFallback: buildOfficialUrl(idToUse, 'png') },
+        },
+      ],
+    };
+  },
+};

--- a/src/services/assets/providers/PackStore.ts
+++ b/src/services/assets/providers/PackStore.ts
@@ -1,0 +1,62 @@
+import { getCardExtensionInfo, isExtensionCard } from '@/data/extensionIntegration';
+import type { AssetProvider } from '../types';
+
+function getPackFallback(cardId: string): string | null {
+  if (isExtensionCard(cardId)) {
+    const extensionInfo = getCardExtensionInfo(cardId);
+    if (extensionInfo?.id?.toLowerCase().includes('cryptids')) {
+      return '/lovable-uploads/c290a92b-014a-4427-8dd2-a78b76dd986e.png';
+    }
+    if (extensionInfo?.id?.toLowerCase().includes('halloween_spooktacular')) {
+      return '/card-art/halloween_spooktacular-Temp-Image.png';
+    }
+  }
+
+  const lower = cardId.toLowerCase();
+  if (lower.startsWith('hallo-')) {
+    return '/card-art/halloween_spooktacular-Temp-Image.png';
+  }
+  if (
+    lower.includes('bigfoot') ||
+    lower.includes('mothman') ||
+    lower.includes('chupacabra') ||
+    lower.includes('cryptid') ||
+    lower.includes('men_in_black') ||
+    lower.includes('area_51') ||
+    lower.includes('roswell')
+  ) {
+    return '/lovable-uploads/c290a92b-014a-4427-8dd2-a78b76dd986e.png';
+  }
+
+  return null;
+}
+
+export const PackStore: AssetProvider = {
+  id: 'pack',
+  priority: 1,
+  shouldSkip: context => context.scope !== 'card' || !context.card,
+  async fetchAssets(_query, context) {
+    const card = context.card;
+    if (!card) {
+      return { candidates: [] };
+    }
+
+    const fallback = getPackFallback(card.id);
+    if (!fallback) {
+      return { candidates: [] };
+    }
+
+    return {
+      candidates: [
+        {
+          id: `pack-${card.id}`,
+          url: fallback,
+          provider: 'pack',
+          credit: card.artAttribution,
+          tags: card.artTags,
+          locked: true,
+        },
+      ],
+    };
+  },
+};

--- a/src/services/assets/providers/WikimediaProvider.ts
+++ b/src/services/assets/providers/WikimediaProvider.ts
@@ -1,0 +1,110 @@
+import type { AssetProvider } from '../types';
+
+interface WikimediaImageInfo {
+  url: string;
+  descriptionurl: string;
+  extmetadata?: Record<string, { value?: string }>;
+}
+
+interface WikimediaPage {
+  title: string;
+  imageinfo?: WikimediaImageInfo[];
+}
+
+const API_BASE = 'https://commons.wikimedia.org/w/api.php';
+
+const ALLOWED_LICENSES = ['public domain', 'cc0', 'cc-by', 'cc-by-sa', 'cc-by-4.0', 'cc-by-sa-4.0'];
+
+function extractLicense(info?: WikimediaImageInfo): string | undefined {
+  const license = info?.extmetadata?.LicenseShortName?.value ?? info?.extmetadata?.License?.value;
+  if (!license) return undefined;
+  return license.replace(/<[^>]+>/g, '').trim();
+}
+
+function extractCredit(info?: WikimediaImageInfo): string | undefined {
+  const artist = info?.extmetadata?.Artist?.value;
+  if (!artist) return undefined;
+  const sanitized = artist.replace(/<[^>]+>/g, '').trim();
+  return sanitized || undefined;
+}
+
+function buildSearchTerm(terms: string[], includeTags: string[]): string {
+  const base = terms.join(' ');
+  if (includeTags.length === 0) {
+    return base;
+  }
+  return `${base} ${includeTags.map(tag => `"${tag}"`).join(' ')}`;
+}
+
+async function fetchWikimedia(query: string, limit = 6): Promise<WikimediaPage[]> {
+  const params = new URLSearchParams({
+    action: 'query',
+    generator: 'search',
+    gsrlimit: `${limit}`,
+    prop: 'imageinfo',
+    iiprop: 'url|extmetadata',
+    iiurlwidth: '1024',
+    format: 'json',
+    origin: '*',
+    gsrsearch: query,
+  });
+
+  const response = await fetch(`${API_BASE}?${params.toString()}`);
+  if (!response.ok) {
+    throw new Error(`Wikimedia request failed with ${response.status}`);
+  }
+
+  const json = await response.json();
+  const pages = json?.query?.pages;
+  if (!pages) {
+    return [];
+  }
+
+  return Object.values(pages) as WikimediaPage[];
+}
+
+export const WikimediaProvider: AssetProvider = {
+  id: 'wikimedia',
+  priority: 10,
+  shouldSkip: () => false,
+  async fetchAssets(queryPlan, _context) {
+    try {
+      const pages = await fetchWikimedia(buildSearchTerm(queryPlan.terms, queryPlan.includeTags));
+      const candidates = pages
+        .map(page => {
+          const info = page.imageinfo?.[0];
+          if (!info?.url) {
+            return null;
+          }
+          const license = extractLicense(info);
+          if (license) {
+            const normalized = license.toLowerCase();
+            const allowed = ALLOWED_LICENSES.some(allowedLicense => normalized.includes(allowedLicense));
+            if (!allowed) {
+              return null;
+            }
+          }
+
+          return {
+            id: page.title,
+            url: info.url,
+            provider: 'wikimedia',
+            credit: extractCredit(info),
+            license,
+            metadata: {
+              source: info.descriptionurl,
+            },
+          };
+        })
+        .filter((candidate): candidate is NonNullable<typeof candidate> => Boolean(candidate));
+
+      return {
+        candidates,
+        licenseHint: 'cc',
+      };
+    } catch (error) {
+      console.warn('[WikimediaProvider] Failed to fetch', error);
+      return { candidates: [] };
+    }
+  },
+};

--- a/src/services/assets/storage/AssetManifest.ts
+++ b/src/services/assets/storage/AssetManifest.ts
@@ -1,0 +1,182 @@
+import type { AssetScope, ManifestEntry, ManifestListener } from '../types';
+
+const isBrowser = () => typeof window !== 'undefined' && typeof window.document !== 'undefined';
+
+const STORAGE_KEY = 'shadowgov:assets:manifest:v1';
+
+type ManifestState = Record<string, ManifestEntry>;
+
+const memoryState: { entries: ManifestState } = { entries: {} };
+
+function canUseLocalStorage(): boolean {
+  if (!isBrowser()) {
+    return false;
+  }
+
+  try {
+    const key = '__shadowgov_manifest_test__';
+    window.localStorage.setItem(key, key);
+    window.localStorage.removeItem(key);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+const useLocalStorage = canUseLocalStorage();
+
+function loadFromStorage(): ManifestState {
+  if (!useLocalStorage) {
+    return { ...memoryState.entries };
+  }
+
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    if (!raw) {
+      return {};
+    }
+
+    const parsed = JSON.parse(raw) as ManifestState;
+    return parsed ?? {};
+  } catch (error) {
+    console.warn('[AssetManifest] Failed to parse manifest from storage', error);
+    return {};
+  }
+}
+
+function persist(state: ManifestState) {
+  if (!useLocalStorage) {
+    memoryState.entries = { ...state };
+    return;
+  }
+
+  try {
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(state));
+  } catch (error) {
+    console.warn('[AssetManifest] Failed to persist manifest', error);
+  }
+}
+
+function sortedEntries(state: ManifestState): ManifestEntry[] {
+  return Object.values(state).sort((a, b) => b.updatedAt - a.updatedAt);
+}
+
+export class AssetManifest {
+  private static instance: AssetManifest | null = null;
+
+  static getInstance(): AssetManifest {
+    if (!AssetManifest.instance) {
+      AssetManifest.instance = new AssetManifest();
+    }
+    return AssetManifest.instance;
+  }
+
+  private state: ManifestState;
+  private listeners = new Set<ManifestListener>();
+
+  private constructor() {
+    this.state = loadFromStorage();
+  }
+
+  getEntries(): ManifestEntry[] {
+    return sortedEntries(this.state);
+  }
+
+  getEntry(key: string): ManifestEntry | undefined {
+    return this.state[key];
+  }
+
+  upsert(entry: ManifestEntry): ManifestEntry {
+    const next: ManifestState = {
+      ...this.state,
+      [entry.key]: { ...entry },
+    };
+
+    this.state = next;
+    persist(this.state);
+    this.emit();
+    return entry;
+  }
+
+  updateCredit(key: string, credit: string | undefined): ManifestEntry | undefined {
+    const existing = this.state[key];
+    if (!existing) {
+      return undefined;
+    }
+
+    const entry: ManifestEntry = {
+      ...existing,
+      credit: credit?.trim() || undefined,
+      updatedAt: Date.now(),
+    };
+
+    this.state = {
+      ...this.state,
+      [key]: entry,
+    };
+
+    persist(this.state);
+    this.emit();
+    return entry;
+  }
+
+  toggleLock(key: string, locked: boolean): ManifestEntry | undefined {
+    const existing = this.state[key];
+    if (!existing) {
+      return undefined;
+    }
+
+    const entry: ManifestEntry = {
+      ...existing,
+      locked,
+      updatedAt: Date.now(),
+    };
+
+    this.state = {
+      ...this.state,
+      [key]: entry,
+    };
+
+    persist(this.state);
+    this.emit();
+    return entry;
+  }
+
+  clear(scope?: AssetScope) {
+    if (!scope) {
+      this.state = {};
+    } else {
+      const next: ManifestState = {};
+      for (const entry of Object.values(this.state)) {
+        if (entry.scope !== scope) {
+          next[entry.key] = entry;
+        }
+      }
+      this.state = next;
+    }
+
+    persist(this.state);
+    this.emit();
+  }
+
+  subscribe(listener: ManifestListener): () => void {
+    this.listeners.add(listener);
+    listener(this.getEntries());
+    return () => {
+      this.listeners.delete(listener);
+    };
+  }
+
+  private emit() {
+    const entries = this.getEntries();
+    for (const listener of this.listeners) {
+      try {
+        listener(entries);
+      } catch (error) {
+        console.warn('[AssetManifest] listener error', error);
+      }
+    }
+  }
+}
+
+export const assetManifest = AssetManifest.getInstance();

--- a/src/services/assets/storage/CacheManager.ts
+++ b/src/services/assets/storage/CacheManager.ts
@@ -1,0 +1,111 @@
+const FALLBACK_TTL = 1000 * 60 * 60; // 1 hour
+
+type CacheEntry<T> = {
+  value: T;
+  expiresAt: number;
+};
+
+const memoryCache = new Map<string, CacheEntry<unknown>>();
+
+const isBrowser = () => typeof window !== 'undefined' && typeof window.document !== 'undefined';
+
+function storageKey(namespace: string, key: string) {
+  return `shadowgov:cache:${namespace}:${key}`;
+}
+
+export class CacheManager<T = unknown> {
+  constructor(private namespace: string) {}
+
+  private getStorage(): Storage | null {
+    if (!isBrowser()) {
+      return null;
+    }
+
+    try {
+      return window.localStorage;
+    } catch {
+      return null;
+    }
+  }
+
+  get(key: string): T | undefined {
+    const storage = this.getStorage();
+    const now = Date.now();
+
+    if (storage) {
+      try {
+        const raw = storage.getItem(storageKey(this.namespace, key));
+        if (raw) {
+          const parsed = JSON.parse(raw) as CacheEntry<T>;
+          if (parsed.expiresAt > now) {
+            return parsed.value;
+          }
+          storage.removeItem(storageKey(this.namespace, key));
+        }
+      } catch (error) {
+        console.warn(`[CacheManager:${this.namespace}] Failed to read item`, error);
+      }
+    }
+
+    const memoryKey = storageKey(this.namespace, key);
+    const entry = memoryCache.get(memoryKey) as CacheEntry<T> | undefined;
+    if (entry) {
+      if (entry.expiresAt > now) {
+        return entry.value;
+      }
+      memoryCache.delete(memoryKey);
+    }
+
+    return undefined;
+  }
+
+  set(key: string, value: T, ttl: number = FALLBACK_TTL) {
+    const entry: CacheEntry<T> = {
+      value,
+      expiresAt: Date.now() + Math.max(1000, ttl),
+    };
+
+    const storage = this.getStorage();
+    const serialized = JSON.stringify(entry);
+
+    if (storage) {
+      try {
+        storage.setItem(storageKey(this.namespace, key), serialized);
+      } catch (error) {
+        console.warn(`[CacheManager:${this.namespace}] Failed to persist item`, error);
+      }
+    }
+
+    memoryCache.set(storageKey(this.namespace, key), entry);
+  }
+
+  clear(key?: string) {
+    const storage = this.getStorage();
+    if (key) {
+      const fullKey = storageKey(this.namespace, key);
+      if (storage) {
+        storage.removeItem(fullKey);
+      }
+      memoryCache.delete(fullKey);
+      return;
+    }
+
+    const prefix = storageKey(this.namespace, '');
+    if (storage) {
+      const toDelete: string[] = [];
+      for (let i = 0; i < storage.length; i += 1) {
+        const storageKeyItem = storage.key(i);
+        if (storageKeyItem && storageKeyItem.startsWith(prefix)) {
+          toDelete.push(storageKeyItem);
+        }
+      }
+      toDelete.forEach(keyToRemove => storage.removeItem(keyToRemove));
+    }
+
+    for (const keyEntry of memoryCache.keys()) {
+      if (keyEntry.startsWith(prefix)) {
+        memoryCache.delete(keyEntry);
+      }
+    }
+  }
+}

--- a/src/services/assets/storage/Credit.ts
+++ b/src/services/assets/storage/Credit.ts
@@ -1,0 +1,33 @@
+import type { ManifestEntry } from '../types';
+
+export function normalizeCredit(credit?: string): string | undefined {
+  if (!credit) return undefined;
+  const trimmed = credit.trim();
+  if (!trimmed) return undefined;
+  return trimmed.replace(/\s+/g, ' ');
+}
+
+export function formatCredit(entry: Pick<ManifestEntry, 'credit' | 'provider' | 'license'>): string {
+  const parts: string[] = [];
+  if (entry.credit) {
+    parts.push(entry.credit);
+  }
+  if (entry.provider) {
+    parts.push(`via ${entry.provider}`);
+  }
+  if (entry.license) {
+    parts.push(`(${entry.license})`);
+  }
+  return parts.join(' ');
+}
+
+export function mergeCredit(existing: string | undefined, incoming: string | undefined): string | undefined {
+  const normalizedExisting = normalizeCredit(existing);
+  const normalizedIncoming = normalizeCredit(incoming);
+  if (!normalizedExisting) return normalizedIncoming;
+  if (!normalizedIncoming) return normalizedExisting;
+  if (normalizedExisting.toLowerCase() === normalizedIncoming.toLowerCase()) {
+    return normalizedExisting;
+  }
+  return `${normalizedExisting}; ${normalizedIncoming}`;
+}

--- a/src/services/assets/storage/Hash.ts
+++ b/src/services/assets/storage/Hash.ts
@@ -1,0 +1,42 @@
+const textEncoder = typeof TextEncoder !== 'undefined' ? new TextEncoder() : null;
+
+async function subtleDigest(message: string): Promise<string> {
+  if (typeof crypto === 'undefined' || !('subtle' in crypto) || !textEncoder) {
+    throw new Error('Subtle crypto not available');
+  }
+
+  const data = textEncoder.encode(message);
+  const hashBuffer = await crypto.subtle.digest('SHA-256', data);
+  const hashArray = Array.from(new Uint8Array(hashBuffer));
+  return hashArray.map(byte => byte.toString(16).padStart(2, '0')).join('');
+}
+
+function fallbackHash(message: string): string {
+  let hash = 0;
+  for (let i = 0; i < message.length; i += 1) {
+    hash = (hash << 5) - hash + message.charCodeAt(i);
+    hash |= 0; // Convert to 32bit integer
+  }
+  return Math.abs(hash).toString(16);
+}
+
+export async function hash(message: string): Promise<string> {
+  try {
+    return await subtleDigest(message);
+  } catch {
+    return fallbackHash(message);
+  }
+}
+
+export function hashSync(message: string): string {
+  try {
+    const cryptoObj = (globalThis as typeof globalThis & { crypto?: Crypto }).crypto;
+    if (cryptoObj && 'subtle' in cryptoObj && textEncoder) {
+      throw new Error('use async hash');
+    }
+  } catch {
+    // ignore
+  }
+
+  return fallbackHash(message);
+}

--- a/src/services/assets/types.ts
+++ b/src/services/assets/types.ts
@@ -1,0 +1,94 @@
+import type { GameCard } from '@/rules/mvp';
+import type { GameEvent } from '@/data/eventDatabase';
+import type { NewsArticle } from '@/types';
+
+export type AssetScope = 'card' | 'event' | 'article';
+
+export interface AssetContext {
+  scope: AssetScope;
+  card?: GameCard;
+  event?: GameEvent;
+  article?: NewsArticle;
+  /** Optional override for image tags */
+  tags?: string[];
+  /** Optional fallback URL when providers fail */
+  fallbackUrl?: string;
+}
+
+export interface AssetCandidate {
+  id: string;
+  url: string;
+  provider: string;
+  credit?: string;
+  license?: string;
+  tags?: string[];
+  locked?: boolean;
+  thumbnailUrl?: string;
+  confidence?: number;
+  metadata?: Record<string, unknown>;
+}
+
+export interface ResolvedAsset {
+  key: string;
+  url: string;
+  styledUrl: string;
+  provider: string;
+  credit?: string;
+  license?: string;
+  locked: boolean;
+  updatedAt: number;
+  tags: string[];
+  metadata?: Record<string, unknown>;
+}
+
+export interface AssetProviderResult {
+  candidates: AssetCandidate[];
+  licenseHint?: string;
+}
+
+export interface AssetProvider {
+  id: string;
+  /** Providers with lower priority run first */
+  priority: number;
+  /**
+   * Returns true when the provider should be skipped for the given context.
+   */
+  shouldSkip(context: AssetContext): boolean;
+  /**
+   * Attempt to fetch assets that match the query and context.
+   */
+  fetchAssets(query: QueryPlan, context: AssetContext): Promise<AssetProviderResult>;
+}
+
+export interface QueryPlan {
+  terms: string[];
+  includeTags: string[];
+  excludeTerms: string[];
+  licensePreference?: 'cc' | 'public-domain' | 'any';
+}
+
+export interface RankingContext {
+  scope: AssetScope;
+  desiredTags: string[];
+  licensePreference?: QueryPlan['licensePreference'];
+  card?: GameCard;
+  event?: GameEvent;
+  article?: NewsArticle;
+}
+
+export interface ManifestEntry {
+  key: string;
+  scope: AssetScope;
+  url: string;
+  styledUrl: string;
+  provider: string;
+  credit?: string;
+  license?: string;
+  locked: boolean;
+  tags: string[];
+  thumbnailUrl?: string;
+  metadata?: Record<string, unknown>;
+  updatedAt: number;
+}
+
+export type ManifestListener = (entries: ManifestEntry[]) => void;

--- a/src/state/featureFlags.ts
+++ b/src/state/featureFlags.ts
@@ -1,11 +1,13 @@
 export type FeatureFlags = {
   newspaperV2: boolean;
   aiVerboseStrategyLog: boolean;
+  autofillCardArt: boolean;
 };
 
 const DEFAULT_FLAGS: FeatureFlags = {
   newspaperV2: true,
   aiVerboseStrategyLog: false,
+  autofillCardArt: true,
 };
 
 const readBoolean = (key: string, fallback: boolean): boolean => {
@@ -39,4 +41,6 @@ export const featureFlags: FeatureFlags = {
   newspaperV2: overrides.newspaperV2 ?? readBoolean('shadowgov:flag:newspaperV2', DEFAULT_FLAGS.newspaperV2),
   aiVerboseStrategyLog:
     overrides.aiVerboseStrategyLog ?? readBoolean('shadowgov:flag:aiVerboseStrategyLog', DEFAULT_FLAGS.aiVerboseStrategyLog),
+  autofillCardArt:
+    overrides.autofillCardArt ?? readBoolean('shadowgov:flag:autofillCardArt', DEFAULT_FLAGS.autofillCardArt),
 };

--- a/src/ui/devtools/AssetAuditPanel.tsx
+++ b/src/ui/devtools/AssetAuditPanel.tsx
@@ -1,0 +1,102 @@
+import { useEffect, useMemo, useState } from 'react';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { Badge } from '@/components/ui/badge';
+import { ScrollArea } from '@/components/ui/scroll-area';
+import { clearManifest, subscribeToManifest } from '@/services/assets/AssetResolver';
+import type { ManifestEntry } from '@/services/assets/types';
+
+const scopeLabels: Record<ManifestEntry['scope'], string> = {
+  card: 'Card',
+  event: 'Event',
+  article: 'Article',
+};
+
+const formatTimestamp = (timestamp: number) => new Date(timestamp).toLocaleString();
+
+const AssetAuditPanel = () => {
+  const [entries, setEntries] = useState<ManifestEntry[]>([]);
+  const [activeScope, setActiveScope] = useState<ManifestEntry['scope'] | 'all'>('all');
+
+  useEffect(() => {
+    const unsubscribe = subscribeToManifest(setEntries);
+    return () => unsubscribe?.();
+  }, []);
+
+  const filteredEntries = useMemo(() => {
+    if (activeScope === 'all') {
+      return entries;
+    }
+    return entries.filter(entry => entry.scope === activeScope);
+  }, [activeScope, entries]);
+
+  const counts = useMemo(() => {
+    return entries.reduce(
+      (acc, entry) => {
+        acc[entry.scope] = (acc[entry.scope] ?? 0) + 1;
+        return acc;
+      },
+      { card: 0, event: 0, article: 0 } as Record<ManifestEntry['scope'], number>,
+    );
+  }, [entries]);
+
+  return (
+    <Card className="bg-background/80">
+      <CardHeader className="pb-3">
+        <CardTitle className="text-base font-semibold">Asset Autofill Audit</CardTitle>
+        <div className="flex flex-wrap gap-2 text-xs text-muted-foreground">
+          <Badge
+            variant={activeScope === 'all' ? 'default' : 'outline'}
+            onClick={() => setActiveScope('all')}
+            className="cursor-pointer"
+          >
+            All {entries.length}
+          </Badge>
+          {(['card', 'event', 'article'] as const).map(scope => (
+            <Badge
+              key={scope}
+              variant={activeScope === scope ? 'default' : 'outline'}
+              onClick={() => setActiveScope(scope)}
+              className="cursor-pointer"
+            >
+              {scopeLabels[scope]} {counts[scope] ?? 0}
+            </Badge>
+          ))}
+        </div>
+      </CardHeader>
+      <CardContent className="pt-0">
+        <div className="flex items-center justify-between pb-2 text-xs text-muted-foreground">
+          <span>Persistent manifest of resolved assets.</span>
+          <Button variant="ghost" size="sm" onClick={() => clearManifest()}>
+            Clear all
+          </Button>
+        </div>
+        <ScrollArea className="h-64 rounded-md border border-border/40">
+          <div className="divide-y divide-border/40 text-xs">
+            {filteredEntries.length === 0 && (
+              <div className="p-4 text-center text-muted-foreground">No assets recorded yet.</div>
+            )}
+            {filteredEntries.map(entry => (
+              <div key={entry.key} className="grid gap-1 p-4">
+                <div className="flex items-center justify-between">
+                  <div className="flex items-center gap-2">
+                    <Badge variant={entry.locked ? 'default' : 'outline'}>{scopeLabels[entry.scope]}</Badge>
+                    <span className="font-semibold text-foreground">{entry.provider}</span>
+                  </div>
+                  <span className="text-[10px] uppercase text-muted-foreground">
+                    {formatTimestamp(entry.updatedAt)}
+                  </span>
+                </div>
+                <div className="truncate text-muted-foreground">{entry.url}</div>
+                {entry.credit && <div className="text-foreground">Credit: {entry.credit}</div>}
+                {entry.license && <div className="text-muted-foreground">License: {entry.license}</div>}
+              </div>
+            ))}
+          </div>
+        </ScrollArea>
+      </CardContent>
+    </Card>
+  );
+};
+
+export default AssetAuditPanel;

--- a/src/ui/devtools/AutofillControls.tsx
+++ b/src/ui/devtools/AutofillControls.tsx
@@ -1,0 +1,127 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { featureFlags } from '@/state/featureFlags';
+import {
+  getManifestEntry,
+  getManifestKey,
+  resolveImage,
+  subscribeToManifest,
+  toggleManifestLock,
+  updateManifestCredit,
+} from '@/services/assets/AssetResolver';
+import type { AssetContext, ResolvedAsset } from '@/services/assets/types';
+import { cn } from '@/lib/utils';
+
+interface AutofillControlsProps {
+  context: AssetContext;
+  disabled?: boolean;
+  onResolved?: (asset: ResolvedAsset | null) => void;
+  className?: string;
+}
+
+const AutofillControls = ({ context, disabled = false, onResolved, className }: AutofillControlsProps) => {
+  const contextKey = useMemo(() => getManifestKey(context), [context]);
+  const [entry, setEntry] = useState(() => getManifestEntry(context));
+  const [creditDraft, setCreditDraft] = useState(entry?.credit ?? '');
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    setEntry(getManifestEntry(context));
+  }, [context]);
+
+  useEffect(() => {
+    setCreditDraft(entry?.credit ?? '');
+  }, [entry?.credit]);
+
+  useEffect(() => {
+    if (!contextKey) {
+      return undefined;
+    }
+
+    return subscribeToManifest(entries => {
+      const next = entries.find(item => item.key === contextKey);
+      setEntry(next);
+    });
+  }, [contextKey]);
+
+  const handleRoll = useCallback(async () => {
+    if (disabled) return;
+    setIsLoading(true);
+    setError(null);
+    try {
+      const result = await resolveImage(context, { forceRefresh: true });
+      setEntry(result ? getManifestEntry(context) : null);
+      if (result) {
+        onResolved?.(result);
+      }
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to resolve');
+    } finally {
+      setIsLoading(false);
+    }
+  }, [context, disabled, onResolved]);
+
+  const handleLockToggle = useCallback(() => {
+    if (!entry || !contextKey) return;
+    toggleManifestLock(context, !entry.locked);
+  }, [context, contextKey, entry]);
+
+  const handleCreditCommit = useCallback(() => {
+    if (!contextKey) return;
+    updateManifestCredit(context, creditDraft);
+  }, [context, contextKey, creditDraft]);
+
+  if (!featureFlags.autofillCardArt) {
+    return null;
+  }
+
+  return (
+    <div
+      className={cn(
+        'mt-2 flex flex-col gap-2 rounded-md border border-border/40 bg-background/80 p-2 text-xs text-muted-foreground',
+        className,
+      )}
+    >
+      <div className="flex items-center justify-between gap-2">
+        <Button
+          variant="outline"
+          size="sm"
+          disabled={disabled || isLoading}
+          onClick={handleRoll}
+        >
+          {isLoading ? 'Rolling…' : 'Roll another'}
+        </Button>
+        <Button
+          variant={entry?.locked ? 'default' : 'outline'}
+          size="sm"
+          disabled={!entry || disabled}
+          onClick={handleLockToggle}
+        >
+          {entry?.locked ? 'Locked' : 'Lock'}
+        </Button>
+      </div>
+      <div className="flex flex-col gap-1">
+        <label className="text-[10px] uppercase tracking-wide text-muted-foreground">Credit</label>
+        <Input
+          value={creditDraft}
+          placeholder="Attribution"
+          onChange={event => setCreditDraft(event.target.value)}
+          onBlur={handleCreditCommit}
+          disabled={disabled}
+          className="h-7 text-xs"
+        />
+      </div>
+      {entry && (
+        <div className="grid gap-1 text-[10px] text-muted-foreground/80">
+          <span className="font-mono uppercase tracking-wide text-muted-foreground">{entry.provider}</span>
+          <span>{entry.license ?? 'No license metadata'}</span>
+        </div>
+      )}
+      {error && <div className="text-[10px] text-amber-500">{error}</div>}
+    </div>
+  );
+};
+
+export default AutofillControls;


### PR DESCRIPTION
## Summary
- implement an asset resolver service with manifest persistence, caching, query/ranking utilities, provider modules, and a style pipeline for card art autofill
- add devtools autofill controls and an asset audit panel wired to the manifest
- refactor card and newspaper rendering to use the resolver, surface credits, and respect the new autofill feature flag

## Testing
- `npm run lint` *(fails: repository contains existing lint errors and parsing issues)*

------
https://chatgpt.com/codex/tasks/task_e_68dbae53eb7083208812a8a040cfa8ef