### PR TITLE
Randomize active state events per campaign

### DIFF
--- a/src/hooks/useGameState.ts
+++ b/src/hooks/useGameState.ts
@@ -985,7 +985,7 @@ export const useGameState = (aiDifficultyOverride?: AIDifficulty) => {
   const aiDifficulty = resolveAiDifficulty(aiDifficultyOverride);
   const [eventManager] = useState(() => new EventManager());
   const achievements = useAchievements();
-  const { triggerStateEvent } = useStateEvents();
+  const { triggerStateEvent, resetStateEvents } = useStateEvents();
 
   const triggerCapturedStateEvents = useCallback(
     (resolution: CardPlayResolution | undefined, nextState: GameState): GameEvent[] => {
@@ -1466,6 +1466,8 @@ export const useGameState = (aiDifficultyOverride?: AIDifficulty) => {
     // Track game start in achievements
     achievements.onGameStart(faction, aiDifficulty);
     achievements.manager.onNewGameStart();
+    eventManager.reset();
+    resetStateEvents();
 
     gameSessionRef.current += 1;
     if (pendingAiTimeoutRef.current) {
@@ -1579,7 +1581,7 @@ export const useGameState = (aiDifficultyOverride?: AIDifficulty) => {
       },
       secretAgendaDifficulty: syncedAgendaDifficulty,
     }));
-  }, [achievements, aiDifficulty]);
+  }, [achievements, aiDifficulty, eventManager, resetStateEvents]);
 
   const playCard = useCallback((cardId: string, targetOverride?: string | null) => {
     setGameState(prev => {

--- a/src/hooks/useStateEvents.ts
+++ b/src/hooks/useStateEvents.ts
@@ -16,7 +16,7 @@ export const useStateEvents = () => {
   const { toast } = useToast();
 
   const triggerStateEvent = useCallback((
-    stateId: string, 
+    stateId: string,
     capturingFaction: 'truth' | 'government',
     gameState: Pick<GameState, 'states' | 'turn'>,
     statePosition?: { x: number; y: number }
@@ -63,10 +63,15 @@ export const useStateEvents = () => {
     eventManager.updateTurn(turn);
   }, [eventManager]);
 
+  const resetStateEvents = useCallback(() => {
+    eventManager.reset();
+  }, [eventManager]);
+
   return {
     triggerStateEvent,
     triggerContestedStateEffects,
     updateEventManagerTurn,
+    resetStateEvents,
     eventManager
   };
 };


### PR DESCRIPTION
## Summary
- shuffle each state's capture-event pool when the event manager resets and track the active selections for the session
- return only the randomized subset of state events instead of every entry
- expose a reset helper for state events and invoke both event manager resets when a new game starts so each campaign gets a unique mix

## Testing
- npm run lint *(fails: pre-existing lint violations in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68dd19eef1e48320829eb8b01b91ccba