### PR TITLE
Align state event trigger chance with event manager

### DIFF
--- a/src/data/eventDatabase.ts
+++ b/src/data/eventDatabase.ts
@@ -1,6 +1,8 @@
 import { featureFlags } from '@/state/featureFlags';
 import type { HotspotKind } from '@/systems/paranormalHotspots';
 
+export const DEFAULT_EVENT_TRIGGER_CHANCE = 0.12;
+
 export interface ParanormalHotspotPayload {
   /** Optional fixed state identifier (FIPS or abbreviation) to anchor the hotspot. */
   stateId?: string;
@@ -4658,7 +4660,7 @@ export const STATE_EVENTS_DATABASE: { [stateId: string]: GameEvent[] } = {
 export class EventManager {
   private eventHistory: string[] = [];
   private turnCount: number = 0;
-  private baseEventChance: number = 0.12;
+  private baseEventChance: number = DEFAULT_EVENT_TRIGGER_CHANCE;
   private readonly paranormalHotspotChance: number = 0.2;
   private readonly stateEventHistoryLimit: number = 3;
   private stateEventHistoryByState: Map<string, string[]> = new Map();

--- a/src/game/__tests__/stateBonuses.test.ts
+++ b/src/game/__tests__/stateBonuses.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from 'bun:test';
+import { DEFAULT_EVENT_TRIGGER_CHANCE } from '@/data/eventDatabase';
 import { assignStateBonuses, computeRoundSeed } from '../stateBonuses';
 
 describe('stateBonuses deterministic selection', () => {
@@ -61,6 +62,24 @@ describe('stateBonuses deterministic selection', () => {
       expect(events.length).toBe(0);
     }
     expect(result.newspaperEvents.length).toBe(0);
+  });
+
+  test('newspaper events carry the shared trigger probability metadata', () => {
+    const result = assignStateBonuses({
+      states: mockStates,
+      baseSeed: 1,
+      round: 3,
+      playerFaction: 'truth',
+    });
+
+    expect(result.newspaperEvents.length).toBeGreaterThan(0);
+
+    for (const event of result.newspaperEvents) {
+      expect(event.triggerChance).toBeCloseTo(DEFAULT_EVENT_TRIGGER_CHANCE);
+      const normalizedWeight = Math.max(1, event.weight ?? 0);
+      const expectedConditional = Math.min(1, DEFAULT_EVENT_TRIGGER_CHANCE / normalizedWeight);
+      expect(event.conditionalChance).toBeCloseTo(expectedConditional);
+    }
   });
 
   test('truth and IP totals split between human and AI controllers', () => {

--- a/src/game/stateBonuses.ts
+++ b/src/game/stateBonuses.ts
@@ -1,4 +1,4 @@
-import type { GameEvent } from '@/data/eventDatabase';
+import { DEFAULT_EVENT_TRIGGER_CHANCE, type GameEvent } from '@/data/eventDatabase';
 import { resolvePoolForState, type ThemedEffect } from '@/data/stateThemedPools';
 import type { ActiveStateBonus, StateRoundEventLogEntry } from '@/hooks/gameStateTypes';
 
@@ -60,7 +60,7 @@ export class StateRoundRNG {
   }
 }
 
-export const STATE_EVENT_CHANCE = 0.35;
+export const STATE_EVENT_CHANCE = DEFAULT_EVENT_TRIGGER_CHANCE;
 
 export const computeRoundSeed = (baseSeed: number, round: number): number => {
   const normalizedBase = baseSeed >>> 0;


### PR DESCRIPTION
## Summary
- export a DEFAULT_EVENT_TRIGGER_CHANCE constant from the event database and reuse it within the EventManager
- wire state bonus generation to the shared constant so their default trigger probability matches the global manager
- extend the state bonus tests to assert the shared trigger metadata and weight-scaled conditional chance

## Testing
- npm run lint *(fails: repository has pre-existing lint errors unrelated to this change)*
- bun test --coverage --coverage-reporter=text *(fails: existing EnhancedUSAMap hotspot test requires browser localStorage)*

------
https://chatgpt.com/codex/tasks/task_e_68debb9fca1c8320b40974b46cef78e3