### PR TITLE
Fix Halloween government truth deltas

### DIFF
--- a/public/data/NarrativeDB.json
+++ b/public/data/NarrativeDB.json
@@ -7719,7 +7719,7 @@
       "setId": "halloween_spooktacular",
       "setName": "Halloween Spooktacular",
       "effects": {
-        "truthDelta": 2
+        "truthDelta": -2
       }
     },
     "hallo-gov-banshee-prime-directive-files-004": {
@@ -7732,7 +7732,7 @@
       "setId": "halloween_spooktacular",
       "setName": "Halloween Spooktacular",
       "effects": {
-        "truthDelta": 3
+        "truthDelta": -3
       }
     },
     "hallo-gov-banshee-shenanigans-incident-018": {
@@ -7758,7 +7758,7 @@
       "setId": "halloween_spooktacular",
       "setName": "Halloween Spooktacular",
       "effects": {
-        "truthDelta": 2
+        "truthDelta": -2
       }
     },
     "hallo-gov-bat-boy-shuffle-020": {
@@ -7810,7 +7810,7 @@
       "setId": "halloween_spooktacular",
       "setName": "Halloween Spooktacular",
       "effects": {
-        "truthDelta": 1
+        "truthDelta": -1
       }
     },
     "hallo-gov-broadcast-of-the-seance-003": {
@@ -7823,7 +7823,7 @@
       "setId": "halloween_spooktacular",
       "setName": "Halloween Spooktacular",
       "effects": {
-        "truthDelta": 2
+        "truthDelta": -2
       }
     },
     "hallo-gov-candy-corn-expedition-protocol-018": {
@@ -7836,7 +7836,7 @@
       "setId": "halloween_spooktacular",
       "setName": "Halloween Spooktacular",
       "effects": {
-        "truthDelta": 2
+        "truthDelta": -2
       }
     },
     "hallo-gov-candy-corn-whispers-064": {
@@ -7875,7 +7875,7 @@
       "setId": "halloween_spooktacular",
       "setName": "Halloween Spooktacular",
       "effects": {
-        "truthDelta": 1
+        "truthDelta": -1
       }
     },
     "hallo-gov-cobweb-report-files-049": {
@@ -7888,7 +7888,7 @@
       "setId": "halloween_spooktacular",
       "setName": "Halloween Spooktacular",
       "effects": {
-        "truthDelta": 1
+        "truthDelta": -1
       }
     },
     "hallo-gov-cobweb-scare-036": {
@@ -7953,7 +7953,7 @@
       "setId": "halloween_spooktacular",
       "setName": "Halloween Spooktacular",
       "effects": {
-        "truthDelta": 3
+        "truthDelta": -3
       }
     },
     "hallo-gov-coven-scare-032": {
@@ -7992,7 +7992,7 @@
       "setId": "halloween_spooktacular",
       "setName": "Halloween Spooktacular",
       "effects": {
-        "truthDelta": 1
+        "truthDelta": -1
       }
     },
     "hallo-gov-dracula-shuffle-protocol-006": {
@@ -8005,7 +8005,7 @@
       "setId": "halloween_spooktacular",
       "setName": "Halloween Spooktacular",
       "effects": {
-        "truthDelta": 1
+        "truthDelta": -1
       }
     },
     "hallo-gov-ectoplasm-brief-files-048": {
@@ -8031,7 +8031,7 @@
       "setId": "halloween_spooktacular",
       "setName": "Halloween Spooktacular",
       "effects": {
-        "truthDelta": 1
+        "truthDelta": -1
       }
     },
     "hallo-gov-frankenstein-flyer-incident-031": {
@@ -8044,7 +8044,7 @@
       "setId": "halloween_spooktacular",
       "setName": "Halloween Spooktacular",
       "effects": {
-        "truthDelta": 1
+        "truthDelta": -1
       }
     },
     "hallo-gov-frankenstein-pamphlet-initiative-025": {
@@ -8083,7 +8083,7 @@
       "setId": "halloween_spooktacular",
       "setName": "Halloween Spooktacular",
       "effects": {
-        "truthDelta": 1
+        "truthDelta": -1
       }
     },
     "hallo-gov-full-moon-shenanigans-067": {
@@ -8109,7 +8109,7 @@
       "setId": "halloween_spooktacular",
       "setName": "Halloween Spooktacular",
       "effects": {
-        "truthDelta": 1
+        "truthDelta": -1
       }
     },
     "hallo-gov-ghost-flyer-protocol-041": {
@@ -8148,7 +8148,7 @@
       "setId": "halloween_spooktacular",
       "setName": "Halloween Spooktacular",
       "effects": {
-        "truthDelta": 1
+        "truthDelta": -1
       }
     },
     "hallo-gov-ghoul-sweep-initiative-001": {
@@ -8200,7 +8200,7 @@
       "setId": "halloween_spooktacular",
       "setName": "Halloween Spooktacular",
       "effects": {
-        "truthDelta": 2
+        "truthDelta": -2
       }
     },
     "hallo-gov-haunted-mansion-whispers-023": {
@@ -8239,7 +8239,7 @@
       "setId": "halloween_spooktacular",
       "setName": "Halloween Spooktacular",
       "effects": {
-        "truthDelta": 2
+        "truthDelta": -2
       }
     },
     "hallo-gov-headless-horseman-investigation-initiative-016": {
@@ -8278,7 +8278,7 @@
       "setId": "halloween_spooktacular",
       "setName": "Halloween Spooktacular",
       "effects": {
-        "truthDelta": 1
+        "truthDelta": -1
       }
     },
     "hallo-gov-jack-o-lantern-rally-incident-066": {
@@ -8291,7 +8291,7 @@
       "setId": "halloween_spooktacular",
       "setName": "Halloween Spooktacular",
       "effects": {
-        "truthDelta": 1
+        "truthDelta": -1
       }
     },
     "hallo-gov-jack-o-lantern-stakeout-006": {
@@ -8317,7 +8317,7 @@
       "setId": "halloween_spooktacular",
       "setName": "Halloween Spooktacular",
       "effects": {
-        "truthDelta": 2
+        "truthDelta": -2
       }
     },
     "hallo-gov-moonlight-deep-cover-007": {
@@ -8330,7 +8330,7 @@
       "setId": "halloween_spooktacular",
       "setName": "Halloween Spooktacular",
       "effects": {
-        "truthDelta": 3
+        "truthDelta": -3
       }
     },
     "hallo-gov-moonlight-expedition-incident-008": {
@@ -8343,7 +8343,7 @@
       "setId": "halloween_spooktacular",
       "setName": "Halloween Spooktacular",
       "effects": {
-        "truthDelta": 2
+        "truthDelta": -2
       }
     },
     "hallo-gov-moonlight-scare-files-021": {
@@ -8369,7 +8369,7 @@
       "setId": "halloween_spooktacular",
       "setName": "Halloween Spooktacular",
       "effects": {
-        "truthDelta": 1
+        "truthDelta": -1
       }
     },
     "hallo-gov-omen-pamphlet-files-051": {
@@ -8395,7 +8395,7 @@
       "setId": "halloween_spooktacular",
       "setName": "Halloween Spooktacular",
       "effects": {
-        "truthDelta": 4
+        "truthDelta": -4
       }
     },
     "hallo-gov-ouija-rumor-061": {
@@ -8421,7 +8421,7 @@
       "setId": "halloween_spooktacular",
       "setName": "Halloween Spooktacular",
       "effects": {
-        "truthDelta": 1
+        "truthDelta": -1
       }
     },
     "hallo-gov-ouija-shuffle-incident-004": {
@@ -8434,7 +8434,7 @@
       "setId": "halloween_spooktacular",
       "setName": "Halloween Spooktacular",
       "effects": {
-        "truthDelta": 1
+        "truthDelta": -1
       }
     },
     "hallo-gov-ploy-of-the-headless-horseman-005": {
@@ -8499,7 +8499,7 @@
       "setId": "halloween_spooktacular",
       "setName": "Halloween Spooktacular",
       "effects": {
-        "truthDelta": 2
+        "truthDelta": -2
       }
     },
     "hallo-gov-poltergeist-report-initiative-039": {
@@ -8512,7 +8512,7 @@
       "setId": "halloween_spooktacular",
       "setName": "Halloween Spooktacular",
       "effects": {
-        "truthDelta": 1
+        "truthDelta": -1
       }
     },
     "hallo-gov-press-release-of-the-full-moon-008": {
@@ -8525,7 +8525,7 @@
       "setId": "halloween_spooktacular",
       "setName": "Halloween Spooktacular",
       "effects": {
-        "truthDelta": 1
+        "truthDelta": -1
       }
     },
     "hallo-gov-raven-flyer-protocol-014": {
@@ -8538,7 +8538,7 @@
       "setId": "halloween_spooktacular",
       "setName": "Halloween Spooktacular",
       "effects": {
-        "truthDelta": 1
+        "truthDelta": -1
       }
     },
     "hallo-gov-raven-project-protocol-006": {
@@ -8551,7 +8551,7 @@
       "setId": "halloween_spooktacular",
       "setName": "Halloween Spooktacular",
       "effects": {
-        "truthDelta": 3
+        "truthDelta": -3
       }
     },
     "hallo-gov-raven-revelation-initiative-002": {
@@ -8564,7 +8564,7 @@
       "setId": "halloween_spooktacular",
       "setName": "Halloween Spooktacular",
       "effects": {
-        "truthDelta": 3
+        "truthDelta": -3
       }
     },
     "hallo-gov-raven-scare-024": {
@@ -8577,7 +8577,7 @@
       "setId": "halloween_spooktacular",
       "setName": "Halloween Spooktacular",
       "effects": {
-        "truthDelta": 1
+        "truthDelta": -1
       }
     },
     "hallo-gov-report-of-the-fog-machine-005": {
@@ -8603,7 +8603,7 @@
       "setId": "halloween_spooktacular",
       "setName": "Halloween Spooktacular",
       "effects": {
-        "truthDelta": 1
+        "truthDelta": -1
       }
     },
     "hallo-gov-revelation-of-the-graveyard-001": {
@@ -8616,7 +8616,7 @@
       "setId": "halloween_spooktacular",
       "setName": "Halloween Spooktacular",
       "effects": {
-        "truthDelta": 3
+        "truthDelta": -3
       }
     },
     "hallo-gov-scare-of-the-ghost-017": {
@@ -8629,7 +8629,7 @@
       "setId": "halloween_spooktacular",
       "setName": "Halloween Spooktacular",
       "effects": {
-        "truthDelta": 1
+        "truthDelta": -1
       }
     },
     "hallo-gov-scare-of-the-midnight-009": {
@@ -8655,7 +8655,7 @@
       "setId": "halloween_spooktacular",
       "setName": "Halloween Spooktacular",
       "effects": {
-        "truthDelta": 1
+        "truthDelta": -1
       }
     },
     "hallo-gov-seance-alert-initiative-037": {
@@ -8681,7 +8681,7 @@
       "setId": "halloween_spooktacular",
       "setName": "Halloween Spooktacular",
       "effects": {
-        "truthDelta": 2
+        "truthDelta": -2
       }
     },
     "hallo-gov-seance-containment-files-005": {
@@ -8694,7 +8694,7 @@
       "setId": "halloween_spooktacular",
       "setName": "Halloween Spooktacular",
       "effects": {
-        "truthDelta": 3
+        "truthDelta": -3
       }
     },
     "hallo-gov-seance-shenanigans-043": {
@@ -8720,7 +8720,7 @@
       "setId": "halloween_spooktacular",
       "setName": "Halloween Spooktacular",
       "effects": {
-        "truthDelta": 1
+        "truthDelta": -1
       }
     },
     "hallo-gov-shuffle-of-the-haunted-056": {
@@ -8798,7 +8798,7 @@
       "setId": "halloween_spooktacular",
       "setName": "Halloween Spooktacular",
       "effects": {
-        "truthDelta": 1
+        "truthDelta": -1
       }
     },
     "hallo-gov-spider-gambit-protocol-020": {
@@ -8811,7 +8811,7 @@
       "setId": "halloween_spooktacular",
       "setName": "Halloween Spooktacular",
       "effects": {
-        "truthDelta": 2
+        "truthDelta": -2
       }
     },
     "hallo-gov-spider-scare-incident-002": {
@@ -8876,7 +8876,7 @@
       "setId": "halloween_spooktacular",
       "setName": "Halloween Spooktacular",
       "effects": {
-        "truthDelta": 1
+        "truthDelta": -1
       }
     },
     "hallo-gov-witch-press-release-incident-070": {
@@ -8941,7 +8941,7 @@
       "setId": "halloween_spooktacular",
       "setName": "Halloween Spooktacular",
       "effects": {
-        "truthDelta": 1
+        "truthDelta": -1
       }
     },
     "hallo-gov-zombie-murmur-network-files-014": {

--- a/public/extensions/halloween_spooktacular_with_temp_image.json
+++ b/public/extensions/halloween_spooktacular_with_temp_image.json
@@ -65,9 +65,9 @@
       "rarity": "common",
       "cost": 3,
       "effects": {
-        "truthDelta": 1
+        "truthDelta": -1
       },
-      "text": "+1% Truth.",
+      "text": "−1% Truth.",
       "flavor": "Approved by the Council of Shadows.",
       "artId": "halloween_spooktacular-Temp-Image"
     },
@@ -95,9 +95,9 @@
       "rarity": "common",
       "cost": 3,
       "effects": {
-        "truthDelta": 1
+        "truthDelta": -1
       },
-      "text": "+1% Truth.",
+      "text": "−1% Truth.",
       "flavor": "Do not taunt the poltergeist.",
       "artId": "halloween_spooktacular-Temp-Image"
     },
@@ -109,9 +109,9 @@
       "rarity": "common",
       "cost": 3,
       "effects": {
-        "truthDelta": 1
+        "truthDelta": -1
       },
-      "text": "+1% Truth.",
+      "text": "−1% Truth.",
       "flavor": "Rated PG‑Paranoid.",
       "artId": "halloween_spooktacular-Temp-Image"
     },
@@ -123,9 +123,9 @@
       "rarity": "common",
       "cost": 3,
       "effects": {
-        "truthDelta": 1
+        "truthDelta": -1
       },
-      "text": "+1% Truth.",
+      "text": "−1% Truth.",
       "flavor": "Whispers from the cornfield.",
       "artId": "halloween_spooktacular-Temp-Image"
     },
@@ -184,9 +184,9 @@
       "rarity": "common",
       "cost": 3,
       "effects": {
-        "truthDelta": 1
+        "truthDelta": -1
       },
-      "text": "+1% Truth.",
+      "text": "−1% Truth.",
       "flavor": "Whispers from the cornfield.",
       "artId": "halloween_spooktacular-Temp-Image"
     },
@@ -214,9 +214,9 @@
       "rarity": "common",
       "cost": 3,
       "effects": {
-        "truthDelta": 1
+        "truthDelta": -1
       },
-      "text": "+1% Truth.",
+      "text": "−1% Truth.",
       "flavor": "They came for the candy, stayed for the cover‑up.",
       "artId": "halloween_spooktacular-Temp-Image"
     },
@@ -244,9 +244,9 @@
       "rarity": "common",
       "cost": 3,
       "effects": {
-        "truthDelta": 1
+        "truthDelta": -1
       },
-      "text": "+1% Truth.",
+      "text": "−1% Truth.",
       "flavor": "‘It was just the wind,’ said the intern.",
       "artId": "halloween_spooktacular-Temp-Image"
     },
@@ -258,9 +258,9 @@
       "rarity": "common",
       "cost": 3,
       "effects": {
-        "truthDelta": 1
+        "truthDelta": -1
       },
-      "text": "+1% Truth.",
+      "text": "−1% Truth.",
       "flavor": "Smells like fog machine and fear.",
       "artId": "halloween_spooktacular-Temp-Image"
     },
@@ -367,9 +367,9 @@
       "rarity": "common",
       "cost": 3,
       "effects": {
-        "truthDelta": 1
+        "truthDelta": -1
       },
-      "text": "+1% Truth.",
+      "text": "−1% Truth.",
       "flavor": "Mind the ectoplasm.",
       "artId": "halloween_spooktacular-Temp-Image"
     },
@@ -396,9 +396,9 @@
       "rarity": "common",
       "cost": 3,
       "effects": {
-        "truthDelta": 1
+        "truthDelta": -1
       },
-      "text": "+1% Truth.",
+      "text": "−1% Truth.",
       "flavor": "Bring a flashlight and plausible deniability.",
       "artId": "halloween_spooktacular-Temp-Image"
     },
@@ -426,9 +426,9 @@
       "rarity": "common",
       "cost": 3,
       "effects": {
-        "truthDelta": 1
+        "truthDelta": -1
       },
-      "text": "+1% Truth.",
+      "text": "−1% Truth.",
       "flavor": "Try not to scream on camera.",
       "artId": "halloween_spooktacular-Temp-Image"
     },
@@ -456,9 +456,9 @@
       "rarity": "common",
       "cost": 3,
       "effects": {
-        "truthDelta": 1
+        "truthDelta": -1
       },
-      "text": "+1% Truth.",
+      "text": "−1% Truth.",
       "flavor": "They came for the candy, stayed for the cover‑up.",
       "artId": "halloween_spooktacular-Temp-Image"
     },
@@ -470,9 +470,9 @@
       "rarity": "common",
       "cost": 3,
       "effects": {
-        "truthDelta": 1
+        "truthDelta": -1
       },
-      "text": "+1% Truth.",
+      "text": "−1% Truth.",
       "flavor": "They came for the candy, stayed for the cover‑up.",
       "artId": "halloween_spooktacular-Temp-Image"
     },
@@ -515,9 +515,9 @@
       "rarity": "common",
       "cost": 3,
       "effects": {
-        "truthDelta": 1
+        "truthDelta": -1
       },
-      "text": "+1% Truth.",
+      "text": "−1% Truth.",
       "flavor": "Mind the ectoplasm.",
       "artId": "halloween_spooktacular-Temp-Image"
     },
@@ -529,9 +529,9 @@
       "rarity": "common",
       "cost": 3,
       "effects": {
-        "truthDelta": 1
+        "truthDelta": -1
       },
-      "text": "+1% Truth.",
+      "text": "−1% Truth.",
       "flavor": "Licensed spooktacular.",
       "artId": "halloween_spooktacular-Temp-Image"
     },
@@ -573,9 +573,9 @@
       "rarity": "common",
       "cost": 3,
       "effects": {
-        "truthDelta": 1
+        "truthDelta": -1
       },
-      "text": "+1% Truth.",
+      "text": "−1% Truth.",
       "flavor": "Red eyes in the rear-view mirror.",
       "artId": "halloween_spooktacular-Temp-Image"
     },
@@ -587,9 +587,9 @@
       "rarity": "common",
       "cost": 3,
       "effects": {
-        "truthDelta": 1
+        "truthDelta": -1
       },
-      "text": "+1% Truth.",
+      "text": "−1% Truth.",
       "flavor": "Mind the ectoplasm.",
       "artId": "halloween_spooktacular-Temp-Image"
     },
@@ -632,9 +632,9 @@
       "rarity": "common",
       "cost": 3,
       "effects": {
-        "truthDelta": 1
+        "truthDelta": -1
       },
-      "text": "+1% Truth.",
+      "text": "−1% Truth.",
       "flavor": "Keep garlic handy.",
       "artId": "halloween_spooktacular-Temp-Image"
     },
@@ -694,9 +694,9 @@
       "rarity": "common",
       "cost": 3,
       "effects": {
-        "truthDelta": 1
+        "truthDelta": -1
       },
-      "text": "+1% Truth.",
+      "text": "−1% Truth.",
       "flavor": "Keep garlic handy.",
       "artId": "halloween_spooktacular-Temp-Image"
     },
@@ -708,9 +708,9 @@
       "rarity": "common",
       "cost": 3,
       "effects": {
-        "truthDelta": 1
+        "truthDelta": -1
       },
-      "text": "+1% Truth.",
+      "text": "−1% Truth.",
       "flavor": "The crypt Wi‑Fi is excellent.",
       "artId": "halloween_spooktacular-Temp-Image"
     },
@@ -738,9 +738,9 @@
       "rarity": "common",
       "cost": 3,
       "effects": {
-        "truthDelta": 1
+        "truthDelta": -1
       },
-      "text": "+1% Truth.",
+      "text": "−1% Truth.",
       "flavor": "Someone left the portal open again.",
       "artId": "halloween_spooktacular-Temp-Image"
     },
@@ -752,9 +752,9 @@
       "rarity": "common",
       "cost": 3,
       "effects": {
-        "truthDelta": 1
+        "truthDelta": -1
       },
-      "text": "+1% Truth.",
+      "text": "−1% Truth.",
       "flavor": "Bring a flashlight and plausible deniability.",
       "artId": "halloween_spooktacular-Temp-Image"
     },
@@ -829,9 +829,9 @@
       "rarity": "common",
       "cost": 3,
       "effects": {
-        "truthDelta": 1
+        "truthDelta": -1
       },
-      "text": "+1% Truth.",
+      "text": "−1% Truth.",
       "flavor": "Sticky with sugar and secrets.",
       "artId": "halloween_spooktacular-Temp-Image"
     },
@@ -905,9 +905,9 @@
       "rarity": "common",
       "cost": 3,
       "effects": {
-        "truthDelta": 1
+        "truthDelta": -1
       },
-      "text": "+1% Truth.",
+      "text": "−1% Truth.",
       "flavor": "Licensed spooktacular.",
       "artId": "halloween_spooktacular-Temp-Image"
     },
@@ -983,9 +983,9 @@
       "rarity": "common",
       "cost": 3,
       "effects": {
-        "truthDelta": 1
+        "truthDelta": -1
       },
-      "text": "+1% Truth.",
+      "text": "−1% Truth.",
       "flavor": "All treats, suspicious tricks.",
       "artId": "halloween_spooktacular-Temp-Image"
     },
@@ -997,9 +997,9 @@
       "rarity": "common",
       "cost": 3,
       "effects": {
-        "truthDelta": 1
+        "truthDelta": -1
       },
-      "text": "+1% Truth.",
+      "text": "−1% Truth.",
       "flavor": "Do not taunt the poltergeist.",
       "artId": "halloween_spooktacular-Temp-Image"
     },
@@ -1091,9 +1091,9 @@
       "rarity": "uncommon",
       "cost": 4,
       "effects": {
-        "truthDelta": 2
+        "truthDelta": -2
       },
-      "text": "+2% Truth.",
+      "text": "−2% Truth.",
       "flavor": "This is fine. Probably.",
       "artId": "halloween_spooktacular-Temp-Image"
     },
@@ -1105,9 +1105,9 @@
       "rarity": "uncommon",
       "cost": 4,
       "effects": {
-        "truthDelta": 2
+        "truthDelta": -2
       },
-      "text": "+2% Truth.",
+      "text": "−2% Truth.",
       "flavor": "Whispers from the cornfield.",
       "artId": "halloween_spooktacular-Temp-Image"
     },
@@ -1167,9 +1167,9 @@
       "rarity": "uncommon",
       "cost": 4,
       "effects": {
-        "truthDelta": 2
+        "truthDelta": -2
       },
-      "text": "+2% Truth.",
+      "text": "−2% Truth.",
       "flavor": "Rated PG‑Paranoid.",
       "artId": "halloween_spooktacular-Temp-Image"
     },
@@ -1181,9 +1181,9 @@
       "rarity": "uncommon",
       "cost": 4,
       "effects": {
-        "truthDelta": 2
+        "truthDelta": -2
       },
-      "text": "+2% Truth.",
+      "text": "−2% Truth.",
       "flavor": "They came for the candy, stayed for the cover‑up.",
       "artId": "halloween_spooktacular-Temp-Image"
     },
@@ -1195,9 +1195,9 @@
       "rarity": "uncommon",
       "cost": 4,
       "effects": {
-        "truthDelta": 2
+        "truthDelta": -2
       },
-      "text": "+2% Truth.",
+      "text": "−2% Truth.",
       "flavor": "Licensed spooktacular.",
       "artId": "halloween_spooktacular-Temp-Image"
     },
@@ -1209,9 +1209,9 @@
       "rarity": "uncommon",
       "cost": 4,
       "effects": {
-        "truthDelta": 2
+        "truthDelta": -2
       },
-      "text": "+2% Truth.",
+      "text": "−2% Truth.",
       "flavor": "Do not feed after midnight.",
       "artId": "halloween_spooktacular-Temp-Image"
     },
@@ -1223,9 +1223,9 @@
       "rarity": "uncommon",
       "cost": 4,
       "effects": {
-        "truthDelta": 2
+        "truthDelta": -2
       },
-      "text": "+2% Truth.",
+      "text": "−2% Truth.",
       "flavor": "Smells like fog machine and fear.",
       "artId": "halloween_spooktacular-Temp-Image"
     },
@@ -1283,9 +1283,9 @@
       "rarity": "uncommon",
       "cost": 4,
       "effects": {
-        "truthDelta": 2
+        "truthDelta": -2
       },
-      "text": "+2% Truth.",
+      "text": "−2% Truth.",
       "flavor": "This is fine. Probably.",
       "artId": "halloween_spooktacular-Temp-Image"
     },
@@ -1312,9 +1312,9 @@
       "rarity": "uncommon",
       "cost": 4,
       "effects": {
-        "truthDelta": 2
+        "truthDelta": -2
       },
-      "text": "+2% Truth.",
+      "text": "−2% Truth.",
       "flavor": "Licensed spooktacular.",
       "artId": "halloween_spooktacular-Temp-Image"
     },
@@ -1326,9 +1326,9 @@
       "rarity": "uncommon",
       "cost": 4,
       "effects": {
-        "truthDelta": 2
+        "truthDelta": -2
       },
-      "text": "+2% Truth.",
+      "text": "−2% Truth.",
       "flavor": "This is fine. Probably.",
       "artId": "halloween_spooktacular-Temp-Image"
     },
@@ -1355,9 +1355,9 @@
       "rarity": "uncommon",
       "cost": 4,
       "effects": {
-        "truthDelta": 2
+        "truthDelta": -2
       },
-      "text": "+2% Truth.",
+      "text": "−2% Truth.",
       "flavor": "Batteries not included.",
       "artId": "halloween_spooktacular-Temp-Image"
     },
@@ -1369,9 +1369,9 @@
       "rarity": "rare",
       "cost": 5,
       "effects": {
-        "truthDelta": 3
+        "truthDelta": -3
       },
-      "text": "+3% Truth.",
+      "text": "−3% Truth.",
       "flavor": "They came for the candy, stayed for the cover‑up.",
       "artId": "halloween_spooktacular-Temp-Image"
     },
@@ -1383,9 +1383,9 @@
       "rarity": "rare",
       "cost": 5,
       "effects": {
-        "truthDelta": 3
+        "truthDelta": -3
       },
-      "text": "+3% Truth.",
+      "text": "−3% Truth.",
       "flavor": "The crypt Wi‑Fi is excellent.",
       "artId": "halloween_spooktacular-Temp-Image"
     },
@@ -1414,9 +1414,9 @@
       "rarity": "rare",
       "cost": 5,
       "effects": {
-        "truthDelta": 3
+        "truthDelta": -3
       },
-      "text": "+3% Truth.",
+      "text": "−3% Truth.",
       "flavor": "Try not to scream on camera.",
       "artId": "halloween_spooktacular-Temp-Image"
     },
@@ -1428,9 +1428,9 @@
       "rarity": "rare",
       "cost": 5,
       "effects": {
-        "truthDelta": 3
+        "truthDelta": -3
       },
-      "text": "+3% Truth.",
+      "text": "−3% Truth.",
       "flavor": "Rated PG‑Paranoid.",
       "artId": "halloween_spooktacular-Temp-Image"
     },
@@ -1442,9 +1442,9 @@
       "rarity": "rare",
       "cost": 5,
       "effects": {
-        "truthDelta": 3
+        "truthDelta": -3
       },
-      "text": "+3% Truth.",
+      "text": "−3% Truth.",
       "flavor": "Filed under ‘Seasonal Anomalies’.",
       "artId": "halloween_spooktacular-Temp-Image"
     },
@@ -1456,9 +1456,9 @@
       "rarity": "rare",
       "cost": 5,
       "effects": {
-        "truthDelta": 3
+        "truthDelta": -3
       },
-      "text": "+3% Truth.",
+      "text": "−3% Truth.",
       "flavor": "Someone left the portal open again.",
       "artId": "halloween_spooktacular-Temp-Image"
     },
@@ -2909,9 +2909,9 @@
       "rarity": "legendary",
       "cost": 6,
       "effects": {
-        "truthDelta": 4
+        "truthDelta": -4
       },
-      "text": "+4% Truth.",
+      "text": "−4% Truth.",
       "flavor": "Approved by the Starbucks Council of Shadows.",
       "artId": "halloween_spooktacular-Temp-Image"
     },
@@ -2923,9 +2923,9 @@
       "rarity": "rare",
       "cost": 5,
       "effects": {
-        "truthDelta": 3
+        "truthDelta": -3
       },
-      "text": "+3% Truth.",
+      "text": "−3% Truth.",
       "flavor": "Stake, garlic, plausible deniability.",
       "artId": "halloween_spooktacular-Temp-Image"
     },

--- a/src/data/expansions/halloween_MVP.ts
+++ b/src/data/expansions/halloween_MVP.ts
@@ -57,10 +57,10 @@ const cards: GameCard[] = [
     "rarity": "common",
     "cost": 3,
     "effects": {
-      "truthDelta": 1
+      "truthDelta": -1
     },
     "extId": "halloween",
-    "text": "+1% Truth.",
+    "text": "−1% Truth.",
     "flavor": "Approved by the Council of Shadows."
   },
   {
@@ -87,10 +87,10 @@ const cards: GameCard[] = [
     "rarity": "common",
     "cost": 3,
     "effects": {
-      "truthDelta": 1
+      "truthDelta": -1
     },
     "extId": "halloween",
-    "text": "+1% Truth.",
+    "text": "−1% Truth.",
     "flavor": "Do not taunt the poltergeist."
   },
   {
@@ -101,10 +101,10 @@ const cards: GameCard[] = [
     "rarity": "common",
     "cost": 3,
     "effects": {
-      "truthDelta": 1
+      "truthDelta": -1
     },
     "extId": "halloween",
-    "text": "+1% Truth.",
+    "text": "−1% Truth.",
     "flavor": "Rated PG‑Paranoid."
   },
   {
@@ -115,10 +115,10 @@ const cards: GameCard[] = [
     "rarity": "common",
     "cost": 3,
     "effects": {
-      "truthDelta": 1
+      "truthDelta": -1
     },
     "extId": "halloween",
-    "text": "+1% Truth.",
+    "text": "−1% Truth.",
     "flavor": "Whispers from the cornfield."
   },
   {
@@ -179,10 +179,10 @@ const cards: GameCard[] = [
     "rarity": "common",
     "cost": 3,
     "effects": {
-      "truthDelta": 1
+      "truthDelta": -1
     },
     "extId": "halloween",
-    "text": "+1% Truth.",
+    "text": "−1% Truth.",
     "flavor": "Whispers from the cornfield."
   },
   {
@@ -209,10 +209,10 @@ const cards: GameCard[] = [
     "rarity": "common",
     "cost": 3,
     "effects": {
-      "truthDelta": 1
+      "truthDelta": -1
     },
     "extId": "halloween",
-    "text": "+1% Truth.",
+    "text": "−1% Truth.",
     "flavor": "They came for the candy, stayed for the cover‑up."
   },
   {
@@ -239,10 +239,10 @@ const cards: GameCard[] = [
     "rarity": "common",
     "cost": 3,
     "effects": {
-      "truthDelta": 1
+      "truthDelta": -1
     },
     "extId": "halloween",
-    "text": "+1% Truth.",
+    "text": "−1% Truth.",
     "flavor": "‘It was just the wind,’ said the intern."
   },
   {
@@ -253,10 +253,10 @@ const cards: GameCard[] = [
     "rarity": "common",
     "cost": 3,
     "effects": {
-      "truthDelta": 1
+      "truthDelta": -1
     },
     "extId": "halloween",
-    "text": "+1% Truth.",
+    "text": "−1% Truth.",
     "flavor": "Smells like fog machine and fear."
   },
   {
@@ -365,10 +365,10 @@ const cards: GameCard[] = [
     "rarity": "common",
     "cost": 3,
     "effects": {
-      "truthDelta": 1
+      "truthDelta": -1
     },
     "extId": "halloween",
-    "text": "+1% Truth.",
+    "text": "−1% Truth.",
     "flavor": "Mind the ectoplasm."
   },
   {
@@ -397,10 +397,10 @@ const cards: GameCard[] = [
     "rarity": "common",
     "cost": 3,
     "effects": {
-      "truthDelta": 1
+      "truthDelta": -1
     },
     "extId": "halloween",
-    "text": "+1% Truth.",
+    "text": "−1% Truth.",
     "flavor": "Bring a flashlight and plausible deniability."
   },
   {
@@ -427,10 +427,10 @@ const cards: GameCard[] = [
     "rarity": "common",
     "cost": 3,
     "effects": {
-      "truthDelta": 1
+      "truthDelta": -1
     },
     "extId": "halloween",
-    "text": "+1% Truth.",
+    "text": "−1% Truth.",
     "flavor": "Try not to scream on camera."
   },
   {
@@ -457,10 +457,10 @@ const cards: GameCard[] = [
     "rarity": "common",
     "cost": 3,
     "effects": {
-      "truthDelta": 1
+      "truthDelta": -1
     },
     "extId": "halloween",
-    "text": "+1% Truth.",
+    "text": "−1% Truth.",
     "flavor": "They came for the candy, stayed for the cover‑up."
   },
   {
@@ -471,10 +471,10 @@ const cards: GameCard[] = [
     "rarity": "common",
     "cost": 3,
     "effects": {
-      "truthDelta": 1
+      "truthDelta": -1
     },
     "extId": "halloween",
-    "text": "+1% Truth.",
+    "text": "−1% Truth.",
     "flavor": "They came for the candy, stayed for the cover‑up."
   },
   {
@@ -519,10 +519,10 @@ const cards: GameCard[] = [
     "rarity": "common",
     "cost": 3,
     "effects": {
-      "truthDelta": 1
+      "truthDelta": -1
     },
     "extId": "halloween",
-    "text": "+1% Truth.",
+    "text": "−1% Truth.",
     "flavor": "Mind the ectoplasm."
   },
   {
@@ -533,10 +533,10 @@ const cards: GameCard[] = [
     "rarity": "common",
     "cost": 3,
     "effects": {
-      "truthDelta": 1
+      "truthDelta": -1
     },
     "extId": "halloween",
-    "text": "+1% Truth.",
+    "text": "−1% Truth.",
     "flavor": "Licensed spooktacular."
   },
   {
@@ -583,10 +583,10 @@ const cards: GameCard[] = [
     "rarity": "common",
     "cost": 3,
     "effects": {
-      "truthDelta": 1
+      "truthDelta": -1
     },
     "extId": "halloween",
-    "text": "+1% Truth.",
+    "text": "−1% Truth.",
     "flavor": "Red eyes in the rear-view mirror."
   },
   {
@@ -597,10 +597,10 @@ const cards: GameCard[] = [
     "rarity": "common",
     "cost": 3,
     "effects": {
-      "truthDelta": 1
+      "truthDelta": -1
     },
     "extId": "halloween",
-    "text": "+1% Truth.",
+    "text": "−1% Truth.",
     "flavor": "Mind the ectoplasm."
   },
   {
@@ -645,10 +645,10 @@ const cards: GameCard[] = [
     "rarity": "common",
     "cost": 3,
     "effects": {
-      "truthDelta": 1
+      "truthDelta": -1
     },
     "extId": "halloween",
-    "text": "+1% Truth.",
+    "text": "−1% Truth.",
     "flavor": "Keep garlic handy."
   },
   {
@@ -707,10 +707,10 @@ const cards: GameCard[] = [
     "rarity": "common",
     "cost": 3,
     "effects": {
-      "truthDelta": 1
+      "truthDelta": -1
     },
     "extId": "halloween",
-    "text": "+1% Truth.",
+    "text": "−1% Truth.",
     "flavor": "Keep garlic handy."
   },
   {
@@ -721,10 +721,10 @@ const cards: GameCard[] = [
     "rarity": "common",
     "cost": 3,
     "effects": {
-      "truthDelta": 1
+      "truthDelta": -1
     },
     "extId": "halloween",
-    "text": "+1% Truth.",
+    "text": "−1% Truth.",
     "flavor": "The crypt Wi‑Fi is excellent."
   },
   {
@@ -751,10 +751,10 @@ const cards: GameCard[] = [
     "rarity": "common",
     "cost": 3,
     "effects": {
-      "truthDelta": 1
+      "truthDelta": -1
     },
     "extId": "halloween",
-    "text": "+1% Truth.",
+    "text": "−1% Truth.",
     "flavor": "Someone left the portal open again."
   },
   {
@@ -765,10 +765,10 @@ const cards: GameCard[] = [
     "rarity": "common",
     "cost": 3,
     "effects": {
-      "truthDelta": 1
+      "truthDelta": -1
     },
     "extId": "halloween",
-    "text": "+1% Truth.",
+    "text": "−1% Truth.",
     "flavor": "Bring a flashlight and plausible deniability."
   },
   {
@@ -845,10 +845,10 @@ const cards: GameCard[] = [
     "rarity": "common",
     "cost": 3,
     "effects": {
-      "truthDelta": 1
+      "truthDelta": -1
     },
     "extId": "halloween",
-    "text": "+1% Truth.",
+    "text": "−1% Truth.",
     "flavor": "Sticky with sugar and secrets."
   },
   {
@@ -927,10 +927,10 @@ const cards: GameCard[] = [
     "rarity": "common",
     "cost": 3,
     "effects": {
-      "truthDelta": 1
+      "truthDelta": -1
     },
     "extId": "halloween",
-    "text": "+1% Truth.",
+    "text": "−1% Truth.",
     "flavor": "Licensed spooktacular."
   },
   {
@@ -1005,10 +1005,10 @@ const cards: GameCard[] = [
     "rarity": "common",
     "cost": 3,
     "effects": {
-      "truthDelta": 1
+      "truthDelta": -1
     },
     "extId": "halloween",
-    "text": "+1% Truth.",
+    "text": "−1% Truth.",
     "flavor": "All treats, suspicious tricks."
   },
   {
@@ -1019,10 +1019,10 @@ const cards: GameCard[] = [
     "rarity": "common",
     "cost": 3,
     "effects": {
-      "truthDelta": 1
+      "truthDelta": -1
     },
     "extId": "halloween",
-    "text": "+1% Truth.",
+    "text": "−1% Truth.",
     "flavor": "Do not taunt the poltergeist."
   },
   {
@@ -1113,10 +1113,10 @@ const cards: GameCard[] = [
     "rarity": "uncommon",
     "cost": 4,
     "effects": {
-      "truthDelta": 2
+      "truthDelta": -2
     },
     "extId": "halloween",
-    "text": "+2% Truth.",
+    "text": "−2% Truth.",
     "flavor": "This is fine. Probably."
   },
   {
@@ -1127,10 +1127,10 @@ const cards: GameCard[] = [
     "rarity": "uncommon",
     "cost": 4,
     "effects": {
-      "truthDelta": 2
+      "truthDelta": -2
     },
     "extId": "halloween",
-    "text": "+2% Truth.",
+    "text": "−2% Truth.",
     "flavor": "Whispers from the cornfield."
   },
   {
@@ -1189,10 +1189,10 @@ const cards: GameCard[] = [
     "rarity": "uncommon",
     "cost": 4,
     "effects": {
-      "truthDelta": 2
+      "truthDelta": -2
     },
     "extId": "halloween",
-    "text": "+2% Truth.",
+    "text": "−2% Truth.",
     "flavor": "Rated PG‑Paranoid."
   },
   {
@@ -1203,10 +1203,10 @@ const cards: GameCard[] = [
     "rarity": "uncommon",
     "cost": 4,
     "effects": {
-      "truthDelta": 2
+      "truthDelta": -2
     },
     "extId": "halloween",
-    "text": "+2% Truth.",
+    "text": "−2% Truth.",
     "flavor": "They came for the candy, stayed for the cover‑up."
   },
   {
@@ -1217,10 +1217,10 @@ const cards: GameCard[] = [
     "rarity": "uncommon",
     "cost": 4,
     "effects": {
-      "truthDelta": 2
+      "truthDelta": -2
     },
     "extId": "halloween",
-    "text": "+2% Truth.",
+    "text": "−2% Truth.",
     "flavor": "Licensed spooktacular."
   },
   {
@@ -1231,10 +1231,10 @@ const cards: GameCard[] = [
     "rarity": "uncommon",
     "cost": 4,
     "effects": {
-      "truthDelta": 2
+      "truthDelta": -2
     },
     "extId": "halloween",
-    "text": "+2% Truth.",
+    "text": "−2% Truth.",
     "flavor": "Do not feed after midnight."
   },
   {
@@ -1245,10 +1245,10 @@ const cards: GameCard[] = [
     "rarity": "uncommon",
     "cost": 4,
     "effects": {
-      "truthDelta": 2
+      "truthDelta": -2
     },
     "extId": "halloween",
-    "text": "+2% Truth.",
+    "text": "−2% Truth.",
     "flavor": "Smells like fog machine and fear."
   },
   {
@@ -1311,10 +1311,10 @@ const cards: GameCard[] = [
     "rarity": "uncommon",
     "cost": 4,
     "effects": {
-      "truthDelta": 2
+      "truthDelta": -2
     },
     "extId": "halloween",
-    "text": "+2% Truth.",
+    "text": "−2% Truth.",
     "flavor": "This is fine. Probably."
   },
   {
@@ -1343,10 +1343,10 @@ const cards: GameCard[] = [
     "rarity": "uncommon",
     "cost": 4,
     "effects": {
-      "truthDelta": 2
+      "truthDelta": -2
     },
     "extId": "halloween",
-    "text": "+2% Truth.",
+    "text": "−2% Truth.",
     "flavor": "Licensed spooktacular."
   },
   {
@@ -1357,10 +1357,10 @@ const cards: GameCard[] = [
     "rarity": "uncommon",
     "cost": 4,
     "effects": {
-      "truthDelta": 2
+      "truthDelta": -2
     },
     "extId": "halloween",
-    "text": "+2% Truth.",
+    "text": "−2% Truth.",
     "flavor": "This is fine. Probably."
   },
   {
@@ -1389,10 +1389,10 @@ const cards: GameCard[] = [
     "rarity": "uncommon",
     "cost": 4,
     "effects": {
-      "truthDelta": 2
+      "truthDelta": -2
     },
     "extId": "halloween",
-    "text": "+2% Truth.",
+    "text": "−2% Truth.",
     "flavor": "Batteries not included."
   },
   {
@@ -1403,10 +1403,10 @@ const cards: GameCard[] = [
     "rarity": "rare",
     "cost": 5,
     "effects": {
-      "truthDelta": 3
+      "truthDelta": -3
     },
     "extId": "halloween",
-    "text": "+3% Truth.",
+    "text": "−3% Truth.",
     "flavor": "They came for the candy, stayed for the cover‑up."
   },
   {
@@ -1417,10 +1417,10 @@ const cards: GameCard[] = [
     "rarity": "rare",
     "cost": 5,
     "effects": {
-      "truthDelta": 3
+      "truthDelta": -3
     },
     "extId": "halloween",
-    "text": "+3% Truth.",
+    "text": "−3% Truth.",
     "flavor": "The crypt Wi‑Fi is excellent."
   },
   {
@@ -1448,10 +1448,10 @@ const cards: GameCard[] = [
     "rarity": "rare",
     "cost": 5,
     "effects": {
-      "truthDelta": 3
+      "truthDelta": -3
     },
     "extId": "halloween",
-    "text": "+3% Truth.",
+    "text": "−3% Truth.",
     "flavor": "Try not to scream on camera."
   },
   {
@@ -1462,10 +1462,10 @@ const cards: GameCard[] = [
     "rarity": "rare",
     "cost": 5,
     "effects": {
-      "truthDelta": 3
+      "truthDelta": -3
     },
     "extId": "halloween",
-    "text": "+3% Truth.",
+    "text": "−3% Truth.",
     "flavor": "Rated PG‑Paranoid."
   },
   {
@@ -1476,10 +1476,10 @@ const cards: GameCard[] = [
     "rarity": "rare",
     "cost": 5,
     "effects": {
-      "truthDelta": 3
+      "truthDelta": -3
     },
     "extId": "halloween",
-    "text": "+3% Truth.",
+    "text": "−3% Truth.",
     "flavor": "Filed under ‘Seasonal Anomalies’."
   },
   {
@@ -1490,10 +1490,10 @@ const cards: GameCard[] = [
     "rarity": "rare",
     "cost": 5,
     "effects": {
-      "truthDelta": 3
+      "truthDelta": -3
     },
     "extId": "halloween",
-    "text": "+3% Truth.",
+    "text": "−3% Truth.",
     "flavor": "Someone left the portal open again."
   },
   {
@@ -2997,10 +2997,10 @@ const cards: GameCard[] = [
     "rarity": "legendary",
     "cost": 6,
     "effects": {
-      "truthDelta": 4
+      "truthDelta": -4
     },
     "extId": "halloween",
-    "text": "+4% Truth.",
+    "text": "−4% Truth.",
     "flavor": "Approved by the Starbucks Council of Shadows."
   },
   {
@@ -3011,10 +3011,10 @@ const cards: GameCard[] = [
     "rarity": "rare",
     "cost": 5,
     "effects": {
-      "truthDelta": 3
+      "truthDelta": -3
     },
     "extId": "halloween",
-    "text": "+3% Truth.",
+    "text": "−3% Truth.",
     "flavor": "Stake, garlic, plausible deniability."
   },
   {


### PR DESCRIPTION
## Summary
- flip Halloween Spooktacular government MEDIA card truth deltas to negative values so they suppress Truth as intended
- update the expansion JSON and generated narrative database to mirror the corrected Truth penalties

## Testing
- npm run lint *(fails: repository currently has unrelated lint violations)*
- bun test --coverage --coverage-reporter=text *(fails: existing EnhancedUSAMap hotspot test relies on browser localStorage)*

------
https://chatgpt.com/codex/tasks/task_e_68dedddb36e88320838d39dddeb0740d