### PR TITLE
Fix event state requirement reference

### DIFF
--- a/src/hooks/useGameState.ts
+++ b/src/hooks/useGameState.ts
@@ -1997,7 +1997,7 @@ export const useGameState = (aiDifficultyOverride?: AIDifficulty) => {
                 eventStateContext.stateId,
                 eventStateContext.state,
                 eventStateContext.stateAbbreviation,
-                maybeEvent.conditions?.requiresState,
+                activeEvent.conditions?.requiresState,
               );
 
               if (truthDeltaFromEffects !== 0) {


### PR DESCRIPTION
## Summary
- use the in-scope active event when collecting state identifiers during event resolution to prevent undefined references

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dcfcc1f2fc83209459e07a183be0af