### PR TITLE
Fix truth delta handling for government state events

### DIFF
--- a/src/hooks/__tests__/useGameState.stateEvents.test.ts
+++ b/src/hooks/__tests__/useGameState.stateEvents.test.ts
@@ -548,14 +548,14 @@ describe('useGameState state event truth adjustments', () => {
     });
 
     const event: GameEvent = {
-      id: 'coverup_sweep',
-      title: 'Cover-Up Sweep',
-      content: 'Suppress dissenting voices.',
+      id: 'ut_antechamber_checkpoint',
+      title: 'Antechamber Checkpoint',
+      content: 'Clamp down on dissenters.',
       type: 'state',
       rarity: 'common',
       weight: 1,
       effects: {
-        truth: 5,
+        truthChange: -5,
       },
     } as GameEvent;
 


### PR DESCRIPTION
## Summary
- stop flipping state event truth deltas for the government faction when building summaries
- apply the event-defined truth delta directly during captures and propagate it to summaries
- cover a government capture event with a native negative truthChange in the state event tests

## Testing
- bun test src/hooks/__tests__/useGameState.stateEvents.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68de95e067888320be249fe2f3166e0b