### PR TITLE
Reset owned state pressure in engine conversion

### DIFF
--- a/src/systems/__tests__/cardResolution.regression.test.ts
+++ b/src/systems/__tests__/cardResolution.regression.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from 'bun:test';
+
+import type { GameCard } from '@/rules/mvp';
+
+import {
+  resolveCardMVP,
+  type CardActor,
+  type GameSnapshot,
+} from '../cardResolution';
+
+const createBaseSnapshot = (overrides: Partial<GameSnapshot> = {}): GameSnapshot => ({
+  truth: 50,
+  ip: 10,
+  aiIP: 10,
+  hand: [],
+  aiHand: [],
+  controlledStates: [],
+  aiControlledStates: [],
+  round: 1,
+  turn: 1,
+  faction: 'truth',
+  states: [
+    {
+      id: 'NY',
+      name: 'New York',
+      abbreviation: 'NY',
+      baseIP: 3,
+      baseDefense: 1,
+      defense: 1,
+      pressure: 0,
+      pressurePlayer: 0,
+      pressureAi: 0,
+      contested: false,
+      owner: 'neutral',
+    },
+  ],
+  ...overrides,
+});
+
+describe('resolveCardMVP regression', () => {
+  const actor: CardActor = 'human';
+
+  it('clears enemy pressure when the player already controls the state', () => {
+    const gameState = createBaseSnapshot({
+      controlledStates: ['NY'],
+      states: [
+        {
+          id: 'NY',
+          name: 'New York',
+          abbreviation: 'NY',
+          baseIP: 3,
+          baseDefense: 1,
+          defense: 1,
+          pressure: 3,
+          pressurePlayer: 0,
+          pressureAi: 3,
+          contested: false,
+          owner: 'player',
+        },
+      ],
+    });
+    const card: GameCard = {
+      id: 'noop',
+      name: 'No-Op',
+      type: 'MEDIA',
+      faction: 'truth',
+      rarity: 'common',
+      cost: 0,
+    };
+
+    let result: ReturnType<typeof resolveCardMVP> | undefined;
+    expect(() => {
+      result = resolveCardMVP(gameState, card, null, actor);
+    }).not.toThrow();
+
+    expect(result).toBeDefined();
+    const [state] = result!.states;
+    expect(state?.pressureAi).toBe(0);
+    expect(state?.pressurePlayer).toBe(0);
+  });
+});

--- a/src/systems/cardResolution.ts
+++ b/src/systems/cardResolution.ts
@@ -170,16 +170,24 @@ const toEngineState = (
     stateDefense[state.id] = state.defense;
     const owner = state.owner;
     const fallbackPressure = Math.max(0, state.pressure ?? 0);
-    const playerPressure = Number.isFinite(state.pressurePlayer)
+    let playerPressure = Number.isFinite(state.pressurePlayer)
       ? Math.max(0, state.pressurePlayer)
       : owner === 'player'
         ? 0
         : fallbackPressure;
-    const aiPressure = Number.isFinite(state.pressureAi)
+    let aiPressure = Number.isFinite(state.pressureAi)
       ? Math.max(0, state.pressureAi)
       : owner === 'ai'
         ? fallbackPressure
         : 0;
+
+    if (owner === 'player') {
+      playerPressure = 0;
+      aiPressure = 0;
+    } else if (owner === 'ai') {
+      aiPressure = 0;
+      playerPressure = 0;
+    }
 
     if (owner === 'player') {
       playerStates.add(state.id);


### PR DESCRIPTION
## Summary
- clear any stored pressure for the controlling side when translating snapshots into engine state
- ensure opponent pressure is cleared when the controlling player already owns the state
- add a regression test that covers a player-owned state with stray AI pressure before card resolution

## Testing
- npm run lint *(fails: repository contains existing lint violations unrelated to this change)*
- bun test --coverage --coverage-reporter=text *(fails: existing EnhancedUSAMap hotspot test relies on browser APIs unavailable in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dec12577ac83209a6b3debadb5379a