### PR TITLE
Gate event-driven hotspots when HotspotDirector is enabled

### DIFF
--- a/src/data/eventDatabase.test.ts
+++ b/src/data/eventDatabase.test.ts
@@ -1,4 +1,6 @@
-import { describe, expect, it } from 'bun:test';
+import { afterEach, describe, expect, it } from 'bun:test';
+
+import { featureFlags } from '@/state/featureFlags';
 
 import type { GameEvent } from './eventDatabase';
 import { EventManager } from './eventDatabase';
@@ -62,6 +64,128 @@ describe('EventManager.selectStateEvent', () => {
     expect(selectedIds.length).toBe(4);
     expect(new Set(selectedIds).size).toBe(3);
     expect(selectedIds[0]).toBe(selectedIds[3]);
+  });
+});
+
+describe('EventManager.maybeSelectRandomEvent', () => {
+  const originalHotspotFlag = featureFlags.hotspotDirectorEnabled;
+
+  afterEach(() => {
+    featureFlags.hotspotDirectorEnabled = originalHotspotFlag;
+  });
+
+  it('considers paranormal hotspot pool when the director is disabled', () => {
+    featureFlags.hotspotDirectorEnabled = false;
+
+    const manager = new EventManager();
+    const paranormalEvent: GameEvent = {
+      id: 'paranormal-test',
+      title: 'Paranormal Test Event',
+      content: 'Spawns a hotspot when allowed.',
+      type: 'random',
+      rarity: 'rare',
+      weight: 1,
+      paranormalHotspot: {
+        label: 'Test Hotspot',
+        duration: 2,
+        truthReward: 4,
+        defenseBoost: 2,
+      },
+    };
+    const fallbackEvent: GameEvent = {
+      id: 'standard-test',
+      title: 'Standard Event',
+      content: 'No hotspot payload.',
+      type: 'random',
+      rarity: 'common',
+      weight: 1,
+    };
+
+    const pools: Array<{ pool: GameEvent[]; chanceFactor: number }> = [];
+    (manager as unknown as { getAvailableEvents(): GameEvent[] }).getAvailableEvents = () => [
+      paranormalEvent,
+      fallbackEvent,
+    ];
+    (manager as unknown as {
+      selectEventFromPool(pool: GameEvent[], chanceFactor: number): GameEvent | null;
+    }).selectEventFromPool = (pool: GameEvent[], chanceFactor: number) => {
+      pools.push({ pool, chanceFactor });
+      return pool[0] ?? null;
+    };
+
+    const originalRandom = Math.random;
+    let callCount = 0;
+    Math.random = () => {
+      callCount += 1;
+      return callCount === 1 ? 0.05 : 0.01;
+    };
+
+    try {
+      const result = manager.maybeSelectRandomEvent({});
+      expect(result).toBe(paranormalEvent);
+      expect(pools).toHaveLength(1);
+      expect(pools[0]?.chanceFactor).toBeCloseTo(0.2);
+      expect(pools[0]?.pool).toContain(paranormalEvent);
+    } finally {
+      Math.random = originalRandom;
+    }
+  });
+
+  it('skips the paranormal hotspot pool when the director is enabled', () => {
+    featureFlags.hotspotDirectorEnabled = true;
+
+    const manager = new EventManager();
+    const paranormalEvent: GameEvent = {
+      id: 'paranormal-test',
+      title: 'Paranormal Test Event',
+      content: 'Spawns a hotspot when allowed.',
+      type: 'random',
+      rarity: 'rare',
+      weight: 1,
+      paranormalHotspot: {
+        label: 'Test Hotspot',
+        duration: 2,
+        truthReward: 4,
+        defenseBoost: 2,
+      },
+    };
+    const fallbackEvent: GameEvent = {
+      id: 'standard-test',
+      title: 'Standard Event',
+      content: 'No hotspot payload.',
+      type: 'random',
+      rarity: 'common',
+      weight: 1,
+    };
+
+    const pools: Array<{ pool: GameEvent[]; chanceFactor: number }> = [];
+    (manager as unknown as { getAvailableEvents(): GameEvent[] }).getAvailableEvents = () => [
+      paranormalEvent,
+      fallbackEvent,
+    ];
+    (manager as unknown as {
+      selectEventFromPool(pool: GameEvent[], chanceFactor: number): GameEvent | null;
+    }).selectEventFromPool = (pool: GameEvent[], chanceFactor: number) => {
+      pools.push({ pool, chanceFactor });
+      return pool[0] ?? null;
+    };
+
+    const originalRandom = Math.random;
+    let callCount = 0;
+    Math.random = () => {
+      callCount += 1;
+      return callCount === 1 ? 0.05 : 0.01;
+    };
+
+    try {
+      const result = manager.maybeSelectRandomEvent({});
+      expect(result).toBe(paranormalEvent);
+      expect(pools).toHaveLength(1);
+      expect(pools[0]?.chanceFactor).toBeCloseTo(0.12);
+      expect(pools[0]?.pool).toContain(paranormalEvent);
+    } finally {
+      Math.random = originalRandom;
+    }
   });
 });
 

--- a/src/data/eventDatabase.ts
+++ b/src/data/eventDatabase.ts
@@ -1,3 +1,5 @@
+import { featureFlags } from '@/state/featureFlags';
+
 export interface ParanormalHotspotPayload {
   /** Optional fixed state identifier (FIPS or abbreviation) to anchor the hotspot. */
   stateId?: string;
@@ -4780,8 +4782,11 @@ export class EventManager {
       return null;
     }
 
-    const paranormalEvents = availableEvents.filter(event => Boolean(event.paranormalHotspot));
-    if (paranormalEvents.length > 0 && Math.random() < this.paranormalHotspotChance) {
+    const eventHotspotsEnabled = !featureFlags.hotspotDirectorEnabled;
+    const paranormalEvents = eventHotspotsEnabled
+      ? availableEvents.filter(event => Boolean(event.paranormalHotspot))
+      : [];
+    if (eventHotspotsEnabled && paranormalEvents.length > 0 && Math.random() < this.paranormalHotspotChance) {
       const paranormalSelection = this.selectEventFromPool(
         paranormalEvents,
         this.paranormalHotspotChance,

--- a/src/hooks/useGameState.ts
+++ b/src/hooks/useGameState.ts
@@ -2382,7 +2382,7 @@ export const useGameState = (aiDifficultyOverride?: AIDifficulty) => {
               }
             }
 
-            if (activeEvent.paranormalHotspot) {
+            if (!featureFlags.hotspotDirectorEnabled && activeEvent.paranormalHotspot) {
               const target = selectHotspotTargetState({
                 states: statesAfterHotspot,
                 activeHotspots: hotspotsAfterHotspot,

--- a/src/state/featureFlags.ts
+++ b/src/state/featureFlags.ts
@@ -1,11 +1,13 @@
 export type FeatureFlags = {
   newspaperV2: boolean;
   aiVerboseStrategyLog: boolean;
+  hotspotDirectorEnabled: boolean;
 };
 
 const DEFAULT_FLAGS: FeatureFlags = {
   newspaperV2: true,
   aiVerboseStrategyLog: false,
+  hotspotDirectorEnabled: true,
 };
 
 const readBoolean = (key: string, fallback: boolean): boolean => {
@@ -39,4 +41,7 @@ export const featureFlags: FeatureFlags = {
   newspaperV2: overrides.newspaperV2 ?? readBoolean('shadowgov:flag:newspaperV2', DEFAULT_FLAGS.newspaperV2),
   aiVerboseStrategyLog:
     overrides.aiVerboseStrategyLog ?? readBoolean('shadowgov:flag:aiVerboseStrategyLog', DEFAULT_FLAGS.aiVerboseStrategyLog),
+  hotspotDirectorEnabled:
+    overrides.hotspotDirectorEnabled
+      ?? readBoolean('shadowgov:flag:hotspotDirectorEnabled', DEFAULT_FLAGS.hotspotDirectorEnabled),
 };


### PR DESCRIPTION
## Summary
- add a hotspotDirectorEnabled feature flag and use it to disable event-driven hotspot spawning when the new director is active
- skip the paranormal hotspot event pool while the director flag is on and ensure the game-state hook only spawns hotspots when allowed
- expand the event manager tests to cover both sides of the new toggle

## Testing
- bun test src/data/eventDatabase.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68de418051988320b825fd1c452326d9