### PR TITLE
Document state-themed pool catalog

### DIFF
--- a/docs/TECHNICAL_README.md
+++ b/docs/TECHNICAL_README.md
@@ -25,6 +25,179 @@ The runtime promotes story arcs and state-themed bonuses during the same end-of-
 
 State-themed bonuses use the same round gate. Each new round re-seeds the deterministic `stateRoundSeed`, builds a snapshot of existing bonuses, and only re-rolls assignments if the round counter has advanced.【F:src/hooks/useGameState.ts†L1483-L1494】【F:src/hooks/useGameState.ts†L2598-L2635】 `assignStateBonuses` hashes the base seed with the round number, reuses any `existingBonuses` for stability, and otherwise drafts weighted effects and anomaly events from each state’s themed pool while recording pressure/IP/Truth adjustments for the owning faction.【F:src/game/stateBonuses.ts†L63-L120】【F:src/game/stateBonuses.ts†L214-L284】 Finally, `applyStateBonusAssignmentToState` fans those results back into `GameState`: it extends the turn log, applies Truth/IP adjustments, updates per-state pressure and anomaly feeds, stamps `lastStateBonusRound`, and pipes any newspaper-ready events into the edition queue for UI consumption.【F:src/hooks/stateBonusAssignment.ts†L1-L83】 Debug hooks expose the seeded rolls in development builds so designers can verify reproducible outcomes across sessions.【F:src/hooks/useGameState.ts†L2624-L2632】
 
+#### State-themed pool reference
+The table below keeps designers out of TypeScript while they balance the weights and write new oddities. Each pool comes straight from `STATE_THEMED_POOLS`, grouped by tag label with the exact state identifiers, pulp headlines, and resource swings spelled out for quick audits.
+
+##### Cheyenne Listening Range (`WY`, `56`)
+**Bonuses**
+- `wy_bonus_black_helicopter_subsidy` — *FEDS TOP OFF UNMARKED HELICOPTERS OVER PRAIRIE* — Unlogged tankers hover in at dusk, topping off the clandestine fleet and leaving behind “truth fumes.” Effects: Truth +4, IP +1, Pressure +0.
+- `wy_bonus_bigfoot_cattle_congress` — *SASQUATCH UNIONIZES WYOMING CATTLE* — Ranchers wake to bovine picket lines patrolled by shaggy silhouettes whispering classified coordinates. Effects: Truth +2, IP +0, Pressure +1.
+- `wy_bonus_tourist_roadside_psychics` — *FORTUNE TELLERS SET UP MIRAGE CHECKPOINTS* — A caravan of neon campers performs aura screenings and leaks sanitized intel to any operative brave enough to stop. Effects: Truth +0, IP +2, Pressure +0.
+**Events**
+- `wy_event_thunder_basement` — *CHEYENNE HEARS DRUMBEAT BENEATH MAIN STREET* — Locals swear the silo complex below town is hosting a rave for remote viewers; everyone feels strangely patriotic. Effects: Truth +3, IP -1, Pressure +0.
+- `wy_event_skygrid_blackout` — *NORTHERN SKY BLINKS LIKE GLITCHING SPREADSHEET* — Constellations flicker, spelling out coordinates to anyone tuned to the right AM frequency; some agents get there first. Effects: Truth +1, IP +0, Pressure +2.
+- `wy_event_dusty_clone_convoy` — *IDENTICAL RANCHERS DRIVE IDENTICAL TRUCKS SOUTH* — A midnight convoy waves forged credentials and chants classified slogans out the windows. Effects: Truth +0, IP +2, Pressure +0.
+
+##### Bakken Riftline (`ND`, `38`)
+**Bonuses**
+- `nd_bonus_glow_derrick` — *RIG WORKERS REPORT “NIGHT-SHIFT AURAS”* — Entire crews emit chartreuse light and hear coded numbers in the drilling vibrations, boosting yield and belief. Effects: Truth +3, IP +0, Pressure +0.
+- `nd_bonus_fracked_memory` — *GROUNDWATER STARTS REMEMBERING PASSWORDS* — Kitchen faucets mutter login credentials for long-deleted agency accounts; quick listeners bank the intel. Effects: Truth +0, IP +2, Pressure +0.
+- `nd_bonus_satellite_seed_rain` — *MICROCHIP “HAIL” COATS FIELDS* — Debris from a spy satellite sprinkles firmware shards over the prairie, turbocharging surveillance harvests. Effects: Truth +1, IP +1, Pressure +0.
+**Events**
+- `nd_event_pipeline_echo` — *VALVES HUM “WE KNOW WHAT YOU DID”* — The mainline sings through the night, naming every operative who ever tapped the crude supply. Effects: Truth +2, IP +0, Pressure +0.
+- `nd_event_frozen_drone_yard` — *HUNDREDS OF DRONES FREEZE MID-TAKEOFF* — A winter microburst flash-freezes classified deliveries; whoever thaws them first gets the manifests. Effects: Truth +0, IP +2, Pressure +0.
+- `nd_event_williston_time_loop` — *DINER CLOCKS RUN BACKWARDS FOR ONE SHIFT* — Analysts rerun the same intel drop three times while skeptics wake up already convinced. Effects: Truth +1, IP +0, Pressure +1.
+
+##### Florida Manifold (`FL`, `12`)
+**Bonuses**
+- `fl_bonus_airboat_numbers` — *EVERGLADES TOUR GUIDE BROADCASTS PRIME NUMBERS* — Night rides pipe coded instructions through static loudspeakers synced with swamp fireflies. Effects: Truth +2, IP +1, Pressure +0.
+- `fl_bonus_motel_oracle` — *EXIT-7 MOTEL CLERK TELLS FUTURE, TAKES CASH* — Check-in ritual unlocks glimpses of next week’s cover-up while management insists he just “reads people well.” Effects: Truth +0, IP +3, Pressure +0.
+- `fl_bonus_tourist_ufo_ferry` — *PANHANDLE FERRY CROSSES TRIANGLE IN 12 MINUTES* — The route slices through a geometry glitch, catapulting operatives ahead of schedule and straight into soft targets. Effects: Truth +1, IP +0, Pressure +1.
+**Events**
+- `fl_event_reptilian_press_conference` — *STATE CAPITOL MICROPHONES HISS IN REPTO-SPEAK* — A televised briefing devolves into forked-tongue revelations before the feed mysteriously burns out. Effects: Truth +4, IP -1, Pressure +0.
+- `fl_event_themepark_blackout` — *MASCOTS FREEZE, EYES GLOW BLUE* — Animatronics lock into a perfect salute, projecting classified coordinates on the nearest rollercoaster. Effects: Truth +0, IP +2, Pressure +0.
+- `fl_event_citrus_psychic_bloom` — *ORANGE GROVES BLOSSOM WITH WIFI SIGNALS* — Harvest crews record hyper-clear dreams after squeezing the crop while rivals scramble to jam the orchard. Effects: Truth +2, IP +0, Pressure +1.
+
+##### Nevada Neon Occult (`NV`, `32`)
+**Bonuses**
+- `nv_bonus_slot_machine_divination` — *JACKPOTS SPELL OUT AGENCY CALL SIGNS* — High rollers pull triple oracle-7s and leave with more intel than chips as pit bosses comp the truth drinks. Effects: Truth +2, IP +1, Pressure +0.
+- `nv_bonus_desert_zeppelin_drop` — *BLIMP RAINS POLYGRAPH BALLOONS* — The night sky fills with helium truth orbs gently landing on suburban lawns, each a working interrogation rig. Effects: Truth +3, IP +0, Pressure +0.
+- `nv_bonus_area51_clearance_sale` — *SURPLUS HANGAR HOLDS “CLASSIFIED GARAGE SALE”* — Retired engineers dump prototypes at discount rates; savvy operatives snag cloaking blankets and EMP clipboards. Effects: Truth +0, IP +3, Pressure +0.
+**Events**
+- `nv_event_mirrorstorm` — *CASINO MIRRORS REFLECT ALTERNATE TIMELINE* — Reflections show tomorrow’s scandals; surveillance teams race to photograph the future before it blinks out. Effects: Truth +3, IP +0, Pressure +0.
+- `nv_event_coyote_oracle` — *PACK OF COYOTES HOWLS ENCRYPTED WEBSITES* — Desert radios light up with root passwords as field teams scramble to transcribe the chorus. Effects: Truth +0, IP +2, Pressure +0.
+- `nv_event_phantom_table_games` — *DEALERS SERVE INVISIBLE HIGH ROLLERS* — Roulette wheels spin themselves, landing on coordinates only insiders recognize. Effects: Truth +1, IP +0, Pressure +1.
+
+##### Jersey Megacorridor (`NJ`, `34`)
+**Bonuses**
+- `nj_bonus_turnpike_cb_rally` — *TRUCKERS JAM CHANNEL 19 WITH REDACTED RECIPES* — Rest stops hum with rigs swapping hush-hush intelligence disguised as slow-cooker gossip. Effects: Truth +2, IP +1, Pressure +0.
+- `nj_bonus_pharma_samples` — *REPS DUMP UNLABELED CASES AT WAREHOUSE B* — Overstock shipments hide morale boosters and memory serums that operatives requisition before the audit. Effects: Truth +0, IP +3, Pressure +0.
+- `nj_bonus_pine_barrens_signal` — *BLUE FLAMES SPELL OUT ROUTING NUMBERS* — Night hikers watch will-o’-wisps render clandestine bank transfers in the treetops. Effects: Truth +1, IP +0, Pressure +1.
+**Events**
+- `nj_event_turnpike_time_fog` — *EXIT 12 COVERED IN CLOCK-STOPPING MIST* — A luminescent fog halts time, letting operatives reposition surveillance vans in reversed traffic. Effects: Truth +2, IP +0, Pressure +0.
+- `nj_event_reststop_flashmob` — *JANITORS BREAK INTO CHOREOGRAPHED LEAK* — Molly Pitcher staff perform a whistleblower routine while drivers record and upload the scoop. Effects: Truth +1, IP +2, Pressure +0.
+- `nj_event_gwb_lightcode` — *GEORGE WASHINGTON BRIDGE BLINKS BINARY* — An 8-bit aurora uploads clearance keys to anyone stuck in traffic with a dashcam. Effects: Truth +0, IP +0, Pressure +2.
+
+##### Pacific Quantum Coast (`CA`, `WA`, `OR`, `AK`, `HI`)
+**Bonuses**
+- `pacific_bonus_tsunami_briefing_buoys` — *PACIFIC BUOY FLASHES TOP-SECRET WAVE ALERTS* — Buoy lights blink clearance codes in Morse while surfers nod solemnly and paddle toward the anomaly. Effects: Truth +2, IP +1, Pressure +0.
+- `pacific_bonus_seaweed_encryption_wrack` — *KELP WASHES UP SPELLED LIKE FILEPATHS* — Tidal mats arrange into login prompts and satellite keys before the tide rips them away. Effects: Truth +0, IP +2, Pressure +0.
+- `pacific_bonus_volcano_listening_post` — *KILAUEA STEAM RUMORS MATCH PENTAGON MINUTES* — Lava vents sigh transcripts of classified hearings while agents roast marshmallows and take notes. Effects: Truth +1, IP +0, Pressure +1.
+**Events**
+- `pacific_event_cascadia_sync_quake` — *EARTHQUAKE VIBRATES EXACTLY AT 440 HZ* — Windows rattle in tune from Seattle to San Diego, unlocking archives keyed to resonant desk drawers. Effects: Truth +2, IP +1, Pressure +0.
+- `pacific_event_aurora_bunker_ferry` — *ALASKAN FERRY DOCKS INSIDE SECRET GLACIER HANGAR* — A sudden aurora opens the glacier wall, and passengers disembark into a cache of surplus thermal bugs. Effects: Truth +0, IP +2, Pressure +0.
+- `pacific_event_pacific_whale_courier` — *MIGRATING WHALES TAP SOS IN SUBMARINE HULLS* — Pods thump hulls with vault coordinates before sounding deep-cover horns. Effects: Truth +1, IP +0, Pressure +1.
+
+##### Four Corners Echo (`AZ`, `UT`, `CO`, `NM`)
+**Bonuses**
+- `fourcorners_bonus_monument_projection` — *DESERT ARCHES PROJECT CLASSIFIED POWERPOINT* — Sunset light refracts through sandstone, finishing government briefings minus the reptile roll call. Effects: Truth +2, IP +1, Pressure +0.
+- `fourcorners_bonus_labyrinth_helicoid` — *UFO TOURISTS FORM PERFECT MAZE AROUND AREA RIDGE* — Pilgrims trace spirals in red dust, charging buried antennas that beam metadata into waiting briefcases. Effects: Truth +0, IP +2, Pressure +0.
+- `fourcorners_bonus_hot_spring_debrief` — *MOUNTAIN SPA OPENS “CLASSIFIED MINERAL” WING* — Agents in towels trade debriefs while geysers hiss encryption keys across the plateau. Effects: Truth +1, IP +0, Pressure +1.
+**Events**
+- `fourcorners_event_chaco_time_beacon` — *ANCIENT PUEBLO KIVA LIGHTS UP LIKE SERVER ROOM* — Stone walls pulse fiber-optic colors, syncing satellite passes and extending mission clocks. Effects: Truth +2, IP +1, Pressure +0.
+- `fourcorners_event_canyon_echo_court` — *JUDGES HOLD SECRET HEARING IN SLOT CANYON* — Sealed proceedings echo back stamped verdicts to operatives waiting on the rim. Effects: Truth +0, IP +2, Pressure +0.
+- `fourcorners_event_balloon_vortex_derby` — *FESTIVAL BALLOONS SPIN INTO PERFECT SURVEILLANCE ARRAY* — Hot-air pilots salute and broadcast raw reconnaissance straight into auditor holding pens. Effects: Truth +1, IP +0, Pressure +1.
+
+##### Mountain Thunderline (`MT`, `ID`, `WY`)
+**Bonuses**
+- `mountain_bonus_powder_cache_caravan` — *SNOWCATS DELIVER “AVALANCHE PREPAREDNESS” CRATES* — Mountain patrols haul unmarked containers uphill, leaving spare dossiers beside the trail mix. Effects: Truth +0, IP +2, Pressure +0.
+- `mountain_bonus_sasquatch_zoning_board` — *FOREST COUNCIL MEETING INCLUDES VERY TALL “RANGER”* — The board approves clandestine antenna farms with a unanimous grunt and hairy endorsement. Effects: Truth +2, IP +0, Pressure +1.
+- `mountain_bonus_idaho_tater_array` — *POTATO FARMS AIM SPUD-POWERED RADARS SKYWARD* — Irrigation rigs become spiral antennas that bake truth signals into every casserole. Effects: Truth +1, IP +1, Pressure +0.
+**Events**
+- `mountain_event_grizzly_signal_drill` — *RANGERS TRAIN BEARS TO DELIVER FLASH DRIVES* — Tagged grizzlies stroll into operations tents with USB collars, dropping undeniable footage. Effects: Truth +2, IP +0, Pressure +0.
+- `mountain_event_timberline_aurora` — *NORTHERN LIGHTS DESCEND TO SKI LODGE LOBBY* — Chandeliers glow green, aligning satphone channels so analysts siphon premium bandwidth all night. Effects: Truth +0, IP +2, Pressure +0.
+- `mountain_event_militia_podcast_marathon` — *TWENTY-FOUR HOURS OF “JUST ASKING QUESTIONS”* — Prepper broadcasters forget to mute the encrypted channel, gifting raw intel and a cult of auditors. Effects: Truth +1, IP +0, Pressure +1.
+
+##### High Plains Number Run (`ND`, `SD`, `NE`, `KS`)
+**Bonuses**
+- `plains_bonus_wheatfield_lasergrid` — *COMBINES CUT PERFECT QR CODES INTO CROPS* — Satellite flyovers decode glowing circuits and forward supply manifests straight into the bunker. Effects: Truth +0, IP +2, Pressure +0.
+- `plains_bonus_tornado_spotter_network` — *STORM CHASERS SHARE LIVE UFO ROSTER* — Volunteer spotters triangulate both cyclones and clandestine drop-points, faxing coordinates from pickup dashboards. Effects: Truth +2, IP +0, Pressure +1.
+- `plains_bonus_grain_elevator_townhall` — *SILO LOUDSPEAKERS HOST MIDNIGHT FOIA READING* — County clerks project censored documents across the prairie while locals clap politely. Effects: Truth +1, IP +1, Pressure +0.
+**Events**
+- `plains_event_blacksite_tractor_pull` — *COUNTY FAIR ANNOUNCES “CLASSIFIED” WEIGHT CLASS* — Hydraulic beasts drag mystery cargo across the arena, flinging open cases of leverage at the finish line. Effects: Truth +0, IP +2, Pressure +0.
+- `plains_event_floodlight_migration` — *MILLIONS OF FIREFLIES FORM TOP-SECRET FLIGHTPATH* — The glowing swarm charts hidden safehouses from Fargo to Topeka. Effects: Truth +2, IP +0, Pressure +0.
+- `plains_event_cornfield_conference_call` — *IRRIGATION PIVOTS BROADCAST 12-WAY COVER-UP* — Sprinkler arms click like switchboards, patching together decision-makers who forget the county is listening. Effects: Truth +1, IP +0, Pressure +1.
+
+##### Heartland Feedback Loop (`IA`, `MO`, `IL`, `IN`, `OH`)
+**Bonuses**
+- `heartland_bonus_mississippi_barge_brief` — *BARGES FORM FLOATING CLASSIFIED CONVOY* — Towboats sync horns in Morse, ferrying sealed crates of leverage upriver while reporters wave. Effects: Truth +2, IP +1, Pressure +0.
+- `heartland_bonus_factory_breakroom_tipline` — *AUTOMAKERS INSTALL “ANONYMOUS GOSSIP” BUTTON* — Coffee machines dispense latte art featuring classified schematics everyone pretends is foam. Effects: Truth +0, IP +2, Pressure +0.
+- `heartland_bonus_rail_yard_gospel_choir` — *TRAIN WORKERS SING SCHEDULES TO HEAVEN* — Harmony lines reveal troop movements and caucus times; recordings sell out before the encore. Effects: Truth +1, IP +0, Pressure +1.
+**Events**
+- `heartland_event_siloed_votes_recount` — *COUNTY FAIR BLUE-RIBBON BOOTHS DEMAND AUDIT* — Prize pies hide ballots exposing clandestine caucus tallies, forcing bureaucrats to eat humble pie. Effects: Truth +2, IP +0, Pressure +0.
+- `heartland_event_rustbelt_lightning_strike` — *ABANDONED FACTORY TAKES DIRECT HIT, BOOTS BACK UP* — Machines whir alive, printing decades of sealed expense reports while tourists film the sparks. Effects: Truth +0, IP +2, Pressure +0.
+- `heartland_event_cornbelt_call_in_show` — *LATE-NIGHT AM HOST GIVES OUT PARKING GARAGE KEYS* — Listeners dial in, receive directions to hush-hush meetings, and arrive before the spin doctors. Effects: Truth +1, IP +0, Pressure +1.
+
+##### Great Lakes Signal (`MI`, `WI`, `MN`)
+**Bonuses**
+- `lakes_bonus_ice_shanty_router` — *FROZEN LAKES HOST SECRET WI-FI HOTSPOTS* — Shanties glow midnight blue, bouncing encrypted podcasts to every operative willing to bait a hole. Effects: Truth +0, IP +2, Pressure +0.
+- `lakes_bonus_supersupper_briefing` — *FRIDAY FISH FRY ANNOUNCES “MYSTERY FILET SPECIAL”* — Community halls fry cod while a back-room projector spills sealed whistleblower footage. Effects: Truth +2, IP +0, Pressure +0.
+- `lakes_bonus_ore_freighter_maildrop` — *LAKE BOAT DUMPS LOCKER OF “MISPLACED” POUCHES* — Waterproof satchels bob ashore, each holding pristine intel wrapped in flannel napkins. Effects: Truth +1, IP +0, Pressure +1.
+**Events**
+- `lakes_event_aurora_coast_guard` — *NORTHERN LIGHTS TURN CUTTERS INTO BILLBOARDS* — Patrol ships glow neon, displaying tomorrow’s classified routes to every binocular on the beach. Effects: Truth +2, IP +1, Pressure +0.
+- `lakes_event_superior_mist_memory` — *DAWN FOG REPLAYS DELETED SECURITY FOOTAGE* — Mist screens show reruns of buried scandals until the sun dissolves the evidence. Effects: Truth +2, IP +0, Pressure +0.
+- `lakes_event_paulbunyan_press_gang` — *TWINS LEGEND RECRUITS OPERATIVES WITH AXE-INSPIRED NDA* — A giant mascot leads a halftime parade into a secure locker room loaded with press badges. Effects: Truth +0, IP +2, Pressure +0.
+
+##### Gulf Surge Protocol (`TX`, `LA`, `MS`, `AL`, `FL`)
+**Bonuses**
+- `gulf_bonus_refinery_confessional` — *OIL PLANT INSTALLS “SAFETY SUGGESTION” POD* — The booth records anonymous grievances that just happen to include off-book shipment ledgers. Effects: Truth +0, IP +3, Pressure +0.
+- `gulf_bonus_mardi_gras_mask_drop` — *PARADE KREWE THROWS CLASSIFIED LENTICULARS* — Throws include holographic dossiers and hush-money beads; catchers suddenly remember every off-shore account. Effects: Truth +2, IP +0, Pressure +1.
+- `gulf_bonus_shrimp_boat_sensor_net` — *TRAWLERS DRAG MILES OF BUGGED NETTING* — Every catch includes miniature black boxes chirping intercepted cabinet chatter over the deck speakers. Effects: Truth +1, IP +1, Pressure +0.
+**Events**
+- `gulf_event_hurricane_truthsirens` — *EVACUATION SIRENS BROADCAST BUDGET CUT SCANDAL* — Storm sirens belt a confession about siphoned relief funds; evacuees record before power returns. Effects: Truth +3, IP +0, Pressure +0.
+- `gulf_event_oilrig_lightning_rodeo` — *PLATFORMS COMPETE FOR BIGGEST STATIC DISCHARGE* — Blazing arcs brand the night sky with coordinates to supply caches hidden along the coastline. Effects: Truth +0, IP +2, Pressure +0.
+- `gulf_event_gator_press_pool` — *ALLIGATORS WEAR MEDIA BADGES AT SWAMP BRIEFING* — The reptiles record everything on waterproof lapel cams and dump it to an “anonymous” leak drive. Effects: Truth +1, IP +0, Pressure +1.
+
+##### Appalachian Whisper Network (`GA`, `SC`, `NC`, `TN`, `KY`, `VA`, `WV`)
+**Bonuses**
+- `appalachian_bonus_moonshine_modems` — *DISTILLERIES BOIL OFF ENCRYPTED BROADCASTS* — Copper coils hum with dial-up shrieks that decrypt into lists of corrupt subcommittees. Effects: Truth +2, IP +1, Pressure +0.
+- `appalachian_bonus_coaltrain_couriers` — *FREIGHT CREWS PASS ENVELOPES BETWEEN TUNNELS* — Each tunnel handoff drops untraceable intel packets into lunch pails bound for sympathetic clerks. Effects: Truth +0, IP +2, Pressure +0.
+- `appalachian_bonus_ballad_broadcast` — *FIDDLE JAM DOUBLES AS DECLASSIFIED SING-ALONG* — Local radio airs haunting harmonies that sneak truth into every porch conversation. Effects: Truth +1, IP +0, Pressure +1.
+**Events**
+- `appalachian_event_blue_ridge_bugbear` — *CRYPTID CRASHES COUNTY COMMISSION LIVE STREAM* — A mossy witness drops binders of receipts then vanishes, leaving viewers with irrefutable screen grabs. Effects: Truth +3, IP +0, Pressure +0.
+- `appalachian_event_thunderhead_signal` — *RIDGETOP STORM CLOUD BEAMS BLUEPRINTS IN LIGHTNING* — Bolts etch schematics across valley floors, empowering field teams overnight. Effects: Truth +0, IP +2, Pressure +0.
+- `appalachian_event_trail_of_leaks` — *HIKERS FIND QR CODES BURNED INTO SHELTER LOGBOOKS* — Every waypoint unlocks a dead drop with truth-saturated ration bars and unredacted memos. Effects: Truth +1, IP +0, Pressure +1.
+
+##### Capital Corridor Coverup (`DC`, `MD`, `DE`, `PA`, `NJ`)
+**Bonuses**
+- `capital_bonus_rotunda_soundcheck` — *CAPITOL TOUR GUIDE TESTS MIC WITH SECRET BUDGET LINE* — The echoing dome transmits itemized slush funds to anyone hiding behind the velvet rope. Effects: Truth +2, IP +1, Pressure +0.
+- `capital_bonus_beltway_badge_swap` — *COMMUTERS TRADE LANYARDS DURING GRIDLOCK* — Standstill traffic turns into a clearance bazaar arming operatives with high-value visitor passes. Effects: Truth +0, IP +2, Pressure +0.
+- `capital_bonus_boardwalk_blackmail` — *ATLANTIC CITY ARCADE DISPENSES “SOUVENIR” DOSSIERS* — Skee-ball jackpots spit sealed envelopes stuffed with deposition transcripts. Effects: Truth +1, IP +0, Pressure +1.
+**Events**
+- `capital_event_smithsonian_reclassification` — *MUSEUM RELABELS UFO AS “ARTIFACT OF BUREAUCRACY”* — The new placard links to a “mistakenly” public archive of coverups and hush payments. Effects: Truth +3, IP +0, Pressure +0.
+- `capital_event_delaware_shell_company_gala` — *WILMINGTON HOSTS INVISIBLE DONOR BANQUET* — Projected guests sign receipts that print midair before dropping onto every plate. Effects: Truth +0, IP +2, Pressure +0.
+- `capital_event_liberty_bell_push_notification` — *BELL CRACK FLASHES BREAKING NEWS ALERTS* — Every camera flash triggers headlines about suppressed hearings, sending spin doctors sprinting. Effects: Truth +1, IP +0, Pressure +1.
+
+##### Empire Codex Circuit (`NY`, `MA`, `CT`, `RI`)
+**Bonuses**
+- `empire_bonus_subway_manifesto` — *COMMUTERS HANDED FOLDERS LABELED “NOT FOR MEDIA”* — Rush-hour trains flood with pamphlets outlining clandestine mergers and reptilian board meetings. Effects: Truth +2, IP +1, Pressure +0.
+- `empire_bonus_ivy_league_footnote` — *FOOTNOTES IN JOURNAL REVEAL CLASSIFIED RESEARCH* — Academic citations hyperlink directly to redacted memos; grad students mirror the goods overnight. Effects: Truth +2, IP +0, Pressure +0.
+- `empire_bonus_harbor_beacon_swap` — *STATEN ISLAND FERRY LIGHT BLINKS STOCK TICKERS* — Lighthouses coordinate to flash insider trading alerts disguised as safety drills. Effects: Truth +0, IP +2, Pressure +0.
+**Events**
+- `empire_event_broadway_truth_revue` — *MATINEE CAST BREAKS INTO CLASSIFIED SHOWTUNE* — Spotlights reveal dossier photocopies raining from the rafters as ushers pass out NDAs. Effects: Truth +3, IP +0, Pressure +0.
+- `empire_event_boston_telex_regatta` — *ROWERS TOW FLOATING PRINTERS DOWN CHARLES* — Inkjet wakes spit oversight transcripts, giving every spectator a damp scoop. Effects: Truth +0, IP +2, Pressure +0.
+- `empire_event_ri_mob_family_reunion` — *FAMILY REUNION REGISTERS AS INTERNATIONAL TREATY* — Pentagonal tables release scent-activated truth serum across the banquet hall. Effects: Truth +1, IP +0, Pressure +1.
+
+##### Northern Rumor Coast (`ME`, `NH`, `VT`)
+**Bonuses**
+- `rumor_bonus_lobster_wiretap_coop` — *TRAPS PING SUBMARINE FREQUENCIES* — Boats haul crates of shell-bound transmitters repeating clandestine coastal agreements. Effects: Truth +2, IP +1, Pressure +0.
+- `rumor_bonus_maple_syrup_memory` — *SUGAR SHACK BARRELS STORE CLASSIFIED AUDIO* — Each pour leaks sweet recordings of closed-door caucuses; breakfast crowds sip and nod. Effects: Truth +2, IP +0, Pressure +0.
+- `rumor_bonus_white_mountain_retreat` — *SKI LODGE OFFERS “ANONYMIZED” PRESS PACKAGES* — Guests receive unmarked dossiers with their lift tickets, plus cocoa branded with riddles. Effects: Truth +0, IP +2, Pressure +0.
+**Events**
+- `rumor_event_portland_foghorn_archive` — *HARBOR FOGHORN PLAYS BACK CONGRESSIONAL VOICEMAIL* — Mournful blasts replay apology messages from senators trying to bury a deep-state audit. Effects: Truth +3, IP +0, Pressure +0.
+- `rumor_event_green_mountain_flash_mob` — *FARMERS MARKET FREEZES, PERFORMS DATA DROP* — Vendors spell encryption keys with heirloom carrots before handing over the receipts. Effects: Truth +0, IP +2, Pressure +0.
+- `rumor_event_whitecap_signal_boat` — *SAILBOARDS PAINT WAKE MESSAGES IN BIOLUMINESCENCE* — Glowing trails encode the next leak drop, broadcast worldwide before sunrise. Effects: Truth +1, IP +0, Pressure +1.
+
+##### Ozark Veil Syndicate (`AR`, `OK`, `MO`)
+**Bonuses**
+- `ozark_bonus_crystal_radio_cavern` — *CAVE CHOIR BROADCASTS FROM STALACTITE ANTENNAS* — Echoes channel truth through limestone, handing operatives perfect transcripts disguised as souvenir mixtapes. Effects: Truth +2, IP +1, Pressure +0.
+- `ozark_bonus_riverboat_intel_buffet` — *PADDLEWHEEL CASINO RUNS “UNMARKED DOCUMENT” CARVING STATION* — Buffet trays hide microfiche between ribs and coleslaw; diners leave sticky-fingered and briefed. Effects: Truth +0, IP +2, Pressure +0.
+- `ozark_bonus_thunderbird_tailgate` — *HIGHWAY REST STOP HOSTS CRYPTID FAN CLUB* — Enthusiasts swap Polaroids with embedded map overlays, fueling field teams with protein and intel. Effects: Truth +1, IP +0, Pressure +1.
+**Events**
+- `ozark_event_plateau_blackout` — *POWER GRID CUTS OUT DURING GOVERNOR’S BALL* — Chandeliers flicker Morse code revealing slush funds while guests slow-dance and record. Effects: Truth +2, IP +0, Pressure +0.
+- `ozark_event_route66_data_parade` — *CLASSIC CARS STREAM WIFI FROM TAILFINS* — Chrome convertibles blast an unfiltered data dump down the highway as confetti spells login credentials. Effects: Truth +0, IP +2, Pressure +0.
+- `ozark_event_bass_fishing_press_conference` — *ANGLERS HOIST MICROPHONES INSTEAD OF TROPHIES* — Winning teams reel in suitcases of deposition audio and hand copies to every bait-shop journalist. Effects: Truth +1, IP +0, Pressure +1.
+
 ### Catch-up swing math
 `computeTurnIpIncome` now layers a swing-tax/catch-up module on top of the existing reserve maintenance. The routine compares the active player's reserves and state holdings to their opponent and scores two separate gaps: IP and controlled states. Full steps beyond the grace windows generate modifiers according to the piecewise formula
 


### PR DESCRIPTION
## Summary
- document every state-themed pool under the campaign event manager section
- list the associated states plus their bonus and event effects with headlines and resource deltas

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dcd9b5ed7c832089d296cb2295bf60