### PR TITLE
Align state bonus adjustments across factions

### DIFF
--- a/src/hooks/__tests__/stateBonusAssignment.test.ts
+++ b/src/hooks/__tests__/stateBonusAssignment.test.ts
@@ -1,0 +1,168 @@
+import { describe, expect, test } from 'bun:test';
+import type { GameState } from '../gameStateTypes';
+import type { AssignStateBonusesResult } from '@/game/stateBonuses';
+import { applyStateBonusAssignmentToState } from '../stateBonusAssignment';
+
+const createBaseGameState = (faction: 'truth' | 'government'): GameState => ({
+  faction,
+  phase: 'newspaper',
+  turn: 2,
+  round: 3,
+  currentPlayer: 'human',
+  aiDifficulty: 'easy',
+  truth: 50,
+  ip: 42,
+  aiIP: 30,
+  hand: [],
+  aiHand: [],
+  isGameOver: false,
+  deck: [],
+  aiDeck: [],
+  cardsPlayedThisTurn: 0,
+  cardsPlayedThisRound: [],
+  playHistory: [],
+  turnPlays: [],
+  comboTruthDeltaThisRound: 0,
+  controlledStates: [],
+  aiControlledStates: [],
+  states: [
+    {
+      id: '48',
+      name: 'Texas',
+      abbreviation: 'TX',
+      baseIP: 0,
+      baseDefense: 0,
+      defense: 0,
+      pressure: faction === 'truth' ? 3 : 0,
+      pressurePlayer: faction === 'truth' ? 3 : 0,
+      pressureAi: faction === 'truth' ? 0 : 3,
+      contested: false,
+      owner: 'player',
+      stateEventHistory: [],
+      roundEvents: [],
+    },
+  ],
+  currentEvents: [],
+  pendingEditionEvents: [],
+  showNewspaper: false,
+  log: ['Initial log'],
+  agendaIssue: {
+    id: 'agenda:test',
+    label: 'Agenda Test',
+    stateId: null,
+    owner: 'human',
+    phase: 'inactive',
+    progress: 0,
+    target: 0,
+  },
+  agendaIssueCounters: {},
+  agendaRoundCounters: {},
+  animating: false,
+  aiTurnInProgress: false,
+  selectedCard: null,
+  targetState: null,
+  drawMode: 'standard',
+  cardDrawState: { cardsPlayedLastTurn: 0, lastTurnWithoutPlay: false },
+  stateCombinationBonusIP: 0,
+  activeStateCombinationIds: [],
+  stateCombinationEffects: {},
+  truthAbove80Streak: 0,
+  truthBelow20Streak: 0,
+  timeBasedGoalCounters: {},
+  paranormalHotspots: {},
+  stateRoundSeed: 123,
+  lastStateBonusRound: 1,
+  stateRoundEvents: {},
+  activeCampaignArcs: [],
+  pendingArcEvents: [],
+});
+
+const createAssignment = (): AssignStateBonusesResult => ({
+  bonuses: {
+    TX: {
+      source: 'state-themed',
+      id: 'bonus:tx',
+      stateId: '48',
+      stateName: 'Texas',
+      stateAbbreviation: 'TX',
+      round: 3,
+      label: 'Mystery Subsidy',
+      summary: 'Economic incentives flow freely.',
+      headline: 'State coffers swell',
+      truthDelta: -2,
+      ipDelta: 4,
+      pressureDelta: 1,
+    },
+  },
+  roundEvents: {
+    TX: [
+      {
+        source: 'state-themed',
+        id: 'event:tx',
+        stateId: '48',
+        stateName: 'Texas',
+        stateAbbreviation: 'TX',
+        round: 3,
+        headline: 'Investigative Lead',
+        summary: 'Agents pursue promising intel.',
+        truthDelta: -1,
+        ipDelta: 2,
+        pressureDelta: 1,
+      },
+    ],
+  },
+  logs: ['⭐️ Texas activates Mystery Subsidy'],
+  truthDelta: -2,
+  ipDelta: 4,
+  pressureAdjustments: { TX: 1 },
+  newspaperEvents: [],
+  debug: { seed: 99, rolls: [] },
+});
+
+describe('applyStateBonusAssignmentToState', () => {
+  test('applies logged adjustments for the truth faction without flipping signs', () => {
+    const baseState = createBaseGameState('truth');
+    const assignment = createAssignment();
+
+    const updated = applyStateBonusAssignmentToState(baseState, assignment);
+
+    expect(updated.truth).toBe(48);
+    expect(updated.ip).toBe(46);
+    expect(updated.lastStateBonusRound).toBe(baseState.round);
+    expect(updated.stateRoundEvents['TX']).toEqual(assignment.roundEvents['TX']);
+
+    const state = updated.states[0];
+    expect(state.pressurePlayer).toBe(4);
+    expect(state.pressureAi).toBe(0);
+    expect(state.pressure).toBe(4);
+    expect(state.activeStateBonus?.id).toBe('bonus:tx');
+
+    expect(updated.log).toContain('⭐️ Texas activates Mystery Subsidy');
+    expect(updated.log.some(entry => entry.startsWith('Truth manipulation'))).toBe(true);
+    expect(updated.log.at(-1)).toBe('State bonuses adjusted IP by +4');
+
+    // original state remains unchanged
+    expect(baseState.truth).toBe(50);
+    expect(baseState.ip).toBe(42);
+    expect(baseState.states[0].pressurePlayer).toBe(3);
+  });
+
+  test('updates government faction using the same signed adjustments', () => {
+    const baseState = createBaseGameState('government');
+    const assignment = createAssignment();
+
+    const updated = applyStateBonusAssignmentToState(baseState, assignment);
+
+    expect(updated.truth).toBe(48);
+    expect(updated.ip).toBe(46);
+
+    const state = updated.states[0];
+    expect(state.pressureAi).toBe(4);
+    expect(state.pressurePlayer).toBe(0);
+    expect(state.pressure).toBe(4);
+
+    expect(updated.log.at(-1)).toBe('State bonuses adjusted IP by +4');
+    expect(updated.log.some(entry => entry.startsWith('Truth manipulation'))).toBe(true);
+  });
+});
+

--- a/src/hooks/stateBonusAssignment.ts
+++ b/src/hooks/stateBonusAssignment.ts
@@ -1,0 +1,87 @@
+import { buildEditionEvents } from './eventEdition';
+import type { GameState } from './gameStateTypes';
+import type { AssignStateBonusesResult } from '@/game/stateBonuses';
+import { applyTruthDelta } from '@/utils/truth';
+
+export const applyStateBonusAssignmentToState = (
+  baseState: GameState,
+  assignment: AssignStateBonusesResult,
+): GameState => {
+  let nextState: GameState = {
+    ...baseState,
+    log:
+      assignment.logs.length > 0
+        ? [...baseState.log, ...assignment.logs]
+        : [...baseState.log],
+  };
+
+  if (assignment.truthDelta !== 0) {
+    nextState = applyTruthDelta(nextState, assignment.truthDelta, 'human');
+  }
+
+  if (assignment.ipDelta !== 0) {
+    const ipDelta = assignment.ipDelta;
+    nextState = {
+      ...nextState,
+      ip: Math.max(0, Math.round(nextState.ip + ipDelta)),
+      log: [
+        ...nextState.log,
+        `State bonuses adjusted IP by ${ipDelta >= 0 ? '+' : ''}${ipDelta}`,
+      ],
+    };
+  }
+
+  const pressureKey: 'pressurePlayer' | 'pressureAi' =
+    nextState.faction === 'truth' ? 'pressurePlayer' : 'pressureAi';
+  const rivalKey = pressureKey === 'pressurePlayer' ? 'pressureAi' : 'pressurePlayer';
+
+  const updatedStates = nextState.states.map(state => {
+    const bonus = assignment.bonuses[state.abbreviation] ?? null;
+    const hasController = state.owner === 'player' || state.owner === 'ai';
+    const roundEvents = hasController ? assignment.roundEvents[state.abbreviation] ?? [] : [];
+    const pressureDelta = assignment.pressureAdjustments[state.abbreviation] ?? 0;
+
+    if (pressureDelta === 0) {
+      return {
+        ...state,
+        activeStateBonus: bonus,
+        roundEvents,
+      };
+    }
+
+    const updatedPressureOwner = Math.max(0, (state[pressureKey] ?? 0) + pressureDelta);
+    const opponentPressure = Math.max(0, state[rivalKey] ?? 0);
+
+    return {
+      ...state,
+      [pressureKey]: updatedPressureOwner,
+      pressure: Math.max(updatedPressureOwner, opponentPressure),
+      activeStateBonus: bonus,
+      roundEvents,
+    } as typeof state;
+  });
+
+  const stateRoundEvents = Object.fromEntries(
+    updatedStates.map(state => [state.abbreviation, state.roundEvents ?? []]),
+  );
+
+  nextState = {
+    ...nextState,
+    states: updatedStates,
+    stateRoundEvents,
+    lastStateBonusRound: nextState.round,
+  };
+
+  if (assignment.newspaperEvents.length > 0) {
+    nextState = {
+      ...nextState,
+      currentEvents: buildEditionEvents(
+        { turn: nextState.turn, round: nextState.round, currentEvents: nextState.currentEvents },
+        assignment.newspaperEvents,
+      ),
+    };
+  }
+
+  return nextState;
+};
+


### PR DESCRIPTION
## Summary
- remove faction-based inversion when applying state bonus truth/IP/pressure deltas
- centralize state bonus assignment updates in a shared helper for reuse and clarity
- add unit tests covering truth and government factions to verify signed adjustments match logs

## Testing
- bun test

------
https://chatgpt.com/codex/tasks/task_e_68dc2c6329fc8320bbb28fca56fe6a54