### PR TITLE
Replace surveillance HUD with redaction stripes

### DIFF
--- a/src/components/effects/GovernmentSurveillance.tsx
+++ b/src/components/effects/GovernmentSurveillance.tsx
@@ -49,16 +49,6 @@ const GovernmentSurveillance: React.FC<GovernmentSurveillanceProps> = ({
     '--threat-level': threatLevel.toLowerCase(),
   }) as React.CSSProperties, [x, y, threatLevel]);
 
-  const agencyCode = useMemo(() => {
-    const codes = ['NSA', 'CIA', 'FBI', 'DHS', 'DOD', '███'];
-    return codes[Math.floor(Math.random() * codes.length)];
-  }, []);
-
-  const classificationLevel = useMemo(() => {
-    const levels = ['CONFIDENTIAL', 'SECRET', 'TOP SECRET', '█████████'];
-    return levels[Math.floor(Math.random() * levels.length)];
-  }, []);
-
   if (reducedMotion) return null;
 
   return (
@@ -70,51 +60,31 @@ const GovernmentSurveillance: React.FC<GovernmentSurveillanceProps> = ({
       aria-label={`Government surveillance scanning ${targetName}`}
     >
       <div className="surveillance-frame">
-        <div className="surveillance-crosshair" />
-        <div className="surveillance-grid" />
-        <div className="surveillance-scanline" 
-             style={{ transform: `translateY(${scanProgress * 2}px)` }} />
-        
-        <div className="surveillance-hud">
-          <div className="hud-corner hud-corner--tl" />
-          <div className="hud-corner hud-corner--tr" />
-          <div className="hud-corner hud-corner--bl" />
-          <div className="hud-corner hud-corner--br" />
-        </div>
-
-        <div className="surveillance-data">
-          <div className="data-header">
-            <span className="agency-code">{agencyCode}</span>
-            <span className="classification">{classificationLevel}</span>
-          </div>
-          
-          <div className="data-body">
-            <div className="data-row">
-              <span className="label">TARGET:</span>
-              <span className="value">{targetName}</span>
-            </div>
-            <div className="data-row">
-              <span className="label">THREAT:</span>
-              <span className={`value threat-${threatLevel.toLowerCase()}`}>
-                {threatLevel}
-              </span>
-            </div>
-            <div className="data-row">
-              <span className="label">SCAN:</span>
-              <span className="value">{scanProgress}%</span>
-            </div>
+        <div className="surveillance-redaction-overlay">
+          <div className="redaction-header">
+            <div className="redaction-label">CLEARANCE CHECK</div>
+            <div className="redaction-target">{targetName}</div>
           </div>
 
-          {scanProgress >= 100 && (
-            <div className="scan-complete">
-              <span className="status-text">
-                {threatLevel === 'HIGH' ? '⚠️ SUBJECT FLAGGED' : '✓ SCAN COMPLETE'}
+          <div className="redaction-body">
+            <div className="redaction-stripe redaction-stripe--primary" />
+            <div className="redaction-stripe redaction-stripe--secondary" />
+            <div className="redaction-stripe redaction-stripe--primary" />
+            <div className="redaction-progress">
+              <span className="redaction-label">SCANNING…</span>
+              <div className="redaction-bar">
+                <div className="redaction-bar-fill" style={{ width: `${scanProgress}%` }} />
+              </div>
+              <span className="redaction-progress-label">{scanProgress}%
               </span>
             </div>
-          )}
+            <div className={`redaction-status ${threatLevel === 'HIGH' ? 'redaction-status--alert' : ''}`}>
+              <span>{threatLevel === 'HIGH' ? 'SUBJECT FLAGGED' : 'SCAN COMPLETE'}</span>
+            </div>
+          </div>
         </div>
       </div>
-      
+
       <div className="surveillance-noise" />
       {isScanning && <div className="surveillance-pulse" />}
     </div>

--- a/src/index.css
+++ b/src/index.css
@@ -2620,166 +2620,148 @@ html, body, #root {
   animation: surveillance-activate 0.8s ease-out;
 }
 
+
 .surveillance-frame {
   width: 320px;
   height: 240px;
-  background: rgba(0, 0, 0, 0.9);
+  background: rgba(0, 0, 0, 0.92);
   border: 2px solid var(--effect-surveillance);
-  border-radius: 4px;
+  border-radius: 6px;
   position: relative;
-  box-shadow: 
-    0 0 20px var(--effect-surveillance),
-    inset 0 0 20px rgba(255, 68, 68, 0.1);
+  overflow: hidden;
+  box-shadow:
+    0 0 24px rgba(0, 0, 0, 0.6),
+    inset 0 0 18px rgba(0, 0, 0, 0.8);
 }
 
-.surveillance-crosshair {
+.surveillance-redaction-overlay {
   position: absolute;
-  top: 50%;
-  left: 50%;
-  transform: translate(-50%, -50%);
-  width: 60px;
-  height: 60px;
-  border: 2px solid var(--effect-surveillance);
-  border-radius: 50%;
-  opacity: 0.8;
+  inset: 0;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  padding: 16px;
+  background: linear-gradient(160deg, rgba(0, 0, 0, 0.65), rgba(0, 0, 0, 0.82));
+  color: white;
+  font-family: 'IBM Plex Mono', 'Courier New', Courier, monospace;
 }
 
-.surveillance-crosshair::before,
-.surveillance-crosshair::after {
+.redaction-header {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  font-size: 0.7rem;
+  text-transform: uppercase;
+  letter-spacing: 0.25em;
+  color: rgba(255, 255, 255, 0.85);
+}
+
+.redaction-label {
+  font-weight: 600;
+}
+
+.redaction-target {
+  font-weight: 700;
+  letter-spacing: 0.16em;
+  font-size: 0.65rem;
+  border-bottom: 1px dashed rgba(255, 255, 255, 0.25);
+  padding-bottom: 4px;
+}
+
+.redaction-body {
+  display: grid;
+  gap: 10px;
+}
+
+.redaction-stripe {
+  height: 20px;
+  border-radius: 6px;
+  background: repeating-linear-gradient(
+    -35deg,
+    rgba(0, 0, 0, 0.85) 0px,
+    rgba(0, 0, 0, 0.85) 8px,
+    rgba(30, 30, 30, 0.9) 8px,
+    rgba(30, 30, 30, 0.9) 16px
+  );
+  position: relative;
+  overflow: hidden;
+}
+
+.redaction-stripe::before {
   content: '';
   position: absolute;
-  background: var(--effect-surveillance);
+  inset: 0;
+  background: linear-gradient(
+    90deg,
+    transparent,
+    rgba(255, 255, 255, 0.1),
+    transparent
+  );
+  animation: redaction-gloss 3s ease-in-out infinite;
 }
 
-.surveillance-crosshair::before {
-  top: 50%;
-  left: -10px;
-  right: -10px;
-  height: 1px;
-  transform: translateY(-50%);
+.redaction-stripe--secondary {
+  height: 14px;
+  background: repeating-linear-gradient(
+    -25deg,
+    rgba(0, 0, 0, 0.9) 0px,
+    rgba(0, 0, 0, 0.9) 6px,
+    rgba(24, 24, 24, 0.85) 6px,
+    rgba(24, 24, 24, 0.85) 12px
+  );
 }
 
-.surveillance-crosshair::after {
-  left: 50%;
-  top: -10px;
-  bottom: -10px;
-  width: 1px;
-  transform: translateX(-50%);
+.redaction-progress {
+  display: grid;
+  gap: 6px;
+  font-size: 0.65rem;
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+  color: rgba(255, 255, 255, 0.8);
 }
 
-.surveillance-grid {
+.redaction-bar {
+  position: relative;
+  height: 10px;
+  border-radius: 999px;
+  border: 1px solid rgba(255, 255, 255, 0.25);
+  overflow: hidden;
+  background: rgba(0, 0, 0, 0.45);
+}
+
+.redaction-bar-fill {
   position: absolute;
-  inset: 10px;
-  background-image: 
-    linear-gradient(var(--effect-surveillance) 1px, transparent 1px),
-    linear-gradient(90deg, var(--effect-surveillance) 1px, transparent 1px);
-  background-size: 20px 20px;
-  opacity: 0.3;
+  inset: 0;
+  width: 0;
+  background: linear-gradient(90deg, rgba(32, 32, 32, 0.6), rgba(0, 0, 0, 0.95));
+  transition: width 0.2s ease;
 }
 
-.surveillance-scanline {
-  position: absolute;
-  left: 0;
-  right: 0;
-  height: 2px;
-  background: linear-gradient(90deg, 
-    transparent 0%, 
-    var(--effect-surveillance) 50%, 
-    transparent 100%);
-  box-shadow: 0 0 10px var(--effect-surveillance);
-  animation: scanline-pulse 0.5s ease-in-out infinite alternate;
+.redaction-progress-label {
+  align-self: flex-end;
+  font-size: 0.6rem;
+  letter-spacing: 0.14em;
 }
 
-.surveillance-hud {
-  position: absolute;
-  inset: 10px;
-}
-
-.hud-corner {
-  position: absolute;
-  width: 20px;
-  height: 20px;
-  border: 2px solid var(--effect-surveillance);
-}
-
-.hud-corner--tl {
-  top: 0;
-  left: 0;
-  border-right: none;
-  border-bottom: none;
-}
-
-.hud-corner--tr {
-  top: 0;
-  right: 0;
-  border-left: none;
-  border-bottom: none;
-}
-
-.hud-corner--bl {
-  bottom: 0;
-  left: 0;
-  border-right: none;
-  border-top: none;
-}
-
-.hud-corner--br {
-  bottom: 0;
-  right: 0;
-  border-left: none;
-  border-top: none;
-}
-
-.surveillance-data {
-  position: absolute;
-  top: 10px;
-  left: 10px;
-  right: 10px;
-  color: var(--effect-surveillance);
-  font-family: 'Courier New', monospace;
-  font-size: 0.75rem;
-  text-shadow: 0 0 5px currentColor;
-}
-
-.data-header {
+.redaction-status {
   display: flex;
-  justify-content: space-between;
-  margin-bottom: 8px;
-  font-weight: bold;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  padding: 8px;
+  border-radius: 6px;
+  border: 1px solid rgba(255, 255, 255, 0.15);
+  text-transform: uppercase;
+  font-weight: 700;
+  letter-spacing: 0.18em;
+  background: rgba(0, 0, 0, 0.35);
 }
 
-.data-row {
-  display: flex;
-  justify-content: space-between;
-  margin-bottom: 4px;
-}
-
-.label {
-  opacity: 0.8;
-}
-
-.value {
-  font-weight: bold;
-}
-
-.value.threat-high {
-  color: #ff4444;
-  animation: threat-blink 1s infinite;
-}
-
-.value.threat-medium {
-  color: #ffaa00;
-}
-
-.value.threat-low {
-  color: #44ff44;
-}
-
-.scan-complete {
-  margin-top: 12px;
-  text-align: center;
-  font-weight: bold;
-  animation: scan-complete-flash 0.5s ease-in-out;
+.redaction-status--alert {
+  background: rgba(255, 0, 0, 0.1);
+  border-color: rgba(255, 0, 0, 0.45);
+  color: rgba(255, 148, 148, 0.95);
+  box-shadow: 0 0 14px rgba(255, 0, 0, 0.35);
 }
 
 .surveillance-noise {
@@ -3270,20 +3252,9 @@ html, body, #root {
   }
 }
 
-@keyframes scanline-pulse {
-  0% { opacity: 0.5; }
-  100% { opacity: 1; }
-}
-
-@keyframes threat-blink {
-  0%, 50% { opacity: 1; }
-  51%, 100% { opacity: 0.3; }
-}
-
-@keyframes scan-complete-flash {
-  0% { transform: scale(1); }
-  50% { transform: scale(1.1); }
-  100% { transform: scale(1); }
+@keyframes redaction-gloss {
+  0%, 100% { transform: translateX(-100%); }
+  50% { transform: translateX(100%); }
 }
 
 @keyframes surveillance-pulse {


### PR DESCRIPTION
## Summary
- replace the government surveillance HUD overlay with redaction stripes that sweep the played cards
- update overlay styling to use animated blackout bands, clearance headers, and progress indicator
- remove unused CSS for the old crosshair interface and add new redaction gloss animation

## Testing
- npm run lint *(fails: repository has existing lint violations unrelated to this change)*
- bun test --coverage --coverage-reporter=text *(fails: repository has existing failing test EnhancedUSAMap paranormal hotspots)*

------
https://chatgpt.com/codex/tasks/task_e_68ded0436ce48320b14173ed4d9753bf