### PR TITLE
Add paranormal hotspot scaffolding and data stubs

### DIFF
--- a/src/data/cryptids.homestate.json
+++ b/src/data/cryptids.homestate.json
@@ -1,0 +1,4 @@
+{
+  "cryptids": [],
+  "regions": {}
+}

--- a/src/data/hotspots.catalog.json
+++ b/src/data/hotspots.catalog.json
@@ -1,0 +1,7 @@
+{
+  "hotspots": [],
+  "metadata": {
+    "version": "0.0.0",
+    "generatedAt": null
+  }
+}

--- a/src/data/hotspots.config.json
+++ b/src/data/hotspots.config.json
@@ -1,0 +1,8 @@
+{
+  "cooldowns": {},
+  "intensityThresholds": {},
+  "defaults": {
+    "spawnRate": 0,
+    "decayRate": 0
+  }
+}

--- a/src/systems/paranormalHotspots.ts
+++ b/src/systems/paranormalHotspots.ts
@@ -1,0 +1,58 @@
+import hotspotsCatalog from '@/data/hotspots.catalog.json';
+import hotspotsConfig from '@/data/hotspots.config.json';
+import cryptidHomeStates from '@/data/cryptids.homestate.json';
+
+export type HotspotKind =
+  | 'anomaly'
+  | 'disturbance'
+  | 'manifestation'
+  | 'phenomenon'
+  | 'encounter';
+
+export interface Hotspot {
+  id: string;
+  name: string;
+  kind: HotspotKind;
+  location: string;
+  intensity: number;
+  status: 'spawning' | 'active' | 'resolved' | 'expired';
+  tags: string[];
+}
+
+type HotspotCatalog = typeof hotspotsCatalog;
+type HotspotConfig = typeof hotspotsConfig;
+type CryptidHomeState = typeof cryptidHomeStates;
+
+export class HotspotDirector {
+  private readonly catalog: HotspotCatalog;
+
+  private readonly config: HotspotConfig;
+
+  private readonly cryptids: CryptidHomeState;
+
+  constructor(
+    catalog: HotspotCatalog = hotspotsCatalog,
+    config: HotspotConfig = hotspotsConfig,
+    cryptids: CryptidHomeState = cryptidHomeStates,
+  ) {
+    this.catalog = catalog;
+    this.config = config;
+    this.cryptids = cryptids;
+  }
+
+  initialize(): void {
+    // TODO: Hydrate working sets, indexes, and orchestration timers.
+  }
+
+  getCatalog(): HotspotCatalog {
+    return this.catalog;
+  }
+
+  getConfig(): HotspotConfig {
+    return this.config;
+  }
+
+  getCryptids(): CryptidHomeState {
+    return this.cryptids;
+  }
+}

--- a/src/ui/hotspots.toasts.ts
+++ b/src/ui/hotspots.toasts.ts
@@ -1,0 +1,13 @@
+import type { Hotspot } from '@/systems/paranormalHotspots';
+
+export function queueHotspotSpawnToast(_hotspot: Hotspot): void {
+  // TODO: Implement toast notification for new hotspot spawns.
+}
+
+export function queueHotspotResolveToast(_hotspot: Hotspot): void {
+  // TODO: Implement toast notification for resolved hotspots.
+}
+
+export function queueHotspotExpireToast(_hotspot: Hotspot): void {
+  // TODO: Implement toast notification for expired hotspots.
+}


### PR DESCRIPTION
## Summary
- add paranormal hotspot catalog, config, and cryptid homestate stubs
- scaffold a HotspotDirector with exported hotspot types
- stub toast helper functions for hotspot spawn, resolve, and expire events

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68de2585ed448320baca9cb5741b645b