### PR TITLE
Align combo reward truth formatting with faction sign

### DIFF
--- a/src/components/game/Newspaper.tsx
+++ b/src/components/game/Newspaper.tsx
@@ -252,7 +252,9 @@ const Newspaper = ({ events, playedCards, faction, onClose }: NewspaperProps) =>
         id: result.definition.id,
         name: result.definition.name,
         description: result.definition.description,
-        reward: formatComboReward(result.appliedReward).replace(/[()]/g, '').trim(),
+        reward: formatComboReward(result.appliedReward, { faction: comboSummary.playerFaction })
+          .replace(/[()]/g, '')
+          .trim(),
         matched: result.details.matchedPlays.map(play => play.cardName).filter(Boolean),
         fxText: result.definition.fxText,
       })),

--- a/src/components/game/TabloidNewspaperLegacy.tsx
+++ b/src/components/game/TabloidNewspaperLegacy.tsx
@@ -318,7 +318,9 @@ const LegacyTabloidNewspaper = ({ events, playedCards, faction, truth, onClose }
         id: result.definition.id,
         name: result.definition.name,
         description: result.definition.description,
-        reward: formatComboReward(result.appliedReward).replace(/[()]/g, '').trim(),
+        reward: formatComboReward(result.appliedReward, { faction: comboSummary.playerFaction })
+          .replace(/[()]/g, '')
+          .trim(),
         matched: result.details.matchedPlays.map(play => play.cardName).filter(Boolean),
         fxText: result.definition.fxText,
       })),

--- a/src/components/game/TabloidNewspaperV2.tsx
+++ b/src/components/game/TabloidNewspaperV2.tsx
@@ -534,7 +534,9 @@ const TabloidNewspaperV2 = ({
         id: result.definition.id,
         name: result.definition.name,
         description: result.definition.description,
-        reward: formatComboReward(result.appliedReward).replace(/[()]/g, '').trim(),
+        reward: formatComboReward(result.appliedReward, { faction: comboSummary.playerFaction })
+          .replace(/[()]/g, '')
+          .trim(),
         matchedPlays: result.details.matchedPlays.map(play => play.cardName).filter(Boolean),
         fxText: result.definition.fxText,
       })),

--- a/src/game/__tests__/comboEngine.test.ts
+++ b/src/game/__tests__/comboEngine.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, test } from 'bun:test';
+
+import { applyComboRewards, evaluateCombos, formatComboReward } from '../comboEngine';
+import type { GameState, TurnPlay } from '../combo.types';
+
+const buildMediaPlay = (sequence: number): TurnPlay => ({
+  sequence,
+  stage: 'resolve',
+  owner: 'P2',
+  cardId: `media_${sequence}`,
+  cardName: `Media Blast ${sequence}`,
+  cardType: 'MEDIA',
+  cardRarity: 'common',
+  cost: 1,
+});
+
+describe('comboEngine truth formatting', () => {
+  test('government combos display signed truth change', () => {
+    const turnPlays: TurnPlay[] = [buildMediaPlay(1), buildMediaPlay(2), buildMediaPlay(3)];
+
+    const state: GameState = {
+      turn: 3,
+      currentPlayer: 'P2',
+      truth: 50,
+      players: {
+        P1: { id: 'P1', faction: 'truth', deck: [], hand: [], discard: [], ip: 0, states: [] },
+        P2: {
+          id: 'P2',
+          faction: 'government',
+          deck: [],
+          hand: [],
+          discard: [],
+          ip: 0,
+          states: [],
+        },
+      },
+      pressureByState: {},
+      stateDefense: {},
+      playsThisTurn: turnPlays.length,
+      turnPlays,
+      log: [],
+    } satisfies GameState;
+
+    const initialTruth = state.truth;
+    const evaluation = evaluateCombos(state, 'P2');
+    expect(evaluation.results.length).toBeGreaterThan(0);
+
+    const formattedTruthValues = evaluation.results
+      .map(result => formatComboReward(result.appliedReward, { faction: 'government' }))
+      .map(text => {
+        const match = text.match(/([+-]\d+)\s+Truth/);
+        return match ? Number(match[1]) : 0;
+      })
+      .filter(value => value !== 0);
+
+    expect(formattedTruthValues.length).toBeGreaterThan(0);
+
+    const updated = applyComboRewards(state, 'P2', evaluation);
+    const actualTruthDelta = updated.truth - initialTruth;
+    const displayedTruthDelta = formattedTruthValues.reduce((sum, value) => sum + value, 0);
+
+    expect(displayedTruthDelta).toBe(actualTruthDelta);
+  });
+});

--- a/src/game/combo.types.ts
+++ b/src/game/combo.types.ts
@@ -120,5 +120,6 @@ export interface ComboOptions extends Partial<ComboSettings> {
 
 export interface ComboSummary extends ComboEvaluation {
   player: PlayerId;
+  playerFaction: 'truth' | 'government';
   turn: number;
 }

--- a/src/hooks/comboAdapter.ts
+++ b/src/hooks/comboAdapter.ts
@@ -99,9 +99,10 @@ export const evaluateCombosForTurn = (
   const rewardedState = applyComboRewards(engineState, playerId, evaluation);
   const rewardLogs = rewardedState.log.slice(logStart);
   const truthDelta = rewardedState.truth - state.truth;
+  const comboPlayerFaction = engineState.players[playerId]?.faction === 'government' ? 'government' : 'truth';
 
   const comboMessages = evaluation.results.map(result => {
-    const rewardText = formatComboReward(result.appliedReward);
+    const rewardText = formatComboReward(result.appliedReward, { faction: comboPlayerFaction });
     return rewardText ? `${result.definition.name} ${rewardText}` : result.definition.name;
   });
 

--- a/src/mvp/engine.ts
+++ b/src/mvp/engine.ts
@@ -519,16 +519,18 @@ export function endTurn(
   turnLog.push(discardMessage.trim());
 
   const comboEvaluation = evaluateCombos(cloned, currentId, options.combo);
+  const comboPlayerFaction = cloned.players[currentId]?.faction === 'government' ? 'government' : 'truth';
   const comboSummary: ComboSummary = {
     ...comboEvaluation,
     player: currentId,
+    playerFaction: comboPlayerFaction,
     turn: turnNumber,
   };
 
   if (comboEvaluation.results.length > 0) {
     const summaryText = comboEvaluation.results
       .map(result => {
-        const rewardText = formatComboReward(result.appliedReward);
+        const rewardText = formatComboReward(result.appliedReward, { faction: comboPlayerFaction });
         return rewardText ? `${result.definition.name} ${rewardText}` : result.definition.name;
       })
       .join('; ');
@@ -554,7 +556,7 @@ export function endTurn(
     for (const result of comboEvaluation.results) {
       callbacks?.onComboFx?.(result);
       if (typeof window !== 'undefined' && typeof (window as any).uiComboToast === 'function') {
-        const rewardText = formatComboReward(result.appliedReward);
+        const rewardText = formatComboReward(result.appliedReward, { faction: comboPlayerFaction });
         (window as any).uiComboToast(
           rewardText ? `${result.definition.name} ${rewardText}` : result.definition.name,
         );

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -329,7 +329,9 @@ const buildComboHighlights = (
   const ownerLabel = resolveComboOwnerLabel(summary.player);
 
   return summary.results.map(result => {
-    const rewardLabel = formatComboReward(result.appliedReward).replace(/[()]/g, '').trim();
+    const rewardLabel = formatComboReward(result.appliedReward, { faction: summary.playerFaction })
+      .replace(/[()]/g, '')
+      .trim();
     return {
       id: result.definition.id,
       name: result.definition.name ?? result.definition.id,


### PR DESCRIPTION
## Summary
- adjust combo reward formatting to normalize player faction and preserve signed truth deltas
- update combo evaluation consumers to pass faction information so UI and FX text match applied truth changes
- add a regression test ensuring government combos display the same truth delta that is applied to game state

## Testing
- bun test

------
https://chatgpt.com/codex/tasks/task_e_68dc2de130c483208cddd1ceeec74628