### PR TITLE
Add configurable hotspot resolution rewards and toast handling

### DIFF
--- a/src/data/hotspots.config.json
+++ b/src/data/hotspots.config.json
@@ -39,5 +39,48 @@
       "perCryptid": 0.2,
       "max": 1.5
     }
+  },
+  "resolution": {
+    "truthRewards": {
+      "defaults": {
+        "base": 8,
+        "min": 2,
+        "max": 18
+      },
+      "states": {
+        "WA": {
+          "base": 11,
+          "max": 20
+        },
+        "OR": {
+          "base": 9
+        },
+        "WV": {
+          "base": 10,
+          "min": 3
+        },
+        "NJ": {
+          "base": 9
+        },
+        "NM": {
+          "base": 10
+        }
+      },
+      "expansionBonuses": {
+        "cryptids": {
+          "flat": 1,
+          "states": {
+            "WA": {
+              "flat": 2
+            },
+            "OR": 1,
+            "NM": {
+              "flat": 1,
+              "multiplier": 1.05
+            }
+          }
+        }
+      }
+    }
   }
 }


### PR DESCRIPTION
## Summary
- add resolution truth reward configuration and a resolveHotspot helper that applies expansion bonuses and clamps results
- integrate the computed hotspot outcome into card and AI resolution flows, recording truth deltas and clearing active hotspots while triggering resolution/expiry toasts
- update hotspot tests for the new resolution data

## Testing
- bun test

------
https://chatgpt.com/codex/tasks/task_e_68de296ddb448320b1f64f24c447b580