### PR TITLE
Add hotspot extra article and hotspot logging updates

### DIFF
--- a/src/components/dev/HotspotInspector.tsx
+++ b/src/components/dev/HotspotInspector.tsx
@@ -5,6 +5,7 @@ import { Button } from '@/components/ui/button';
 import { ScrollArea } from '@/components/ui/scroll-area';
 import { type ActiveParanormalHotspot } from '@/hooks/gameStateTypes';
 import { VisualEffectsCoordinator } from '@/utils/visualEffects';
+import { getHotspotIdleMessage } from '@/state/useGameLog';
 
 interface HotspotInspectorProps {
   hotspots?: Record<string, ActiveParanormalHotspot>;
@@ -63,7 +64,7 @@ const HotspotInspector = ({ hotspots, onTriggerEvent }: HotspotInspectorProps) =
       <CardContent className="p-0">
         {entries.length === 0 ? (
           <div className="p-6 text-center text-sm text-slate-400">
-            No active hotspots detected. Fire an event that spawns anomalies to populate this panel.
+            {getHotspotIdleMessage()} Skyt inn en hendelse for å generere nye anomalier.
           </div>
         ) : (
           <ScrollArea className="max-h-72">

--- a/src/components/game/EnhancedUSAMap.tsx
+++ b/src/components/game/EnhancedUSAMap.tsx
@@ -8,6 +8,7 @@ import { geoAlbersUsa, geoPath } from 'd3-geo';
 import { AlertTriangle, Target, Shield } from 'lucide-react';
 import { VisualEffectsCoordinator } from '@/utils/visualEffects';
 import { areParanormalEffectsEnabled } from '@/state/settings';
+import { getHotspotIdleMessage } from '@/state/useGameLog';
 import type {
   ActiveStateBonus,
   StateEventBonusSummary,
@@ -110,7 +111,7 @@ export const StateHotspotDetails: React.FC<StateHotspotDetailsProps> = ({ hotspo
             })()}
           </>
         ) : (
-          <div className="text-muted-foreground leading-snug">No active hotspot detected.</div>
+          <div className="text-muted-foreground leading-snug">{getHotspotIdleMessage()}</div>
         )}
         {entries.length > 0 && (
           <div className={`mt-1 ${hasHotspot ? 'border-t border-purple-500/20 pt-2' : ''}`}>

--- a/src/components/game/TabloidNewspaperLegacy.tsx
+++ b/src/components/game/TabloidNewspaperLegacy.tsx
@@ -11,6 +11,7 @@ import type { AgendaMoment } from '@/hooks/usePressArchive';
 import CardImage from '@/components/game/CardImage';
 import { formatComboReward, getLastComboSummary } from '@/game/comboEngine';
 import type { ArcProgressSummary } from '@/types/campaign';
+import type { HotspotDirector, WeightedHotspotCandidate } from '@/systems/paranormalHotspots';
 
 export interface TabloidPlayedCard {
   card: GameCard;
@@ -31,6 +32,8 @@ export interface TabloidNewspaperProps {
   agendaIssue?: AgendaIssueState;
   agendaMoments?: AgendaMoment[];
   onArcProgress?: (summaries: ArcProgressSummary[]) => void;
+  hotspotDirector?: HotspotDirector;
+  activeHotspot?: WeightedHotspotCandidate | null;
 }
 
 interface NewspaperData {

--- a/src/components/game/TabloidNewspaperV2.tsx
+++ b/src/components/game/TabloidNewspaperV2.tsx
@@ -7,6 +7,7 @@ import CardImage from '@/components/game/CardImage';
 import { loadNewspaperData, pick, shuffle, type NewspaperData } from '@/lib/newspaperData';
 import { generateIssue, type NarrativeIssue, type PlayedCardInput } from '@/engine/newspaper/IssueGenerator';
 import type { TabloidNewspaperProps } from './TabloidNewspaperLegacy';
+import type { HotspotExtraArticle } from '@/systems/paranormalHotspots';
 import type { Card } from '@/types';
 import { formatComboReward, getLastComboSummary } from '@/game/comboEngine';
 import { buildRoundContext, formatTruthDelta } from './tabloidRoundUtils';
@@ -271,6 +272,8 @@ const TabloidNewspaperV2 = ({
   agendaIssue,
   agendaMoments = [],
   onArcProgress,
+  hotspotDirector,
+  activeHotspot,
 }: TabloidNewspaperProps) => {
   const [data, setData] = useState<NewspaperData | null>(null);
   const [masthead, setMasthead] = useState('THE PARANOID TIMES');
@@ -738,6 +741,19 @@ const TabloidNewspaperV2 = ({
     [events],
   );
 
+  const hotspotExtraArticle = useMemo<HotspotExtraArticle | null>(() => {
+    if (!hotspotDirector || !activeHotspot) {
+      return null;
+    }
+
+    try {
+      return hotspotDirector.buildHotspotExtraArticle(activeHotspot);
+    } catch (error) {
+      console.error('Failed to compose hotspot extra article:', error);
+      return null;
+    }
+  }, [hotspotDirector, activeHotspot]);
+
   const campaignArcGroups = useMemo<CampaignArcGroup[]>(() => {
     if (!events.length) {
       return [];
@@ -1114,14 +1130,41 @@ const TabloidNewspaperV2 = ({
                   ) : null}
                 </div>
               </div>
-            </article>
+          </article>
 
-            <aside className="space-y-4">
-              {comboNarrative ? (
-                <section className="rounded-md border border-newspaper-border bg-white/70 p-4 shadow-sm">
-                  <h3 className="mb-2 text-sm font-black uppercase tracking-wide text-newspaper-text">
-                    Combo Dispatch
-                  </h3>
+          <aside className="space-y-4">
+            {hotspotExtraArticle ? (
+              <section className="rounded-md border border-newspaper-border bg-white/70 p-4 shadow-sm">
+                <div className="flex flex-wrap items-center justify-between gap-2 text-[11px] font-semibold uppercase tracking-wide text-newspaper-text/60">
+                  <span
+                    className={cn(
+                      'inline-flex items-center gap-2 rounded-full border px-2 py-0.5 text-[11px] font-semibold uppercase tracking-wide',
+                      hotspotExtraArticle.badgeClassName || 'bg-purple-950/80 border-purple-400/70 text-purple-100',
+                    )}
+                  >
+                    <span aria-hidden="true">🛸</span>
+                    {hotspotExtraArticle.badgeLabel}
+                  </span>
+                  <span className="rounded border border-dashed border-newspaper-border/60 px-2 py-0.5">
+                    Intensitet {hotspotExtraArticle.intensity}
+                  </span>
+                </div>
+                <div className="mt-2 text-[10px] font-semibold uppercase tracking-[0.35em] text-newspaper-text/50">
+                  Hotspot Oppdaget
+                </div>
+                <h3 className="mt-1 text-base font-black uppercase tracking-wide text-newspaper-headline">
+                  {hotspotExtraArticle.headline}
+                </h3>
+                <p className="mt-2 text-sm leading-relaxed text-newspaper-text/80">
+                  {hotspotExtraArticle.blurb}
+                </p>
+              </section>
+            ) : null}
+            {comboNarrative ? (
+              <section className="rounded-md border border-newspaper-border bg-white/70 p-4 shadow-sm">
+                <h3 className="mb-2 text-sm font-black uppercase tracking-wide text-newspaper-text">
+                  Combo Dispatch
+                </h3>
                   <div className="text-[11px] font-semibold uppercase tracking-wide text-newspaper-text/60">
                     Chain: {comboNarrative.magnitude} · {comboNarrative.tags.join(' • ')}
                   </div>

--- a/src/data/hotspots.config.json
+++ b/src/data/hotspots.config.json
@@ -82,5 +82,49 @@
         }
       }
     }
+  },
+  "ui": {
+    "badges": {
+      "default": {
+        "className": "bg-slate-950/80 border-slate-500/60 text-slate-200"
+      },
+      "anomaly": {
+        "className": "bg-indigo-950/80 border-indigo-500/70 text-indigo-200"
+      },
+      "disturbance": {
+        "className": "bg-amber-950/80 border-amber-500/60 text-amber-200"
+      },
+      "manifestation": {
+        "className": "bg-rose-950/75 border-rose-500/60 text-rose-200"
+      },
+      "phenomenon": {
+        "className": "bg-purple-950/80 border-purple-400/70 text-purple-100"
+      },
+      "encounter": {
+        "className": "bg-sky-950/80 border-sky-500/60 text-sky-200"
+      }
+    },
+    "blurbs": {
+      "default": [
+        "Sensorene melder {KIND}-anomali over {STATE}. Intensitet {INTENSITY}.",
+        "Feltteam rapporterer ustabil energi i {STATE_TITLE}. Intensitet {INTENSITY}."
+      ],
+      "phenomenon": [
+        "Spektrale bølger forstyrrer {STATE_TITLE}. Målt intensitet {INTENSITY}.",
+        "Pressesenteret registrerer en fenomen-krusning over {STATE_TITLE}. Intensitet {INTENSITY}."
+      ],
+      "encounter": [
+        "Vitner i {STATE_TITLE} rapporterer nærkontakt. Intensitet {INTENSITY}.",
+        "Operatører i {STATE_TITLE} låser inn på ukjent signatur. Intensitet {INTENSITY}."
+      ],
+      "disturbance": [
+        "Lokale nett i {STATE_TITLE} flimrer mens en forstyrrelse bygger seg opp. Intensitet {INTENSITY}.",
+        "Alarmnettet noterer en taktisk forstyrrelse i {STATE_TITLE}. Intensitet {INTENSITY}."
+      ],
+      "manifestation": [
+        "Materialiserte former driver over {STATE_TITLE}. Intensitet {INTENSITY}.",
+        "Observatører melder om manifestasjoner i {STATE_TITLE}. Intensitet {INTENSITY}."
+      ]
+    }
   }
 }

--- a/src/hooks/useGameState.ts
+++ b/src/hooks/useGameState.ts
@@ -42,6 +42,7 @@ import {
 import { VisualEffectsCoordinator } from '@/utils/visualEffects';
 import { getEnabledExpansionIdsSnapshot } from '@/data/expansions/state';
 import { queueHotspotResolveToast, queueHotspotExpireToast } from '@/ui/hotspots.toasts';
+import { formatHotspotSpawnLog, getHotspotIdleLog } from '@/state/useGameLog';
 import type {
   ActiveCampaignArcState,
   ActiveParanormalHotspot,
@@ -2415,7 +2416,7 @@ export const useGameState = (aiDifficultyOverride?: AIDifficulty) => {
                   eventForEdition = { ...activeEvent, headline: dynamicHeadline };
                 }
               } else {
-                eventEffectLog.push('👻 Paranormal surge failed to find a viable hotspot target.');
+                eventEffectLog.push(getHotspotIdleLog());
               }
             }
 
@@ -2867,9 +2868,11 @@ export const useGameState = (aiDifficultyOverride?: AIDifficulty) => {
       const rolledHotspot = hotspotDirector.rollForSpawn(prev.round, prev, {
         enabledExpansions,
       });
-      const hotspotLogs = rolledHotspot
-        ? [`👻 ${rolledHotspot.name} rumored near ${rolledHotspot.stateName ?? rolledHotspot.location}.`]
-        : [];
+      let hotspotLogs: string[] = [];
+      if (rolledHotspot) {
+        const extraArticle = hotspotDirector.buildHotspotExtraArticle(rolledHotspot);
+        hotspotLogs = [formatHotspotSpawnLog(extraArticle)];
+      }
       const logsWithHotspot = hotspotLogs.length > 0 ? [...baseLogs, ...hotspotLogs] : baseLogs;
 
       let nextState: GameState = {
@@ -3590,5 +3593,6 @@ export const useGameState = (aiDifficultyOverride?: AIDifficulty) => {
     deleteSave,
     checkVictoryConditions,
     registerParanormalSighting,
+    hotspotDirector,
   };
 };

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -717,6 +717,7 @@ const Index = () => {
     loadGame,
     getSaveInfo,
     registerParanormalSighting,
+    hotspotDirector,
   } = useGameState();
   const audio = useAudioContext();
   const { animatePlayCard, isAnimating } = useCardAnimation();
@@ -3019,6 +3020,8 @@ const Index = () => {
           agendaMoments={agendaMoments}
           onClose={handleCloseNewspaper}
           onArcProgress={handleArcProgress}
+          hotspotDirector={hotspotDirector}
+          activeHotspot={gameState.activeHotspot}
         />
       )}
     </>

--- a/src/state/useGameLog.ts
+++ b/src/state/useGameLog.ts
@@ -1,0 +1,18 @@
+import type { HotspotExtraArticle } from '@/systems/paranormalHotspots';
+
+const HOTSPOT_IDLE_MESSAGE = 'Ingen hotspot-signaler registrert. Sensorene holder linjen åpen.';
+
+export const formatHotspotSpawnLog = (article: HotspotExtraArticle): string => {
+  const stateLabel = article.stateName ? article.stateName.toUpperCase() : 'UKJENT OMRÅDE';
+  return `🛸 HOTSPOT OPPDAGET: ${stateLabel}. ${article.headline} — ${article.blurb}`;
+};
+
+export const getHotspotIdleMessage = (): string => HOTSPOT_IDLE_MESSAGE;
+
+export const getHotspotIdleLog = (): string => `🛰️ ${HOTSPOT_IDLE_MESSAGE}`;
+
+export const useGameLog = () => ({
+  formatHotspotSpawnLog,
+  getHotspotIdleMessage,
+  getHotspotIdleLog,
+});


### PR DESCRIPTION
## Summary
- add hotspot UI badge colors and blurbs to the config and teach `HotspotDirector` to generate extra articles from them
- surface the hotspot extra article in the v2 newspaper while passing the director/active hotspot through game state
- centralize hotspot log copy and update the map/inspector fallback text to the new message

## Testing
- npm run lint *(fails: pre-existing lint errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68de2e5ae14883208aead827858bb8fa