### PR TITLE
Update agenda documentation for parity improvements

### DIFF
--- a/public/how-to-play-mvp.md
+++ b/public/how-to-play-mvp.md
@@ -14,7 +14,7 @@ These same conditions apply to the AI, so watch its progress meters as closely a
 
 ## Factions & Setup
 1. **Choose a faction** (Truth Seekers or Government). Both sides begin at 50% Truth, 5 IP, and draw a five-card opening hand from a 40-card weighted deck tailored to their faction.
-2. **Receive a Secret Agenda** tied to the current Weekly Issue. Progress and completion are tracked in the right-hand panel, with optional reveals triggered by specific cards or events.
+2. **Pick your Secret Agenda** from the curated list tied to the current Weekly Issue. Each entry shows its difficulty tier and requirements so you can lock in the objective that fits your plan. Progress and completion are tracked in the right-hand panel, with optional reveals triggered by specific cards or events.
 3. **Map state control** starts neutral, so the first few turns focus on scouting, pressure, and setup plays.
 
 Hand size is capped at five cards by default, though combo bonuses and events can temporarily raise the draw cap.
@@ -43,9 +43,9 @@ Every state has a base IP yield, a defense value, and often a special bonus (tec
 Controlling specific clusters (e.g., Silicon Valley or Military Triangle) unlocks State Combination rewards such as cheaper MEDIA cards, extra card draw, flat IP income, or bonus defense. Track these bonuses in the State Synergy panel and adapt your route accordingly.
 
 ## Secret Agendas
-Agendas are faction-flavoured mini-campaigns ranging from holding themed regions to sustaining Truth streaks. Progress bars advance when you fulfil their listed triggers during play. Completing your agenda outranks every other win condition, so protect your own progress while scouting for the AI’s agenda tells.
+Agendas are faction-flavoured mini-campaigns ranging from holding themed regions to sustaining Truth streaks. Progress bars advance when you fulfil their listed triggers during play. Completing your agenda outranks every other win condition, so protect your own progress while scouting for the AI’s agenda tells. The roster has been expanded dramatically, so every faction and difficulty tier now surfaces multiple options during setup.
 
-Some events, cards, or investigative plays can expose the opponent’s agenda, revealing its target so you can plan a counter-strategy.
+Some events, cards, or investigative plays can expose the opponent’s agenda, revealing its target so you can plan a counter-strategy. When you lock in an agenda at the start of the game, the AI receives one from the same difficulty tier to keep the campaign fair—if the opposing faction lacks that tier the selector falls back to the nearest match and flags the change in the round log.
 
 ## Campaign & Anomalies
 Campaign storylines will occasionally override the random tabloids at the end of a round. When you see the 📖 log stamp in the Extra Edition, it means a campaign arc has advanced, and the next chapter is already queued to appear in a future paper—finale headlines close the loop and clear the queue entirely.【F:src/hooks/useGameState.ts†L204-L320】 State-themed bonuses resolve in the same window. Any state with an active bonus gets a glowing green intel panel in the map drawer that lists its icon, headline, and Truth/IP/pressure swings for the current round.【F:src/components/game/EnhancedUSAMap.tsx†L780-L820】 The blue “Current Anomalies” feed underneath only shows up while a faction actually controls the state, so neutral regions hide anomaly warnings until someone claims them.【F:src/components/game/EnhancedUSAMap.tsx†L821-L864】
@@ -60,5 +60,6 @@ Campaign storylines will occasionally override the random tabloids at the end of
 - Use MEDIA to push Truth toward your victory thresholds while denying the opponent their extremes.
 - Stack pressure across neighbouring states to threaten multiple captures and force defensive reactions.
 - Peek at agenda progress frequently; diverting a single play to deny the AI’s agenda can save the match.
+- Watch the Objectives button in the HUD—it now pulses softly whenever new agenda progress or objectives are waiting for review. Reduced-motion mode swaps the pulse for a static highlight so you still get the cue without the animation.
 
 Study the newspaper between rounds—the satire is optional, but the intel is real. Good luck, operative!


### PR DESCRIPTION
## Summary
- document the agenda difficulty parity plan in the technical guide, including expansion and UI notes
- update the how-to-play guide to cover agenda selection, expanded roster, fairness lock, and pulsing objectives cue

## Testing
- not run (documentation only)


------
https://chatgpt.com/codex/tasks/task_e_68dd021b6ad88320a9aa73514fb4f20f