### PR TITLE
Fix cached bonus recalculation for government takeovers

### DIFF
--- a/src/game/stateBonuses.ts
+++ b/src/game/stateBonuses.ts
@@ -257,7 +257,14 @@ export const assignStateBonuses = (
         : null;
 
     const bonusRecord = normalizedExistingBonus
-      ? { ...normalizedExistingBonus, round: options.round }
+      ? (() => {
+          const matchingEffect = pool.bonuses.find(effect => effect.id === normalizedExistingBonus.id);
+          if (!matchingEffect) {
+            return { ...normalizedExistingBonus, round: options.round };
+          }
+          const recalculated = toBonus(matchingEffect, state, options.round, ownerFaction);
+          return { ...normalizedExistingBonus, ...recalculated };
+        })()
       : (() => {
           const bonus =
             rng.pickWeighted(pool.bonuses.map(entry => ({ weight: entry.weight, value: entry }))) ?? null;


### PR DESCRIPTION
## Summary
- recompute cached state bonuses through the current controller so Truth/IP deltas update when ownership changes
- add coverage ensuring neutral bonuses flip sign when a government player captures the state

## Testing
- npm run lint *(fails: pre-existing repository lint violations)*
- bun test --coverage --coverage-reporter=text *(fails: 2 unrelated hotspot regression tests)*

------
https://chatgpt.com/codex/tasks/task_e_68deac8c0bac832091ef78be05092879