### PR TITLE
Refactor paranormal hotspot spawning to use catalog data

### DIFF
--- a/src/components/game/__tests__/EnhancedUSAMap.hotspot.test.tsx
+++ b/src/components/game/__tests__/EnhancedUSAMap.hotspot.test.tsx
@@ -407,12 +407,12 @@ describe('EnhancedUSAMap paranormal hotspots', () => {
     const oregon = createState('41', 'Oregon', 'OR', 'ai');
     const california = createState('06', 'California', 'CA', 'neutral');
 
-    const baseWeight = { base: 1, expansion: 0, cryptid: 0 };
+    const baseWeight = { base: 1, catalog: 0, type: 0, expansion: 0, cryptid: 0 };
 
     const defaultCandidate: WeightedHotspotCandidate = {
       id: 'ufo-sighting',
       name: 'Cascade Lights',
-      kind: 'anomaly',
+      kind: 'ufo',
       location: 'Seattle Skyline',
       intensity: 4,
       status: 'spawning',
@@ -435,6 +435,7 @@ describe('EnhancedUSAMap paranormal hotspots', () => {
       stateId: oregon.id,
       stateName: oregon.name,
       stateAbbreviation: oregon.abbreviation,
+      kind: 'cryptid',
     };
 
     const halloweenCandidate: WeightedHotspotCandidate = {
@@ -446,6 +447,7 @@ describe('EnhancedUSAMap paranormal hotspots', () => {
       stateId: california.id,
       stateName: california.name,
       stateAbbreviation: california.abbreviation,
+      kind: 'ghost',
     };
 
     const washingtonHotspot = createDirectorStyleHotspot({

--- a/src/data/hotspots.config.json
+++ b/src/data/hotspots.config.json
@@ -6,6 +6,9 @@
     "decayRate": 0.05
   },
   "spawn": {
+    "defaults": {
+      "spawnRate": 0.2
+    },
     "baseWeights": {
       "default": 1,
       "states": {

--- a/src/hooks/useGameState.ts
+++ b/src/hooks/useGameState.ts
@@ -104,7 +104,7 @@ const buildResolvedHotspotToast = (resolution: CardHotspotResolution): Hotspot =
   return {
     id: resolution.hotspotId,
     name: resolution.label,
-    kind: 'phenomenon',
+    kind: 'normal',
     location: resolution.stateName,
     intensity: computeHotspotToastIntensity(resolution.truthReward || resolution.truthDelta),
     status: 'resolved',
@@ -119,7 +119,7 @@ const buildResolvedHotspotToast = (resolution: CardHotspotResolution): Hotspot =
 const buildExpiredHotspotToast = (hotspot: ActiveParanormalHotspot): Hotspot => ({
   id: hotspot.id,
   name: hotspot.label,
-  kind: 'phenomenon',
+  kind: 'normal',
   location: hotspot.stateName,
   intensity: computeHotspotToastIntensity(hotspot.truthReward),
   status: 'expired',
@@ -553,19 +553,25 @@ const createDirectorHotspotEntries = (params: {
     : 3;
   const defenseBoost = Math.max(1, Math.round(rawIntensity / 2));
   const duration = Math.max(2, Math.min(4, Math.round(rawIntensity / 2) + 1));
-  const truthReward = Math.max(1, Math.round(Math.abs(truthResolution.truthDelta)));
+  const truthReward = Math.max(
+    1,
+    Math.round(
+      Math.abs(candidate.truthRewardHint ?? truthResolution.truthDelta ?? 0),
+    ),
+  );
 
   const icon = deriveHotspotIcon({
     icon: candidate.icon,
     tags: candidate.tags,
     expansionTag: candidate.expansionTag,
+    kind: candidate.kind,
   });
   const label = candidate.name ?? `${state.name} Hotspot`;
 
   const payload: ParanormalHotspotPayload = {
     stateId: state.id,
     label,
-    description: candidate.location,
+    description: candidate.summary ?? candidate.location,
     icon,
     duration,
     truthReward,
@@ -577,7 +583,7 @@ const createDirectorHotspotEntries = (params: {
     id: candidate.id,
     title: label,
     headline: candidate.name?.toUpperCase(),
-    content: candidate.location ?? `${state.name} hotspot`,
+    content: candidate.summary ?? candidate.location ?? `${state.name} hotspot`,
     type: 'random',
     faction: 'neutral',
     rarity: 'rare',

--- a/src/systems/__tests__/resolveCardMVP.hotspot.test.ts
+++ b/src/systems/__tests__/resolveCardMVP.hotspot.test.ts
@@ -94,17 +94,17 @@ describe('resolveCardMVP hotspot handling', () => {
       const candidate: WeightedHotspotCandidate = {
         id: 'auto:OR:1:seed',
         name: 'Oregon Phenomenon',
-        kind: 'phenomenon',
+        kind: 'cryptid',
         location: 'Oregon',
         intensity: 6,
         status: 'spawning',
         tags: ['auto-spawn', 'expansion:cryptids'],
-        icon: '🛸',
+        icon: '🦶',
         stateId: 'OR',
         stateName: 'Oregon',
         stateAbbreviation: 'OR',
         totalWeight: 5,
-        weightBreakdown: { base: 3, expansion: 1, cryptid: 1 },
+        weightBreakdown: { base: 3, catalog: 0.5, type: 0.5, expansion: 1, cryptid: 1 },
       };
 
       const baseDefense = 2;

--- a/src/ui/__tests__/hotspots.toasts.test.ts
+++ b/src/ui/__tests__/hotspots.toasts.test.ts
@@ -35,18 +35,18 @@ describe('hotspot toast formatting', () => {
   const sampleHotspot: Hotspot = {
     id: 'test-hotspot',
     name: 'Cascade Rift',
-    kind: 'phenomenon',
+    kind: 'normal',
     location: 'Washington',
     intensity: 5,
     status: 'spawning',
     tags: ['auto-spawn'],
-    icon: '🛸',
+    icon: '👻',
     expansionTag: undefined,
     stateId: '53',
     stateName: 'Washington',
     stateAbbreviation: 'WA',
     totalWeight: 1,
-    weightBreakdown: { base: 1, expansion: 0, cryptid: 0 },
+    weightBreakdown: { base: 1, catalog: 0, type: 0, expansion: 0, cryptid: 0 },
     truthDelta: 4,
   };
 


### PR DESCRIPTION
## Summary
- drive auto-spawned hotspots from the catalog with spawn-rate gating, catalog/type weighting, and truth hint propagation
- expose catalog metadata to downstream UI helpers and toast builders while updating the hotspot config defaults
- refresh hotspot-related tests to account for probabilistic spawns and the new kind/icon semantics

## Testing
- bun test src/systems/__tests__/paranormalHotspots.test.ts
- bun test src/ui/__tests__/hotspots.toasts.test.ts
- bun test src/systems/__tests__/resolveCardMVP.hotspot.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68de61ee83f08320836ce9111c99cc7c