### PR TITLE
Prevent duplicate paranormal sightings

### DIFF
--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -58,6 +58,7 @@ import { formatComboReward, getLastComboSummary } from '@/game/comboEngine';
 import { usePressArchive } from '@/hooks/usePressArchive';
 import { useIntelArchive } from '@/hooks/useIntelArchive';
 import type { IntelArchiveDraft } from '@/hooks/useIntelArchive';
+import { upsertParanormalSighting } from '@/utils/paranormalSightings';
 import type {
   AgendaSummary,
   ImpactType,
@@ -838,11 +839,7 @@ const Index = () => {
   );
 
   const pushSighting = useCallback((entry: ParanormalSighting) => {
-    setParanormalSightings(prev => {
-      const merged = [...prev, entry];
-      const MAX_ENTRIES = 12;
-      return merged.length > MAX_ENTRIES ? merged.slice(merged.length - MAX_ENTRIES) : merged;
-    });
+    setParanormalSightings(prev => upsertParanormalSighting(prev, entry));
     registerParanormalSighting(entry.metadata?.source ?? undefined);
   }, [registerParanormalSighting]);
 

--- a/src/utils/__tests__/paranormalSightings.test.ts
+++ b/src/utils/__tests__/paranormalSightings.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, test } from 'bun:test';
+import type { ParanormalSighting } from '@/types/paranormal';
+import { upsertParanormalSighting } from '../paranormalSightings';
+
+describe('upsertParanormalSighting', () => {
+  const baseSighting: ParanormalSighting = {
+    id: 'sighting-1',
+    timestamp: 1,
+    category: 'cryptid',
+    headline: 'Initial headline',
+    subtext: 'Original subtext',
+    metadata: {
+      stateId: 'CA',
+      bonusIP: 1,
+      source: 'truth',
+    },
+  };
+
+  test('replaces an existing sighting with the same id and merges metadata', () => {
+    const updatedSighting: ParanormalSighting = {
+      id: 'sighting-1',
+      timestamp: 2,
+      category: 'cryptid',
+      headline: 'Updated headline',
+      subtext: 'New details emerge',
+      metadata: {
+        bonusIP: 3,
+        stateName: 'California',
+      },
+    };
+
+    const result = upsertParanormalSighting([baseSighting], updatedSighting);
+
+    expect(result).toHaveLength(1);
+    expect(result[0]).toEqual({
+      id: 'sighting-1',
+      timestamp: 2,
+      category: 'cryptid',
+      headline: 'Updated headline',
+      subtext: 'New details emerge',
+      metadata: {
+        stateId: 'CA',
+        source: 'truth',
+        bonusIP: 3,
+        stateName: 'California',
+      },
+    });
+  });
+
+  test('appends new sightings while enforcing the entry cap', () => {
+    const sightings = Array.from({ length: 12 }, (_, index) => ({
+      ...baseSighting,
+      id: `sighting-${index + 1}`,
+      timestamp: index,
+    }));
+
+    const newEntry: ParanormalSighting = {
+      ...baseSighting,
+      id: 'sighting-13',
+      timestamp: 99,
+    };
+
+    const result = upsertParanormalSighting(sightings, newEntry);
+
+    expect(result).toHaveLength(12);
+    expect(result[11].id).toBe('sighting-13');
+    expect(result[0].id).toBe('sighting-2');
+  });
+});

--- a/src/utils/paranormalSightings.ts
+++ b/src/utils/paranormalSightings.ts
@@ -1,0 +1,31 @@
+import type { ParanormalSighting } from '@/types/paranormal';
+
+const MAX_PARANORMAL_SIGHTINGS = 12;
+
+export const upsertParanormalSighting = (
+  sightings: ParanormalSighting[],
+  entry: ParanormalSighting,
+  maxEntries: number = MAX_PARANORMAL_SIGHTINGS,
+): ParanormalSighting[] => {
+  const index = sightings.findIndex(existing => existing.id === entry.id);
+
+  if (index !== -1) {
+    const existing = sightings[index];
+    const hasMetadata = existing.metadata !== undefined || entry.metadata !== undefined;
+    const metadata = hasMetadata ? { ...existing.metadata, ...entry.metadata } : undefined;
+    const merged: ParanormalSighting = {
+      ...existing,
+      ...entry,
+      metadata,
+    };
+    const next = sightings.slice();
+    next[index] = merged;
+    return next;
+  }
+
+  const next = [...sightings, entry];
+  if (next.length > maxEntries) {
+    return next.slice(next.length - maxEntries);
+  }
+  return next;
+};


### PR DESCRIPTION
## Summary
- introduce a reusable helper that upserts paranormal sightings and enforces the 12-item cap
- update the Index page to reuse the helper so repeat IDs refresh existing entries while still registering agenda counters
- add unit tests covering replacement logic and cap trimming

## Testing
- bun test src/utils/__tests__/paranormalSightings.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68dd9c21d50883209113f700a52d04d3