### PR TITLE
Add pulsing hotspot animation with reduced motion support

### DIFF
--- a/src/components/game/EnhancedUSAMap.tsx
+++ b/src/components/game/EnhancedUSAMap.tsx
@@ -1028,8 +1028,27 @@ const EnhancedUSAMap: React.FC<EnhancedUSAMapProps> = ({
         .state-path.hotspot-active {
           stroke: rgba(74, 222, 128, 0.95);
           stroke-width: 3;
+          fill: rgba(74, 222, 128, 0.26);
           filter: drop-shadow(0 0 16px rgba(74, 222, 128, 0.55));
-          transition: filter 200ms ease, stroke 200ms ease;
+          transition: filter 200ms ease, stroke 200ms ease, fill-opacity 200ms ease;
+          animation: hotspotActivePulse 2.2s ease-in-out infinite;
+          mix-blend-mode: screen;
+        }
+
+        @keyframes hotspotActivePulse {
+          0%,
+          100% {
+            filter: drop-shadow(0 0 16px rgba(74, 222, 128, 0.55));
+            fill: rgba(74, 222, 128, 0.26);
+          }
+          45% {
+            filter: drop-shadow(0 0 22px rgba(74, 222, 128, 0.75));
+            fill: rgba(74, 222, 128, 0.34);
+          }
+          55% {
+            filter: drop-shadow(0 0 26px rgba(74, 222, 128, 0.9));
+            fill: rgba(74, 222, 128, 0.28);
+          }
         }
 
         .contested-radar {
@@ -1182,6 +1201,11 @@ const EnhancedUSAMap: React.FC<EnhancedUSAMapProps> = ({
           }
           .paranormal-hotspot-marker {
             animation: none !important;
+          }
+          .state-path.hotspot-active {
+            animation: none !important;
+            filter: drop-shadow(0 0 18px rgba(74, 222, 128, 0.7));
+            fill: rgba(74, 222, 128, 0.32);
           }
         }
 


### PR DESCRIPTION
## Summary
- add a translucent green fill and pulsing animation to hotspot-active map states
- introduce mix-blend styling and keyframes to keep ownership colors visible
- fall back to a static glow for users who prefer reduced motion

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dcea92898c8320b94d3e45c5c23aff