### PR TITLE
Implement secret agenda modal assignment flow

### DIFF
--- a/src/components/game/FactionSelectTabloid.tsx
+++ b/src/components/game/FactionSelectTabloid.tsx
@@ -1,21 +1,10 @@
 import { Card } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
-import type { SecretAgenda } from '@/data/agendaDatabase';
-
 interface FactionSelectTabloidProps {
-  onStartGame: (faction: 'government' | 'truth', agendaId?: string) => Promise<void>;
+  onStartGame: (faction: 'government' | 'truth') => Promise<void>;
   onFactionHover?: (faction: 'government' | 'truth' | null) => void;
   onBack: () => void;
   audio?: any;
-  agendas: {
-    government: SecretAgenda[];
-    truth: SecretAgenda[];
-  };
-  selectedAgendas: {
-    government: string | null;
-    truth: string | null;
-  };
-  onAgendaSelect?: (faction: 'government' | 'truth', value: string) => void;
 }
 
 const FactionSelectTabloid = ({
@@ -23,9 +12,6 @@ const FactionSelectTabloid = ({
   onFactionHover,
   onBack,
   audio,
-  agendas,
-  selectedAgendas,
-  onAgendaSelect,
 }: FactionSelectTabloidProps) => {
   const tabloidButtonClass = `
     w-full border-2 border-black bg-white text-black
@@ -36,13 +22,6 @@ const FactionSelectTabloid = ({
     active:translate-x-[2px] active:translate-y-[2px]
     focus:outline-none focus:ring-4 focus:ring-gray-300
   `;
-
-  const selectedGovernmentAgenda = selectedAgendas.government
-    ? agendas.government.find(agenda => agenda.id === selectedAgendas.government)
-    : undefined;
-  const selectedTruthAgenda = selectedAgendas.truth
-    ? agendas.truth.find(agenda => agenda.id === selectedAgendas.truth)
-    : undefined;
 
   return (
     <div className="min-h-screen bg-[var(--paper)] flex items-center justify-center p-4 md:p-8">
@@ -92,31 +71,17 @@ const FactionSelectTabloid = ({
               <div className="text-[10px] font-black uppercase tracking-[0.3em] text-black/70">
                 SECRET AGENDA
               </div>
-              <select
-                className="w-full border-2 border-black bg-white px-3 py-2 font-mono text-xs uppercase"
-                value={selectedAgendas.government ?? 'random'}
-                onChange={(event) => onAgendaSelect?.('government', event.target.value)}
-              >
-                <option value="random">RANDOM ASSIGNMENT</option>
-                {agendas.government.map(agenda => (
-                  <option key={agenda.id} value={agenda.id}>
-                    {agenda.title} ({agenda.difficulty.toUpperCase()})
-                  </option>
-                ))}
-              </select>
-              {selectedGovernmentAgenda && (
-                <Card className="border-2 border-dashed border-black/40 bg-[#f5f5f5] p-3 text-[11px] font-mono text-black">
-                  <p className="font-black uppercase tracking-wide text-[10px]">
-                    {selectedGovernmentAgenda.headline}
-                  </p>
-                  <p className="text-[11px] normal-case">{selectedGovernmentAgenda.description}</p>
-                </Card>
-              )}
+              <Card className="border-2 border-dashed border-black/40 bg-[#f5f5f5] p-3 text-[11px] font-mono text-black">
+                <p className="font-black uppercase tracking-wide text-[10px]">Classified briefing</p>
+                <p className="text-[11px] normal-case">
+                  Choose your strategy after the first briefing once operations begin.
+                </p>
+              </Card>
             </div>
             <Button
               onClick={async () => {
                 audio?.playSFX?.('click');
-                await onStartGame('government', selectedAgendas.government ?? undefined);
+                await onStartGame('government');
               }}
               className={tabloidButtonClass}
             >
@@ -143,31 +108,17 @@ const FactionSelectTabloid = ({
               <div className="text-[10px] font-black uppercase tracking-[0.3em] text-black/70">
                 SECRET AGENDA
               </div>
-              <select
-                className="w-full border-2 border-black bg-white px-3 py-2 font-mono text-xs uppercase"
-                value={selectedAgendas.truth ?? 'random'}
-                onChange={(event) => onAgendaSelect?.('truth', event.target.value)}
-              >
-                <option value="random">RANDOM ASSIGNMENT</option>
-                {agendas.truth.map(agenda => (
-                  <option key={agenda.id} value={agenda.id}>
-                    {agenda.title} ({agenda.difficulty.toUpperCase()})
-                  </option>
-                ))}
-              </select>
-              {selectedTruthAgenda && (
-                <Card className="border-2 border-dashed border-black/40 bg-[#f5f5f5] p-3 text-[11px] font-mono text-black">
-                  <p className="font-black uppercase tracking-wide text-[10px]">
-                    {selectedTruthAgenda.headline}
-                  </p>
-                  <p className="text-[11px] normal-case">{selectedTruthAgenda.description}</p>
-                </Card>
-              )}
+              <Card className="border-2 border-dashed border-black/40 bg-[#f5f5f5] p-3 text-[11px] font-mono text-black">
+                <p className="font-black uppercase tracking-wide text-[10px]">Encrypted dossier</p>
+                <p className="text-[11px] normal-case">
+                  Lock in your secret objective right after the game briefing begins.
+                </p>
+              </Card>
             </div>
             <Button
               onClick={async () => {
                 audio?.playSFX?.('click');
-                await onStartGame('truth', selectedAgendas.truth ?? undefined);
+                await onStartGame('truth');
               }}
               className={tabloidButtonClass}
             >

--- a/src/components/game/GameMenu.tsx
+++ b/src/components/game/GameMenu.tsx
@@ -1,6 +1,6 @@
 import { Card } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
-import { useState, useEffect, useMemo } from 'react';
+import { useState, useEffect } from 'react';
 import Credits from './Credits';
 import HowToPlay from './HowToPlay';
 import Options from './Options';
@@ -12,10 +12,9 @@ import CardCollectionTabloid from './CardCollectionTabloid';
 import StartScreen from '@/components/start/StartScreen';
 import FactionSelectTabloid from './FactionSelectTabloid';
 import { useUiTheme } from '@/hooks/useTheme';
-import { getAgendasByFaction, type SecretAgenda } from '@/data/agendaDatabase';
 
 interface GameMenuProps {
-  onStartGame: (faction: 'government' | 'truth', agendaId?: string) => Promise<void>;
+  onStartGame: (faction: 'government' | 'truth') => Promise<void>;
   onFactionHover?: (faction: 'government' | 'truth' | null) => void;
   audio?: any;
   onBackToMainMenu?: () => void;
@@ -46,30 +45,6 @@ const GameMenu = ({ onStartGame, onFactionHover, audio, onBackToMainMenu, onSave
     rotate: Math.random() * 4 - 2,
   })));
   const [showCollection, setShowCollection] = useState(false);
-  const [agendaSelections, setAgendaSelections] = useState<{ government: string | null; truth: string | null }>({
-    government: null,
-    truth: null,
-  });
-
-  const governmentAgendas = useMemo<SecretAgenda[]>(() => getAgendasByFaction('government'), []);
-  const truthAgendas = useMemo<SecretAgenda[]>(() => getAgendasByFaction('truth'), []);
-
-  const handleAgendaSelect = (faction: 'government' | 'truth', value: string) => {
-    setAgendaSelections(prev => ({
-      ...prev,
-      [faction]: value === 'random' ? null : value,
-    }));
-  };
-
-  const getSelectedAgenda = (faction: 'government' | 'truth'): SecretAgenda | undefined => {
-    const selectedId = agendaSelections[faction];
-    const agendaPool = faction === 'government' ? governmentAgendas : truthAgendas;
-    return selectedId ? agendaPool.find(agenda => agenda.id === selectedId) : undefined;
-  };
-
-  const selectedGovernmentAgenda = getSelectedAgenda('government');
-  const selectedTruthAgenda = getSelectedAgenda('truth');
-
   const handleShowCollection = () => {
     if (onShowCardCollection) {
       onShowCardCollection();
@@ -223,12 +198,6 @@ const GameMenu = ({ onStartGame, onFactionHover, audio, onBackToMainMenu, onSave
         onFactionHover={onFactionHover}
         onBack={() => setShowFactionSelect(false)}
         audio={audio}
-        agendas={{
-          government: governmentAgendas,
-          truth: truthAgendas,
-        }}
-        selectedAgendas={agendaSelections}
-        onAgendaSelect={handleAgendaSelect}
       />
     ) : (
       <div className="min-h-screen bg-newspaper-bg flex items-center justify-center p-8 relative overflow-hidden">
@@ -300,24 +269,9 @@ const GameMenu = ({ onStartGame, onFactionHover, audio, onBackToMainMenu, onSave
                 <div className="text-xs font-semibold uppercase tracking-[0.25em] text-newspaper-text/60">
                   Secret Agenda
                 </div>
-                <select
-                  className="w-full rounded border border-newspaper-text bg-newspaper-bg px-3 py-2 text-sm font-mono text-newspaper-text shadow-sm"
-                  value={agendaSelections.government ?? 'random'}
-                  onChange={(event) => handleAgendaSelect('government', event.target.value)}
-                >
-                  <option value="random">Random Assignment</option>
-                  {governmentAgendas.map(agenda => (
-                    <option key={agenda.id} value={agenda.id}>
-                      {agenda.title} ({agenda.difficulty.toUpperCase()})
-                    </option>
-                  ))}
-                </select>
-                {selectedGovernmentAgenda && (
-                  <div className="rounded border border-dashed border-newspaper-text/40 bg-newspaper-bg/60 p-3 text-xs font-mono text-newspaper-text/80">
-                    <p className="font-semibold text-newspaper-text">{selectedGovernmentAgenda.headline}</p>
-                    <p>{selectedGovernmentAgenda.description}</p>
-                  </div>
-                )}
+                <p className="rounded border border-dashed border-newspaper-text/40 bg-newspaper-bg/60 p-3 text-xs font-mono text-newspaper-text/80">
+                  Assigned during briefing after the opening round begins.
+                </p>
               </div>
 
               <div className="bg-newspaper-text/10 p-3 mb-4 text-xs italic text-newspaper-text">
@@ -327,7 +281,7 @@ const GameMenu = ({ onStartGame, onFactionHover, audio, onBackToMainMenu, onSave
               <Button
                 onClick={async () => {
                   audio?.playSFX?.('click');
-                  await onStartGame('government', agendaSelections.government ?? undefined);
+                  await onStartGame('government');
                 }}
                 className="w-full bg-government-blue hover:bg-government-blue/80 text-white group-hover:animate-pulse"
               >
@@ -363,24 +317,9 @@ const GameMenu = ({ onStartGame, onFactionHover, audio, onBackToMainMenu, onSave
                 <div className="text-xs font-semibold uppercase tracking-[0.25em] text-newspaper-text/60">
                   Secret Agenda
                 </div>
-                <select
-                  className="w-full rounded border border-newspaper-text bg-newspaper-bg px-3 py-2 text-sm font-mono text-newspaper-text shadow-sm"
-                  value={agendaSelections.truth ?? 'random'}
-                  onChange={(event) => handleAgendaSelect('truth', event.target.value)}
-                >
-                  <option value="random">Random Assignment</option>
-                  {truthAgendas.map(agenda => (
-                    <option key={agenda.id} value={agenda.id}>
-                      {agenda.title} ({agenda.difficulty.toUpperCase()})
-                    </option>
-                  ))}
-                </select>
-                {selectedTruthAgenda && (
-                  <div className="rounded border border-dashed border-newspaper-text/40 bg-newspaper-bg/60 p-3 text-xs font-mono text-newspaper-text/80">
-                    <p className="font-semibold text-newspaper-text">{selectedTruthAgenda.headline}</p>
-                    <p>{selectedTruthAgenda.description}</p>
-                  </div>
-                )}
+                <p className="rounded border border-dashed border-newspaper-text/40 bg-newspaper-bg/60 p-3 text-xs font-mono text-newspaper-text/80">
+                  Assigned during briefing after the opening round begins.
+                </p>
               </div>
 
               <div className="bg-newspaper-text/10 p-3 mb-4 text-xs italic text-newspaper-text">
@@ -390,7 +329,7 @@ const GameMenu = ({ onStartGame, onFactionHover, audio, onBackToMainMenu, onSave
               <Button
                 onClick={async () => {
                   audio?.playSFX?.('click');
-                  await onStartGame('truth', agendaSelections.truth ?? undefined);
+                  await onStartGame('truth');
                 }}
                 className="w-full bg-truth-red hover:bg-truth-red/80 text-white group-hover:animate-pulse"
               >

--- a/src/components/game/SecretAgendaModal.tsx
+++ b/src/components/game/SecretAgendaModal.tsx
@@ -1,0 +1,122 @@
+import { useEffect, useMemo, useState } from 'react';
+import clsx from 'clsx';
+import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription } from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
+import { ScrollArea } from '@/components/ui/scroll-area';
+import { getAgendasByFaction, type SecretAgenda } from '@/data/agendaDatabase';
+
+interface SecretAgendaModalProps {
+  open: boolean;
+  faction: 'government' | 'truth';
+  onConfirm: (agendaId: string | null) => void;
+  onCancel: () => void;
+}
+
+const difficultyTone: Record<SecretAgenda['difficulty'], string> = {
+  easy: 'bg-emerald-600/20 text-emerald-600 border-emerald-600/40',
+  medium: 'bg-amber-500/20 text-amber-600 border-amber-500/40',
+  hard: 'bg-rose-500/20 text-rose-600 border-rose-500/40',
+  legendary: 'bg-purple-600/20 text-purple-600 border-purple-600/40',
+};
+
+export const SecretAgendaModal = ({ open, faction, onConfirm, onCancel }: SecretAgendaModalProps) => {
+  const agendas = useMemo(() => getAgendasByFaction(faction), [faction]);
+  const [selectedAgendaId, setSelectedAgendaId] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!open) {
+      setSelectedAgendaId(null);
+      return;
+    }
+
+    setSelectedAgendaId(null);
+  }, [open, faction]);
+
+  const handleConfirm = () => {
+    if (!selectedAgendaId) {
+      return;
+    }
+    onConfirm(selectedAgendaId);
+  };
+
+  return (
+    <Dialog open={open}>
+      <DialogContent
+        className="max-w-3xl gap-6 border-4 border-black bg-[var(--paper)] p-0 text-[var(--ink)]"
+        onPointerDownOutside={(event) => event.preventDefault()}
+        onEscapeKeyDown={(event) => event.preventDefault()}
+      >
+        <DialogHeader className="space-y-2 border-b-4 border-black bg-black/5 px-6 py-4 text-left">
+          <DialogTitle className="text-2xl font-black uppercase tracking-wide">
+            Select Your Secret Agenda
+          </DialogTitle>
+          <DialogDescription className="text-sm font-mono uppercase tracking-[0.2em] text-black/60">
+            Choose a classified objective or skip to receive a random dossier.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="px-6 pb-6">
+          <ScrollArea className="max-h-[360px] pr-3">
+            <div className="grid gap-3 py-4">
+              {agendas.map(agenda => (
+                <button
+                  key={agenda.id}
+                  type="button"
+                  onClick={() => setSelectedAgendaId(agenda.id)}
+                  className={clsx(
+                    'flex w-full flex-col gap-2 rounded border-2 bg-white p-4 text-left transition',
+                    'hover:-translate-y-0.5 hover:shadow-lg focus:outline-none focus-visible:ring-4 focus-visible:ring-secret-red/40',
+                    selectedAgendaId === agenda.id
+                      ? 'border-secret-red shadow-lg'
+                      : 'border-black/40 hover:border-secret-red/60'
+                  )}
+                >
+                  <div className="flex items-center justify-between">
+                    <div>
+                      <p className="text-xs font-black uppercase tracking-[0.3em] text-black/60">
+                        Operation
+                      </p>
+                      <h3 className="text-xl font-black uppercase tracking-tight text-black">
+                        {agenda.title}
+                      </h3>
+                    </div>
+                    <span
+                      className={clsx(
+                        'rounded-full border px-3 py-1 text-xs font-semibold uppercase tracking-[0.3em]',
+                        difficultyTone[agenda.difficulty]
+                      )}
+                    >
+                      {agenda.difficulty}
+                    </span>
+                  </div>
+                  <p className="font-mono text-sm text-black/80">{agenda.headline}</p>
+                  <p className="text-sm text-black/70">{agenda.description}</p>
+                </button>
+              ))}
+            </div>
+          </ScrollArea>
+
+          <div className="mt-6 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+            <Button
+              onClick={handleConfirm}
+              disabled={!selectedAgendaId}
+              className="w-full border-2 border-black bg-secret-red text-white hover:bg-secret-red/90 sm:w-auto"
+            >
+              Confirm Selection
+            </Button>
+            <Button
+              type="button"
+              variant="secondary"
+              onClick={onCancel}
+              className="w-full border-2 border-black bg-white text-black hover:bg-black/5 sm:w-auto"
+            >
+              Assign Random Agenda
+            </Button>
+          </div>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+};
+
+export default SecretAgendaModal;

--- a/src/components/start/StartScreen.tsx
+++ b/src/components/start/StartScreen.tsx
@@ -4,7 +4,7 @@ import ArticleButton from './ArticleButton';
 import '@/styles/newspaper.css';
 
 type StartScreenProps = {
-  onStartGame: (faction: 'government' | 'truth', agendaId?: string) => void | Promise<void>;
+  onStartGame: (faction: 'government' | 'truth') => void | Promise<void>;
   onManageExpansions: () => void;
   onHowToPlay: () => void;
   onOptions: () => void;


### PR DESCRIPTION
## Summary
- remove pre-game secret agenda dropdowns from the menu and tabloid faction picker so games start without an agenda selected
- add an assignSecretAgenda helper in useGameState that synchronizes player and AI agendas and logs, leaving initGame without an agenda until it is invoked
- introduce a SecretAgendaModal that lets players choose or randomize an agenda after turn one begins and wire it into the main index page with interaction locks

## Testing
- bun test src/components/game/__tests__/FinalEditionLayout.agenda.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68ddb7d842588320b3ea29e1bbef8599