### PR TITLE
Fix government media truth deltas in Cryptids

### DIFF
--- a/public/extensions/cryptids.json
+++ b/public/extensions/cryptids.json
@@ -2695,7 +2695,7 @@
     "type": "MEDIA",
     "rarity": "rare",
     "effects": {
-      "truthDelta": 3
+      "truthDelta": -3
     },
     "tags": [
       "cryptid"
@@ -2759,7 +2759,7 @@
     "type": "MEDIA",
     "rarity": "uncommon",
     "effects": {
-      "truthDelta": 2
+      "truthDelta": -2
     },
     "tags": [
       "cryptid"
@@ -2775,7 +2775,7 @@
     "type": "MEDIA",
     "rarity": "rare",
     "effects": {
-      "truthDelta": 3
+      "truthDelta": -3
     },
     "tags": [
       "cryptid"
@@ -2863,7 +2863,7 @@
     "type": "MEDIA",
     "rarity": "common",
     "effects": {
-      "truthDelta": 1
+      "truthDelta": -1
     },
     "tags": [
       "cryptid"
@@ -3084,7 +3084,7 @@
     "type": "MEDIA",
     "rarity": "legendary",
     "effects": {
-      "truthDelta": 4
+      "truthDelta": -4
     },
     "tags": [
       "cryptid"
@@ -3116,7 +3116,7 @@
     "type": "MEDIA",
     "rarity": "uncommon",
     "effects": {
-      "truthDelta": 2
+      "truthDelta": -2
     },
     "tags": [
       "cryptid"
@@ -3310,7 +3310,7 @@
     "type": "MEDIA",
     "rarity": "rare",
     "effects": {
-      "truthDelta": 3
+      "truthDelta": -3
     },
     "tags": [
       "cryptid"
@@ -3342,7 +3342,7 @@
     "type": "MEDIA",
     "rarity": "legendary",
     "effects": {
-      "truthDelta": 4
+      "truthDelta": -4
     },
     "tags": [
       "cryptid"
@@ -3392,7 +3392,7 @@
     "type": "MEDIA",
     "rarity": "rare",
     "effects": {
-      "truthDelta": 3
+      "truthDelta": -3
     },
     "tags": [
       "cryptid"
@@ -3490,7 +3490,7 @@
     "type": "MEDIA",
     "rarity": "uncommon",
     "effects": {
-      "truthDelta": 2
+      "truthDelta": -2
     },
     "tags": [
       "cryptid"
@@ -3525,7 +3525,7 @@
     "type": "MEDIA",
     "rarity": "uncommon",
     "effects": {
-      "truthDelta": 2
+      "truthDelta": -2
     },
     "tags": [
       "cryptid"
@@ -3541,7 +3541,7 @@
     "type": "MEDIA",
     "rarity": "uncommon",
     "effects": {
-      "truthDelta": 2
+      "truthDelta": -2
     },
     "tags": [
       "cryptid"
@@ -3557,7 +3557,7 @@
     "type": "MEDIA",
     "rarity": "rare",
     "effects": {
-      "truthDelta": 3
+      "truthDelta": -3
     },
     "tags": [
       "cryptid"
@@ -3640,7 +3640,7 @@
     "type": "MEDIA",
     "rarity": "rare",
     "effects": {
-      "truthDelta": 3
+      "truthDelta": -3
     },
     "tags": [
       "cryptid"
@@ -3693,7 +3693,7 @@
     "type": "MEDIA",
     "rarity": "uncommon",
     "effects": {
-      "truthDelta": 2
+      "truthDelta": -2
     },
     "tags": [
       "cryptid"
@@ -3709,7 +3709,7 @@
     "type": "MEDIA",
     "rarity": "uncommon",
     "effects": {
-      "truthDelta": 2
+      "truthDelta": -2
     },
     "tags": [
       "cryptid"
@@ -3757,7 +3757,7 @@
     "type": "MEDIA",
     "rarity": "rare",
     "effects": {
-      "truthDelta": 3
+      "truthDelta": -3
     },
     "tags": [
       "cryptid"
@@ -3887,7 +3887,7 @@
     "type": "MEDIA",
     "rarity": "common",
     "effects": {
-      "truthDelta": 1
+      "truthDelta": -1
     },
     "tags": [
       "cryptid",
@@ -3905,7 +3905,7 @@
     "type": "MEDIA",
     "rarity": "common",
     "effects": {
-      "truthDelta": 1
+      "truthDelta": -1
     },
     "tags": [
       "cryptid",
@@ -3943,7 +3943,7 @@
     "type": "MEDIA",
     "rarity": "common",
     "effects": {
-      "truthDelta": 1
+      "truthDelta": -1
     },
     "tags": [
       "cryptid",
@@ -3997,7 +3997,7 @@
     "type": "MEDIA",
     "rarity": "common",
     "effects": {
-      "truthDelta": 1
+      "truthDelta": -1
     },
     "tags": [
       "cryptid",
@@ -4015,7 +4015,7 @@
     "type": "MEDIA",
     "rarity": "common",
     "effects": {
-      "truthDelta": 1
+      "truthDelta": -1
     },
     "tags": [
       "cryptid",
@@ -4033,7 +4033,7 @@
     "type": "MEDIA",
     "rarity": "common",
     "effects": {
-      "truthDelta": 1
+      "truthDelta": -1
     },
     "tags": [
       "cryptid",
@@ -4051,7 +4051,7 @@
     "type": "MEDIA",
     "rarity": "common",
     "effects": {
-      "truthDelta": 1
+      "truthDelta": -1
     },
     "tags": [
       "cryptid",
@@ -4069,7 +4069,7 @@
     "type": "MEDIA",
     "rarity": "common",
     "effects": {
-      "truthDelta": 1
+      "truthDelta": -1
     },
     "tags": [
       "cryptid",
@@ -4087,7 +4087,7 @@
     "type": "MEDIA",
     "rarity": "common",
     "effects": {
-      "truthDelta": 1
+      "truthDelta": -1
     },
     "tags": [
       "cryptid",
@@ -4123,7 +4123,7 @@
     "type": "MEDIA",
     "rarity": "common",
     "effects": {
-      "truthDelta": 1
+      "truthDelta": -1
     },
     "tags": [
       "cryptid",
@@ -4141,7 +4141,7 @@
     "type": "MEDIA",
     "rarity": "common",
     "effects": {
-      "truthDelta": 1
+      "truthDelta": -1
     },
     "tags": [
       "cryptid",
@@ -4159,7 +4159,7 @@
     "type": "MEDIA",
     "rarity": "common",
     "effects": {
-      "truthDelta": 1
+      "truthDelta": -1
     },
     "tags": [
       "cryptid",
@@ -4177,7 +4177,7 @@
     "type": "MEDIA",
     "rarity": "common",
     "effects": {
-      "truthDelta": 1
+      "truthDelta": -1
     },
     "tags": [
       "cryptid",
@@ -4195,7 +4195,7 @@
     "type": "MEDIA",
     "rarity": "common",
     "effects": {
-      "truthDelta": 1
+      "truthDelta": -1
     },
     "tags": [
       "cryptid",
@@ -4213,7 +4213,7 @@
     "type": "MEDIA",
     "rarity": "common",
     "effects": {
-      "truthDelta": 1
+      "truthDelta": -1
     },
     "tags": [
       "cryptid",
@@ -4231,7 +4231,7 @@
     "type": "MEDIA",
     "rarity": "common",
     "effects": {
-      "truthDelta": 1
+      "truthDelta": -1
     },
     "tags": [
       "cryptid",
@@ -4249,7 +4249,7 @@
     "type": "MEDIA",
     "rarity": "common",
     "effects": {
-      "truthDelta": 1
+      "truthDelta": -1
     },
     "tags": [
       "cryptid",
@@ -4267,7 +4267,7 @@
     "type": "MEDIA",
     "rarity": "common",
     "effects": {
-      "truthDelta": 1
+      "truthDelta": -1
     },
     "tags": [
       "cryptid",
@@ -4305,7 +4305,7 @@
     "type": "MEDIA",
     "rarity": "common",
     "effects": {
-      "truthDelta": 1
+      "truthDelta": -1
     },
     "tags": [
       "cryptid",
@@ -4323,7 +4323,7 @@
     "type": "MEDIA",
     "rarity": "common",
     "effects": {
-      "truthDelta": 1
+      "truthDelta": -1
     },
     "tags": [
       "cryptid",
@@ -4341,7 +4341,7 @@
     "type": "MEDIA",
     "rarity": "common",
     "effects": {
-      "truthDelta": 1
+      "truthDelta": -1
     },
     "tags": [
       "cryptid",
@@ -4359,7 +4359,7 @@
     "type": "MEDIA",
     "rarity": "common",
     "effects": {
-      "truthDelta": 1
+      "truthDelta": -1
     },
     "tags": [
       "cryptid",
@@ -4377,7 +4377,7 @@
     "type": "MEDIA",
     "rarity": "common",
     "effects": {
-      "truthDelta": 1
+      "truthDelta": -1
     },
     "tags": [
       "cryptid",
@@ -4395,7 +4395,7 @@
     "type": "MEDIA",
     "rarity": "common",
     "effects": {
-      "truthDelta": 1
+      "truthDelta": -1
     },
     "tags": [
       "cryptid",
@@ -4453,7 +4453,7 @@
     "type": "MEDIA",
     "rarity": "common",
     "effects": {
-      "truthDelta": 1
+      "truthDelta": -1
     },
     "tags": [
       "cryptid",
@@ -4471,7 +4471,7 @@
     "type": "MEDIA",
     "rarity": "common",
     "effects": {
-      "truthDelta": 1
+      "truthDelta": -1
     },
     "tags": [
       "cryptid",
@@ -4489,7 +4489,7 @@
     "type": "MEDIA",
     "rarity": "common",
     "effects": {
-      "truthDelta": 1
+      "truthDelta": -1
     },
     "tags": [
       "cryptid",
@@ -4507,7 +4507,7 @@
     "type": "MEDIA",
     "rarity": "common",
     "effects": {
-      "truthDelta": 1
+      "truthDelta": -1
     },
     "tags": [
       "cryptid",
@@ -4525,7 +4525,7 @@
     "type": "MEDIA",
     "rarity": "common",
     "effects": {
-      "truthDelta": 1
+      "truthDelta": -1
     },
     "tags": [
       "cryptid",
@@ -4543,7 +4543,7 @@
     "type": "MEDIA",
     "rarity": "common",
     "effects": {
-      "truthDelta": 1
+      "truthDelta": -1
     },
     "tags": [
       "cryptid",
@@ -4561,7 +4561,7 @@
     "type": "MEDIA",
     "rarity": "common",
     "effects": {
-      "truthDelta": 1
+      "truthDelta": -1
     },
     "tags": [
       "cryptid",
@@ -4579,7 +4579,7 @@
     "type": "MEDIA",
     "rarity": "common",
     "effects": {
-      "truthDelta": 1
+      "truthDelta": -1
     },
     "tags": [
       "cryptid",
@@ -4597,7 +4597,7 @@
     "type": "MEDIA",
     "rarity": "common",
     "effects": {
-      "truthDelta": 1
+      "truthDelta": -1
     },
     "tags": [
       "cryptid",
@@ -4615,7 +4615,7 @@
     "type": "MEDIA",
     "rarity": "common",
     "effects": {
-      "truthDelta": 1
+      "truthDelta": -1
     },
     "tags": [
       "cryptid",
@@ -4633,7 +4633,7 @@
     "type": "MEDIA",
     "rarity": "common",
     "effects": {
-      "truthDelta": 1
+      "truthDelta": -1
     },
     "tags": [
       "cryptid",
@@ -4671,7 +4671,7 @@
     "type": "MEDIA",
     "rarity": "common",
     "effects": {
-      "truthDelta": 1
+      "truthDelta": -1
     },
     "tags": [
       "cryptid",
@@ -4689,7 +4689,7 @@
     "type": "MEDIA",
     "rarity": "common",
     "effects": {
-      "truthDelta": 1
+      "truthDelta": -1
     },
     "tags": [
       "cryptid",
@@ -4707,7 +4707,7 @@
     "type": "MEDIA",
     "rarity": "common",
     "effects": {
-      "truthDelta": 1
+      "truthDelta": -1
     },
     "tags": [
       "cryptid",
@@ -4725,7 +4725,7 @@
     "type": "MEDIA",
     "rarity": "common",
     "effects": {
-      "truthDelta": 1
+      "truthDelta": -1
     },
     "tags": [
       "cryptid",
@@ -4783,7 +4783,7 @@
     "type": "MEDIA",
     "rarity": "common",
     "effects": {
-      "truthDelta": 1
+      "truthDelta": -1
     },
     "tags": [
       "cryptid",
@@ -4837,7 +4837,7 @@
     "type": "MEDIA",
     "rarity": "common",
     "effects": {
-      "truthDelta": 1
+      "truthDelta": -1
     },
     "tags": [
       "snallygaster",
@@ -5051,7 +5051,7 @@
     "type": "MEDIA",
     "rarity": "common",
     "effects": {
-      "truthDelta": 1
+      "truthDelta": -1
     },
     "tags": [
       "rougarou",

--- a/src/data/expansions/cryptids_MVP.ts
+++ b/src/data/expansions/cryptids_MVP.ts
@@ -2312,7 +2312,7 @@ const cards: GameCard[] = [
     "rarity": "rare",
     "cost": 5,
     "effects": {
-      "truthDelta": 3
+      "truthDelta": -3
     },
     "extId": "cryptids",
     "flavor": "\"CLASSIFIED INTELLIGENCE: Awaiting lab results; likely weather and shadows.\""
@@ -2376,7 +2376,7 @@ const cards: GameCard[] = [
     "rarity": "uncommon",
     "cost": 4,
     "effects": {
-      "truthDelta": 2
+      "truthDelta": -2
     },
     "extId": "cryptids",
     "flavor": "\"CLASSIFIED INTELLIGENCE: Public guidance issued; no roswell detected.\""
@@ -2389,7 +2389,7 @@ const cards: GameCard[] = [
     "rarity": "rare",
     "cost": 5,
     "effects": {
-      "truthDelta": 3
+      "truthDelta": -3
     },
     "extId": "cryptids",
     "flavor": "\"CLASSIFIED INTELLIGENCE: Awaiting lab results; likely weather and shadows.\""
@@ -2466,7 +2466,7 @@ const cards: GameCard[] = [
     "rarity": "common",
     "cost": 3,
     "effects": {
-      "truthDelta": 1
+      "truthDelta": -1
     },
     "extId": "cryptids",
     "flavor": "\"CLASSIFIED INTELLIGENCE: Awaiting lab results; likely weather and shadows.\""
@@ -2672,7 +2672,7 @@ const cards: GameCard[] = [
     "rarity": "legendary",
     "cost": 6,
     "effects": {
-      "truthDelta": 4
+      "truthDelta": -4
     },
     "extId": "cryptids",
     "flavor": "\"CLASSIFIED INTELLIGENCE: Situation normal—memo drafted and archived.\""
@@ -2702,7 +2702,7 @@ const cards: GameCard[] = [
     "rarity": "uncommon",
     "cost": 4,
     "effects": {
-      "truthDelta": 2
+      "truthDelta": -2
     },
     "extId": "cryptids",
     "flavor": "\"CLASSIFIED INTELLIGENCE: Public guidance issued; no time detected.\""
@@ -2900,7 +2900,7 @@ const cards: GameCard[] = [
     "rarity": "rare",
     "cost": 5,
     "effects": {
-      "truthDelta": 3
+      "truthDelta": -3
     },
     "extId": "cryptids",
     "flavor": "\"CLASSIFIED INTELLIGENCE: Public guidance issued; no giant detected.\""
@@ -2930,7 +2930,7 @@ const cards: GameCard[] = [
     "rarity": "legendary",
     "cost": 6,
     "effects": {
-      "truthDelta": 4
+      "truthDelta": -4
     },
     "extId": "cryptids",
     "flavor": "\"CLASSIFIED INTELLIGENCE: Public guidance issued; no invisible detected.\""
@@ -2975,7 +2975,7 @@ const cards: GameCard[] = [
     "rarity": "rare",
     "cost": 5,
     "effects": {
-      "truthDelta": 3
+      "truthDelta": -3
     },
     "extId": "cryptids",
     "flavor": "\"CLASSIFIED INTELLIGENCE: Situation normal—memo drafted and archived.\""
@@ -3071,7 +3071,7 @@ const cards: GameCard[] = [
     "rarity": "uncommon",
     "cost": 4,
     "effects": {
-      "truthDelta": 2
+      "truthDelta": -2
     },
     "extId": "cryptids",
     "flavor": "\"CLASSIFIED INTELLIGENCE: Public guidance issued; no neuralyzer detected.\""
@@ -3100,7 +3100,7 @@ const cards: GameCard[] = [
     "rarity": "uncommon",
     "cost": 4,
     "effects": {
-      "truthDelta": 2
+      "truthDelta": -2
     },
     "extId": "cryptids",
     "flavor": "\"CLASSIFIED INTELLIGENCE: Public guidance issued; no operation detected.\""
@@ -3113,7 +3113,7 @@ const cards: GameCard[] = [
     "rarity": "uncommon",
     "cost": 4,
     "effects": {
-      "truthDelta": 2
+      "truthDelta": -2
     },
     "extId": "cryptids",
     "flavor": "\"CLASSIFIED INTELLIGENCE: Public guidance issued; no holographic detected.\""
@@ -3126,7 +3126,7 @@ const cards: GameCard[] = [
     "rarity": "rare",
     "cost": 5,
     "effects": {
-      "truthDelta": 3
+      "truthDelta": -3
     },
     "extId": "cryptids",
     "flavor": "\"CLASSIFIED INTELLIGENCE: Situation normal—memo drafted and archived.\""
@@ -3206,7 +3206,7 @@ const cards: GameCard[] = [
     "rarity": "rare",
     "cost": 5,
     "effects": {
-      "truthDelta": 3
+      "truthDelta": -3
     },
     "extId": "cryptids",
     "flavor": "\"CLASSIFIED INTELLIGENCE: Public guidance issued; no cosmic detected.\""
@@ -3250,7 +3250,7 @@ const cards: GameCard[] = [
     "rarity": "uncommon",
     "cost": 4,
     "effects": {
-      "truthDelta": 2
+      "truthDelta": -2
     },
     "extId": "cryptids",
     "flavor": "\"CLASSIFIED INTELLIGENCE: Situation normal—memo drafted and archived.\""
@@ -3263,7 +3263,7 @@ const cards: GameCard[] = [
     "rarity": "uncommon",
     "cost": 4,
     "effects": {
-      "truthDelta": 2
+      "truthDelta": -2
     },
     "extId": "cryptids",
     "flavor": "\"CLASSIFIED INTELLIGENCE: Public guidance issued; no cryptid detected.\""
@@ -3310,7 +3310,7 @@ const cards: GameCard[] = [
     "rarity": "rare",
     "cost": 5,
     "effects": {
-      "truthDelta": 3
+      "truthDelta": -3
     },
     "extId": "cryptids",
     "flavor": "\"CLASSIFIED INTELLIGENCE: Awaiting lab results; likely weather and shadows.\""
@@ -3440,7 +3440,7 @@ const cards: GameCard[] = [
     "rarity": "common",
     "cost": 3,
     "effects": {
-      "truthDelta": 1
+      "truthDelta": -1
     },
     "extId": "cryptids",
     "flavor": "\"CLASSIFIED INTELLIGENCE: Public bulletin: Do not feed the alabama cryptid.\""
@@ -3453,7 +3453,7 @@ const cards: GameCard[] = [
     "rarity": "common",
     "cost": 3,
     "effects": {
-      "truthDelta": 1
+      "truthDelta": -1
     },
     "extId": "cryptids",
     "flavor": "\"CLASSIFIED INTELLIGENCE: Public bulletin: Do not feed the tizheruk.\""
@@ -3481,7 +3481,7 @@ const cards: GameCard[] = [
     "rarity": "common",
     "cost": 3,
     "effects": {
-      "truthDelta": 1
+      "truthDelta": -1
     },
     "extId": "cryptids",
     "flavor": "\"CLASSIFIED INTELLIGENCE: Public bulletin: Do not feed the fouke monster.\""
@@ -3528,7 +3528,7 @@ const cards: GameCard[] = [
     "rarity": "common",
     "cost": 3,
     "effects": {
-      "truthDelta": 1
+      "truthDelta": -1
     },
     "extId": "cryptids",
     "flavor": "\"CLASSIFIED INTELLIGENCE: Public bulletin: Do not feed the connecticut cryptid.\""
@@ -3541,7 +3541,7 @@ const cards: GameCard[] = [
     "rarity": "common",
     "cost": 3,
     "effects": {
-      "truthDelta": 1
+      "truthDelta": -1
     },
     "extId": "cryptids",
     "flavor": "\"CLASSIFIED INTELLIGENCE: Public bulletin: Do not feed the delaware cryptid.\""
@@ -3554,7 +3554,7 @@ const cards: GameCard[] = [
     "rarity": "common",
     "cost": 3,
     "effects": {
-      "truthDelta": 1
+      "truthDelta": -1
     },
     "extId": "cryptids",
     "flavor": "\"CLASSIFIED INTELLIGENCE: Public bulletin: Do not feed the skunk ape.\""
@@ -3567,7 +3567,7 @@ const cards: GameCard[] = [
     "rarity": "common",
     "cost": 3,
     "effects": {
-      "truthDelta": 1
+      "truthDelta": -1
     },
     "extId": "cryptids",
     "flavor": "\"CLASSIFIED INTELLIGENCE: Public bulletin: Do not feed the georgia cryptid.\""
@@ -3580,7 +3580,7 @@ const cards: GameCard[] = [
     "rarity": "common",
     "cost": 3,
     "effects": {
-      "truthDelta": 1
+      "truthDelta": -1
     },
     "extId": "cryptids",
     "flavor": "\"CLASSIFIED INTELLIGENCE: Public bulletin: Do not feed the hawaii cryptid.\""
@@ -3593,7 +3593,7 @@ const cards: GameCard[] = [
     "rarity": "common",
     "cost": 3,
     "effects": {
-      "truthDelta": 1
+      "truthDelta": -1
     },
     "extId": "cryptids",
     "flavor": "\"CLASSIFIED INTELLIGENCE: Public bulletin: Do not feed the idaho cryptid.\""
@@ -3623,7 +3623,7 @@ const cards: GameCard[] = [
     "rarity": "common",
     "cost": 3,
     "effects": {
-      "truthDelta": 1
+      "truthDelta": -1
     },
     "extId": "cryptids",
     "flavor": "\"CLASSIFIED INTELLIGENCE: Public bulletin: Do not feed the indiana cryptid.\""
@@ -3636,7 +3636,7 @@ const cards: GameCard[] = [
     "rarity": "common",
     "cost": 3,
     "effects": {
-      "truthDelta": 1
+      "truthDelta": -1
     },
     "extId": "cryptids",
     "flavor": "\"CLASSIFIED INTELLIGENCE: Public bulletin: Do not feed the iowa cryptid.\""
@@ -3649,7 +3649,7 @@ const cards: GameCard[] = [
     "rarity": "common",
     "cost": 3,
     "effects": {
-      "truthDelta": 1
+      "truthDelta": -1
     },
     "extId": "cryptids",
     "flavor": "\"CLASSIFIED INTELLIGENCE: Public bulletin: Do not feed the kansas cryptid.\""
@@ -3662,7 +3662,7 @@ const cards: GameCard[] = [
     "rarity": "common",
     "cost": 3,
     "effects": {
-      "truthDelta": 1
+      "truthDelta": -1
     },
     "extId": "cryptids",
     "flavor": "\"CLASSIFIED INTELLIGENCE: Public bulletin: Do not feed the kelly–hopkinsville goblins.\""
@@ -3675,7 +3675,7 @@ const cards: GameCard[] = [
     "rarity": "common",
     "cost": 3,
     "effects": {
-      "truthDelta": 1
+      "truthDelta": -1
     },
     "extId": "cryptids",
     "flavor": "\"CLASSIFIED INTELLIGENCE: Public bulletin: Do not feed the rougarou.\""
@@ -3688,7 +3688,7 @@ const cards: GameCard[] = [
     "rarity": "common",
     "cost": 3,
     "effects": {
-      "truthDelta": 1
+      "truthDelta": -1
     },
     "extId": "cryptids",
     "flavor": "\"CLASSIFIED INTELLIGENCE: Public bulletin: Do not feed the maine cryptid.\""
@@ -3701,7 +3701,7 @@ const cards: GameCard[] = [
     "rarity": "common",
     "cost": 3,
     "effects": {
-      "truthDelta": 1
+      "truthDelta": -1
     },
     "extId": "cryptids",
     "flavor": "\"CLASSIFIED INTELLIGENCE: Public bulletin: Do not feed the snallygaster.\""
@@ -3714,7 +3714,7 @@ const cards: GameCard[] = [
     "rarity": "common",
     "cost": 3,
     "effects": {
-      "truthDelta": 1
+      "truthDelta": -1
     },
     "extId": "cryptids",
     "flavor": "\"CLASSIFIED INTELLIGENCE: Public bulletin: Do not feed the dover demon.\""
@@ -3727,7 +3727,7 @@ const cards: GameCard[] = [
     "rarity": "common",
     "cost": 3,
     "effects": {
-      "truthDelta": 1
+      "truthDelta": -1
     },
     "extId": "cryptids",
     "flavor": "\"CLASSIFIED INTELLIGENCE: Public bulletin: Do not feed the dogman.\""
@@ -3755,7 +3755,7 @@ const cards: GameCard[] = [
     "rarity": "common",
     "cost": 3,
     "effects": {
-      "truthDelta": 1
+      "truthDelta": -1
     },
     "extId": "cryptids",
     "flavor": "\"CLASSIFIED INTELLIGENCE: Public bulletin: Do not feed the mississippi cryptid.\""
@@ -3768,7 +3768,7 @@ const cards: GameCard[] = [
     "rarity": "common",
     "cost": 3,
     "effects": {
-      "truthDelta": 1
+      "truthDelta": -1
     },
     "extId": "cryptids",
     "flavor": "\"CLASSIFIED INTELLIGENCE: Public bulletin: Do not feed the missouri cryptid.\""
@@ -3781,7 +3781,7 @@ const cards: GameCard[] = [
     "rarity": "common",
     "cost": 3,
     "effects": {
-      "truthDelta": 1
+      "truthDelta": -1
     },
     "extId": "cryptids",
     "flavor": "\"CLASSIFIED INTELLIGENCE: Public bulletin: Do not feed the shunka warakin.\""
@@ -3794,7 +3794,7 @@ const cards: GameCard[] = [
     "rarity": "common",
     "cost": 3,
     "effects": {
-      "truthDelta": 1
+      "truthDelta": -1
     },
     "extId": "cryptids",
     "flavor": "\"CLASSIFIED INTELLIGENCE: Public bulletin: Do not feed the nebraska cryptid.\""
@@ -3807,7 +3807,7 @@ const cards: GameCard[] = [
     "rarity": "common",
     "cost": 3,
     "effects": {
-      "truthDelta": 1
+      "truthDelta": -1
     },
     "extId": "cryptids",
     "flavor": "\"CLASSIFIED INTELLIGENCE: Public bulletin: Do not feed the tahoe tessie.\""
@@ -3820,7 +3820,7 @@ const cards: GameCard[] = [
     "rarity": "common",
     "cost": 3,
     "effects": {
-      "truthDelta": 1
+      "truthDelta": -1
     },
     "extId": "cryptids",
     "flavor": "\"CLASSIFIED INTELLIGENCE: Public bulletin: Do not feed the wood devils.\""
@@ -3863,7 +3863,7 @@ const cards: GameCard[] = [
     "rarity": "common",
     "cost": 3,
     "effects": {
-      "truthDelta": 1
+      "truthDelta": -1
     },
     "extId": "cryptids",
     "flavor": "\"CLASSIFIED INTELLIGENCE: Public bulletin: Do not feed the montauk monster.\""
@@ -3876,7 +3876,7 @@ const cards: GameCard[] = [
     "rarity": "common",
     "cost": 3,
     "effects": {
-      "truthDelta": 1
+      "truthDelta": -1
     },
     "extId": "cryptids",
     "flavor": "\"CLASSIFIED INTELLIGENCE: Public bulletin: Do not feed the north carolina cryptid.\""
@@ -3889,7 +3889,7 @@ const cards: GameCard[] = [
     "rarity": "common",
     "cost": 3,
     "effects": {
-      "truthDelta": 1
+      "truthDelta": -1
     },
     "extId": "cryptids",
     "flavor": "\"CLASSIFIED INTELLIGENCE: Public bulletin: Do not feed the north dakota cryptid.\""
@@ -3902,7 +3902,7 @@ const cards: GameCard[] = [
     "rarity": "common",
     "cost": 3,
     "effects": {
-      "truthDelta": 1
+      "truthDelta": -1
     },
     "extId": "cryptids",
     "flavor": "\"CLASSIFIED INTELLIGENCE: Public bulletin: Do not feed the loveland frogman.\""
@@ -3915,7 +3915,7 @@ const cards: GameCard[] = [
     "rarity": "common",
     "cost": 3,
     "effects": {
-      "truthDelta": 1
+      "truthDelta": -1
     },
     "extId": "cryptids",
     "flavor": "\"CLASSIFIED INTELLIGENCE: Public bulletin: Do not feed the oklahoma cryptid.\""
@@ -3928,7 +3928,7 @@ const cards: GameCard[] = [
     "rarity": "common",
     "cost": 3,
     "effects": {
-      "truthDelta": 1
+      "truthDelta": -1
     },
     "extId": "cryptids",
     "flavor": "\"CLASSIFIED INTELLIGENCE: Public bulletin: Do not feed the bigfoot.\""
@@ -3941,7 +3941,7 @@ const cards: GameCard[] = [
     "rarity": "common",
     "cost": 3,
     "effects": {
-      "truthDelta": 1
+      "truthDelta": -1
     },
     "extId": "cryptids",
     "flavor": "\"CLASSIFIED INTELLIGENCE: Public bulletin: Do not feed the pennsylvania cryptid.\""
@@ -3954,7 +3954,7 @@ const cards: GameCard[] = [
     "rarity": "common",
     "cost": 3,
     "effects": {
-      "truthDelta": 1
+      "truthDelta": -1
     },
     "extId": "cryptids",
     "flavor": "\"CLASSIFIED INTELLIGENCE: Public bulletin: Do not feed the rhode island cryptid.\""
@@ -3967,7 +3967,7 @@ const cards: GameCard[] = [
     "rarity": "common",
     "cost": 3,
     "effects": {
-      "truthDelta": 1
+      "truthDelta": -1
     },
     "extId": "cryptids",
     "flavor": "\"CLASSIFIED INTELLIGENCE: Public bulletin: Do not feed the south carolina cryptid.\""
@@ -3980,7 +3980,7 @@ const cards: GameCard[] = [
     "rarity": "common",
     "cost": 3,
     "effects": {
-      "truthDelta": 1
+      "truthDelta": -1
     },
     "extId": "cryptids",
     "flavor": "\"CLASSIFIED INTELLIGENCE: Public bulletin: Do not feed the south dakota cryptid.\""
@@ -3993,7 +3993,7 @@ const cards: GameCard[] = [
     "rarity": "common",
     "cost": 3,
     "effects": {
-      "truthDelta": 1
+      "truthDelta": -1
     },
     "extId": "cryptids",
     "flavor": "\"CLASSIFIED INTELLIGENCE: Public bulletin: Do not feed the tennessee cryptid.\""
@@ -4021,7 +4021,7 @@ const cards: GameCard[] = [
     "rarity": "common",
     "cost": 3,
     "effects": {
-      "truthDelta": 1
+      "truthDelta": -1
     },
     "extId": "cryptids",
     "flavor": "\"CLASSIFIED INTELLIGENCE: Public bulletin: Do not feed the utah cryptid.\""
@@ -4034,7 +4034,7 @@ const cards: GameCard[] = [
     "rarity": "common",
     "cost": 3,
     "effects": {
-      "truthDelta": 1
+      "truthDelta": -1
     },
     "extId": "cryptids",
     "flavor": "\"CLASSIFIED INTELLIGENCE: Public bulletin: Do not feed the champ.\""
@@ -4047,7 +4047,7 @@ const cards: GameCard[] = [
     "rarity": "common",
     "cost": 3,
     "effects": {
-      "truthDelta": 1
+      "truthDelta": -1
     },
     "extId": "cryptids",
     "flavor": "\"CLASSIFIED INTELLIGENCE: Public bulletin: Do not feed the virginia cryptid.\""
@@ -4060,7 +4060,7 @@ const cards: GameCard[] = [
     "rarity": "common",
     "cost": 3,
     "effects": {
-      "truthDelta": 1
+      "truthDelta": -1
     },
     "extId": "cryptids",
     "flavor": "\"CLASSIFIED INTELLIGENCE: Public bulletin: Do not feed the bigfoot.\""
@@ -4103,7 +4103,7 @@ const cards: GameCard[] = [
     "rarity": "common",
     "cost": 3,
     "effects": {
-      "truthDelta": 1
+      "truthDelta": -1
     },
     "extId": "cryptids",
     "flavor": "\"CLASSIFIED INTELLIGENCE: Public bulletin: Do not feed the wyoming cryptid.\""
@@ -4148,7 +4148,7 @@ const cards: GameCard[] = [
     "rarity": "common",
     "cost": 3,
     "effects": {
-      "truthDelta": 1
+      "truthDelta": -1
     },
     "extId": "cryptids",
     "flavor": "\"CLASSIFIED INTELLIGENCE: Standard operating procedure, nothing to see.\""
@@ -4338,7 +4338,7 @@ const cards: GameCard[] = [
     "rarity": "common",
     "cost": 3,
     "effects": {
-      "truthDelta": 1
+      "truthDelta": -1
     },
     "extId": "cryptids",
     "flavor": "\"CLASSIFIED INTELLIGENCE: Standard operating procedure, nothing to see.\""


### PR DESCRIPTION
## Summary
- flip the truthDelta values for all government media cards in the Cryptids MVP source to be negative
- mirror the negative truthDelta adjustments in the published Cryptids extension JSON for deployment parity

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dcb39b9608832083cdb13ab9ea0eb6