### PR TITLE
Fix state event truth adjustments for government captures

### DIFF
--- a/src/hooks/__tests__/useGameState.stateEvents.test.ts
+++ b/src/hooks/__tests__/useGameState.stateEvents.test.ts
@@ -1,0 +1,386 @@
+import React from 'react';
+import { describe, expect, it, beforeEach, afterEach, afterAll, mock } from 'bun:test';
+import TestRenderer, { act } from 'react-test-renderer';
+
+type MockGameEvent = {
+  id: string;
+  title: string;
+  content: string;
+  type: string;
+  rarity: string;
+  weight: number;
+  effects?: {
+    truth?: number;
+    truthChange?: number;
+  };
+};
+
+const eventQueue: MockGameEvent[] = [];
+const stateEventQueue: Array<{ stateId: string; event: MockGameEvent }> = [];
+
+class MockEventManager {
+  maybeSelectRandomEvent(): MockGameEvent | null {
+    return eventQueue.shift() ?? null;
+  }
+
+  selectStateEvent(stateId: string): MockGameEvent | null {
+    if (!stateEventQueue.length) {
+      return null;
+    }
+
+    const index = stateEventQueue.findIndex(entry => entry.stateId === stateId);
+    const [match] = index >= 0 ? stateEventQueue.splice(index, 1) : stateEventQueue.splice(0, 1);
+    return match?.event ?? null;
+  }
+
+  updateTurn() {}
+
+  reset() {}
+}
+
+const pushMockStateEvent = (stateId: string, event: MockGameEvent) => {
+  stateEventQueue.push({ stateId, event });
+};
+
+const resetMockEvents = () => {
+  eventQueue.splice(0, eventQueue.length);
+  stateEventQueue.splice(0, stateEventQueue.length);
+};
+
+const createLocalStorageMock = (): Storage => {
+  const store = new Map<string, string>();
+  return {
+    get length() {
+      return store.size;
+    },
+    clear: () => {
+      store.clear();
+    },
+    getItem: (key: string) => (store.has(key) ? store.get(key)! : null),
+    key: (index: number) => Array.from(store.keys())[index] ?? null,
+    removeItem: (key: string) => {
+      store.delete(key);
+    },
+    setItem: (key: string, value: string) => {
+      store.set(key, value);
+    },
+  } as Storage;
+};
+
+if (typeof (globalThis as Partial<typeof globalThis>).localStorage === 'undefined') {
+  (globalThis as Partial<typeof globalThis>).localStorage = createLocalStorageMock();
+}
+
+mock.module('@/hooks/comboAdapter', () => ({
+  evaluateCombosForTurn: (state: any, owner: 'human' | 'ai') => ({
+    evaluation: { results: [] },
+    updatedTruth: state.truth,
+    truthDelta: 0,
+    updatedPlayerIp: owner === 'human' ? state.ip : state.aiIP,
+    updatedOpponentIp: owner === 'human' ? state.aiIP : state.ip,
+    logEntries: [],
+    fxMessages: [],
+  }),
+}));
+
+mock.module('@/ai/enhancedController', () => ({
+  chooseTurnActions: () => ({ actions: [], sequenceDetails: [] }),
+}));
+
+mock.module('@/hooks/aiTurnActions', () => ({
+  processAiActions: async () => ({ gameOver: false }),
+}));
+
+mock.module('@/data/aiFactory', () => ({
+  AIFactory: {
+    createStrategist: () => ({
+      personality: { name: 'Mock Strategist' },
+      recordAiPlayOutcome: () => {},
+    }),
+  },
+}));
+
+mock.module('@/contexts/AchievementContext', () => ({
+  useAchievements: () => ({
+    manager: {
+      onNewGameStart: () => {},
+    },
+    stats: {
+      total_states_controlled: 0,
+      max_states_controlled_single_game: 0,
+      max_ip_reached: 0,
+      max_truth_reached: 0,
+      min_truth_reached: 100,
+    },
+    unlockedAchievements: [],
+    lockedAchievements: [],
+    newlyUnlocked: [],
+    updateStats: () => {},
+    onGameStart: () => {},
+    onGameEnd: () => {},
+    onCardPlayed: () => {},
+    onCombosResolved: () => {},
+    exportData: () => ({}),
+    importData: () => true,
+    resetProgress: () => {},
+    clearNewlyUnlocked: () => {},
+  }),
+}));
+
+mock.module('@/data/eventDatabase', () => {
+  (globalThis as any).__pushMockStateEvent = pushMockStateEvent;
+  (globalThis as any).__resetMockEvents = resetMockEvents;
+
+  return {
+    EventManager: MockEventManager,
+    EVENT_DATABASE: [] as MockGameEvent[],
+    STATE_EVENTS_DATABASE: {} as Record<string, MockGameEvent[]>,
+    pushMockStateEvent,
+    resetMockEvents,
+  };
+});
+
+mock.module('@/hooks/useStateEvents', () => ({
+  useStateEvents: () => {
+    const eventManager = new MockEventManager();
+    return {
+      triggerStateEvent: (
+        stateId: string,
+        capturingFaction: 'truth' | 'government',
+        gameState: any,
+      ) => {
+        const event = eventManager.selectStateEvent(stateId);
+        if (!event) {
+          return null;
+        }
+
+        return {
+          stateId,
+          event,
+          capturingFaction,
+          triggeredOnTurn: typeof gameState.turn === 'number' ? Math.max(1, gameState.turn) : 1,
+        };
+      },
+      triggerContestedStateEffects: () => {},
+      updateEventManagerTurn: () => {},
+      resetStateEvents: () => {},
+      eventManager,
+    };
+  },
+}));
+
+mock.module('@/systems/cardResolution', () => ({
+  resolveCardMVP: (prev: any, card: any, targetState: string | null, owner: 'human' | 'ai') => {
+    const resolvedState = targetState
+      ? prev.states.find(
+          (state: any) =>
+            state.id === targetState
+            || state.abbreviation === targetState
+            || state.name === targetState,
+        )
+      : undefined;
+
+    const captureId = resolvedState?.id;
+    const updatedStates = prev.states.map((state: any) => {
+      if (captureId && state.id === captureId) {
+        const ownerLabel = owner === 'human' ? 'player' : 'ai';
+        return { ...state, owner: ownerLabel };
+      }
+      return { ...state };
+    });
+
+    const addControlledState = (states: string[], abbreviation: string | undefined) => {
+      if (!abbreviation) return states;
+      if (states.includes(abbreviation)) return states;
+      return [...states, abbreviation];
+    };
+
+    const controlledStates = owner === 'human' && resolvedState
+      ? addControlledState(prev.controlledStates, resolvedState.abbreviation)
+      : prev.controlledStates;
+    const aiControlledStates = owner === 'ai' && resolvedState
+      ? addControlledState(prev.aiControlledStates, resolvedState.abbreviation)
+      : prev.aiControlledStates;
+
+    return {
+      ip: prev.ip,
+      aiIP: prev.aiIP,
+      truth: prev.truth,
+      states: updatedStates,
+      controlledStates,
+      aiControlledStates,
+      capturedStateIds: captureId ? [captureId] : [],
+      targetState: captureId ?? null,
+      selectedCard: card?.id ?? null,
+      logEntries: [],
+      damageDealt: 0,
+    };
+  },
+}));
+
+declare module '@/data/eventDatabase' {
+  export function pushMockStateEvent(stateId: string, event: any): void;
+  export function resetMockEvents(): void;
+}
+
+import { useGameState } from '@/hooks/useGameState';
+import type { GameEvent } from '@/data/eventDatabase';
+
+const renderHook = <T,>(callback: () => T) => {
+  const result: { current: T | undefined } = { current: undefined };
+
+  const TestComponent = () => {
+    result.current = callback();
+    return null;
+  };
+
+  const renderer = TestRenderer.create(React.createElement(TestComponent));
+
+  return {
+    result,
+    rerender: () => renderer.update(React.createElement(TestComponent)),
+    unmount: () => renderer.unmount(),
+  };
+};
+
+describe('useGameState state event truth adjustments', () => {
+  const originalRandom = Math.random;
+
+  let pushStateEvent: (stateId: string, event: GameEvent) => void;
+  let resetEvents: () => void;
+
+  beforeEach(() => {
+    globalThis.localStorage = createLocalStorageMock();
+    pushStateEvent = (globalThis as any).__pushMockStateEvent as (stateId: string, event: GameEvent) => void;
+    resetEvents = (globalThis as any).__resetMockEvents as () => void;
+    resetEvents();
+    Math.random = () => 0;
+  });
+
+  afterEach(() => {
+    Math.random = originalRandom;
+    resetEvents();
+    if (!Reflect.deleteProperty(globalThis as Record<string, unknown>, 'localStorage')) {
+      (globalThis as Partial<typeof globalThis>).localStorage = undefined;
+    }
+  });
+
+  afterAll(() => {
+    mock.restore();
+  });
+
+  it('raises truth for the Truth faction when capturing a bonus state event', async () => {
+    const hook = renderHook(() => useGameState());
+
+    await act(async () => {
+      hook.result.current?.initGame('truth');
+    });
+
+    const initialState = hook.result.current?.gameState;
+    expect(initialState).toBeDefined();
+    if (!initialState) return;
+
+    const [firstCard] = initialState.hand;
+    expect(firstCard).toBeDefined();
+    if (!firstCard) return;
+
+    await act(async () => {
+      hook.result.current?.setGameState(prev => ({
+        ...prev,
+        ip: 50,
+        hand: prev.hand.map((card, index) => (index === 0 ? { ...card, cost: 0 } : card)),
+      }));
+    });
+
+    const event: GameEvent = {
+      id: 'truth_rally',
+      title: 'Truth Rally',
+      content: 'Grassroots support surges.',
+      type: 'state',
+      rarity: 'common',
+      weight: 1,
+      effects: {
+        truth: 5,
+      },
+    } as GameEvent;
+
+    pushStateEvent('CA', event);
+
+    await act(async () => {
+      hook.result.current?.playCard(firstCard.id, 'CA');
+    });
+
+    const latestState = hook.result.current?.gameState;
+    expect(latestState).toBeDefined();
+    if (!latestState) return;
+
+    expect(latestState.truth).toBe(55);
+    expect(latestState.log.some(entry => entry.includes('Truth manipulation ↑'))).toBe(true);
+
+    const california = latestState.states.find(state => state.abbreviation === 'CA');
+    expect(california).toBeDefined();
+    if (!california) return;
+
+    const summaryEntry = california.stateEventHistory[california.stateEventHistory.length - 1];
+    expect(summaryEntry.effectSummary).toBeDefined();
+    expect(summaryEntry.effectSummary).toContain('Truth +5%');
+  });
+
+  it('reduces truth for the Government faction when capturing a bonus state event', async () => {
+    const hook = renderHook(() => useGameState());
+
+    await act(async () => {
+      hook.result.current?.initGame('government');
+    });
+
+    const initialState = hook.result.current?.gameState;
+    expect(initialState).toBeDefined();
+    if (!initialState) return;
+
+    const [firstCard] = initialState.hand;
+    expect(firstCard).toBeDefined();
+    if (!firstCard) return;
+
+    await act(async () => {
+      hook.result.current?.setGameState(prev => ({
+        ...prev,
+        ip: 50,
+        hand: prev.hand.map((card, index) => (index === 0 ? { ...card, cost: 0 } : card)),
+      }));
+    });
+
+    const event: GameEvent = {
+      id: 'coverup_sweep',
+      title: 'Cover-Up Sweep',
+      content: 'Suppress dissenting voices.',
+      type: 'state',
+      rarity: 'common',
+      weight: 1,
+      effects: {
+        truth: 5,
+      },
+    } as GameEvent;
+
+    pushStateEvent('CA', event);
+
+    await act(async () => {
+      hook.result.current?.playCard(firstCard.id, 'CA');
+    });
+
+    const latestState = hook.result.current?.gameState;
+    expect(latestState).toBeDefined();
+    if (!latestState) return;
+
+    expect(latestState.truth).toBe(45);
+    expect(latestState.log.some(entry => entry.includes('Truth manipulation ↓'))).toBe(true);
+
+    const california = latestState.states.find(state => state.abbreviation === 'CA');
+    expect(california).toBeDefined();
+    if (!california) return;
+
+    const summaryEntry = california.stateEventHistory[california.stateEventHistory.length - 1];
+    expect(summaryEntry.effectSummary).toBeDefined();
+    expect(summaryEntry.effectSummary).toContain('Truth -5%');
+  });
+});
+

--- a/src/hooks/useGameState.ts
+++ b/src/hooks/useGameState.ts
@@ -484,7 +484,13 @@ const cloneEventEffects = (
     : undefined;
 };
 
-const buildStateEventEffectSummary = (effects: GameEvent['effects'] | undefined): string[] => {
+const buildStateEventEffectSummary = (params: {
+  effects: GameEvent['effects'] | undefined;
+  faction: 'truth' | 'government';
+  truthDeltaOverride?: number | null;
+}): string[] => {
+  const { effects, faction, truthDeltaOverride } = params;
+
   if (!effects || typeof effects !== 'object') {
     return [];
   }
@@ -492,9 +498,16 @@ const buildStateEventEffectSummary = (effects: GameEvent['effects'] | undefined)
   const summary: string[] = [];
   const formatSigned = (value: number) => (value >= 0 ? `+${value}` : `${value}`);
 
-  const truthDelta = (effects.truth ?? 0) + (effects.truthChange ?? 0);
-  if (truthDelta) {
-    summary.push(`Truth ${formatSigned(truthDelta)}%`);
+  const hasTruthOverride = typeof truthDeltaOverride === 'number' && Number.isFinite(truthDeltaOverride);
+  const rawTruthDelta = (effects.truth ?? 0) + (effects.truthChange ?? 0);
+  const adjustedTruthDelta = hasTruthOverride
+    ? (truthDeltaOverride as number)
+    : faction === 'government'
+      ? -rawTruthDelta
+      : rawTruthDelta;
+
+  if (adjustedTruthDelta) {
+    summary.push(`Truth ${formatSigned(adjustedTruthDelta)}%`);
   }
 
   const ipDelta = (effects.ip ?? 0) + (effects.ipChange ?? 0);
@@ -541,8 +554,9 @@ const createStateEventBonusSummary = (params: {
   event: GameEvent;
   faction: 'truth' | 'government';
   turn: number;
+  truthDeltaOverride?: number | null;
 }): StateEventBonusSummary => {
-  const { event, faction, turn } = params;
+  const { event, faction, turn, truthDeltaOverride } = params;
   const labelSource = typeof event.title === 'string' && event.title.trim().length > 0
     ? event.title.trim()
     : typeof event.headline === 'string' && event.headline.trim().length > 0
@@ -554,7 +568,11 @@ const createStateEventBonusSummary = (params: {
       ? event.content.trim()
       : undefined;
   const effects = cloneEventEffects(event.effects);
-  const effectSummary = buildStateEventEffectSummary(event.effects);
+  const effectSummary = buildStateEventEffectSummary({
+    effects: effects ?? event.effects,
+    faction,
+    truthDeltaOverride,
+  });
 
   return {
     source: 'state-event',
@@ -601,12 +619,11 @@ const normalizeStateEventBonus = (
   const faction = data.faction === 'truth' || data.faction === 'government'
     ? data.faction
     : 'truth';
-  const effectSummary = Array.isArray(data.effectSummary)
-    ? data.effectSummary
-        .map(entry => (typeof entry === 'string' ? entry.trim() : ''))
-        .filter(entry => entry.length > 0)
-    : undefined;
   const effects = cloneEventEffects((data as { effects?: GameEvent['effects'] }).effects);
+  const recomputedSummary = buildStateEventEffectSummary({
+    effects: effects ?? (data as { effects?: GameEvent['effects'] }).effects,
+    faction,
+  });
 
   return {
     source: 'state-event',
@@ -616,7 +633,7 @@ const normalizeStateEventBonus = (
     triggeredOnTurn,
     faction,
     effects,
-    effectSummary: effectSummary && effectSummary.length > 0 ? effectSummary : undefined,
+    effectSummary: recomputedSummary.length > 0 ? recomputedSummary : undefined,
   } satisfies StateEventBonusSummary;
 };
 
@@ -1114,13 +1131,16 @@ export const useGameState = (aiDifficultyOverride?: AIDifficulty) => {
         const eventEffects = trigger.event.effects;
 
         let immediateDrawNote: string | null = null;
+        let adjustedTruthDeltaForSummary: number | undefined;
 
         if (eventEffects && typeof eventEffects === 'object') {
-          const truthDelta = (eventEffects.truth ?? 0) + (eventEffects.truthChange ?? 0);
-          if (truthDelta) {
+          const rawTruthDelta = (eventEffects.truth ?? 0) + (eventEffects.truthChange ?? 0);
+          const adjustedTruthDelta = capturingFaction === 'government' ? -rawTruthDelta : rawTruthDelta;
+          adjustedTruthDeltaForSummary = adjustedTruthDelta;
+          if (adjustedTruthDelta) {
             const truthMutation = { truth, log: [] as string[] };
             const truthActor = capturingFaction === nextState.faction ? 'human' : 'ai';
-            applyTruthDelta(truthMutation, truthDelta, truthActor);
+            applyTruthDelta(truthMutation, adjustedTruthDelta, truthActor);
             if (truthMutation.log.length > 0) {
               eventLogs.push(...truthMutation.log);
             }
@@ -1227,6 +1247,7 @@ export const useGameState = (aiDifficultyOverride?: AIDifficulty) => {
           event: trigger.event,
           faction: trigger.capturingFaction,
           turn: trigger.triggeredOnTurn,
+          truthDeltaOverride: adjustedTruthDeltaForSummary,
         });
         const updatedHistory = trimStateEventHistory([...targetState.stateEventHistory, summary]);
         targetState.stateEventHistory = updatedHistory;


### PR DESCRIPTION
## Summary
- adjust captured state event truth changes to flip for government captures and recompute summaries on load
- include faction-aware truth delta formatting when building state event bonus summaries
- add hook tests that cover truth and government captures and validate log/summary output

## Testing
- bun test src/hooks/__tests__/useGameState.stateEvents.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68dd21f76c708320a4131cd17de82889