### PR TITLE
feat: allow choosing secret agendas at game start

### DIFF
--- a/src/components/game/FactionSelectTabloid.tsx
+++ b/src/components/game/FactionSelectTabloid.tsx
@@ -1,18 +1,31 @@
 import { Card } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
+import type { SecretAgenda } from '@/data/agendaDatabase';
 
 interface FactionSelectTabloidProps {
-  onStartGame: (faction: 'government' | 'truth') => Promise<void>;
+  onStartGame: (faction: 'government' | 'truth', agendaId?: string) => Promise<void>;
   onFactionHover?: (faction: 'government' | 'truth' | null) => void;
   onBack: () => void;
   audio?: any;
+  agendas: {
+    government: SecretAgenda[];
+    truth: SecretAgenda[];
+  };
+  selectedAgendas: {
+    government: string | null;
+    truth: string | null;
+  };
+  onAgendaSelect?: (faction: 'government' | 'truth', value: string) => void;
 }
 
-const FactionSelectTabloid = ({ 
-  onStartGame, 
-  onFactionHover, 
-  onBack, 
-  audio 
+const FactionSelectTabloid = ({
+  onStartGame,
+  onFactionHover,
+  onBack,
+  audio,
+  agendas,
+  selectedAgendas,
+  onAgendaSelect,
 }: FactionSelectTabloidProps) => {
   const tabloidButtonClass = `
     w-full border-2 border-black bg-white text-black
@@ -24,11 +37,18 @@ const FactionSelectTabloid = ({
     focus:outline-none focus:ring-4 focus:ring-gray-300
   `;
 
+  const selectedGovernmentAgenda = selectedAgendas.government
+    ? agendas.government.find(agenda => agenda.id === selectedAgendas.government)
+    : undefined;
+  const selectedTruthAgenda = selectedAgendas.truth
+    ? agendas.truth.find(agenda => agenda.id === selectedAgendas.truth)
+    : undefined;
+
   return (
     <div className="min-h-screen bg-[var(--paper)] flex items-center justify-center p-4 md:p-8">
       <div className="max-w-[980px] mx-auto w-full">
         {/* Back Button */}
-        <Button 
+        <Button
           onClick={() => {
             audio?.playSFX?.('click');
             onBack();
@@ -68,10 +88,35 @@ const FactionSelectTabloid = ({
             <div className="aspect-[4/3] bg-[#e9e9e9] border-2 border-black mb-4">
               {/* Government building placeholder */}
             </div>
-            <Button 
+            <div className="mb-4 space-y-2">
+              <div className="text-[10px] font-black uppercase tracking-[0.3em] text-black/70">
+                SECRET AGENDA
+              </div>
+              <select
+                className="w-full border-2 border-black bg-white px-3 py-2 font-mono text-xs uppercase"
+                value={selectedAgendas.government ?? 'random'}
+                onChange={(event) => onAgendaSelect?.('government', event.target.value)}
+              >
+                <option value="random">RANDOM ASSIGNMENT</option>
+                {agendas.government.map(agenda => (
+                  <option key={agenda.id} value={agenda.id}>
+                    {agenda.title} ({agenda.difficulty.toUpperCase()})
+                  </option>
+                ))}
+              </select>
+              {selectedGovernmentAgenda && (
+                <Card className="border-2 border-dashed border-black/40 bg-[#f5f5f5] p-3 text-[11px] font-mono text-black">
+                  <p className="font-black uppercase tracking-wide text-[10px]">
+                    {selectedGovernmentAgenda.headline}
+                  </p>
+                  <p className="text-[11px] normal-case">{selectedGovernmentAgenda.description}</p>
+                </Card>
+              )}
+            </div>
+            <Button
               onClick={async () => {
                 audio?.playSFX?.('click');
-                await onStartGame('government');
+                await onStartGame('government', selectedAgendas.government ?? undefined);
               }}
               className={tabloidButtonClass}
             >
@@ -94,10 +139,35 @@ const FactionSelectTabloid = ({
             <div className="aspect-[4/3] bg-[#e9e9e9] border-2 border-black mb-4">
               {/* UFO + Bigfoot placeholder */}
             </div>
-            <Button 
+            <div className="mb-4 space-y-2">
+              <div className="text-[10px] font-black uppercase tracking-[0.3em] text-black/70">
+                SECRET AGENDA
+              </div>
+              <select
+                className="w-full border-2 border-black bg-white px-3 py-2 font-mono text-xs uppercase"
+                value={selectedAgendas.truth ?? 'random'}
+                onChange={(event) => onAgendaSelect?.('truth', event.target.value)}
+              >
+                <option value="random">RANDOM ASSIGNMENT</option>
+                {agendas.truth.map(agenda => (
+                  <option key={agenda.id} value={agenda.id}>
+                    {agenda.title} ({agenda.difficulty.toUpperCase()})
+                  </option>
+                ))}
+              </select>
+              {selectedTruthAgenda && (
+                <Card className="border-2 border-dashed border-black/40 bg-[#f5f5f5] p-3 text-[11px] font-mono text-black">
+                  <p className="font-black uppercase tracking-wide text-[10px]">
+                    {selectedTruthAgenda.headline}
+                  </p>
+                  <p className="text-[11px] normal-case">{selectedTruthAgenda.description}</p>
+                </Card>
+              )}
+            </div>
+            <Button
               onClick={async () => {
                 audio?.playSFX?.('click');
-                await onStartGame('truth');
+                await onStartGame('truth', selectedAgendas.truth ?? undefined);
               }}
               className={tabloidButtonClass}
             >

--- a/src/components/start/StartScreen.tsx
+++ b/src/components/start/StartScreen.tsx
@@ -4,7 +4,7 @@ import ArticleButton from './ArticleButton';
 import '@/styles/newspaper.css';
 
 type StartScreenProps = {
-  onStartGame: (faction: 'government' | 'truth') => void | Promise<void>;
+  onStartGame: (faction: 'government' | 'truth', agendaId?: string) => void | Promise<void>;
   onManageExpansions: () => void;
   onHowToPlay: () => void;
   onOptions: () => void;

--- a/src/hooks/useGameState.ts
+++ b/src/hooks/useGameState.ts
@@ -1425,7 +1425,7 @@ export const useGameState = (aiDifficultyOverride?: AIDifficulty) => {
     [achievements],
   );
 
-  const initGame = useCallback((faction: 'government' | 'truth') => {
+  const initGame = useCallback((faction: 'government' | 'truth', agendaId?: string) => {
     const startingTruth = 50;
     const startingIP = 5;
     const aiStartingIP = 5;
@@ -1447,7 +1447,13 @@ export const useGameState = (aiDifficultyOverride?: AIDifficulty) => {
     const initialControl = getInitialStateControl(faction);
     const issueDefinition = advanceAgendaIssue();
     const issueState = agendaIssueToState(issueDefinition);
-    const playerAgendaTemplate = getRandomAgenda(faction, { issueId: issueState.id });
+    const providedAgenda = agendaId ? getAgendaById(agendaId) : undefined;
+    const isAgendaCompatible = providedAgenda
+      ? providedAgenda.faction === faction || providedAgenda.faction === 'both'
+      : false;
+    const playerAgendaTemplate = isAgendaCompatible
+      ? providedAgenda!
+      : getRandomAgenda(faction, { issueId: issueState.id });
     const syncedAgendaDifficulty = playerAgendaTemplate.difficulty;
     const aiAgendaTemplate = getRandomAgenda(aiFaction, {
       issueId: issueState.id,
@@ -1549,6 +1555,7 @@ export const useGameState = (aiDifficultyOverride?: AIDifficulty) => {
         `Controlled states: ${initialControl.player.join(', ')}`,
         `Weekly Issue: ${issueState.label}`,
         `Issue Spotlight: ${issueState.description}`,
+        `Secret Agenda Assigned: ${playerAgendaTemplate.title} (${playerAgendaTemplate.difficulty.toUpperCase()})`,
         `Secret Agenda Difficulty Sync: ${syncedAgendaDifficulty.toUpperCase()}${aiAgendaFallback ? ` (AI fallback to ${aiAgendaFallback.toUpperCase()})` : ''}`,
       ],
       drawMode,

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -1934,7 +1934,7 @@ const Index = () => {
     }
   };
 
-  const startNewGame = async (faction: 'government' | 'truth') => {
+  const startNewGame = async (faction: 'government' | 'truth', agendaId?: string) => {
     console.log('🎵 Index: Starting new game with faction:', faction);
     persistFaction(faction);
     setVictoryState({ isVictory: false, type: null });
@@ -1942,7 +1942,7 @@ const Index = () => {
     setReadingEdition(null);
     setShowExtraEdition(false);
     setParanormalSightings([]);
-    await initGame(faction);
+    await initGame(faction, agendaId);
     setShowMenu(false);
     setShowIntro(false);
     audio.setGameplayMusic(faction);


### PR DESCRIPTION
## Summary
- let players pick a specific secret agenda during faction selection in both start menu variants
- thread the chosen agenda id through the start flow so game initialization uses it and syncs AI difficulty
- log the selected agenda at game start while keeping save/load compatibility

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dd09c38fd883209ce5647815b220d6