### PR TITLE
Reset end-of-match state when starting a new game

### DIFF
--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -1937,6 +1937,11 @@ const Index = () => {
   const startNewGame = async (faction: 'government' | 'truth') => {
     console.log('🎵 Index: Starting new game with faction:', faction);
     persistFaction(faction);
+    setVictoryState({ isVictory: false, type: null });
+    setFinalEdition(null);
+    setReadingEdition(null);
+    setShowExtraEdition(false);
+    setParanormalSightings([]);
     await initGame(faction);
     setShowMenu(false);
     setShowIntro(false);


### PR DESCRIPTION
## Summary
- clear any lingering victory and final edition state before initializing a new session
- reset paranormal sightings and extra edition visibility so new games start fresh

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dc38b66728832080de81f1cb274c32