### PR TITLE
Align secret agenda difficulty across factions

### DIFF
--- a/src/components/game/SecretAgenda.tsx
+++ b/src/components/game/SecretAgenda.tsx
@@ -364,10 +364,20 @@ const SecretAgenda = ({ agenda, isPlayer = true }: SecretAgendaProps) => {
                 AI OBJECTIVE
               </h3>
             </div>
-            <span className={`flex items-center gap-1 rounded-full border px-2 py-0.5 text-[9px] font-bold uppercase tracking-wide ${statusClasses}`}>
-              {agenda.revealed ? <Eye size={10} /> : <Lock size={10} />}
-              {statusLabel}
-            </span>
+            <div className="flex items-center gap-2">
+              <span
+                className={`flex items-center gap-1 rounded-full border px-2 py-0.5 text-[9px] font-bold uppercase tracking-wide ${statusClasses}`}
+              >
+                {agenda.revealed ? <Eye size={10} /> : <Lock size={10} />}
+                {statusLabel}
+              </span>
+              <span
+                className={`rounded-full px-2 py-0.5 text-[9px] font-bold uppercase tracking-wide ${difficultyBadgeClass}`}
+                aria-label={`Secret agenda difficulty ${agenda.difficulty}`}
+              >
+                {agenda.difficulty.toUpperCase()}
+              </span>
+            </div>
           </div>
           {agenda.revealed ? (
             renderCompactContent()

--- a/src/data/agendaDatabase.ts
+++ b/src/data/agendaDatabase.ts
@@ -925,6 +925,7 @@ export const AGENDA_DATABASE: SecretAgenda[] = [
 export interface AgendaSelectionOptions {
   issueId?: string;
   excludeIds?: string[];
+  difficulty?: SecretAgenda['difficulty'];
 }
 
 export const getRandomAgenda = (
@@ -944,7 +945,15 @@ export const getRandomAgenda = (
   }
 
   const issueId = options?.issueId;
-  const weightedPool = factionAgendas.flatMap(agenda => {
+  const desiredDifficulty = options?.difficulty;
+  const difficultyMatchedAgendas = desiredDifficulty
+    ? factionAgendas.filter(agenda => agenda.difficulty === desiredDifficulty)
+    : factionAgendas;
+  const eligibleAgendas = difficultyMatchedAgendas.length > 0
+    ? difficultyMatchedAgendas
+    : factionAgendas;
+
+  const weightedPool = eligibleAgendas.flatMap(agenda => {
     const baseWeight = agenda.difficulty === 'easy'
       ? 4
       : agenda.difficulty === 'medium'
@@ -956,6 +965,10 @@ export const getRandomAgenda = (
     const effectiveWeight = Math.max(1, Math.round(baseWeight * multiplier));
     return Array.from({ length: effectiveWeight }, () => agenda);
   });
+
+  if (weightedPool.length === 0) {
+    return factionAgendas[Math.floor(Math.random() * factionAgendas.length)];
+  }
 
   return weightedPool[Math.floor(Math.random() * weightedPool.length)];
 };

--- a/src/hooks/gameStateTypes.ts
+++ b/src/hooks/gameStateTypes.ts
@@ -92,6 +92,7 @@ export interface GameState {
     revealed: boolean;
     stageId?: string;
   };
+  secretAgendaDifficulty?: SecretAgenda['difficulty'] | null;
   animating: boolean;
   aiTurnInProgress: boolean;
   selectedCard: string | null;

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -2350,6 +2350,19 @@ const Index = () => {
 
     return (
       <div className="secret-agenda rounded border border-newspaper-border bg-newspaper-bg p-3 shadow-sm">
+        {gameState.secretAgendaDifficulty && (
+          <div className="mb-2 flex flex-wrap items-center justify-between gap-2 text-[10px] uppercase tracking-[0.25em] text-newspaper-text/70">
+            <span className="font-semibold">Synced Agenda Difficulty</span>
+            <span className="font-mono text-newspaper-text">
+              {gameState.secretAgendaDifficulty.toUpperCase()}
+            </span>
+          </div>
+        )}
+        {gameState.secretAgendaDifficulty && aiAgenda && aiAgenda.difficulty !== gameState.secretAgendaDifficulty && (
+          <div className="mb-2 text-[10px] font-mono text-newspaper-text/60">
+            AI fallback difficulty: {aiAgenda.difficulty.toUpperCase()}
+          </div>
+        )}
         {content}
       </div>
     );


### PR DESCRIPTION
## Summary
- add an optional difficulty filter to secret agenda selection so weights stay within the requested tier when possible
- record the player agenda difficulty in game state and reuse it when rolling the AI agenda, updating logs and save restoration for synchronized difficulty (with fallback messaging)
- surface the shared agenda difficulty in the UI and show badges for hidden AI agendas so the sync is visible to players

## Testing
- npm run lint *(fails: pre-existing lint errors across unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68dd036b9a04832086759c536c35e7f7