### PR TITLE
Add agenda stage transition overlay

### DIFF
--- a/src/components/game/TabloidNewspaperLegacy.tsx
+++ b/src/components/game/TabloidNewspaperLegacy.tsx
@@ -7,6 +7,7 @@ import type { GameCard } from '@/rules/mvp';
 import type { GameEvent } from '@/data/eventDatabase';
 import type { ParanormalSighting } from '@/types/paranormal';
 import type { AgendaIssueState } from '@/data/agendaIssues';
+import type { AgendaMoment } from '@/hooks/usePressArchive';
 import CardImage from '@/components/game/CardImage';
 import { formatComboReward, getLastComboSummary } from '@/game/comboEngine';
 
@@ -27,6 +28,7 @@ export interface TabloidNewspaperProps {
   onClose: () => void;
   sightings?: ParanormalSighting[];
   agendaIssue?: AgendaIssueState;
+  agendaMoments?: AgendaMoment[];
 }
 
 interface NewspaperData {

--- a/src/hooks/gameStateTypes.ts
+++ b/src/hooks/gameStateTypes.ts
@@ -86,11 +86,13 @@ export interface GameState {
     progress: number;
     completed: boolean;
     revealed: boolean;
+    stageId?: string;
   };
   aiSecretAgenda?: SecretAgenda & {
     progress: number;
     completed: boolean;
     revealed: boolean;
+    stageId?: string;
   };
   animating: boolean;
   aiTurnInProgress: boolean;

--- a/src/index.css
+++ b/src/index.css
@@ -755,6 +755,72 @@ All colors MUST be HSL.
     transition: all 0.1s cubic-bezier(0.4, 0, 0.2, 1);
   }
 
+  .agenda-stage-overlay {
+    animation: agenda-stage-enter 0.45s cubic-bezier(0.22, 1, 0.36, 1);
+    backdrop-filter: blur(8px);
+  }
+
+  .agenda-stage-overlay__glint {
+    position: absolute;
+    inset: -25% -10%;
+    background: linear-gradient(120deg, rgba(255, 255, 255, 0) 0%, rgba(255, 255, 255, 0.35) 45%, rgba(255, 255, 255, 0) 80%);
+    transform: translateX(-120%) rotate(4deg);
+    animation: agenda-stage-glint 1.6s ease-out forwards;
+    mix-blend-mode: screen;
+    pointer-events: none;
+  }
+
+  .agenda-stage-overlay--static {
+    animation: none;
+  }
+
+  .agenda-stage-overlay--static .agenda-stage-overlay__glint {
+    animation: none;
+    opacity: 0.2;
+    transform: translateX(0) rotate(4deg);
+  }
+
+  @keyframes agenda-stage-enter {
+    0% {
+      opacity: 0;
+      transform: scale(0.92);
+    }
+    55% {
+      opacity: 1;
+      transform: scale(1.04);
+    }
+    100% {
+      opacity: 1;
+      transform: scale(1);
+    }
+  }
+
+  @keyframes agenda-stage-glint {
+    0% {
+      opacity: 0;
+      transform: translateX(-120%) rotate(4deg);
+    }
+    20% {
+      opacity: 0.75;
+    }
+    100% {
+      opacity: 0;
+      transform: translateX(120%) rotate(4deg);
+    }
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .agenda-stage-overlay {
+      animation: none;
+    }
+
+    .agenda-stage-overlay__glint {
+      animation: none;
+      opacity: 0.25;
+      transform: translateX(0) rotate(4deg);
+    }
+  }
+
   /* Error State Animations */
   .error-shake {
     animation: error-shake 0.5s ease-in-out;

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -587,7 +587,12 @@ const Index = () => {
   const { animatePlayCard, isAnimating } = useCardAnimation();
   const { discoverCard, playCard: recordCardPlay } = useCardCollection();
   const { checkSynergies, getActiveCombinations, getTotalBonusIP } = useSynergyDetection();
-  const { issues: pressArchive, archiveEdition, removeEditionFromArchive } = usePressArchive();
+  const {
+    issues: pressArchive,
+    archiveEdition,
+    removeEditionFromArchive,
+    agendaMoments,
+  } = usePressArchive();
   const {
     entries: intelArchiveEntries,
     archiveIntelEvents,
@@ -2561,6 +2566,7 @@ const Index = () => {
           comboTruthDelta={gameState.comboTruthDeltaThisRound}
           sightings={paranormalSightings}
           agendaIssue={gameState.agendaIssue}
+          agendaMoments={agendaMoments}
           onClose={handleCloseNewspaper}
         />
       )}


### PR DESCRIPTION
## Summary
- expand agenda data to include stage descriptors and progress reporting via `defineAgenda`
- thread agenda stage ids through game state, logging, and newspaper surfaces so UI can react to stage shifts
- render stage-aware cards and classification overlays in `SecretAgenda`, broadcast agenda moments to the press archive, and animate stage transitions with the new agenda overlay styling

## Testing
- npm run lint *(fails: existing lint violations across the project unrelated to this change)*

------
https://chatgpt.com/codex/tasks/task_e_68dbf7b972788320acac43d76bd4cb68