### PR TITLE
Disable autofill card art by default via runtime config

### DIFF
--- a/src/components/game/CardImage.tsx
+++ b/src/components/game/CardImage.tsx
@@ -4,6 +4,7 @@ import { isExtensionCard, getCardExtensionInfo } from '@/data/extensionIntegrati
 import { getAllCardsSnapshot } from '@/data/cardDatabase';
 import type { ResolvedAsset } from '@/services/assets/types';
 import { resolveImage } from '@/services/assets/AssetResolver';
+import { featureFlags } from '@/state/featureFlags';
 import AutofillControls from '@/ui/devtools/AutofillControls';
 
 interface CardImageProps {
@@ -54,6 +55,7 @@ const CardImage: React.FC<CardImageProps> = ({ cardId, className = '', fit = 'co
   const [imageLoaded, setImageLoaded] = useState(false);
   const [imageError, setImageError] = useState(false);
   const [isResolving, setIsResolving] = useState(false);
+  const autofillEnabled = featureFlags.autofillCardArt;
 
   const assetContext = useMemo(() => {
     if (!card) return null;
@@ -72,9 +74,10 @@ const CardImage: React.FC<CardImageProps> = ({ cardId, className = '', fit = 'co
   }, [fallbackImagePath, cardId]);
 
   useEffect(() => {
-    if (!assetContext) {
+    if (!assetContext || !autofillEnabled) {
       setAsset(null);
       setImageUrl(fallbackImagePath);
+      setIsResolving(false);
       return;
     }
 
@@ -107,7 +110,7 @@ const CardImage: React.FC<CardImageProps> = ({ cardId, className = '', fit = 'co
     return () => {
       cancelled = true;
     };
-  }, [assetContext, fallbackImagePath]);
+  }, [assetContext, autofillEnabled, fallbackImagePath]);
 
   const handleImageLoad = useCallback(() => {
     setImageLoaded(true);
@@ -159,11 +162,11 @@ const CardImage: React.FC<CardImageProps> = ({ cardId, className = '', fit = 'co
     [],
   );
 
-  const showControls = assetContext && card?.artPolicy !== 'manual';
+  const showControls = autofillEnabled && assetContext && card?.artPolicy !== 'manual';
 
   return (
     <div className={containerClassName}>
-      {(!imageLoaded || isResolving) && (
+      {autofillEnabled && (!imageLoaded || isResolving) && (
         <div className={loadingClassName}>
           {isResolving ? 'Resolving art…' : 'Loading...'}
         </div>

--- a/src/config/autofill.ts
+++ b/src/config/autofill.ts
@@ -1,0 +1,3 @@
+export const AUTOFILL = {
+  ENABLED: false,
+} as const;

--- a/src/state/featureFlags.ts
+++ b/src/state/featureFlags.ts
@@ -1,3 +1,5 @@
+import { AUTOFILL } from '@/config/autofill';
+
 export type FeatureFlags = {
   newspaperV2: boolean;
   aiVerboseStrategyLog: boolean;
@@ -7,7 +9,7 @@ export type FeatureFlags = {
 const DEFAULT_FLAGS: FeatureFlags = {
   newspaperV2: true,
   aiVerboseStrategyLog: false,
-  autofillCardArt: true,
+  autofillCardArt: AUTOFILL.ENABLED,
 };
 
 const readBoolean = (key: string, fallback: boolean): boolean => {


### PR DESCRIPTION
## Summary
- add a runtime autofill config that defaults the feature to disabled
- plumb the autofillCardArt feature flag default through the new config
- gate card art resolution behind the flag so autofill stays off until re-enabled

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dbb8041e808320bbbae0c0fc979a59