### PR TITLE
Handle official assets in manifest resolution

### DIFF
--- a/src/services/assets/types.ts
+++ b/src/services/assets/types.ts
@@ -28,6 +28,8 @@ export interface AssetCandidate {
   metadata?: Record<string, unknown>;
 }
 
+export type ManifestSource = 'official' | 'download';
+
 export interface ResolvedAsset {
   key: string;
   url: string;
@@ -39,6 +41,7 @@ export interface ResolvedAsset {
   updatedAt: number;
   tags: string[];
   metadata?: Record<string, unknown>;
+  source: ManifestSource;
 }
 
 export interface AssetProviderResult {
@@ -89,6 +92,7 @@ export interface ManifestEntry {
   thumbnailUrl?: string;
   metadata?: Record<string, unknown>;
   updatedAt: number;
+  source: ManifestSource;
 }
 
 export type ManifestListener = (entries: ManifestEntry[]) => void;


### PR DESCRIPTION
## Summary
- add a manifest `source` field and normalize persisted entries so official assets remain flagged
- short-circuit resolution when an entry is official/locked and persist official art via `OfficialStore.lookup`
- refresh the manifest before writing downloads to avoid clobbering official entries mid-flight

## Testing
- npm run lint *(fails: existing lint violations in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68dbb8ef43588320acff6c067ed8beb7