### PR TITLE
Expand secret agenda reveals and highlight Files on the Loose

### DIFF
--- a/src/components/game/Newspaper.tsx
+++ b/src/components/game/Newspaper.tsx
@@ -393,48 +393,60 @@ const Newspaper = ({ events, playedCards, faction, onClose }: NewspaperProps) =>
             </Card>
 
             {/* Main Articles */}
-            {allArticles.slice(0, 4).map((article, index) => (
-              <article key={article.id} className="border-b-2 border-newspaper-border pb-4">
-                <h2 className={`text-3xl font-black mb-3 font-serif leading-tight ${
-                  article.isEvent 
-                    ? 'text-secret-red' 
-                    : 'text-newspaper-text hover:text-secret-red transition-colors cursor-pointer'
-                }`}>
-                  {article.headline}
-                </h2>
-                
-                {article.image && (
-                  <div className="w-full h-32 mb-3 border-2 border-newspaper-border overflow-hidden">
-                    <img 
-                      src={article.image} 
-                      alt={article.title}
-                      className="w-full h-full object-cover"
-                      onError={(e) => {
-                        e.currentTarget.src = '/placeholder-card.png';
-                      }}
-                    />
+            {allArticles.slice(0, 4).map((article, index) => {
+              const isFilesOnTheLoose = article.id === 'deepfile_dump_crochet_forum';
+              return (
+                <article
+                  key={article.id}
+                  className={`border-b-2 border-newspaper-border pb-4 ${
+                    isFilesOnTheLoose ? 'animate-pulse ring-2 ring-secret-red/70 shadow-[0_0_20px_rgba(248,113,113,0.4)] rounded-md px-3 py-2' : ''
+                  }`}
+                >
+                  <h2
+                    className={`text-3xl font-black mb-3 font-serif leading-tight ${
+                      article.isEvent
+                        ? 'text-secret-red'
+                        : 'text-newspaper-text hover:text-secret-red transition-colors cursor-pointer'
+                    } ${isFilesOnTheLoose ? 'drop-shadow-[0_0_18px_rgba(248,113,113,0.6)]' : ''}`}
+                  >
+                    {article.headline}
+                  </h2>
+
+                  {article.image && (
+                    <div className="w-full h-32 mb-3 border-2 border-newspaper-border overflow-hidden">
+                      <img
+                        src={article.image}
+                        alt={article.title}
+                        className="w-full h-full object-cover"
+                        onError={(e) => {
+                          e.currentTarget.src = '/placeholder-card.png';
+                        }}
+                      />
+                    </div>
+                  )}
+
+                  <p
+                    className={`leading-relaxed font-serif ${
+                      article.isEvent ? 'text-secret-red' : 'text-newspaper-text'
+                    } ${isFilesOnTheLoose ? 'animate-pulse drop-shadow-[0_0_12px_rgba(248,113,113,0.5)]' : ''}`}
+                  >
+                    {article.content}
+                  </p>
+
+                  {index === 0 && (
+                    <div className="mt-3 text-sm text-newspaper-text/70 italic">
+                      Continued on page A-{Math.floor(Math.random() * 20) + 1}...
+                      <span className="text-secret-red ml-2">[REMAINDER REDACTED]</span>
+                    </div>
+                  )}
+
+                  <div className="flex justify-between items-center mt-2 text-xs text-newspaper-text/60">
+                    <span>By: {article.isEvent ? 'Crisis Reporter' : 'Agent ████████'}</span>
+                    <span>Source: {article.isEvent ? 'EMERGENCY BROADCAST' : 'Classified Intel'}</span>
                   </div>
-                )}
-                
-                <p className={`leading-relaxed font-serif ${
-                  article.isEvent ? 'text-secret-red' : 'text-newspaper-text'
-                }`}>
-                  {article.content}
-                </p>
-                
-                {index === 0 && (
-                  <div className="mt-3 text-sm text-newspaper-text/70 italic">
-                    Continued on page A-{Math.floor(Math.random() * 20) + 1}... 
-                    <span className="text-secret-red ml-2">[REMAINDER REDACTED]</span>
-                  </div>
-                )}
-                
-                <div className="flex justify-between items-center mt-2 text-xs text-newspaper-text/60">
-                  <span>By: {article.isEvent ? 'Crisis Reporter' : 'Agent ████████'}</span>
-                  <span>Source: {article.isEvent ? 'EMERGENCY BROADCAST' : 'Classified Intel'}</span>
-                </div>
-              </article>
-            ))}
+                </article>
+              );
+            })}
           </div>
 
           {/* Sidebar - Takes up 1 column */}

--- a/src/components/game/TabloidNewspaperLegacy.tsx
+++ b/src/components/game/TabloidNewspaperLegacy.tsx
@@ -45,6 +45,7 @@ interface Article {
   isCard?: boolean;
   cardId?: string;
   player?: 'human' | 'ai';
+  eventId?: string;
 }
 
 const LegacyTabloidNewspaper = ({ events, playedCards, faction, truth, onClose }: TabloidNewspaperProps) => {
@@ -228,7 +229,8 @@ const LegacyTabloidNewspaper = ({ events, playedCards, faction, truth, onClose }
     const eventHeadlines = filteredEvents.map(event => ({
       headline: `🚨 ${event.headline || `BREAKING: ${event.title.toUpperCase()}`} 🚨`,
       content: `URGENT UPDATE: ${event.content} This developing story continues to unfold as authorities scramble to contain the situation.${formatGameEffects(event.effects)}`,
-      isEvent: true
+      isEvent: true,
+      eventId: event.id
     }));
     
     return eventHeadlines;
@@ -489,93 +491,106 @@ const LegacyTabloidNewspaper = ({ events, playedCards, faction, truth, onClose }
 
           {/* MAIN ARTICLES - True tabloid style */}
           <div className="space-y-8">
-            {selectedHeadlines.map((article, index) => (
-              <article key={index} className={`border-8 border-black bg-white p-6 shadow-lg transform ${
-                index % 2 === 0 ? 'rotate-0' : 'rotate-0'
-              } ${article.isEvent ? 'bg-red-50' : 'bg-white'}`}>
-                
-                {/* EVENT BADGE for event articles */}
-                {article.isEvent && (
-                  <div className="absolute -top-4 -right-4 bg-red-600 text-white px-4 py-2 border-4 border-black transform rotate-12 z-10">
-                    <span className="font-black text-lg" style={{ fontFamily: 'Anton, sans-serif' }}>EVENT</span>
-                  </div>
-                )}
-                
-                {/* MASSIVE TABLOID HEADLINE */}
-                <h2 className={`text-5xl md:text-7xl font-black mb-6 text-center leading-none transform -rotate-1 ${
-                  article.isEvent ? 'text-red-600 animate-pulse' : 'text-black'
-                } uppercase tracking-tight`} style={{ fontFamily: 'Anton, Impact, sans-serif' }}>
-                  {article.headline}
-                </h2>
-                
-                {/* Subtitle/Dek */}
-                <div className="text-center mb-6">
-                  <p className="text-lg italic text-gray-600 border-t-2 border-b-2 border-black py-2 bg-gray-100">
-                    {article.isEvent ? 'DEVELOPING STORY - AUTHORITIES BAFFLED' : 'EXCLUSIVE INVESTIGATION'}
-                  </p>
-                </div>
-                
-                {/* Article Layout with Tabloid Photo */}
-                <div className="grid md:grid-cols-4 gap-6">
-                  {/* TABLOID PHOTO - Left column */}
-                  <div className="md:col-span-2 relative">
-                    {article.isCard && article.cardId ? (
-                      <div className="relative border-8 border-black bg-white p-2 shadow-lg">
-                        <CardImage 
-                          cardId={article.cardId}
-                          className="w-full h-48 md:h-64 object-cover grayscale contrast-125 sepia-[0.2]"
-                        />
-                        <div className="absolute -bottom-2 -right-2 bg-black text-white text-xs px-3 py-2 font-bold border-4 border-white">
-                          CLASSIFIED DOCUMENT PHOTO
-                        </div>
-                        {/* Tape effect */}
-                        <div className="absolute -top-4 left-1/2 transform -translate-x-1/2 bg-yellow-200 border border-yellow-400 px-8 py-1 opacity-80">
-                          EVIDENCE
-                        </div>
-                      </div>
-                    ) : (
-                      <div className="border-8 border-black bg-black text-white h-48 md:h-64 flex items-center justify-center shadow-lg">
-                        <div className="text-center">
-                          <div className="text-4xl font-bold mb-2 animate-pulse" style={{ fontFamily: 'Anton, sans-serif' }}>
-                            [CLASSIFIED]
-                          </div>
-                          <div className="text-lg">PHOTO CENSORED</div>
-                        </div>
-                      </div>
-                    )}
-                  </div>
-                  
-                  {/* ARTICLE TEXT - Right columns */}
-                  <div className="md:col-span-2">
-                    <p className={`text-lg leading-relaxed font-serif ${
-                      article.isEvent ? 'text-red-800 font-bold' : 'text-black'
-                    } text-justify`}>
-                      {article.content}
+            {selectedHeadlines.map((article, index) => {
+              const isFilesOnTheLoose = article.eventId === 'deepfile_dump_crochet_forum';
+              return (
+                <article
+                  key={index}
+                  className={`border-8 border-black bg-white p-6 shadow-lg transform ${
+                    index % 2 === 0 ? 'rotate-0' : 'rotate-0'
+                  } ${article.isEvent ? 'bg-red-50' : 'bg-white'} ${
+                    isFilesOnTheLoose ? 'animate-pulse ring-4 ring-red-500/80 shadow-[0_0_30px_rgba(248,113,113,0.5)]' : ''
+                  }`}
+                >
+
+                  {/* EVENT BADGE for event articles */}
+                  {article.isEvent && (
+                    <div className="absolute -top-4 -right-4 bg-red-600 text-white px-4 py-2 border-4 border-black transform rotate-12 z-10">
+                      <span className="font-black text-lg" style={{ fontFamily: 'Anton, sans-serif' }}>EVENT</span>
+                    </div>
+                  )}
+
+                  {/* MASSIVE TABLOID HEADLINE */}
+                  <h2
+                    className={`text-5xl md:text-7xl font-black mb-6 text-center leading-none transform -rotate-1 ${
+                      article.isEvent ? 'text-red-600 animate-pulse' : 'text-black'
+                    } ${isFilesOnTheLoose ? 'drop-shadow-[0_0_22px_rgba(248,113,113,0.7)]' : ''} uppercase tracking-tight`}
+                    style={{ fontFamily: 'Anton, Impact, sans-serif' }}
+                  >
+                    {article.headline}
+                  </h2>
+
+                  {/* Subtitle/Dek */}
+                  <div className="text-center mb-6">
+                    <p className="text-lg italic text-gray-600 border-t-2 border-b-2 border-black py-2 bg-gray-100">
+                      {article.isEvent ? 'DEVELOPING STORY - AUTHORITIES BAFFLED' : 'EXCLUSIVE INVESTIGATION'}
                     </p>
-                    
-                    {/* Continuation notice */}
-                    {index === 0 && (
-                      <div className="mt-4 p-3 bg-yellow-100 border-4 border-black transform rotate-1">
-                        <div className="text-sm text-gray-800 italic text-center">
-                          Continued on page A-{Math.floor(Math.random() * 20) + 1}... 
-                          <span className="text-red-600 ml-2 font-black">[REMAINDER CLASSIFIED]</span>
-                        </div>
-                      </div>
-                    )}
                   </div>
-                </div>
-                
-                {/* BYLINE AND SOURCE - Tabloid style */}
-                <div className="flex justify-between items-center mt-6 text-xs border-t-4 border-black pt-3 bg-gray-50 px-4 py-2">
-                  <span className="font-mono font-bold">
-                    By: {article.isEvent ? 'CRISIS REPORTER' : ['Agent X', 'Deep Throat Jr.', 'Anonymous Tipster', 'Florida Man'][Math.floor(Math.random() * 4)]}
-                  </span>
-                  <span className="font-mono">
-                    Source: {article.isEvent ? 'EMERGENCY BROADCAST' : ['Totally Reliable', 'My Cousin\'s Blog', 'Overheard at Denny\'s'][Math.floor(Math.random() * 3)]}
-                  </span>
-                </div>
-              </article>
-            ))}
+
+                  {/* ARTICLE LAYOUT WITH TABLOID PHOTO */}
+                  <div className="grid md:grid-cols-4 gap-6">
+                    {/* TABLOID PHOTO - Left column */}
+                    <div className="md:col-span-2 relative">
+                      {article.isCard && article.cardId ? (
+                        <div className="relative border-8 border-black bg-white p-2 shadow-lg">
+                          <CardImage
+                            cardId={article.cardId}
+                            className="w-full h-48 md:h-64 object-cover grayscale contrast-125 sepia-[0.2]"
+                          />
+                          <div className="absolute -bottom-2 -right-2 bg-black text-white text-xs px-3 py-2 font-bold border-4 border-white">
+                            CLASSIFIED DOCUMENT PHOTO
+                          </div>
+                          {/* Tape effect */}
+                          <div className="absolute -top-4 left-1/2 transform -translate-x-1/2 bg-yellow-200 border border-yellow-400 px-8 py-1 opacity-80">
+                            EVIDENCE
+                          </div>
+                        </div>
+                      ) : (
+                        <div className="border-8 border-black bg-black text-white h-48 md:h-64 flex items-center justify-center shadow-lg">
+                          <div className="text-center">
+                            <div className="text-4xl font-bold mb-2 animate-pulse" style={{ fontFamily: 'Anton, sans-serif' }}>
+                              [CLASSIFIED]
+                            </div>
+                            <div className="text-lg">PHOTO CENSORED</div>
+                          </div>
+                        </div>
+                      )}
+                    </div>
+
+                    {/* ARTICLE TEXT - Right columns */}
+                    <div className="md:col-span-2">
+                      <p
+                        className={`text-lg leading-relaxed font-serif ${
+                          article.isEvent ? 'text-red-800 font-bold' : 'text-black'
+                        } ${isFilesOnTheLoose ? 'animate-pulse drop-shadow-[0_0_14px_rgba(248,113,113,0.45)]' : ''} text-justify`}
+                      >
+                        {article.content}
+                      </p>
+
+                      {/* Continuation notice */}
+                      {index === 0 && (
+                        <div className="mt-4 p-3 bg-yellow-100 border-4 border-black transform rotate-1">
+                          <div className="text-sm text-gray-800 italic text-center">
+                            Continued on page A-{Math.floor(Math.random() * 20) + 1}...
+                            <span className="text-red-600 ml-2 font-black">[REMAINDER CLASSIFIED]</span>
+                          </div>
+                        </div>
+                      )}
+                    </div>
+                  </div>
+
+                  {/* BYLINE AND SOURCE - Tabloid style */}
+                  <div className="flex justify-between items-center mt-6 text-xs border-t-4 border-black pt-3 bg-gray-50 px-4 py-2">
+                    <span className="font-mono font-bold">
+                      By: {article.isEvent ? 'CRISIS REPORTER' : ['Agent X', 'Deep Throat Jr.', 'Anonymous Tipster', 'Florida Man'][Math.floor(Math.random() * 4)]}
+                    </span>
+                    <span className="font-mono">
+                      Source: {article.isEvent ? 'EMERGENCY BROADCAST' : ['Totally Reliable', 'My Cousin\'s Blog', 'Overheard at Denny\'s'][Math.floor(Math.random() * 3)]}
+                    </span>
+                  </div>
+                </article>
+              );
+            })}
           </div>
           
           {/* TABLOID ADS SECTION - Bottom of page */}

--- a/src/components/game/TabloidNewspaperV2.tsx
+++ b/src/components/game/TabloidNewspaperV2.tsx
@@ -674,6 +674,7 @@ const TabloidNewspaperV2 = ({
   );
 
   const heroIsEvent = Boolean(heroEvent);
+  const heroIsFilesOnTheLoose = heroEvent?.id === 'deepfile_dump_crochet_forum';
   const heroTypeLabel = heroArticle?.typeLabel
     ?? (heroEvent ? `[${(heroEvent.type ?? 'Event').toUpperCase()}]` : comboReport ? '[PLAYER HIGHLIGHT]' : '[STATUS BRIEF]');
   const heroTarget = heroArticle?.stateLabel ?? (heroEvent ? null : comboOwnerLabel ?? null);
@@ -1001,14 +1002,20 @@ const TabloidNewspaperV2 = ({
                   <h2
                     className={`text-3xl font-black leading-tight sm:text-4xl ${
                       heroIsEvent ? 'text-secret-red' : 'text-newspaper-headline'
+                    } ${
+                      heroIsFilesOnTheLoose ? 'animate-pulse drop-shadow-[0_0_20px_rgba(248,113,113,0.65)]' : ''
                     }`}
                   >
                     {heroHeadline}
                   </h2>
                   <p
                     className={`text-lg font-semibold italic ${
-                      heroIsEvent ? 'text-secret-red/80' : 'text-newspaper-text/80'
-                    }`}
+                      heroIsEvent
+                        ? heroIsFilesOnTheLoose
+                          ? 'text-secret-red drop-shadow-[0_0_12px_rgba(248,113,113,0.55)]'
+                          : 'text-secret-red/80'
+                        : 'text-newspaper-text/80'
+                    } ${heroIsFilesOnTheLoose ? 'animate-pulse' : ''}`}
                   >
                     {heroSubhead}
                   </p>
@@ -1017,7 +1024,13 @@ const TabloidNewspaperV2 = ({
                     <span>{sourceLine}</span>
                   </div>
                   {heroIsEvent && (heroTriggerChance || heroConditionalChance) ? (
-                    <div className="flex flex-wrap gap-2 text-[10px] font-semibold uppercase tracking-wide text-secret-red/80">
+                    <div
+                      className={`flex flex-wrap gap-2 text-[10px] font-semibold uppercase tracking-wide ${
+                        heroIsFilesOnTheLoose
+                          ? 'text-secret-red animate-pulse drop-shadow-[0_0_12px_rgba(248,113,113,0.5)]'
+                          : 'text-secret-red/80'
+                      }`}
+                    >
                       {formatChance(heroTriggerChance) ? (
                         <span className="rounded border border-secret-red/50 px-2 py-0.5">
                           Chance This Turn: {formatChance(heroTriggerChance)}
@@ -1033,6 +1046,8 @@ const TabloidNewspaperV2 = ({
                   <div
                     className={`space-y-4 text-sm leading-relaxed ${
                       heroIsEvent ? 'text-secret-red/90' : ''
+                    } ${
+                      heroIsFilesOnTheLoose ? 'animate-pulse drop-shadow-[0_0_14px_rgba(248,113,113,0.4)]' : ''
                     }`}
                   >
                     {heroBody.map((paragraph, index) => (
@@ -1333,26 +1348,66 @@ const TabloidNewspaperV2 = ({
                 <section className="rounded-md border border-newspaper-border bg-white/70 p-4 shadow-sm">
                   <h3 className="mb-3 text-sm font-black uppercase tracking-wide text-secret-red">Event Wire</h3>
                   <div className="space-y-3 text-sm text-secret-red/90">
-                    {eventStories.slice(0, 3).map(story => (
-                      <div key={story.id} className="border-b border-dashed border-newspaper-border/60 pb-2 last:border-0 last:pb-0">
-                        <div className="text-[11px] font-semibold uppercase tracking-wide text-secret-red/80">{story.typeLabel}</div>
-                        <p className="font-semibold leading-snug text-secret-red">{story.headline}</p>
-                        <p className="text-xs italic text-secret-red/80">{story.subhead}</p>
-                        {formatChance(story.triggerChance) || formatChance(story.conditionalChance) ? (
-                          <div className="text-[10px] font-semibold uppercase tracking-wide text-secret-red/70">
-                            {formatChance(story.triggerChance) ? (
-                              <span>Chance This Turn: {formatChance(story.triggerChance)}</span>
-                            ) : null}
-                            {formatChance(story.triggerChance) && formatChance(story.conditionalChance) ? (
-                              <span> · </span>
-                            ) : null}
-                            {formatChance(story.conditionalChance) ? (
-                              <span>If Triggered: {formatChance(story.conditionalChance)}</span>
-                            ) : null}
+                    {eventStories.slice(0, 3).map(story => {
+                      const isFilesOnTheLoose = story.id === 'deepfile_dump_crochet_forum';
+                      return (
+                        <div
+                          key={story.id}
+                          className={`border-b border-dashed border-newspaper-border/60 pb-2 last:border-0 last:pb-0 ${
+                            isFilesOnTheLoose
+                              ? 'rounded-md bg-white/95 px-3 py-2 shadow-[0_0_20px_rgba(248,113,113,0.35)] ring-2 ring-secret-red/60'
+                              : ''
+                          }`}
+                        >
+                          <div
+                            className={`text-[11px] font-semibold uppercase tracking-wide ${
+                              isFilesOnTheLoose
+                                ? 'text-secret-red animate-pulse drop-shadow-[0_0_10px_rgba(248,113,113,0.65)]'
+                                : 'text-secret-red/80'
+                            }`}
+                          >
+                            {story.typeLabel}
                           </div>
-                        ) : null}
-                      </div>
-                    ))}
+                          <p
+                            className={`font-semibold leading-snug text-secret-red ${
+                              isFilesOnTheLoose
+                                ? 'animate-pulse drop-shadow-[0_0_16px_rgba(248,113,113,0.6)]'
+                                : ''
+                            }`}
+                          >
+                            {story.headline}
+                          </p>
+                          <p
+                            className={`text-xs italic ${
+                              isFilesOnTheLoose
+                                ? 'text-secret-red animate-pulse drop-shadow-[0_0_12px_rgba(248,113,113,0.5)]'
+                                : 'text-secret-red/80'
+                            }`}
+                          >
+                            {story.subhead}
+                          </p>
+                          {formatChance(story.triggerChance) || formatChance(story.conditionalChance) ? (
+                            <div
+                              className={`text-[10px] font-semibold uppercase tracking-wide ${
+                                isFilesOnTheLoose
+                                  ? 'text-secret-red animate-pulse drop-shadow-[0_0_10px_rgba(248,113,113,0.55)]'
+                                  : 'text-secret-red/70'
+                              }`}
+                            >
+                              {formatChance(story.triggerChance) ? (
+                                <span>Chance This Turn: {formatChance(story.triggerChance)}</span>
+                              ) : null}
+                              {formatChance(story.triggerChance) && formatChance(story.conditionalChance) ? (
+                                <span> · </span>
+                              ) : null}
+                              {formatChance(story.conditionalChance) ? (
+                                <span>If Triggered: {formatChance(story.conditionalChance)}</span>
+                              ) : null}
+                            </div>
+                          ) : null}
+                        </div>
+                      );
+                    })}
                   </div>
                 </section>
               ) : null}

--- a/src/data/core/government-batch-1.ts
+++ b/src/data/core/government-batch-1.ts
@@ -38,7 +38,8 @@ export const governmentBatch1: GameCard[] = [
     "effects": {
       "ipDelta": {
         "opponent": 2
-      }
+      },
+      "revealSecretAgenda": true
     },
     "flavor": "Democracy is great. Backups are greater.",
     "flavorTruth": "When democracy fails, what takes its place?",
@@ -116,7 +117,8 @@ export const governmentBatch1: GameCard[] = [
     "effects": {
       "ipDelta": {
         "opponent": 2
-      }
+      },
+      "revealSecretAgenda": true
     },
     "flavor": "They don't need badges when they have clipboards."
   },
@@ -142,7 +144,8 @@ export const governmentBatch1: GameCard[] = [
     "effects": {
       "ipDelta": {
         "opponent": 1
-      }
+      },
+      "revealSecretAgenda": true
     },
     "flavor": "Static is the sound of safety."
   },
@@ -192,7 +195,8 @@ export const governmentBatch1: GameCard[] = [
     "effects": {
       "ipDelta": {
         "opponent": 1
-      }
+      },
+      "revealSecretAgenda": true
     },
     "flavor": "If it beeped, we kept it."
   },

--- a/src/data/core/government-batch-2.ts
+++ b/src/data/core/government-batch-2.ts
@@ -11,7 +11,8 @@ export const governmentBatch2: GameCard[] = [
     "effects": {
       "ipDelta": {
         "opponent": 2
-      }
+      },
+      "revealSecretAgenda": true
     },
     "flavor": "Nobody remembers the encounter… and that's the point."
   },
@@ -61,7 +62,8 @@ export const governmentBatch2: GameCard[] = [
     "effects": {
       "ipDelta": {
         "opponent": 1
-      }
+      },
+      "revealSecretAgenda": true
     },
     "flavor": "Forms must be filed in triplicate, notarized, and burned."
   },
@@ -192,7 +194,8 @@ export const governmentBatch2: GameCard[] = [
     "effects": {
       "ipDelta": {
         "opponent": 2
-      }
+      },
+      "revealSecretAgenda": true
     },
     "flavor": "Always in the background, always adjusting his tie."
   },
@@ -266,7 +269,8 @@ export const governmentBatch2: GameCard[] = [
     "effects": {
       "ipDelta": {
         "opponent": 3
-      }
+      },
+      "revealSecretAgenda": true
     },
     "flavor": "One ring controls all."
   },

--- a/src/data/core/government-batch-3.ts
+++ b/src/data/core/government-batch-3.ts
@@ -24,7 +24,8 @@ export const governmentBatch3: GameCard[] = [
       "ipDelta": {
         "opponent": 3
       },
-      "discardOpponent": 1
+      "discardOpponent": 1,
+      "revealSecretAgenda": true
     },
     "flavor": "He shakes with one hand and pockets with the other."
   },
@@ -86,7 +87,8 @@ export const governmentBatch3: GameCard[] = [
     "rarity": "uncommon",
     "cost": 5,
     "effects": {
-      "pressureDelta": 2
+      "pressureDelta": 2,
+      "revealSecretAgenda": true
     },
     "flavor": "Bleach for inconvenient ink."
   },

--- a/src/data/core/truth-batch-1.ts
+++ b/src/data/core/truth-batch-1.ts
@@ -45,7 +45,8 @@ export const truthBatch1: GameCard[] = [
     "rarity": "uncommon",
     "cost": 4,
     "effects": {
-      "truthDelta": 3
+      "truthDelta": 3,
+      "revealSecretAgenda": true
     },
     "flavor": "His platform: windows with no curtains."
   },
@@ -121,7 +122,8 @@ export const truthBatch1: GameCard[] = [
     "rarity": "rare",
     "cost": 5,
     "effects": {
-      "truthDelta": 4
+      "truthDelta": 4,
+      "revealSecretAgenda": true
     },
     "flavor": "Ink smudges reveal more than black bars."
   },
@@ -171,7 +173,8 @@ export const truthBatch1: GameCard[] = [
     "effects": {
       "ipDelta": {
         "opponent": 1
-      }
+      },
+      "revealSecretAgenda": true
     },
     "flavor": "Phones are better than binoculars."
   },
@@ -200,7 +203,8 @@ export const truthBatch1: GameCard[] = [
       "ipDelta": {
         "opponent": 3,
         "opponentPercent": 0.08
-      }
+      },
+      "revealSecretAgenda": true
     },
     "flavor": "The squeak heard round the world."
   },
@@ -236,7 +240,8 @@ export const truthBatch1: GameCard[] = [
     "rarity": "uncommon",
     "cost": 5,
     "effects": {
-      "pressureDelta": 2
+      "pressureDelta": 2,
+      "revealSecretAgenda": true
     },
     "flavor": "Rollback prices on cursed dolls."
   },
@@ -272,7 +277,8 @@ export const truthBatch1: GameCard[] = [
     "rarity": "uncommon",
     "cost": 5,
     "effects": {
-      "pressureDelta": 2
+      "pressureDelta": 2,
+      "revealSecretAgenda": true
     },
     "flavor": "Burning love, steady income."
   },

--- a/src/data/core/truth-batch-2.ts
+++ b/src/data/core/truth-batch-2.ts
@@ -11,7 +11,8 @@ export const truthBatch2: GameCard[] = [
     "effects": {
       "ipDelta": {
         "opponent": 1
-      }
+      },
+      "revealSecretAgenda": true
     },
     "flavor": "Security was no match for flip-flops and fury."
   },

--- a/src/data/core/truth-batch-3.ts
+++ b/src/data/core/truth-batch-3.ts
@@ -26,7 +26,8 @@ export const truthBatch3: GameCard[] = [
     "effects": {
       "ipDelta": {
         "opponent": 2
-      }
+      },
+      "revealSecretAgenda": true
     },
     "flavor": "If it's stamped 'secret', it's stapled to our to-do list."
   },
@@ -103,7 +104,8 @@ export const truthBatch3: GameCard[] = [
     "rarity": "rare",
     "cost": 5,
     "effects": {
-      "truthDelta": 3
+      "truthDelta": 3,
+      "revealSecretAgenda": true
     },
     "flavor": "Screams in AP style."
   },


### PR DESCRIPTION
## Summary
- expand the number of Truth and Government cards that grant `revealSecretAgenda`, ensuring each faction now has ten reveal tools available
- accentuate the "Files on the Loose" tabloid event in both newspaper implementations with pulsing red treatments so the reveal moment stands out

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dd4b05aa948320842825e0c5cd67dd