### PR TITLE
Remove contested particle effect and calm contested visuals

### DIFF
--- a/src/components/effects/ParticleSystem.tsx
+++ b/src/components/effects/ParticleSystem.tsx
@@ -24,7 +24,6 @@ export type ParticleEffectType =
   | 'chain'
   | 'flash'
   | 'stateevent'
-  | 'contested'
   | 'broadcast'
   | 'cryptid';
 
@@ -122,7 +121,6 @@ export const ParticleSystem: React.FC<ParticleSystemProps> = ({
       case 'broadcast':
         return 40;
       case 'chain':
-      case 'contested':
       case 'cryptid':
         return 35;
       case 'deploy':
@@ -170,7 +168,6 @@ export const ParticleSystem: React.FC<ParticleSystemProps> = ({
       case 'broadcast':
         return 3 + Math.random() * 4;
       case 'chain':
-      case 'contested':
       case 'cryptid':
         return 2.5 + Math.random() * 3;
       case 'stateloss':
@@ -202,8 +199,6 @@ export const ParticleSystem: React.FC<ParticleSystemProps> = ({
         return `hsla(${50 + Math.random() * 10}, 95%, ${85 + Math.random() * 10}%, ${0.85 - Math.random() * 0.2})`;
       case 'stateevent':
         return `hsl(${305 + Math.random() * 20}, 88%, ${62 + Math.random() * 12}%)`;
-      case 'contested':
-        return `hsl(${200 + Math.random() * 20}, 72%, ${58 + Math.random() * 10}%)`;
       case 'cryptid':
         return `hsl(${135 + Math.random() * 30}, 60%, ${50 + Math.random() * 15}%)`;
       default:
@@ -223,7 +218,6 @@ export const ParticleSystem: React.FC<ParticleSystemProps> = ({
       case 'broadcast':
         return 70;
       case 'chain':
-      case 'contested':
       case 'cryptid':
         return 60;
       default:
@@ -244,7 +238,6 @@ export const ParticleSystem: React.FC<ParticleSystemProps> = ({
       case 'broadcast':
         return base * 1.3;
       case 'chain':
-      case 'contested':
       case 'cryptid':
         return base * 1.1;
       case 'stateloss':
@@ -266,7 +259,6 @@ export const ParticleSystem: React.FC<ParticleSystemProps> = ({
       case 'broadcast':
         return 4 + Math.random() * 4;
       case 'chain':
-      case 'contested':
       case 'cryptid':
         return 3 + Math.random() * 3;
       case 'stateloss':

--- a/src/components/game/EnhancedUSAMap.tsx
+++ b/src/components/game/EnhancedUSAMap.tsx
@@ -588,13 +588,6 @@ const EnhancedUSAMap: React.FC<EnhancedUSAMapProps> = ({
 
             if (typeof window !== 'undefined') {
               const prefersReducedMotion = window.matchMedia?.('(prefers-reduced-motion: reduce)').matches;
-              if (!prefersReducedMotion) {
-                VisualEffectsCoordinator.triggerParticleEffect('contested', {
-                  x: svgRect.left + centroid[0],
-                  y: svgRect.top + centroid[1]
-                });
-              }
-
               if (areParanormalEffectsEnabled()) {
                 VisualEffectsCoordinator.triggerCryptidSighting({
                   position: {
@@ -1102,36 +1095,37 @@ const EnhancedUSAMap: React.FC<EnhancedUSAMapProps> = ({
         }
 
         .contested-radar {
-          fill: rgba(57, 255, 20, 0.08);
-          stroke: #39ff14;
-          stroke-width: 2.5;
-          stroke-dasharray: 8 10;
-          animation: radarSweep 2.4s linear infinite, contestedPulse 2.4s ease-in-out infinite;
+          fill: rgba(57, 255, 20, 0.12);
+          stroke: rgba(57, 255, 20, 0.8);
+          stroke-width: 2.25;
+          stroke-dasharray: 6 14;
+          animation: contestedCalmPulse 5s ease-in-out infinite;
           transform-origin: center;
-          opacity: 0.85;
-          filter: drop-shadow(0 0 10px rgba(57, 255, 20, 0.35));
+          opacity: 0.72;
+          filter: drop-shadow(0 0 12px rgba(57, 255, 20, 0.45));
           pointer-events: none;
         }
 
         .bigfoot-tracks {
           pointer-events: none;
-          animation: bigfootStride 3.4s ease-in-out infinite;
+          filter: drop-shadow(0 0 8px rgba(32, 72, 46, 0.45));
         }
 
-        .bigfoot-tracks.reduced-motion {
+        .bigfoot-tracks.reduced-motion .bigfoot-track {
           animation: none !important;
         }
 
         .bigfoot-track {
-          fill: rgba(76, 128, 92, 0.7);
-          stroke: rgba(18, 51, 32, 0.85);
+          fill: rgba(76, 128, 92, 0.75);
+          stroke: rgba(18, 51, 32, 0.88);
           stroke-width: 1.2;
-          filter: drop-shadow(0 0 6px rgba(32, 72, 46, 0.6));
+          transform-origin: center;
+          animation: bigfootTrackGlow 6s ease-in-out infinite;
         }
 
-        .bigfoot-track-1 { animation: footprintPulse 2.6s ease-in-out infinite; }
-        .bigfoot-track-2 { animation: footprintPulse 3.1s ease-in-out infinite 0.35s; }
-        .bigfoot-track-3 { animation: footprintPulse 2.4s ease-in-out infinite 0.7s; }
+        .bigfoot-track-1 { animation-delay: 0s; }
+        .bigfoot-track-2 { animation-delay: 1.4s; }
+        .bigfoot-track-3 { animation-delay: 2.8s; }
 
         /* Firefox-specific: reduce costly filter effects */
         @-moz-document url-prefix() {
@@ -1150,48 +1144,29 @@ const EnhancedUSAMap: React.FC<EnhancedUSAMapProps> = ({
           cursor: crosshair;
         }
 
-        @keyframes radarSweep {
-          0% {
-            stroke-dashoffset: 0;
-            transform: scale(0.85);
-            opacity: 0.9;
+        @keyframes contestedCalmPulse {
+          0%, 100% {
+            opacity: 0.75;
+            transform: scale(0.94);
+            filter: drop-shadow(0 0 10px rgba(57, 255, 20, 0.35));
           }
-          60% {
-            opacity: 0.45;
-          }
-          100% {
-            stroke-dashoffset: -140;
-            transform: scale(1.32);
-            opacity: 0;
+          50% {
+            opacity: 0.55;
+            transform: scale(1.05);
+            filter: drop-shadow(0 0 18px rgba(57, 255, 20, 0.6));
           }
         }
 
-        @keyframes contestedPulse {
+        @keyframes bigfootTrackGlow {
           0%, 100% {
-            filter: drop-shadow(0 0 12px rgba(57, 255, 20, 0.45));
+            opacity: 0.85;
+            transform: scale(0.98);
+            filter: drop-shadow(0 0 8px rgba(32, 72, 46, 0.45));
           }
           50% {
-            filter: drop-shadow(0 0 24px rgba(57, 255, 20, 0.85));
-          }
-        }
-
-        @keyframes footprintPulse {
-          0%, 100% {
-            opacity: 0.9;
-            transform: scale(1) translateY(0);
-          }
-          50% {
-            opacity: 0.6;
-            transform: scale(0.92) translateY(-3px);
-          }
-        }
-
-        @keyframes bigfootStride {
-          0%, 100% {
-            transform: translateY(0);
-          }
-          50% {
-            transform: translateY(-2px);
+            opacity: 0.65;
+            transform: scale(1.05);
+            filter: drop-shadow(0 0 14px rgba(32, 72, 46, 0.6));
           }
         }
 
@@ -1248,6 +1223,11 @@ const EnhancedUSAMap: React.FC<EnhancedUSAMapProps> = ({
             opacity: 0.8;
             filter: drop-shadow(0 0 14px rgba(57, 255, 20, 0.6));
             stroke-dasharray: 0;
+          }
+          .bigfoot-track {
+            animation: none !important;
+            filter: drop-shadow(0 0 8px rgba(32, 72, 46, 0.5));
+            opacity: 0.8;
           }
           .paranormal-hotspot-marker {
             animation: none !important;

--- a/src/components/game/__tests__/EnhancedUSAMap.hotspot.test.tsx
+++ b/src/components/game/__tests__/EnhancedUSAMap.hotspot.test.tsx
@@ -260,6 +260,7 @@ const createDirectorStyleHotspot = (params: {
     icon: candidate.icon,
     tags: candidate.tags,
     expansionTag: candidate.expansionTag,
+    kind: candidate.kind,
   });
   const label = candidate.name ?? `${state.name} Hotspot`;
 

--- a/src/hooks/useStateEvents.ts
+++ b/src/hooks/useStateEvents.ts
@@ -55,7 +55,6 @@ export const useStateEvents = () => {
   ) => {
     if (statePosition) {
       VisualEffectsCoordinator.triggerContestedState(statePosition);
-      VisualEffectsCoordinator.triggerParticleEffect('contested', statePosition);
     }
   }, []);
 

--- a/src/utils/visualEffects.ts
+++ b/src/utils/visualEffects.ts
@@ -9,7 +9,7 @@ export interface EffectPosition {
 export class VisualEffectsCoordinator {
   // Trigger particle effect at specific position
   static triggerParticleEffect(
-    type: 'deploy' | 'capture' | 'counter' | 'victory' | 'synergy' | 'bigwin' | 'stateloss' | 'chain' | 'stateevent' | 'contested' | 'flash' | 'broadcast' | 'cryptid',
+    type: 'deploy' | 'capture' | 'counter' | 'victory' | 'synergy' | 'bigwin' | 'stateloss' | 'chain' | 'stateevent' | 'flash' | 'broadcast' | 'cryptid',
     position: EffectPosition
   ): void {
     window.dispatchEvent(new CustomEvent('cardDeployed', {


### PR DESCRIPTION
## Summary
- remove the contested particle effect trigger from the enhanced USA map and refresh the contested/bigfoot styling with a gentle pulse that honours reduced motion preferences
- drop the obsolete `contested` particle effect variant from the particle system and coordinator APIs
- ensure the hotspot map test helper forwards hotspot kind metadata so icon expectations remain accurate

## Testing
- npm run lint *(fails: existing repository lint debt unrelated to this change)*
- bun test --coverage --coverage-reporter=text


------
https://chatgpt.com/codex/tasks/task_e_68df698a47ac8320995947f57128259f