### PR TITLE
Clarify secret agenda objectives in MVP guides

### DIFF
--- a/public/how-to-play-mvp.md
+++ b/public/how-to-play-mvp.md
@@ -5,7 +5,7 @@ Welcome to the current ShadowGov ruleset. The game now layers secret agendas, pa
 ## Mission Objectives
 Victory is evaluated in priority order at every checkpoint. Achieve any of the following to end the game:
 
-1. **Complete your Secret Agenda** – hidden objectives unlocked at setup finish the campaign instantly.
+1. **Complete your Secret Agenda** – each faction starts with a hidden objective; certain cards or tabloid events can expose the AI’s plan, and finishing yours ends the campaign instantly.
 2. **Truth Extremes** – Truth Seekers win at ≥95% Truth, Government wins at ≤5%.
 3. **Resource Dominance** – Bank 300 Influence Points (IP).
 4. **Territorial Control** – Hold 10 U.S. states at once.

--- a/src/content/mvpRules.ts
+++ b/src/content/mvpRules.ts
@@ -48,6 +48,7 @@ export const MVP_RULES_SECTIONS: MvpRulesSection[] = [
       'Control 10 states to secure the map.',
       'Truth faction wins at ≥ 95% Truth; Government faction wins at ≤ 5% Truth.',
       'Reach 300 Influence Points (IP) to overrun your rival’s resources.',
+      'Each faction begins with a secret agenda that stays hidden; watch for cards or tabloid events that can expose the AI’s plan.',
     ],
   },
   {


### PR DESCRIPTION
## Summary
- highlight that both factions begin with hidden secret agendas and that cards or tabloid events can expose the AI’s plan in the Objective section of the MVP rules overlay
- mirror the same wording in the public how-to-play reference so both guides stay aligned

## Testing
- `npm run dev -- --host 0.0.0.0 --port 4173`


------
https://chatgpt.com/codex/tasks/task_e_68dbe735fb8083208a256d0b0cb55466