### PR TITLE
Align Final Edition layout with shared newspaper styling

### DIFF
--- a/src/components/game/ExtraEditionNewspaper.tsx
+++ b/src/components/game/ExtraEditionNewspaper.tsx
@@ -2,6 +2,13 @@ import { Card } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { X, Archive } from 'lucide-react';
 import FinalEditionLayout from '@/components/game/FinalEditionLayout';
+import { cn } from '@/lib/utils';
+import {
+  NEWSPAPER_BODY_CLASS,
+  NEWSPAPER_CARD_CLASS,
+  NEWSPAPER_HEADER_CLASS,
+  NEWSPAPER_META_CLASS,
+} from '@/components/game/newspaperLayout';
 import type { GameOverReport } from '@/types/finalEdition';
 
 interface ExtraEditionNewspaperProps {
@@ -14,17 +21,19 @@ interface ExtraEditionNewspaperProps {
 const ExtraEditionNewspaper = ({ report, onClose, onArchive, isArchived = false }: ExtraEditionNewspaperProps) => {
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-slate-950/90 p-6">
-      <div className="absolute inset-0 bg-[radial-gradient(circle_at_center,_rgba(56,189,248,0.15),_transparent_60%)]" aria-hidden />
-      <Card className="relative z-10 flex max-h-[92vh] w-full max-w-5xl flex-col overflow-hidden border border-emerald-500/40 bg-slate-950/95 shadow-[0_0_65px_rgba(56,189,248,0.25)]">
-        <div className="flex items-center justify-between gap-4 border-b border-emerald-500/20 bg-slate-950/90 px-6 py-4">
+      <div className="absolute inset-0 bg-[radial-gradient(circle_at_center,_rgba(15,118,110,0.12),_transparent_60%)]" aria-hidden />
+      <Card className={cn(NEWSPAPER_CARD_CLASS, 'relative z-10')}>
+        <div className={`${NEWSPAPER_HEADER_CLASS} flex items-center justify-between gap-4`}>
           <div>
-            <p className="font-mono text-xs uppercase tracking-[0.32em] text-emerald-300/80">Extra Edition</p>
-            <h2 className="mt-1 text-2xl font-semibold text-emerald-100">Breakdown of Final Operations</h2>
+            <p className={NEWSPAPER_META_CLASS}>Extra Edition</p>
+            <h2 className="mt-1 text-2xl font-black uppercase tracking-[0.18em] text-newspaper-headline">
+              Breakdown of Final Operations
+            </h2>
           </div>
           <Button
             variant="ghost"
             size="icon"
-            className="text-emerald-200 hover:text-emerald-100"
+            className="rounded-full border-2 border-newspaper-text/40 bg-newspaper-bg/40 text-newspaper-text transition hover:bg-newspaper-bg"
             onClick={onClose}
             aria-label="Close extra edition"
           >
@@ -32,19 +41,19 @@ const ExtraEditionNewspaper = ({ report, onClose, onArchive, isArchived = false 
           </Button>
         </div>
 
-        <div className="flex-1 overflow-y-auto px-6 py-6">
+        <div className={NEWSPAPER_BODY_CLASS}>
           <FinalEditionLayout report={report} />
         </div>
 
-        <div className="flex flex-wrap items-center justify-between gap-3 border-t border-emerald-500/20 bg-slate-950/90 px-6 py-4">
-          <div className="text-xs font-mono uppercase tracking-[0.32em] text-emerald-200/70">
+        <div className="flex flex-wrap items-center justify-between gap-3 border-t-4 border-newspaper-border bg-newspaper-header/90 px-6 py-4 text-newspaper-text">
+          <div className={NEWSPAPER_META_CLASS}>
             Vol. Final • {new Date(report.recordedAt).toLocaleString()}
           </div>
           {onArchive && (
             <Button
               onClick={onArchive}
               disabled={isArchived}
-              className="bg-emerald-500/20 text-emerald-100 hover:bg-emerald-500/30 disabled:opacity-60"
+              className="border border-dashed border-newspaper-border/70 bg-newspaper-bg/70 text-newspaper-text transition hover:bg-white/80 hover:text-newspaper-headline disabled:opacity-60"
             >
               <Archive className="mr-2 h-4 w-4" />
               {isArchived ? 'Already Archived' : 'Archive to Player Hub'}

--- a/src/components/game/FinalEditionLayout.tsx
+++ b/src/components/game/FinalEditionLayout.tsx
@@ -1,6 +1,13 @@
 import CardImage from '@/components/game/CardImage';
 import { Badge } from '@/components/ui/badge';
 import { Progress } from '@/components/ui/progress';
+import { cn } from '@/lib/utils';
+import {
+  NEWSPAPER_BADGE_CLASS,
+  NEWSPAPER_META_CLASS,
+  NEWSPAPER_SECTION_HEADING_CLASS,
+  NewspaperSection,
+} from './newspaperLayout';
 import type { GameOverReport, FinalEditionEventHighlight, MVPReport } from '@/types/finalEdition';
 import {
   getFactionDisplayName,
@@ -143,12 +150,15 @@ const CardArt = ({
 
   return (
     <div
-      className={`relative overflow-hidden rounded-md border border-emerald-500/20 bg-slate-950/60 ${className}`}
+      className={cn(
+        'relative overflow-hidden rounded-md border border-newspaper-border/60 bg-newspaper-header/20',
+        className,
+      )}
     >
       {cardId ? (
         <CardImage cardId={cardId} fit="contain" className="aspect-[63/88] w-full" />
       ) : (
-        <div className="flex aspect-[63/88] w-full items-center justify-center px-3 text-center text-[10px] font-semibold uppercase tracking-[0.28em] text-emerald-200/40">
+        <div className="flex aspect-[63/88] w-full items-center justify-center px-3 text-center text-[10px] font-semibold uppercase tracking-[0.28em] text-newspaper-text/50">
           Archival footage pending clearance.
         </div>
       )}
@@ -161,17 +171,21 @@ const renderMvpPanel = (label: string, mvp?: MVPReport | null) => {
     return null;
   }
   return (
-    <div className="rounded-xl border border-slate-700/60 bg-slate-900/70 p-4">
+    <NewspaperSection className="h-full space-y-4 p-5">
       <div className="flex items-center justify-between">
-        <h4 className="font-mono text-xs uppercase tracking-[0.32em] text-emerald-300/80">{label}</h4>
-        <Badge className="border-emerald-500/40 bg-emerald-500/10 text-emerald-200">{mvp.impactLabel}</Badge>
+        <h4 className={NEWSPAPER_SECTION_HEADING_CLASS}>{label}</h4>
+        <Badge className={cn(NEWSPAPER_BADGE_CLASS, 'rounded-full px-3 py-0.5 tracking-[0.3em] text-[11px]')}>
+          {mvp.impactLabel}
+        </Badge>
       </div>
-      <div className="mt-3 flex flex-col gap-4 sm:flex-row">
+      <div className="flex flex-col gap-4 sm:flex-row">
         <CardArt cardId={mvp.cardId} showPlaceholder className="sm:w-32" />
-        <div className="flex-1">
-          <h3 className="text-xl font-semibold text-emerald-100">{mvp.cardName}</h3>
-          <p className="mt-1 text-sm text-emerald-100/80">{mvp.highlight}</p>
-          <div className="mt-3 grid gap-2 text-xs text-emerald-200/70 sm:grid-cols-2">
+        <div className="flex-1 space-y-3">
+          <div>
+            <h3 className="text-xl font-black uppercase tracking-[0.12em] text-newspaper-headline">{mvp.cardName}</h3>
+            <p className="mt-1 text-sm text-newspaper-text/80">{mvp.highlight}</p>
+          </div>
+          <div className="grid gap-2 text-xs font-semibold uppercase tracking-[0.2em] text-newspaper-text/70 sm:grid-cols-2">
             <div>Truth Delta: {Math.round(mvp.truthDelta)}%</div>
             <div>IP Swing: {mvp.ipDelta >= 0 ? '+' : ''}{Math.round(mvp.ipDelta)}</div>
             <div>States Captured: {mvp.capturedStates.length > 0 ? mvp.capturedStates.join(', ') : '—'}</div>
@@ -179,7 +193,7 @@ const renderMvpPanel = (label: string, mvp?: MVPReport | null) => {
           </div>
         </div>
       </div>
-    </div>
+    </NewspaperSection>
   );
 };
 
@@ -201,60 +215,71 @@ const FinalEditionLayout = ({ report }: FinalEditionLayoutProps) => {
   const oppositionLabel = getOppositionDisplayName(report.playerFaction);
   const outcomeSummary = getOutcomeSummary(report);
   const influenceSummary = `${playerFactionLabel} ${Math.round(report.ipPlayer)} · ${oppositionLabel} ${Math.round(report.ipAI)}`;
+  const editionDate = new Date(report.recordedAt).toLocaleDateString();
+  const showExtraStamp = report.victoryType === 'agenda' && report.winner !== 'draw';
 
   return (
-    <div className="flex flex-col gap-6">
-      <header className="rounded-2xl border border-emerald-500/30 bg-slate-950/90 p-6 shadow-[0_0_35px_rgba(16,185,129,0.2)]">
+    <div className="space-y-6 text-newspaper-text">
+      <NewspaperSection className="relative overflow-hidden px-6 py-6 sm:px-8">
+        {showExtraStamp ? (
+          <div className="stamp stamp--breaking absolute left-6 top-5">EXTRA</div>
+        ) : null}
         <div className="flex flex-wrap items-center justify-between gap-3">
-          <div className="font-mono text-xs uppercase tracking-[0.32em] text-emerald-300/80">
-            Final Edition • {new Date(report.recordedAt).toLocaleDateString()}
-          </div>
-          <div className="flex flex-wrap items-center gap-2">
-            {playerOutcome !== 'Stalemate' && (
-              <Badge className="border-emerald-500/40 bg-emerald-500/15 text-emerald-100">
+          <div className={NEWSPAPER_META_CLASS}>Final Edition • {editionDate}</div>
+          <div className="flex flex-wrap items-center gap-2 text-[10px] font-semibold uppercase tracking-[0.35em] text-newspaper-text/70">
+            {playerOutcome !== 'Stalemate' ? (
+              <Badge className={cn(NEWSPAPER_BADGE_CLASS, 'rounded-full px-3 py-1')}>
                 {playerOutcome}
               </Badge>
-            )}
-            <Badge className="border-emerald-500/40 bg-emerald-500/10 text-emerald-200">
+            ) : null}
+            <Badge className={cn(NEWSPAPER_BADGE_CLASS, 'rounded-full px-3 py-1')}>
               {victoryConditionLabel}
             </Badge>
-            <Badge className="border-emerald-500/40 bg-emerald-500/10 text-emerald-200">
+            <Badge className={cn(NEWSPAPER_BADGE_CLASS, 'rounded-full px-3 py-1')}>
               {playerFactionLabel}
             </Badge>
           </div>
         </div>
-        <h1 className="mt-3 text-3xl font-black tracking-tight text-emerald-100 sm:text-4xl">{headline}</h1>
-        <p className="mt-2 text-sm text-emerald-100/80">{subhead}</p>
-        <p className="mt-2 text-xs uppercase tracking-[0.28em] text-emerald-200/70">{outcomeSummary}</p>
-        <div className="mt-4 grid gap-3 text-xs uppercase tracking-[0.28em] text-emerald-200/70 sm:grid-cols-4">
-          <div className="rounded-lg border border-emerald-500/20 bg-emerald-500/10 p-3">
-            <div className="text-emerald-200/70">Rounds</div>
-            <div className="mt-1 text-emerald-100 text-lg font-semibold tracking-normal">{report.rounds > 0 ? report.rounds : '—'}</div>
+        <h1 className="mt-3 text-3xl font-black uppercase tracking-[0.12em] text-newspaper-headline sm:text-4xl">
+          {headline}
+        </h1>
+        <p className="mt-2 text-lg font-semibold italic text-newspaper-text/80">{subhead}</p>
+        <p className="mt-3 text-xs font-semibold uppercase tracking-[0.4em] text-newspaper-text/60">{outcomeSummary}</p>
+        <div className="mt-5 grid gap-3 text-xs font-semibold uppercase tracking-[0.3em] text-newspaper-text/70 sm:grid-cols-4">
+          <div className="rounded border border-dashed border-newspaper-border/60 bg-newspaper-bg/70 p-3">
+            <div>Rounds</div>
+            <div className="mt-1 text-2xl font-black tracking-tight text-newspaper-headline">
+              {report.rounds > 0 ? report.rounds : '—'}
+            </div>
           </div>
-          <div className="rounded-lg border border-emerald-500/20 bg-emerald-500/10 p-3">
-            <div className="text-emerald-200/70">Truth Meter</div>
-            <div className="mt-1 text-emerald-100 text-lg font-semibold tracking-normal">{Math.round(report.finalTruth)}%</div>
+          <div className="rounded border border-dashed border-newspaper-border/60 bg-newspaper-bg/70 p-3">
+            <div>Truth Meter</div>
+            <div className="mt-1 text-2xl font-black tracking-tight text-newspaper-headline">{Math.round(report.finalTruth)}%</div>
           </div>
-          <div className="rounded-lg border border-emerald-500/20 bg-emerald-500/10 p-3">
-            <div className="text-emerald-200/70">State Control</div>
-            <div className="mt-1 text-emerald-100 text-lg font-semibold tracking-normal">Truth {report.statesTruth} · Gov {report.statesGov}</div>
+          <div className="rounded border border-dashed border-newspaper-border/60 bg-newspaper-bg/70 p-3">
+            <div>State Control</div>
+            <div className="mt-1 text-2xl font-black tracking-tight text-newspaper-headline">
+              Truth {report.statesTruth} · Gov {report.statesGov}
+            </div>
           </div>
-          <div className="rounded-lg border border-emerald-500/20 bg-emerald-500/10 p-3">
-            <div className="text-emerald-200/70">Influence Points</div>
-            <div className="mt-1 text-emerald-100 text-lg font-semibold tracking-normal">{influenceSummary}</div>
+          <div className="rounded border border-dashed border-newspaper-border/60 bg-newspaper-bg/70 p-3">
+            <div>Influence Points</div>
+            <div className="mt-1 text-2xl font-black tracking-tight text-newspaper-headline">{influenceSummary}</div>
           </div>
         </div>
-      </header>
+      </NewspaperSection>
 
       <section className="grid gap-4 md:grid-cols-2">
         {renderMvpPanel('MVP Play', report.mvp)}
         {renderMvpPanel('Runner-Up', report.runnerUp)}
       </section>
 
-      <section className="rounded-2xl border border-slate-700/50 bg-slate-950/80 p-5">
+      <NewspaperSection className="p-5">
         <div className="flex items-center justify-between">
-          <h2 className="font-mono text-sm uppercase tracking-[0.32em] text-emerald-200/80">Key Events</h2>
-          <Badge className="border-emerald-500/40 bg-emerald-500/10 text-emerald-200">{eventHighlights.length}</Badge>
+          <h2 className={NEWSPAPER_SECTION_HEADING_CLASS}>Key Events</h2>
+          <Badge className={cn(NEWSPAPER_BADGE_CLASS, 'rounded-full px-3 py-0.5 text-[11px] tracking-[0.3em]')}>
+            {eventHighlights.length}
+          </Badge>
         </div>
         <div className="mt-4 space-y-4">
           {eventHighlights.map(event => {
@@ -268,170 +293,192 @@ const FinalEditionLayout = ({ report }: FinalEditionLayoutProps) => {
               : null;
             const arcStatusClass = arcSummary
               ? arcSummary.status === 'finale'
-                ? 'border-emerald-400/80 text-emerald-100'
+                ? 'border-secret-red text-secret-red'
                 : arcSummary.status === 'cliffhanger'
-                  ? 'border-emerald-400/60 text-emerald-100/80'
-                  : 'border-emerald-400/40 text-emerald-100/70'
+                  ? 'border-newspaper-border text-newspaper-headline'
+                  : 'border-dashed border-newspaper-border/70 text-newspaper-text/70'
               : '';
 
             return (
-              <div key={event.id} className="rounded-lg border border-slate-700/40 bg-slate-900/70 p-4">
+              <div key={event.id} className="rounded-md border border-newspaper-border/70 bg-white/75 p-4 shadow-sm">
                 <div className="flex flex-col gap-3 sm:flex-row">
                   <CardArt cardId={event.cardId} className="sm:w-28" />
                   <div className="flex-1 space-y-3">
                     <div className="flex flex-wrap items-center justify-between gap-2">
-                      <h3 className="text-lg font-semibold text-emerald-100">{event.headline}</h3>
-                      <Badge variant="outline" className="border-emerald-500/40 text-emerald-200">
+                      <h3 className="text-lg font-black uppercase tracking-[0.12em] text-newspaper-headline">{event.headline}</h3>
+                      <Badge
+                        variant="outline"
+                        className={cn(NEWSPAPER_BADGE_CLASS, 'rounded-full px-3 py-0.5 text-[10px] tracking-[0.3em]')}
+                      >
                         {event.faction.toUpperCase()} · {event.rarity.toUpperCase()}
                       </Badge>
                     </div>
                     <div className="space-y-2">
-                      <p className="text-sm text-emerald-100/80">{event.summary}</p>
-                      {event.kicker && (
-                        <p className="text-xs italic text-emerald-200/70">{event.kicker}</p>
-                      )}
-                      <div className="text-xs text-emerald-200/70">{renderImpactBadges(event)}</div>
+                      <p className="text-sm text-newspaper-text/80">{event.summary}</p>
+                      {event.kicker ? (
+                        <p className="text-xs italic text-newspaper-text/60">{event.kicker}</p>
+                      ) : null}
+                      <div className="text-xs font-semibold uppercase tracking-[0.25em] text-newspaper-text/60">
+                        {renderImpactBadges(event)}
+                      </div>
                     </div>
                     {arcSummary ? (
-                      <div className="rounded-lg border border-emerald-500/20 bg-emerald-500/5 p-3">
-                        <div className="flex flex-wrap items-center justify-between gap-2 text-[10px] font-semibold uppercase tracking-[0.28em] text-emerald-200/70">
+                      <div className="rounded-md border border-dashed border-newspaper-border/60 bg-newspaper-bg/70 p-3">
+                        <div className="flex flex-wrap items-center justify-between gap-2 text-[10px] font-semibold uppercase tracking-[0.28em] text-newspaper-text/70">
                           <span>Campaign Arc</span>
                           <div className="flex items-center gap-2">
                             <span>Chapter {arcSummary.chapter}/{arcSummary.totalChapters}</span>
                             {arcStatusLabel ? (
-                          <span className={`rounded-full border px-2 py-0.5 ${arcStatusClass}`}>
-                            {arcStatusLabel}
-                          </span>
+                              <span className={`rounded-full border px-2 py-0.5 ${arcStatusClass}`}>
+                                {arcStatusLabel}
+                              </span>
+                            ) : null}
+                          </div>
+                        </div>
+                        <p className="mt-2 text-sm font-semibold text-newspaper-headline">{arcSummary.arcName}</p>
+                        <Progress value={arcSummary.progressPercent} className="mt-2 h-1.5 bg-newspaper-header/30" />
+                        <p className="mt-2 text-xs italic text-newspaper-text/60">{arcSummary.tagline}</p>
+                        {arcSummary.events.length ? (
+                          <ul className="mt-2 space-y-1 text-xs text-newspaper-text/70">
+                            {arcSummary.events.slice(0, 2).map(arcEvent => (
+                              <li key={arcEvent.id}>
+                                <span className="font-semibold text-newspaper-headline">{arcEvent.headline}</span>
+                                <span className="block italic text-newspaper-text/60">{arcEvent.subhead}</span>
+                              </li>
+                            ))}
+                            {arcSummary.events.length > 2 ? (
+                              <li className="text-[10px] uppercase tracking-[0.28em] text-newspaper-text/60">…</li>
+                            ) : null}
+                          </ul>
                         ) : null}
                       </div>
-                    </div>
-                    <p className="mt-1 text-sm font-semibold text-emerald-100">{arcSummary.arcName}</p>
-                    <Progress value={arcSummary.progressPercent} className="mt-2 h-1.5 bg-emerald-500/20" />
-                    <p className="mt-2 text-xs italic text-emerald-200/70">{arcSummary.tagline}</p>
-                    {arcSummary.events.length ? (
-                      <ul className="mt-2 space-y-1 text-xs text-emerald-200/70">
-                        {arcSummary.events.slice(0, 2).map(arcEvent => (
-                          <li key={arcEvent.id}>
-                            <span className="font-semibold text-emerald-100/90">{arcEvent.headline}</span>
-                            <span className="block italic text-emerald-200/60">{arcEvent.subhead}</span>
-                          </li>
-                        ))}
-                        {arcSummary.events.length > 2 ? (
-                          <li className="text-[10px] uppercase tracking-[0.28em] text-emerald-200/60">…</li>
-                        ) : null}
-                      </ul>
-                    ) : null}
-                  </div>
                     ) : null}
                   </div>
                 </div>
               </div>
             );
           })}
-          {eventHighlights.length === 0 && (
-            <p className="text-sm text-emerald-100/70">No notable events logged this match.</p>
-          )}
+          {eventHighlights.length === 0 ? (
+            <p className="text-sm text-newspaper-text/70">No notable events logged this match.</p>
+          ) : null}
         </div>
-      </section>
+      </NewspaperSection>
 
       <section className="grid gap-4 md:grid-cols-2">
-        <div className="rounded-2xl border border-slate-700/50 bg-slate-950/80 p-5">
-          <h2 className="font-mono text-sm uppercase tracking-[0.32em] text-emerald-200/80">Combo Highlights</h2>
+        <NewspaperSection className="p-5">
+          <h2 className={NEWSPAPER_SECTION_HEADING_CLASS}>Combo Highlights</h2>
           <div className="mt-4 space-y-3">
             {comboHighlights.map(combo => (
-              <div key={combo.id} className="rounded-lg border border-slate-700/40 bg-slate-900/70 p-3">
+              <div key={combo.id} className="rounded-md border border-newspaper-border/60 bg-white/75 p-3 shadow-sm">
                 <div className="flex flex-col gap-3 sm:flex-row">
                   <CardArt cardId={combo.cardId} className="sm:w-24" />
                   <div className="flex-1 space-y-2">
                     <div className="flex items-center justify-between">
-                      <h3 className="text-sm font-semibold text-emerald-100">{combo.name}</h3>
-                      <Badge variant="outline" className="border-emerald-500/40 text-emerald-200">{combo.rewardLabel}</Badge>
+                      <h3 className="text-sm font-black uppercase tracking-[0.16em] text-newspaper-headline">{combo.name}</h3>
+                      <Badge
+                        variant="outline"
+                        className={cn(NEWSPAPER_BADGE_CLASS, 'rounded-full px-3 py-0.5 text-[10px] tracking-[0.3em]')}
+                      >
+                        {combo.rewardLabel}
+                      </Badge>
                     </div>
-                    <p className="text-xs text-emerald-200/70">Turn {combo.turn} · {combo.ownerLabel}</p>
-                    {combo.description && (
-                      <p className="text-sm text-emerald-100/80">{combo.description}</p>
-                    )}
+                    <p className="text-xs font-semibold uppercase tracking-[0.3em] text-newspaper-text/60">
+                      Turn {combo.turn} · {combo.ownerLabel}
+                    </p>
+                    {combo.description ? (
+                      <p className="text-sm text-newspaper-text/80">{combo.description}</p>
+                    ) : null}
                   </div>
                 </div>
               </div>
             ))}
-            {comboHighlights.length === 0 && (
-              <p className="text-sm text-emerald-100/70">No combo sequences documented.</p>
-            )}
+            {comboHighlights.length === 0 ? (
+              <p className="text-sm text-newspaper-text/70">No combo sequences documented.</p>
+            ) : null}
           </div>
-        </div>
+        </NewspaperSection>
 
-        <div className="rounded-2xl border border-slate-700/50 bg-slate-950/80 p-5">
-          <h2 className="font-mono text-sm uppercase tracking-[0.32em] text-emerald-200/80">Paranormal Sightings</h2>
+        <NewspaperSection className="p-5">
+          <h2 className={NEWSPAPER_SECTION_HEADING_CLASS}>Paranormal Sightings</h2>
           <div className="mt-4 space-y-3">
             {sightings.map(sighting => (
-              <div key={sighting.id} className="rounded-lg border border-slate-700/40 bg-slate-900/70 p-3">
+              <div key={sighting.id} className="rounded-md border border-newspaper-border/60 bg-white/75 p-3 shadow-sm">
                 <div className="flex items-center justify-between gap-2">
-                  <h3 className="text-sm font-semibold text-emerald-100">{sighting.headline}</h3>
-                  <Badge variant="outline" className="border-emerald-500/40 text-emerald-200">{sighting.category.toUpperCase()}</Badge>
+                  <h3 className="text-sm font-black uppercase tracking-[0.16em] text-newspaper-headline">{sighting.headline}</h3>
+                  <Badge
+                    variant="outline"
+                    className={cn(NEWSPAPER_BADGE_CLASS, 'rounded-full px-3 py-0.5 text-[10px] tracking-[0.3em]')}
+                  >
+                    {sighting.category.toUpperCase()}
+                  </Badge>
                 </div>
-                <p className="mt-1 text-sm text-emerald-100/80">{sighting.subtext}</p>
-                {sighting.metadata?.stateName && (
-                  <p className="mt-1 text-xs text-emerald-200/70">{sighting.metadata.stateName}</p>
-                )}
+                <p className="mt-1 text-sm text-newspaper-text/80">{sighting.subtext}</p>
+                {sighting.metadata?.stateName ? (
+                  <p className="mt-1 text-xs font-semibold uppercase tracking-[0.3em] text-newspaper-text/60">
+                    {sighting.metadata.stateName}
+                  </p>
+                ) : null}
               </div>
             ))}
-            {sightings.length === 0 && (
-              <p className="text-sm text-emerald-100/70">No anomalous activity logged for this run.</p>
-            )}
+            {sightings.length === 0 ? (
+              <p className="text-sm text-newspaper-text/70">No anomalous activity logged for this run.</p>
+            ) : null}
           </div>
-        </div>
+        </NewspaperSection>
       </section>
 
-      <section className="rounded-2xl border border-slate-700/50 bg-slate-950/80 p-5">
-        <h2 className="font-mono text-sm uppercase tracking-[0.32em] text-emerald-200/80">After-Action Notes</h2>
-        <div className="mt-3 flex flex-wrap gap-3 text-xs text-emerald-200/70">
+      <NewspaperSection className="p-5">
+        <h2 className={NEWSPAPER_SECTION_HEADING_CLASS}>After-Action Notes</h2>
+        <div className="mt-3 flex flex-wrap gap-3 text-xs text-newspaper-text/70">
           {report.legendaryUsed.length > 0 ? (
-            <Badge variant="outline" className="border-emerald-500/40 text-emerald-200">
+            <Badge variant="outline" className={cn(NEWSPAPER_BADGE_CLASS, 'rounded-full px-3 py-0.5 text-[10px] tracking-[0.3em]')}>
               Legendary Deployments: {report.legendaryUsed.join(', ')}
             </Badge>
           ) : (
-            <Badge variant="outline" className="border-emerald-500/40 text-emerald-200">No legendary cards deployed</Badge>
+            <Badge variant="outline" className={cn(NEWSPAPER_BADGE_CLASS, 'rounded-full px-3 py-0.5 text-[10px] tracking-[0.3em]')}>
+              No legendary cards deployed
+            </Badge>
           )}
-          {playerAgenda && (
-            <Badge variant="outline" className="border-emerald-500/40 text-emerald-200">
+          {playerAgenda ? (
+            <Badge variant="outline" className={cn(NEWSPAPER_BADGE_CLASS, 'rounded-full px-3 py-0.5 text-[10px] tracking-[0.3em]')}>
               Operative Agenda: {playerAgenda.badgeLabel}
             </Badge>
-          )}
-          {aiAgenda && (
-            <Badge variant="outline" className="border-emerald-500/40 text-emerald-200">
+          ) : null}
+          {aiAgenda ? (
+            <Badge variant="outline" className={cn(NEWSPAPER_BADGE_CLASS, 'rounded-full px-3 py-0.5 text-[10px] tracking-[0.3em]')}>
               Opposition Agenda: {aiAgenda.badgeLabel}
             </Badge>
-          )}
+          ) : null}
         </div>
-        {agendaBriefings.length > 0 && (
+        {agendaBriefings.length > 0 ? (
           <div className="mt-6 space-y-4">
-            <h3 className="font-mono text-xs uppercase tracking-[0.28em] text-emerald-200/70">
-              Hidden Agenda Debrief
-            </h3>
+            <h3 className={NEWSPAPER_SECTION_HEADING_CLASS}>Hidden Agenda Debrief</h3>
             {agendaBriefings.map(({ agenda, label, owner }) => (
               <article
                 key={owner}
-                className="rounded-xl border border-emerald-500/20 bg-emerald-500/5 p-4 shadow-[0_0_25px_rgba(16,185,129,0.1)]"
+                className="rounded-md border border-dashed border-newspaper-border/60 bg-newspaper-bg/70 p-4 shadow-sm"
               >
-                <div className="flex flex-wrap items-center gap-2 text-xs uppercase tracking-[0.24em] text-emerald-200/80">
-                  <span className="text-emerald-100">{label}</span>
-                  <Badge variant="outline" className="border-emerald-500/40 text-emerald-200">
+                <div className="flex flex-wrap items-center gap-2 text-xs font-semibold uppercase tracking-[0.28em] text-newspaper-text/70">
+                  <span className="text-newspaper-headline">{label}</span>
+                  <Badge
+                    variant="outline"
+                    className={cn(NEWSPAPER_BADGE_CLASS, 'rounded-full px-3 py-0.5 text-[10px] tracking-[0.3em]')}
+                  >
                     {agenda.statusLabel}
                   </Badge>
-                  <span className="text-emerald-200/70">Progress {agenda.progressLabel}</span>
+                  <span className="text-newspaper-text/60">Progress {agenda.progressLabel}</span>
                 </div>
-                <p className="mt-3 text-sm text-emerald-100/80">{formatAgendaNarrative(agenda, owner)}</p>
-                {agenda.pullQuote && (
-                  <blockquote className="mt-3 border-l-2 border-emerald-500/40 pl-3 text-sm italic text-emerald-200/70">
+                <p className="mt-3 text-sm text-newspaper-text/80">{formatAgendaNarrative(agenda, owner)}</p>
+                {agenda.pullQuote ? (
+                  <blockquote className="mt-3 border-l-2 border-newspaper-border/60 pl-3 text-sm italic text-newspaper-text/60">
                     “{agenda.pullQuote}”
                   </blockquote>
-                )}
+                ) : null}
               </article>
             ))}
           </div>
-        )}
-      </section>
+        ) : null}
+      </NewspaperSection>
     </div>
   );
 };

--- a/src/components/game/TabloidNewspaperV2.tsx
+++ b/src/components/game/TabloidNewspaperV2.tsx
@@ -15,6 +15,14 @@ import type { ParanormalSighting } from '@/types/paranormal';
 import type { AgendaMoment } from '@/hooks/usePressArchive';
 import { EVENT_DATABASE } from '@/data/eventDatabase';
 import type { ArcProgressSummary } from '@/types/campaign';
+import { cn } from '@/lib/utils';
+import {
+  NEWSPAPER_BADGE_CLASS,
+  NEWSPAPER_BODY_CLASS,
+  NEWSPAPER_CARD_CLASS,
+  NEWSPAPER_HEADER_CLASS,
+  NewspaperSection,
+} from './newspaperLayout';
 
 const GLITCH_OPTIONS = ['PAGE NOT FOUND', '░░░ERROR░░░', '▓▓▓SIGNAL LOST▓▓▓', '404 TRUTH NOT FOUND'];
 
@@ -930,8 +938,8 @@ const TabloidNewspaperV2 = ({
 
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 p-4">
-      <UICard className="ink-smudge relative flex h-full max-h-[90vh] w-full max-w-[min(95vw,1280px)] flex-col overflow-hidden border-4 border-newspaper-border bg-newspaper-bg text-newspaper-text shadow-2xl">
-        <header className="relative border-b-4 border-double border-newspaper-border bg-newspaper-header/90 px-6 py-5">
+      <UICard className={NEWSPAPER_CARD_CLASS}>
+        <header className={NEWSPAPER_HEADER_CLASS}>
           {breakingStamp ? (
             <div className="stamp stamp--breaking absolute left-6 top-4">{breakingStamp}</div>
           ) : null}
@@ -962,8 +970,8 @@ const TabloidNewspaperV2 = ({
           </div>
         </header>
 
-        <div className="flex-1 overflow-y-auto px-4 py-5 sm:px-6 sm:py-6 xl:px-5 xl:py-5">
-          <section className="mb-6 rounded-md border border-newspaper-border bg-white/70 px-4 py-3 text-sm text-newspaper-text shadow-sm">
+        <div className={NEWSPAPER_BODY_CLASS}>
+          <NewspaperSection className="mb-6 bg-white/70 px-4 py-3 text-sm text-newspaper-text">
             <div className="flex flex-wrap items-center justify-between gap-3">
               <div className="flex items-center gap-3">
                 <span className="font-semibold uppercase tracking-wide">Truth Index</span>
@@ -987,12 +995,14 @@ const TabloidNewspaperV2 = ({
                 </span>
               </div>
             </div>
-          </section>
+          </NewspaperSection>
 
           <div className="grid gap-4 lg:gap-5 lg:grid-cols-3">
             <article className="lg:col-span-2 space-y-4 rounded-md border border-newspaper-border bg-white/80 p-6 shadow-sm">
               <div className="flex flex-wrap items-center justify-between gap-3 text-xs font-semibold uppercase tracking-wide text-newspaper-text/70">
-                <span className="rounded-full border border-newspaper-border px-2 py-1">{heroTypeLabel}</span>
+                <span className={cn(NEWSPAPER_BADGE_CLASS, 'rounded-full px-2 py-1 text-[11px] tracking-wide text-newspaper-text')}>
+                  {heroTypeLabel}
+                </span>
                 {heroTarget ? (
                   <span className="rounded-full border border-dashed border-newspaper-border px-2 py-1">{heroTarget}</span>
                 ) : null}

--- a/src/components/game/newspaperLayout.tsx
+++ b/src/components/game/newspaperLayout.tsx
@@ -1,0 +1,28 @@
+import type { HTMLAttributes } from 'react';
+
+import { cn } from '@/lib/utils';
+
+export const NEWSPAPER_CARD_CLASS =
+  'ink-smudge relative flex h-full max-h-[90vh] w-full max-w-[min(95vw,1280px)] flex-col overflow-hidden border-4 border-newspaper-border bg-newspaper-bg text-newspaper-text shadow-2xl';
+
+export const NEWSPAPER_HEADER_CLASS =
+  'relative border-b-4 border-double border-newspaper-border bg-newspaper-header/90 px-6 py-5';
+
+export const NEWSPAPER_BODY_CLASS =
+  'flex-1 overflow-y-auto px-4 py-5 sm:px-6 sm:py-6 xl:px-5 xl:py-5';
+
+export const NEWSPAPER_SECTION_CLASS =
+  'rounded-md border border-newspaper-border bg-white/80 shadow-sm';
+
+export const NEWSPAPER_SECTION_HEADING_CLASS =
+  'font-mono text-xs uppercase tracking-[0.32em] text-newspaper-text/70';
+
+export const NEWSPAPER_META_CLASS =
+  'text-[11px] font-semibold uppercase tracking-[0.45em] text-newspaper-text/60';
+
+export const NEWSPAPER_BADGE_CLASS =
+  'border border-newspaper-border bg-newspaper-header/70 text-[11px] font-semibold uppercase tracking-[0.28em] text-newspaper-headline';
+
+export const NewspaperSection = ({ className, ...props }: HTMLAttributes<HTMLElement>) => {
+  return <section className={cn(NEWSPAPER_SECTION_CLASS, className)} {...props} />;
+};


### PR DESCRIPTION
## Summary
- extract shared newspaper layout utilities so tabloid views share container, header, and section styles
- restyle FinalEditionLayout with newspaper tokens and add the agenda victory “EXTRA” stamp
- update supporting views to consume the shared shell for consistent presentation

## Testing
- bun test src/components/game/__tests__/FinalEditionLayout.agenda.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68dd851237648320ad1274ccc399f0d1