### PR TITLE
Apply truth swing to secret agenda completions

### DIFF
--- a/src/data/tutorialSystem.ts
+++ b/src/data/tutorialSystem.ts
@@ -137,7 +137,7 @@ export const TUTORIAL_SEQUENCES: TutorialSequence[] = [
       {
         id: 'victory_conditions',
         title: 'Path to Victory',
-        description: 'Victory checks run in priority order: 1) finish your Secret Agenda, 2) hit Truth ≥95% (Truth) or ≤5% (Government), 3) bank 300 IP, 4) control 10 states. Deny the AI before it crosses any of these thresholds.',
+        description: 'Victory checks run in priority order: 1) spike the Truth meter to ≥95% (Truth) or ≤5% (Government), 2) bank 300 IP, 3) control 10 states. Secret Agendas now fuel that Truth surge based on difficulty—plan around the swing before the AI does.',
         position: 'center',
         delay: 4000
       }

--- a/src/hooks/gameStateTypes.ts
+++ b/src/hooks/gameStateTypes.ts
@@ -87,12 +87,14 @@ export interface GameState {
     completed: boolean;
     revealed: boolean;
     stageId?: string;
+    truthRewardApplied?: boolean;
   };
   aiSecretAgenda?: SecretAgenda & {
     progress: number;
     completed: boolean;
     revealed: boolean;
     stageId?: string;
+    truthRewardApplied?: boolean;
   };
   secretAgendaDifficulty?: SecretAgenda['difficulty'] | null;
   secretAgendasEnabled: boolean;

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -683,7 +683,7 @@ const Index = () => {
   } | null>(null);
   const [previousPhase, setPreviousPhase] = useState('');
   const [hoveredCard, setHoveredCard] = useState<GameCard | null>(null);
-  const [victoryState, setVictoryState] = useState<{ isVictory: boolean; type: 'states' | 'ip' | 'truth' | 'agenda' | null }>({ isVictory: false, type: null });
+  const [victoryState, setVictoryState] = useState<{ isVictory: boolean; type: 'states' | 'ip' | 'truth' | null }>({ isVictory: false, type: null });
   const [showOnboarding, setShowOnboarding] = useState(false);
   const [showInGameOptions, setShowInGameOptions] = useState(false);
   const [finalEdition, setFinalEdition] = useState<GameOverReport | null>(null);
@@ -1221,7 +1221,7 @@ const Index = () => {
     if (gameState.isGameOver || gameState.animating) return;
 
     let winner: "government" | "truth" | "draw" | null = null;
-    let victoryType: 'states' | 'ip' | 'truth' | 'agenda' | null = null;
+    let victoryType: 'states' | 'ip' | 'truth' | null = null;
 
     // Only evaluate victory conditions at proper timing:
     // - After card effects are fully resolved
@@ -1236,25 +1236,16 @@ const Index = () => {
     const playerSecretAgenda = gameState.secretAgenda;
     const aiSecretAgenda = gameState.aiSecretAgenda;
 
-    // Priority 1: Secret Agenda (highest priority)
-    if (playerSecretAgenda?.completed) {
-      winner = gameState.faction;
-      victoryType = 'agenda';
-    } else if (aiSecretAgenda?.completed) {
-      winner = gameState.faction === 'truth' ? 'government' : 'truth';
-      victoryType = 'agenda';
-    }
-    
-    // Priority 2: Truth thresholds (Truth ≥ 95% for Truth Seekers, Truth ≤ 5% for Government)
-    else if (gameState.truth >= 95 && gameState.faction === 'truth') {
+    // Priority 1: Truth thresholds (Truth ≥ 95% for Truth Seekers, Truth ≤ 5% for Government)
+    if (gameState.truth >= 95 && gameState.faction === 'truth') {
       winner = 'truth';
       victoryType = 'truth';
     } else if (gameState.truth <= 5 && gameState.faction === 'government') {
       winner = 'government';
       victoryType = 'truth';
     }
-    
-    // Priority 3: IP victory (300 IP)
+
+    // Priority 2: IP victory (300 IP)
     else if (gameState.ip >= 300) {
       winner = gameState.faction;
       victoryType = 'ip';
@@ -1262,8 +1253,8 @@ const Index = () => {
       winner = gameState.faction === 'government' ? 'truth' : 'government';
       victoryType = 'ip';
     }
-    
-    // Priority 4: State control (10 states)
+
+    // Priority 3: State control (10 states)
     else if (gameState.controlledStates.length >= 10) {
       winner = gameState.faction;
       victoryType = 'states';


### PR DESCRIPTION
## Summary
- award a difficulty-scaled Truth swing when secret agendas cross the finish line, logging the moment and preventing duplicate payouts
- extend the agenda state payload so new runs and saved games remember whether the reward already fired
- drop the agenda auto-win path in the victory evaluation and update onboarding copy to explain the new Truth surge behavior

## Testing
- npm run lint *(fails: repository contains numerous pre-existing lint issues unrelated to this change)*
- bun test --coverage --coverage-reporter=text *(fails: existing test failures in unrelated suites)*

------
https://chatgpt.com/codex/tasks/task_e_68dedaa3f52c83209478b37fe20e6f44