### PR TITLE
Add pulsing glow styles for agenda reveal and legendary cards

### DIFF
--- a/src/components/game/cards/BaseCard.tsx
+++ b/src/components/game/cards/BaseCard.tsx
@@ -70,10 +70,23 @@ export const BaseCard = ({
   );
 
   const wrapperStyle = { '--card-scale': String(SIZE_TO_SCALE[size]) } as CSSProperties;
+  const revealsSecretAgenda = Boolean(
+    (card.effects as { revealSecretAgenda?: boolean } | undefined)?.revealSecretAgenda,
+  );
+  const isLegendaryCard = String(card.rarity ?? '').toLowerCase() === 'legendary';
 
   return (
     <div
-      className={cn('card-frame-wrapper', polaroidHover && 'group', frameClassName, className)}
+      className={cn(
+        'card-frame-wrapper',
+        polaroidHover && 'group',
+        frameClassName,
+        className,
+        {
+          'card-glow-agenda-reveal': revealsSecretAgenda,
+          'card-glow-legendary': isLegendaryCard,
+        },
+      )}
       style={wrapperStyle}
       data-testid="tabloid-card"
     >

--- a/src/index.css
+++ b/src/index.css
@@ -1049,6 +1049,79 @@ All colors MUST be HSL.
   pointer-events: none;
 }
 
+.card-glow-agenda-reveal,
+.card-glow-legendary {
+  position: relative;
+  z-index: 0;
+}
+
+.card-glow-agenda-reveal::before,
+.card-glow-legendary::after {
+  content: "";
+  position: absolute;
+  inset: calc(-14px * var(--card-scale, 1));
+  border-radius: calc(18px * var(--card-scale, 1));
+  pointer-events: none;
+  opacity: 0.85;
+  z-index: -1;
+  transition: opacity 0.3s ease;
+}
+
+.card-glow-agenda-reveal::before {
+  background: radial-gradient(circle, hsl(var(--secret-red) / 0.45) 0%, transparent 70%);
+  box-shadow:
+    0 0 calc(16px * var(--card-scale, 1)) hsl(var(--secret-red) / 0.45),
+    0 0 calc(42px * var(--card-scale, 1)) hsl(var(--secret-red) / 0.25);
+  animation: card-agenda-reveal-pulse 1.8s ease-in-out infinite;
+}
+
+.card-glow-legendary::after {
+  background: radial-gradient(circle, hsl(var(--pt-rarity-legendary) / 0.45) 0%, transparent 70%);
+  box-shadow:
+    0 0 calc(16px * var(--card-scale, 1)) hsl(var(--pt-rarity-legendary) / 0.5),
+    0 0 calc(42px * var(--card-scale, 1)) hsl(var(--pt-rarity-legendary) / 0.28);
+  animation: card-legendary-pulse 2s ease-in-out infinite;
+}
+
+@keyframes card-agenda-reveal-pulse {
+  0%,
+  100% {
+    opacity: 0.7;
+    box-shadow:
+      0 0 calc(10px * var(--card-scale, 1)) hsl(var(--secret-red) / 0.35),
+      0 0 calc(30px * var(--card-scale, 1)) hsl(var(--secret-red) / 0.18);
+  }
+  50% {
+    opacity: 1;
+    box-shadow:
+      0 0 calc(26px * var(--card-scale, 1)) hsl(var(--secret-red) / 0.6),
+      0 0 calc(56px * var(--card-scale, 1)) hsl(var(--secret-red) / 0.32);
+  }
+}
+
+@keyframes card-legendary-pulse {
+  0%,
+  100% {
+    opacity: 0.75;
+    box-shadow:
+      0 0 calc(12px * var(--card-scale, 1)) hsl(var(--pt-rarity-legendary) / 0.42),
+      0 0 calc(32px * var(--card-scale, 1)) hsl(var(--pt-rarity-legendary) / 0.22);
+  }
+  50% {
+    opacity: 1;
+    box-shadow:
+      0 0 calc(28px * var(--card-scale, 1)) hsl(var(--pt-rarity-legendary) / 0.65),
+      0 0 calc(60px * var(--card-scale, 1)) hsl(var(--pt-rarity-legendary) / 0.35);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .card-glow-agenda-reveal::before,
+  .card-glow-legendary::after {
+    animation: none;
+  }
+}
+
 /* Polaroid frame */
 .pt-polaroid {
   background: #ffffff;


### PR DESCRIPTION
## Summary
- highlight cards that reveal secret agendas with a pulsing red frame effect
- add a golden pulse around legendary cards and respect reduced-motion settings
- tag cards in the base card component so the new visual treatments apply automatically

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68de8a146f0c8320b503f09ae792d575