### PR TITLE
Add MVP game state auditing and coverage

### DIFF
--- a/src/mvp/engine.ts
+++ b/src/mvp/engine.ts
@@ -5,6 +5,7 @@ import { applyComboRewards, evaluateCombos, getComboSettings, formatComboReward 
 import type { ComboEvaluation, ComboOptions, ComboSummary, TurnPlay } from '@/game/combo.types';
 import { getStateByAbbreviation, getStateById } from '@/data/usaStates';
 import { cloneGameState } from './validator';
+import { auditGameState } from './gameStateAudit';
 import type { Card, EffectsATTACK, EffectsMEDIA, EffectsZONE, GameState, PlayerState } from './validator';
 import type { MediaResolutionOptions } from './media';
 
@@ -583,6 +584,8 @@ export function endTurn(
     logEntries: turnLog,
     winCheck: winResult.winner ? winResult : null,
   };
+
+  auditGameState(finalState);
 
   return { state: finalState, summary };
 }

--- a/src/mvp/gameStateAudit.ts
+++ b/src/mvp/gameStateAudit.ts
@@ -1,0 +1,166 @@
+import type { GameState, PlayerId, PlayerState } from './validator';
+
+export type GameStateAuditFinding = {
+  level: 'info' | 'warning';
+  message: string;
+};
+
+export class GameStateAuditError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'GameStateAuditError';
+  }
+}
+
+const isFiniteNumber = (value: unknown): value is number =>
+  typeof value === 'number' && Number.isFinite(value);
+
+const assertState = (condition: boolean, message: string): asserts condition => {
+  if (!condition) {
+    throw new GameStateAuditError(message);
+  }
+};
+
+const PLAYER_IDS: readonly PlayerId[] = ['P1', 'P2'];
+
+const validatePlayer = (
+  state: GameState,
+  playerId: PlayerId,
+  playersStates: Map<PlayerId, Set<string>>,
+): GameStateAuditFinding => {
+  const player = state.players[playerId];
+  assertState(Boolean(player), `Missing player entry for ${playerId}`);
+
+  const playerState = player as PlayerState;
+  assertState(playerState.id === playerId, `Player ${playerId} has mismatched id '${playerState.id}'`);
+  assertState(
+    playerState.faction === 'truth' || playerState.faction === 'government',
+    `Player ${playerId} has invalid faction '${playerState.faction}'`,
+  );
+  assertState(isFiniteNumber(playerState.ip), `Player ${playerId} IP must be a finite number`);
+  assertState(playerState.ip >= 0, `Player ${playerId} IP cannot be negative`);
+  assertState(Array.isArray(playerState.deck), `Player ${playerId} deck must be an array`);
+  assertState(Array.isArray(playerState.hand), `Player ${playerId} hand must be an array`);
+  assertState(Array.isArray(playerState.discard), `Player ${playerId} discard must be an array`);
+  assertState(Array.isArray(playerState.states), `Player ${playerId} states must be an array`);
+
+  if (playerState.nextAttackMultiplier !== undefined) {
+    assertState(
+      isFiniteNumber(playerState.nextAttackMultiplier),
+      `Player ${playerId} nextAttackMultiplier must be numeric when defined`,
+    );
+    assertState(
+      playerState.nextAttackMultiplier >= 0,
+      `Player ${playerId} nextAttackMultiplier cannot be negative`,
+    );
+  }
+
+  const normalizedStates = new Set<string>();
+  for (const rawStateId of playerState.states) {
+    assertState(typeof rawStateId === 'string', `Player ${playerId} has non-string state entry`);
+    const stateId = rawStateId.trim();
+    assertState(stateId.length > 0, `Player ${playerId} has blank state entry`);
+    assertState(!normalizedStates.has(stateId), `Player ${playerId} has duplicate state '${stateId}'`);
+    normalizedStates.add(stateId);
+
+    const pressure = state.pressureByState?.[stateId];
+    assertState(pressure !== undefined, `Missing pressure entry for state '${stateId}' controlled by ${playerId}`);
+    assertState(
+      typeof pressure === 'object' && pressure !== null,
+      `Pressure entry for '${stateId}' must be an object`,
+    );
+
+    for (const candidateId of PLAYER_IDS) {
+      const value = (pressure as Record<PlayerId, unknown>)[candidateId];
+      assertState(isFiniteNumber(value), `Pressure for '${stateId}' must include numeric value for ${candidateId}`);
+      assertState((value as number) >= 0, `Pressure for '${stateId}' cannot be negative for ${candidateId}`);
+    }
+
+    const ownerPressure = (pressure as Record<PlayerId, number>)[playerId];
+    assertState(ownerPressure === 0, `Controlled state '${stateId}' must have zero pressure for ${playerId}`);
+
+    const opponentId = playerId === 'P1' ? 'P2' : 'P1';
+    const opponentPressure = (pressure as Record<PlayerId, number>)[opponentId];
+    assertState(
+      opponentPressure === 0,
+      `Controlled state '${stateId}' must not retain opponent pressure (${opponentId})`,
+    );
+
+    const defense = state.stateDefense?.[stateId];
+    assertState(isFiniteNumber(defense), `Missing defense value for controlled state '${stateId}'`);
+    assertState((defense as number) >= 0, `Defense for controlled state '${stateId}' cannot be negative`);
+  }
+
+  playersStates.set(playerId, normalizedStates);
+
+  return {
+    level: 'info',
+    message: `Player ${playerId} controls ${normalizedStates.size} state${
+      normalizedStates.size === 1 ? '' : 's'
+    } with ${playerState.ip} IP`,
+  };
+};
+
+export function auditGameState(state: GameState): GameStateAuditFinding[] {
+  assertState(Boolean(state), 'Game state must be provided');
+  assertState(isFiniteNumber(state.truth), 'Truth value must be a finite number');
+  assertState(state.truth >= 0 && state.truth <= 100, `Truth value ${state.truth} is outside 0-100`);
+  assertState(PLAYER_IDS.includes(state.currentPlayer), `Invalid currentPlayer '${state.currentPlayer}'`);
+  assertState(Number.isInteger(state.turn) && state.turn >= 0, `Turn must be a non-negative integer`);
+  assertState(
+    Number.isInteger(state.playsThisTurn) && state.playsThisTurn >= 0,
+    `playsThisTurn must be a non-negative integer`,
+  );
+  assertState(Array.isArray(state.turnPlays), 'turnPlays must be an array');
+  assertState(Array.isArray(state.log), 'log must be an array');
+  assertState(
+    state.pressureByState !== null && typeof state.pressureByState === 'object',
+    'pressureByState must be an object',
+  );
+  assertState(
+    state.stateDefense !== null && typeof state.stateDefense === 'object',
+    'stateDefense must be an object',
+  );
+
+  const playerStates = new Map<PlayerId, Set<string>>();
+  const findings: GameStateAuditFinding[] = [];
+  for (const playerId of PLAYER_IDS) {
+    findings.push(validatePlayer(state, playerId, playerStates));
+  }
+
+  const p1States = playerStates.get('P1') ?? new Set<string>();
+  const p2States = playerStates.get('P2') ?? new Set<string>();
+  const overlap = Array.from(p1States).filter(stateId => p2States.has(stateId));
+  assertState(overlap.length === 0, `States cannot be controlled by both players: ${overlap.join(', ')}`);
+
+  for (const [stateId, pressure] of Object.entries(state.pressureByState)) {
+    assertState(
+      pressure !== null && typeof pressure === 'object',
+      `Pressure entry for '${stateId}' must be an object`,
+    );
+
+    for (const playerId of PLAYER_IDS) {
+      const value = (pressure as Record<PlayerId, unknown>)[playerId];
+      assertState(isFiniteNumber(value), `Pressure for '${stateId}' must include numeric value for ${playerId}`);
+      assertState((value as number) >= 0, `Pressure for '${stateId}' cannot be negative for ${playerId}`);
+    }
+
+    const defenseValue = state.stateDefense[stateId];
+    if (defenseValue !== undefined) {
+      assertState(isFiniteNumber(defenseValue), `Defense for '${stateId}' must be numeric`);
+      assertState(defenseValue >= 0, `Defense for '${stateId}' cannot be negative`);
+    }
+  }
+
+  for (const [stateId, defense] of Object.entries(state.stateDefense)) {
+    assertState(isFiniteNumber(defense), `Defense for '${stateId}' must be numeric`);
+    assertState(defense >= 0, `Defense for '${stateId}' cannot be negative`);
+  }
+
+  findings.push({
+    level: 'info',
+    message: `Turn ${state.turn} audit completed (truth=${state.truth})`,
+  });
+
+  return findings;
+}

--- a/src/systems/__tests__/gameStateAudit.test.ts
+++ b/src/systems/__tests__/gameStateAudit.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from 'bun:test';
+
+import { auditGameState, GameStateAuditError } from '@/mvp/gameStateAudit';
+import type { GameState, PlayerState } from '@/mvp/validator';
+
+const createPlayer = (overrides: Partial<PlayerState> = {}): PlayerState => ({
+  id: 'P1',
+  faction: 'truth',
+  deck: [],
+  hand: [],
+  discard: [],
+  ip: 10,
+  states: [],
+  ...overrides,
+});
+
+const createGameState = (overrides: Partial<GameState> = {}): GameState => ({
+  turn: 1,
+  currentPlayer: 'P1',
+  truth: 50,
+  players: {
+    P1: createPlayer(),
+    P2: createPlayer({ id: 'P2', faction: 'government' }),
+  },
+  pressureByState: {},
+  stateDefense: {},
+  playsThisTurn: 0,
+  turnPlays: [],
+  log: [],
+  ...overrides,
+});
+
+describe('auditGameState', () => {
+  it('accepts a valid state and returns findings', () => {
+    const state = createGameState({
+      players: {
+        P1: createPlayer({ id: 'P1', faction: 'truth', states: ['NV'], ip: 24 }),
+        P2: createPlayer({ id: 'P2', faction: 'government', states: ['OR'], ip: 18 }),
+      },
+      pressureByState: {
+        NV: { P1: 0, P2: 0 },
+        OR: { P1: 0, P2: 0 },
+      },
+      stateDefense: { NV: 2, OR: 3 },
+    });
+
+    const findings = auditGameState(state);
+
+    expect(findings).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          level: 'info',
+          message: expect.stringContaining('Turn 1 audit completed'),
+        }),
+      ]),
+    );
+  });
+
+  it('throws when truth is outside the allowed range', () => {
+    const state = createGameState({ truth: 120 });
+
+    expect(() => auditGameState(state)).toThrow(GameStateAuditError);
+    expect(() => auditGameState(state)).toThrow(/Truth value 120/);
+  });
+
+  it('throws when a controlled state lacks pressure tracking', () => {
+    const state = createGameState({
+      players: {
+        P1: createPlayer({ id: 'P1', faction: 'truth', states: ['NV'] }),
+        P2: createPlayer({ id: 'P2', faction: 'government' }),
+      },
+      pressureByState: {},
+      stateDefense: {},
+    });
+
+    expect(() => auditGameState(state)).toThrow(/Missing pressure entry/);
+  });
+
+  it('throws when player IP becomes negative', () => {
+    const state = createGameState({
+      players: {
+        P1: createPlayer({ id: 'P1', faction: 'truth', ip: -1 }),
+        P2: createPlayer({ id: 'P2', faction: 'government' }),
+      },
+    });
+
+    expect(() => auditGameState(state)).toThrow(/IP cannot be negative/);
+  });
+});

--- a/src/systems/cardResolution.ts
+++ b/src/systems/cardResolution.ts
@@ -1,4 +1,5 @@
 import { applyEffectsMvp, type PlayerId } from '@/engine/applyEffects-mvp';
+import { auditGameState } from '@/mvp/gameStateAudit';
 import type { MediaResolutionOptions } from '@/mvp/media';
 import { cloneGameState, type Card, type GameState as EngineGameState } from '@/mvp';
 import type { GameCard } from '@/rules/mvp';
@@ -321,6 +322,7 @@ export function resolveCardMVP(
   }
 
   applyEffectsMvp(engineState, ownerId, effectiveCard as Card, targetStateId, mediaOptionsWithCombos);
+  auditGameState(engineState);
 
   const logEntries: string[] = engineLog.map(message => `${card.name}: ${message}`);
   let syncedEngineLogLength = engineLog.length;


### PR DESCRIPTION
## Summary
- add a reusable MVP game state audit with core invariant checks
- hook the audit into card resolution and turn endings
- cover valid and invalid audit scenarios with new tests

## Testing
- bun test src/systems/__tests__/gameStateAudit.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68de9aab718c8320988fdc21ddbb2374