### PR TITLE
Guard newspaper autofill when art exists

### DIFF
--- a/src/components/game/Newspaper.tsx
+++ b/src/components/game/Newspaper.tsx
@@ -7,6 +7,7 @@ import type { GameEvent } from '@/data/eventDatabase';
 import type { NewsArticle } from '@/types';
 import { formatComboReward, getLastComboSummary } from '@/game/comboEngine';
 import { resolveImage } from '@/services/assets/AssetResolver';
+import { shouldAutofillAsset } from '@/services/assets/autofillGuards';
 import { featureFlags } from '@/state/featureFlags';
 
 interface PlayedCard {
@@ -220,7 +221,7 @@ const Newspaper = ({ events, playedCards, faction, onClose }: NewspaperProps) =>
       if (articleAssets[article.id]) {
         return false;
       }
-      return !article.image || !article.imageCredit;
+      return shouldAutofillAsset(article.image);
     });
 
     if (!pending.length) {

--- a/src/components/game/TabloidNewspaperV2.tsx
+++ b/src/components/game/TabloidNewspaperV2.tsx
@@ -13,6 +13,7 @@ import { buildRoundContext, formatTruthDelta } from './tabloidRoundUtils';
 import { useAudioContext } from '@/contexts/AudioContext';
 import type { ParanormalSighting } from '@/types/paranormal';
 import { resolveImage } from '@/services/assets/AssetResolver';
+import { shouldAutofillAsset } from '@/services/assets/autofillGuards';
 import { featureFlags } from '@/state/featureFlags';
 
 const GLITCH_OPTIONS = ['PAGE NOT FOUND', '░░░ERROR░░░', '▓▓▓SIGNAL LOST▓▓▓', '404 TRUTH NOT FOUND'];
@@ -630,7 +631,7 @@ const TabloidNewspaperV2 = ({
       if (eventAssets[event.id]) {
         return false;
       }
-      return !event.image || !event.imageCredit;
+      return shouldAutofillAsset(event.image);
     });
 
     if (!pending.length) {

--- a/src/services/assets/__tests__/autofillGuards.test.ts
+++ b/src/services/assets/__tests__/autofillGuards.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, test } from 'bun:test';
+import { shouldAutofillAsset } from '../autofillGuards';
+
+describe('shouldAutofillAsset', () => {
+  test('returns false when an image is already provided', () => {
+    expect(shouldAutofillAsset('https://example.test/already-set.png')).toBe(false);
+  });
+
+  test('returns true when the image is missing', () => {
+    expect(shouldAutofillAsset(undefined)).toBe(true);
+    expect(shouldAutofillAsset(null)).toBe(true);
+  });
+
+  test('treats blank image strings as missing', () => {
+    expect(shouldAutofillAsset('   ')).toBe(true);
+  });
+});

--- a/src/services/assets/autofillGuards.ts
+++ b/src/services/assets/autofillGuards.ts
@@ -1,0 +1,11 @@
+export const shouldAutofillAsset = (existingImage?: string | null): boolean => {
+  if (existingImage === undefined || existingImage === null) {
+    return true;
+  }
+
+  if (typeof existingImage === 'string') {
+    return existingImage.trim().length === 0;
+  }
+
+  return true;
+};


### PR DESCRIPTION
## Summary
- update the newspaper autofill filters so they only run when an image is missing
- share the guard logic via a new helper to avoid overriding existing artwork
- add a unit test to ensure entries with art skip autofill

## Testing
- bun test

------
https://chatgpt.com/codex/tasks/task_e_68dbbd17810c83209764806205a64c2a