### PR TITLE
Add hotspot resolution symmetry test for expansion bonuses

### DIFF
--- a/src/hooks/useGameState.ts
+++ b/src/hooks/useGameState.ts
@@ -594,6 +594,8 @@ const createDirectorHotspotEntries = (params: {
   return { ...entries, payload };
 };
 
+export const __test_createDirectorHotspotEntries = createDirectorHotspotEntries;
+
 const cloneEventEffects = (
   effects: GameEvent['effects'] | undefined,
 ): NonNullable<GameEvent['effects']> | undefined => {

--- a/src/systems/paranormalHotspots.ts
+++ b/src/systems/paranormalHotspots.ts
@@ -147,6 +147,18 @@ export interface HotspotResolutionOutcome {
 const toFiniteNumber = (value: unknown): number | undefined =>
   typeof value === 'number' && Number.isFinite(value) ? value : undefined;
 
+let testEnabledExpansionOverride: string[] | null = null;
+
+export const __setTestEnabledExpansions = (ids: string[] | null): void => {
+  if (Array.isArray(ids)) {
+    testEnabledExpansionOverride = ids
+      .filter((id): id is string => typeof id === 'string')
+      .map(id => id);
+  } else {
+    testEnabledExpansionOverride = null;
+  }
+};
+
 const resolveTruthRewardsConfig = (): TruthRewardsConfig => {
   const rawResolution = (hotspotsConfig as { resolution?: unknown }).resolution;
   if (!rawResolution || typeof rawResolution !== 'object') {
@@ -197,9 +209,10 @@ export function resolveHotspot(
     ?? Number.POSITIVE_INFINITY;
 
   const expansionConfig = truthRewardsConfig.expansionBonuses ?? {};
-  const enabledExpansions = new Set(
-    options.enabledExpansions ?? getEnabledExpansionIdsSnapshot(),
-  );
+  const enabledExpansionIds = options.enabledExpansions
+    ?? testEnabledExpansionOverride
+    ?? getEnabledExpansionIdsSnapshot();
+  const enabledExpansions = new Set(enabledExpansionIds);
 
   let expansionBonus = 0;
   let totalMultiplier = 1;


### PR DESCRIPTION
## Summary
- export createDirectorHotspotEntries for test coverage and allow tests to override enabled expansions when resolving hotspots
- add regression test that spawns a director hotspot with the cryptids expansion and verifies truth/government captures stay symmetric, restore defense, and record history

## Testing
- bun test src/systems/__tests__/resolveCardMVP.hotspot.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68de5cf1838c8320b869c1f4b3831f7f