### PR TITLE
Align state bonus pressure adjustments with controller

### DIFF
--- a/src/hooks/stateBonusAssignment.ts
+++ b/src/hooks/stateBonusAssignment.ts
@@ -74,28 +74,15 @@ export const applyStateBonusAssignmentToState = (
       };
     }
 
-    const playerFactionPressureKey: 'pressurePlayer' | 'pressureAi' =
-      nextState.faction === 'truth' ? 'pressurePlayer' : 'pressureAi';
-    const aiFactionPressureKey =
-      playerFactionPressureKey === 'pressurePlayer' ? 'pressureAi' : 'pressurePlayer';
-
     let updatedPressurePlayer = state.pressurePlayer ?? 0;
     let updatedPressureAi = state.pressureAi ?? 0;
 
     if (playerPressureDelta !== 0 && state.owner === 'player') {
-      if (playerFactionPressureKey === 'pressurePlayer') {
-        updatedPressurePlayer = Math.max(0, updatedPressurePlayer + playerPressureDelta);
-      } else {
-        updatedPressureAi = Math.max(0, updatedPressureAi + playerPressureDelta);
-      }
+      updatedPressurePlayer = Math.max(0, updatedPressurePlayer + playerPressureDelta);
     }
 
     if (aiPressureDelta !== 0 && state.owner === 'ai') {
-      if (aiFactionPressureKey === 'pressurePlayer') {
-        updatedPressurePlayer = Math.max(0, updatedPressurePlayer + aiPressureDelta);
-      } else {
-        updatedPressureAi = Math.max(0, updatedPressureAi + aiPressureDelta);
-      }
+      updatedPressureAi = Math.max(0, updatedPressureAi + aiPressureDelta);
     }
 
     const updatedPressure = Math.max(updatedPressurePlayer, updatedPressureAi);


### PR DESCRIPTION
## Summary
- update state bonus pressure adjustments to modify the track that matches the controlling side of a state
- extend state bonus assignment tests to cover truth, government, AI-controlled, contested, and neutral state scenarios

## Testing
- `npm run lint`
- `bun test --coverage --coverage-reporter=text`


------
https://chatgpt.com/codex/tasks/task_e_68deb4b15ba08320888f29de0098ac97