### PR TITLE
Prevent neutral states from retaining anomaly events

### DIFF
--- a/src/components/game/EnhancedUSAMap.tsx
+++ b/src/components/game/EnhancedUSAMap.tsx
@@ -828,7 +828,7 @@ const EnhancedUSAMap: React.FC<EnhancedUSAMapProps> = ({
               </div>
             )}
 
-            {stateInfo.roundEvents?.length ? (
+            {stateInfo.owner !== 'neutral' && stateInfo.roundEvents?.length ? (
               <div className="pt-2 border-t border-border">
                 <div className="flex items-center gap-2 text-sm font-bold text-foreground mb-1">
                   <span>🗞️</span>

--- a/src/game/stateBonuses.ts
+++ b/src/game/stateBonuses.ts
@@ -256,7 +256,9 @@ export const assignStateBonuses = (
 
     if (selectedEvent) {
       const eventEntry = toRoundEvent(selectedEvent, state, options.round);
-      roundEvents[state.abbreviation] = [...(roundEvents[state.abbreviation] ?? []), eventEntry];
+      if (owner !== 'neutral') {
+        roundEvents[state.abbreviation] = [...(roundEvents[state.abbreviation] ?? []), eventEntry];
+      }
       if (isPlayerControlled) {
         truthDelta += eventEntry.truthDelta ?? 0;
         ipDelta += eventEntry.ipDelta ?? 0;

--- a/src/hooks/useGameState.ts
+++ b/src/hooks/useGameState.ts
@@ -2404,7 +2404,8 @@ export const useGameState = (aiDifficultyOverride?: AIDifficulty) => {
         const rivalKey = pressureKey === 'pressurePlayer' ? 'pressureAi' : 'pressurePlayer';
         const updatedStates = nextState.states.map(state => {
           const bonus = assignment.bonuses[state.abbreviation] ?? null;
-          const roundEvents = assignment.roundEvents[state.abbreviation] ?? [];
+          const hasController = state.owner === 'player' || state.owner === 'ai';
+          const roundEvents = hasController ? assignment.roundEvents[state.abbreviation] ?? [] : [];
           const deltaBase = assignment.pressureAdjustments[state.abbreviation] ?? 0;
           const effectiveDelta = deltaBase * factionMultiplier;
 


### PR DESCRIPTION
## Summary
- skip recording round anomalies for neutral territories when assigning state bonuses
- clear neutral state round events during game state updates and hide the anomaly panel for neutral states

## Testing
- npm run lint *(fails: existing lint violations in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68dbc7438b5c83208a898509b347ec7f