### PR TITLE
Add hotspot icon assignment for expansion spawns

### DIFF
--- a/src/hooks/__tests__/useGameState.stateEvents.test.ts
+++ b/src/hooks/__tests__/useGameState.stateEvents.test.ts
@@ -184,7 +184,7 @@ mock.module('@/systems/cardResolution', () => ({
     const updatedStates = prev.states.map((state: any) => {
       if (captureId && state.id === captureId) {
         const ownerLabel = owner === 'human' ? 'player' : 'ai';
-        return { ...state, owner: ownerLabel };
+        return { ...state, owner: ownerLabel, paranormalHotspot: undefined };
       }
       return { ...state };
     });
@@ -202,10 +202,33 @@ mock.module('@/systems/cardResolution', () => ({
       ? addControlledState(prev.aiControlledStates, resolvedState.abbreviation)
       : prev.aiControlledStates;
 
+    const truthDelta = 0;
+    const truth = prev.truth;
+
+    const hotspotResolutions = captureId && resolvedState?.paranormalHotspot
+      ? [{
+        stateId: resolvedState.id,
+        stateAbbreviation: resolvedState.abbreviation,
+        stateName: resolvedState.name,
+        hotspotId: resolvedState.paranormalHotspot.id,
+        label: resolvedState.paranormalHotspot.label,
+        defenseBoost: resolvedState.paranormalHotspot.defenseBoost ?? 0,
+        truthReward: 0,
+        truthDelta,
+        expectedTruthDelta: truthDelta,
+        faction: owner === 'human' ? prev.faction : prev.faction === 'truth' ? 'government' : 'truth',
+        source: resolvedState.paranormalHotspot.source ?? 'neutral',
+      }]
+      : undefined;
+
+    const resolvedHotspots = captureId && resolvedState?.paranormalHotspot
+      ? [resolvedState.abbreviation ?? resolvedState.id]
+      : undefined;
+
     return {
       ip: prev.ip,
       aiIP: prev.aiIP,
-      truth: prev.truth,
+      truth,
       states: updatedStates,
       controlledStates,
       aiControlledStates,
@@ -214,6 +237,8 @@ mock.module('@/systems/cardResolution', () => ({
       selectedCard: card?.id ?? null,
       logEntries: [],
       damageDealt: 0,
+      resolvedHotspots,
+      hotspotResolutions,
     };
   },
 }));

--- a/src/hooks/useGameState.ts
+++ b/src/hooks/useGameState.ts
@@ -39,6 +39,7 @@ import {
   resolveHotspot,
   type WeightedHotspotCandidate,
   type Hotspot,
+  deriveHotspotIcon,
 } from '@/systems/paranormalHotspots';
 import { VisualEffectsCoordinator } from '@/utils/visualEffects';
 import { getEnabledExpansionIdsSnapshot } from '@/data/expansions/state';
@@ -554,9 +555,11 @@ const createDirectorHotspotEntries = (params: {
   const duration = Math.max(2, Math.min(4, Math.round(rawIntensity / 2) + 1));
   const truthReward = Math.max(1, Math.round(Math.abs(truthResolution.truthDelta)));
 
-  const icon = candidate.tags.includes('cryptid-home') || candidate.tags.includes('expansion:cryptids')
-    ? '🛸'
-    : '👻';
+  const icon = deriveHotspotIcon({
+    icon: candidate.icon,
+    tags: candidate.tags,
+    expansionTag: candidate.expansionTag,
+  });
   const label = candidate.name ?? `${state.name} Hotspot`;
 
   const payload: ParanormalHotspotPayload = {
@@ -3066,9 +3069,11 @@ export const useGameState = (aiDifficultyOverride?: AIDifficulty) => {
           });
         } else if (rolledHotspot) {
           const label = rolledHotspot.stateName ?? rolledHotspot.location ?? rolledHotspot.name;
-          const icon = rolledHotspot.tags.includes('cryptid-home') ? '🛸' : rolledHotspot.tags.includes('expansion:cryptids')
-            ? '🛸'
-            : '👻';
+          const icon = deriveHotspotIcon({
+            icon: rolledHotspot.icon,
+            tags: rolledHotspot.tags,
+            expansionTag: rolledHotspot.expansionTag,
+          });
           const position = VisualEffectsCoordinator.getRandomCenterPosition(220);
           VisualEffectsCoordinator.triggerParanormalHotspot({
             position,


### PR DESCRIPTION
## Summary
- derive hotspot icon metadata so automatic spawns carry cryptid and Halloween emoji cues
- plumb icon data through hotspot state updates and visual effect handling
- extend spawn tests to cover themed emoji selection and stabilize mocked card resolution output

## Testing
- bun test

------
https://chatgpt.com/codex/tasks/task_e_68de465200c48320841f785750504cb1