### PR TITLE
Add reveal secret agenda messaging to formatEffect

### DIFF
--- a/src/lib/__tests__/cardUi.test.ts
+++ b/src/lib/__tests__/cardUi.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, test } from 'bun:test';
+
+import { formatEffect } from '../cardUi';
+import type { GameCard } from '@/rules/mvp';
+
+describe('formatEffect', () => {
+  const baseCard: Pick<GameCard, 'id' | 'name' | 'type' | 'faction' | 'cost' | 'effects'> = {
+    id: 'test-card',
+    name: 'Test Card',
+    type: 'MEDIA',
+    faction: 'truth',
+    cost: 0,
+    effects: {},
+  };
+
+  test('appends reveal text for ATTACK cards', () => {
+    const card: GameCard = {
+      ...baseCard,
+      type: 'ATTACK',
+      effects: {
+        ipDelta: { opponent: -2 },
+        revealSecretAgenda: true,
+      },
+    };
+
+    expect(formatEffect(card)).toBe('Opponent loses 2 IP · Reveal enemy secret agenda');
+  });
+
+  test('appends reveal text for MEDIA cards', () => {
+    const card: GameCard = {
+      ...baseCard,
+      type: 'MEDIA',
+      effects: {
+        truthDelta: 5,
+        revealSecretAgenda: true,
+      },
+    };
+
+    expect(formatEffect(card)).toBe('Truth +5% · Reveal enemy secret agenda');
+  });
+
+  test('appends reveal text for ZONE cards', () => {
+    const card: GameCard = {
+      ...baseCard,
+      type: 'ZONE',
+      effects: {
+        pressureDelta: 3,
+        revealSecretAgenda: true,
+      },
+    };
+
+    expect(formatEffect(card)).toBe('+3 Pressure to a state · Reveal enemy secret agenda');
+  });
+});

--- a/src/lib/cardUi.ts
+++ b/src/lib/cardUi.ts
@@ -97,6 +97,9 @@ export const formatEffect = (card: GameCard): string => {
     if (typeof effects.discardOpponent === 'number' && effects.discardOpponent > 0) {
       parts.push(`Discard ${effects.discardOpponent}`);
     }
+    if (effects.revealSecretAgenda) {
+      parts.push('Reveal enemy secret agenda');
+    }
     if (parts.length) {
       return parts.join(' · ');
     }
@@ -105,14 +108,22 @@ export const formatEffect = (card: GameCard): string => {
   if (type === 'MEDIA') {
     if (typeof effects.truthDelta === 'number') {
       const sign = effects.truthDelta >= 0 ? '+' : '';
-      return `Truth ${sign}${effects.truthDelta}%`;
+      const parts = [`Truth ${sign}${effects.truthDelta}%`];
+      if (effects.revealSecretAgenda) {
+        parts.push('Reveal enemy secret agenda');
+      }
+      return parts.join(' · ');
     }
   }
 
   if (type === 'ZONE') {
     if (typeof effects.pressureDelta === 'number') {
       const amount = effects.pressureDelta >= 0 ? `+${effects.pressureDelta}` : `${effects.pressureDelta}`;
-      return `${amount} Pressure to a state`;
+      const parts = [`${amount} Pressure to a state`];
+      if (effects.revealSecretAgenda) {
+        parts.push('Reveal enemy secret agenda');
+      }
+      return parts.join(' · ');
     }
   }
 


### PR DESCRIPTION
## Summary
- update formatEffect so ATTACK, MEDIA, and ZONE cards append the "Reveal enemy secret agenda" text when applicable
- add cardUi unit tests covering reveal secret agenda messaging for representative card types

## Testing
- npm run lint *(fails: existing repository lint violations unrelated to this change)*
- bun test --coverage --coverage-reporter=text *(fails: existing EnhancedUSAMap hotspot test relies on browser APIs not available in the test environment)*

------
https://chatgpt.com/codex/tasks/task_e_68df64907bb88320b27272f897243a7d