### PR TITLE
Add data-card-id hooks for playable card elements

### DIFF
--- a/src/components/game/CardDetailOverlay.tsx
+++ b/src/components/game/CardDetailOverlay.tsx
@@ -59,7 +59,7 @@ const TabloidCardDetail: React.FC<CardDetailOverlayProps> = ({
         </div>
 
         <div className="modal-wrapper">
-          <div className="modal-card">
+          <div className="modal-card" data-card-id={card.id}>
             <BaseCard card={card} polaroidHover={false} />
           </div>
         </div>
@@ -170,6 +170,7 @@ const LegacyCardDetail: React.FC<CardDetailOverlayProps> = ({
           isMobile ? 'w-full max-w-sm max-h-[90vh] rounded-xl' : 'w-full max-w-md h-[85vh] rounded-2xl'
         } ${getLegacyRarityFrameClass(card.rarity)} ${getLegacyRarityGlowClass(card.rarity)}`}
         onClick={(e) => e.stopPropagation()}
+        data-card-id={card.id}
       >
         <div className="bg-card/95 backdrop-blur-sm border-b border-border p-4 flex-shrink-0">
           <div className="flex items-start justify-between gap-3">

--- a/src/components/game/EnhancedGameHand.tsx
+++ b/src/components/game/EnhancedGameHand.tsx
@@ -179,6 +179,7 @@ const EnhancedGameHand: React.FC<EnhancedGameHandProps> = ({
                   disabled && 'cursor-default'
                 )}
                 style={{ animationDelay: `${index * 0.03}s` }}
+                data-card-id={card.id}
                 onClick={(e) => {
                   e.preventDefault();
                   audio.playSFX('click');

--- a/src/components/game/GameHand.tsx
+++ b/src/components/game/GameHand.tsx
@@ -42,12 +42,13 @@ const GameHand = ({ cards, onPlayCard, disabled }: GameHandProps) => {
       
       <div className="space-y-2 max-h-96 overflow-y-auto">
         {cards.map((card, index) => (
-          <Card 
-            key={card.id} 
+          <Card
+            key={card.id}
             className={`relative p-0 cursor-pointer transition-all hover:scale-105 hover:-translate-y-2 ${getTypeColor(normalizeCardType(card.type))} ${
               disabled ? 'opacity-50' : ''
             } overflow-hidden animate-card-deal`}
             style={{ animationDelay: `${index * 0.1}s` }}
+            data-card-id={card.id}
           >
             {/* TCG Card Layout */}
             <div className="relative">


### PR DESCRIPTION
## Summary
- add `data-card-id` to enhanced hand buttons so animations can locate the source card
- expose the same attribute in the classic hand layout and card detail overlays for consistency

## Testing
- npm run lint *(fails: repository already has lint errors unrelated to this change)*
- bun test --coverage --coverage-reporter=text *(fails: existing EnhancedUSAMap paranormal hotspot test and localStorage dependency)*

------
https://chatgpt.com/codex/tasks/task_e_68dee656f3bc83209f3157b18d746fed