### PR TITLE
Normalize card flavor text display

### DIFF
--- a/src/components/game/CardDetailOverlay.tsx
+++ b/src/components/game/CardDetailOverlay.tsx
@@ -10,7 +10,7 @@ import { useIsMobile } from '@/hooks/use-mobile';
 import { CardTextGenerator } from '@/systems/CardTextGenerator';
 import BaseCard from '@/components/game/cards/BaseCard';
 import { useUiTheme } from '@/hooks/useTheme';
-import { normalizeCardType as normalizeTabloidCardType } from '@/lib/cardUi';
+import { getFlavorText, normalizeCardType as normalizeTabloidCardType } from '@/lib/cardUi';
 import { cn } from '@/lib/utils';
 
 interface CardDetailOverlayProps {
@@ -157,7 +157,7 @@ const LegacyCardDetail: React.FC<CardDetailOverlayProps> = ({
 
   const faction = getLegacyFaction(card);
   const displayType = normalizeLegacyCardType(card.type);
-  const flavorText = card.flavor ?? card.flavorGov ?? card.flavorTruth ?? 'No intelligence available.';
+  const flavorText = getFlavorText(card) ?? 'No intelligence available.';
 
   return (
     <div
@@ -221,7 +221,7 @@ const LegacyCardDetail: React.FC<CardDetailOverlayProps> = ({
               CLASSIFIED INTELLIGENCE
             </h4>
             <div className="italic text-sm text-foreground border-l-4 border-truth-red bg-truth-red/10 rounded-r border border-truth-red/20 pl-3 pr-3 py-2 leading-relaxed">
-              "{flavorText}"
+              {flavorText}
             </div>
           </div>
 

--- a/src/components/game/cards/__tests__/BaseCard.flavor.test.tsx
+++ b/src/components/game/cards/__tests__/BaseCard.flavor.test.tsx
@@ -1,0 +1,60 @@
+import { describe, expect, test } from 'bun:test';
+import { create } from 'react-test-renderer';
+
+import type { GameCard } from '@/rules/mvp';
+
+const ensureLocalStorage = () => {
+  if (typeof globalThis.localStorage !== 'undefined') {
+    return;
+  }
+
+  const storage = new Map<string, string>();
+  globalThis.localStorage = {
+    getItem: key => (storage.has(key) ? storage.get(key)! : null),
+    setItem: (key, value) => {
+      storage.set(key, value);
+    },
+    removeItem: key => {
+      storage.delete(key);
+    },
+    clear: () => {
+      storage.clear();
+    },
+    key: index => Array.from(storage.keys())[index] ?? null,
+    get length() {
+      return storage.size;
+    },
+  } as Storage;
+};
+
+describe('BaseCard flavor text rendering', () => {
+  test('renders only a single CLASSIFIED INTELLIGENCE line for Chupacabra Protocol', async () => {
+    ensureLocalStorage();
+
+    const { BaseCard } = await import('../BaseCard');
+
+    const mockCard: GameCard = {
+      id: 'gov_chupacabra_protocol',
+      name: 'Chupacabra Protocol',
+      type: 'ATTACK',
+      faction: 'government',
+      rarity: 'uncommon',
+      cost: 7,
+      text: 'Opponent loses 3 IP.',
+      flavor: '"CLASSIFIED INTELLIGENCE: Chupacabra looked straight into the lens."',
+      effects: {
+        ipDelta: { opponent: -3 },
+      },
+    };
+
+    const renderer = create(<BaseCard card={mockCard} />);
+    const serialized = JSON.stringify(renderer.toJSON());
+
+    const occurrences = serialized.match(/CLASSIFIED INTELLIGENCE:/g)?.length ?? 0;
+
+    expect(occurrences).toBe(1);
+    expect(serialized).toContain('Chupacabra looked straight into the lens.');
+
+    renderer.unmount();
+  });
+});

--- a/src/lib/cardUi.ts
+++ b/src/lib/cardUi.ts
@@ -57,8 +57,23 @@ export const getRarityLabel = (rarity?: GameCard['rarity']): string => {
   return `${normalized} ${emoji}`.trim();
 };
 
+const QUOTE_CHARACTERS = /^["'“”‘’]+|["'“”‘’]+$/g;
+
+export const normalizeFlavorText = (text?: string | null): string | undefined => {
+  if (!text) return undefined;
+
+  let normalized = text.trim();
+  if (!normalized) return undefined;
+
+  normalized = normalized.replace(QUOTE_CHARACTERS, '').trim();
+  normalized = normalized.replace(/^CLASSIFIED INTELLIGENCE:\s*/i, '').trim();
+
+  return normalized || undefined;
+};
+
 export const getFlavorText = (card: GameCard): string | undefined => {
-  return card.flavor ?? card.flavorTruth ?? card.flavorGov ?? undefined;
+  const rawFlavor = card.flavor ?? card.flavorTruth ?? card.flavorGov ?? undefined;
+  return normalizeFlavorText(rawFlavor);
 };
 
 export const formatEffect = (card: GameCard): string => {


### PR DESCRIPTION
## Summary
- normalize card flavor text by removing surrounding quotes and redundant CLASSIFIED INTELLIGENCE prefixes
- reuse the normalized flavor text in the card detail overlay to avoid duplicate labeling
- add a regression test that ensures cards like Chupacabra Protocol only render one CLASSIFIED INTELLIGENCE line

## Testing
- bun test src/components/game/cards/__tests__/BaseCard.flavor.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68dd48f09fa483209d03cc75b8bc8582