### PR TITLE
Protect official assets in autofill controls

### DIFF
--- a/src/ui/devtools/__tests__/AutofillControls.test.ts
+++ b/src/ui/devtools/__tests__/AutofillControls.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, test } from 'bun:test';
+import { isLockedOrOfficial } from '../AutofillControls';
+import type { ManifestEntry } from '@/services/assets/types';
+
+describe('isLockedOrOfficial', () => {
+  const buildEntry = (overrides: Partial<ManifestEntry> = {}): ManifestEntry => ({
+    key: overrides.key ?? 'card-1',
+    scope: overrides.scope ?? 'card',
+    url: overrides.url ?? 'https://example.test/image.png',
+    styledUrl: overrides.styledUrl ?? 'https://example.test/styled.png',
+    provider: overrides.provider ?? 'wikimedia',
+    credit: overrides.credit,
+    license: overrides.license,
+    locked: overrides.locked ?? false,
+    tags: overrides.tags ?? [],
+    thumbnailUrl: overrides.thumbnailUrl,
+    metadata: overrides.metadata,
+    updatedAt: overrides.updatedAt ?? 0,
+    source: overrides.source ?? 'download',
+  });
+
+  test('returns false when entry is missing', () => {
+    expect(isLockedOrOfficial(null)).toBe(false);
+    expect(isLockedOrOfficial(undefined)).toBe(false);
+  });
+
+  test('returns true when entry is locked', () => {
+    const entry = buildEntry({ locked: true });
+    expect(isLockedOrOfficial(entry)).toBe(true);
+  });
+
+  test('returns true when entry comes from the official source', () => {
+    const entry = buildEntry({ source: 'official' });
+    expect(isLockedOrOfficial(entry)).toBe(true);
+  });
+
+  test('returns true when entry is provided by the official provider', () => {
+    const entry = buildEntry({ provider: 'official' });
+    expect(isLockedOrOfficial(entry)).toBe(true);
+  });
+
+  test('returns false when entry is unlocked and unofficial', () => {
+    const entry = buildEntry({ locked: false, source: 'download', provider: 'wikimedia' });
+    expect(isLockedOrOfficial(entry)).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- add a helper to detect locked or official manifest entries and disable roll/lock actions in AutofillControls
- prevent callbacks from running when an entry is locked or official to honor the hotfix behaviour
- cover the locked-or-official detection with focused unit tests

## Testing
- bun test

------
https://chatgpt.com/codex/tasks/task_e_68dbbbfdc20c8320b1d5ef006debdf16