### PR TITLE
Preserve state bonus assignments across rounds

### DIFF
--- a/src/hooks/useGameState.ts
+++ b/src/hooks/useGameState.ts
@@ -37,6 +37,7 @@ import { getComboSettings } from '@/game/comboEngine';
 import type {
   ActiveCampaignArcState,
   ActiveParanormalHotspot,
+  ActiveStateBonus,
   GameState,
   PendingCampaignArcEvent,
   StateEventBonusSummary,
@@ -2595,6 +2596,16 @@ export const useGameState = (aiDifficultyOverride?: AIDifficulty) => {
       };
 
       if (nextState.lastStateBonusRound !== nextState.round) {
+        const existingBonuses = nextState.states.reduce<Record<string, ActiveStateBonus | null | undefined>>(
+          (acc, state) => {
+            if (state.activeStateBonus) {
+              acc[state.abbreviation] = state.activeStateBonus;
+            }
+            return acc;
+          },
+          {},
+        );
+
         const assignment = assignStateBonuses({
           states: nextState.states.map(state => ({
             id: state.id,
@@ -2605,6 +2616,7 @@ export const useGameState = (aiDifficultyOverride?: AIDifficulty) => {
           baseSeed: nextState.stateRoundSeed,
           round: nextState.round,
           playerFaction: nextState.faction,
+          existingBonuses,
         });
 
         nextState = applyStateBonusAssignmentToState(nextState, assignment);


### PR DESCRIPTION
## Summary
- reuse any stored state bonuses during round setup so states only roll new bonuses when they lack an assignment
- ensure state bonus application reuses stored effects, logging activations only when bonuses change hands while still applying per-round adjustments
- add regression coverage that simulates successive rounds to confirm bonuses persist and their effects continue to apply

## Testing
- bun test src/hooks/__tests__/stateBonusAssignment.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68dcccac90908320b80c5e0e68215729