### PR TITLE
Fix media multiplier rounding and add symmetry test

### DIFF
--- a/src/engine/applyEffects-mvp.test.ts
+++ b/src/engine/applyEffects-mvp.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from 'bun:test';
+
+import { applyEffectsMvp } from '@/engine/applyEffects-mvp';
+import type { Card, GameState, PlayerId, PlayerState } from '@/mvp/validator';
+
+const createPlayer = (id: PlayerId, faction: PlayerState['faction']): PlayerState => ({
+  id,
+  faction,
+  deck: [],
+  hand: [],
+  discard: [],
+  ip: 10,
+  states: [],
+});
+
+const createGameState = (): GameState => ({
+  turn: 1,
+  currentPlayer: 'P1',
+  truth: 50,
+  players: {
+    P1: createPlayer('P1', 'truth'),
+    P2: createPlayer('P2', 'government'),
+  },
+  pressureByState: {},
+  stateDefense: {},
+  playsThisTurn: 0,
+  turnPlays: [],
+  log: [],
+});
+
+describe('MEDIA resolution (MVP)', () => {
+  it('applies multipliers symmetrically for government plays', () => {
+    const truthCard: Card = {
+      id: 'truth-broadcast',
+      name: 'Truth Broadcast',
+      type: 'MEDIA',
+      faction: 'truth',
+      rarity: 'common',
+      cost: 1,
+      effects: { truthDelta: 4 },
+    };
+
+    const governmentCard: Card = {
+      id: 'gov-broadcast',
+      name: 'Government Broadcast',
+      type: 'MEDIA',
+      faction: 'government',
+      rarity: 'common',
+      cost: 1,
+      effects: { truthDelta: 4 },
+    };
+
+    const multiplier = 1.75;
+    const initialTruth = 50;
+
+    const truthState = createGameState();
+    applyEffectsMvp(truthState, 'P1', truthCard, undefined, { truthMultiplier: multiplier });
+    const truthDelta = truthState.truth - initialTruth;
+
+    const governmentState = createGameState();
+    applyEffectsMvp(governmentState, 'P2', governmentCard, undefined, { truthMultiplier: multiplier });
+    const governmentDelta = governmentState.truth - initialTruth;
+
+    expect(truthDelta).toBeGreaterThan(0);
+    expect(governmentDelta).toBeLessThan(0);
+    expect(governmentDelta).toBe(-truthDelta);
+
+    const bonusLog = governmentState.log.at(-1) ?? '';
+    const baseDelta = -Math.abs(governmentCard.effects.truthDelta);
+    const scaled = Math.round(Math.abs(baseDelta) * multiplier);
+    const expectedDelta = baseDelta >= 0 ? scaled : -scaled;
+    const expectedBonus = expectedDelta - baseDelta;
+
+    expect(bonusLog).toContain(`amplifies MEDIA truth swing by ${expectedBonus}`);
+    expect(bonusLog).toContain('(x1.75)');
+  });
+});

--- a/src/engine/applyEffects-mvp.ts
+++ b/src/engine/applyEffects-mvp.ts
@@ -163,7 +163,11 @@ export function applyEffectsMvp(
     const multiplier = typeof opts.truthMultiplier === 'number' && opts.truthMultiplier > 0
       ? opts.truthMultiplier
       : 1;
-    const delta = multiplier === 1 ? baseDelta : Math.round(baseDelta * multiplier);
+    let delta = baseDelta;
+    if (multiplier !== 1 && baseDelta !== 0) {
+      const scaled = Math.round(Math.abs(baseDelta) * multiplier);
+      delta = baseDelta >= 0 ? scaled : -scaled;
+    }
 
     if (multiplier === 1) {
       warnIfMediaScaling(card, delta);


### PR DESCRIPTION
## Summary
- make MEDIA multiplier scaling sign-aware when applying MVP truth swings
- keep the multiplier bonus log signed by exercising the new rounding path
- add a MEDIA resolution test to confirm government plays mirror truth outcomes

## Testing
- npm run lint *(fails: repository contains pre-existing lint errors in unrelated files)*
- bun test --coverage --coverage-reporter=text *(fails: existing hotspot-related tests are red in main branch)*

------
https://chatgpt.com/codex/tasks/task_e_68deb688449083209a94be6f07a206fc