### PR TITLE
Route contested map alerts through breaking news overlay

### DIFF
--- a/src/components/game/EnhancedUSAMap.tsx
+++ b/src/components/game/EnhancedUSAMap.tsx
@@ -586,20 +586,16 @@ const EnhancedUSAMap: React.FC<EnhancedUSAMapProps> = ({
             }, 50);
             contestedAnimationTimeoutsRef.current.push(timeoutId);
 
-            if (typeof window !== 'undefined') {
-              const prefersReducedMotion = window.matchMedia?.('(prefers-reduced-motion: reduce)').matches;
-              if (areParanormalEffectsEnabled()) {
-                VisualEffectsCoordinator.triggerCryptidSighting({
-                  position: {
-                    x: svgRect.left + centroid[0],
-                    y: svgRect.top + centroid[1]
-                  },
-                  stateId: stateKey,
-                  stateName,
-                  footageQuality: prefersReducedMotion ? 'still' : Math.random() > 0.6 ? 'thermal' : 'grainy',
-                  reducedMotion: prefersReducedMotion,
-                });
-              }
+            if (typeof window !== 'undefined' && areParanormalEffectsEnabled()) {
+              const contestedScreenPosition = convertPointToScreenPosition(centroid as [number, number]);
+              const fallbackPosition = contestedScreenPosition ?? VisualEffectsCoordinator.getScreenCenter();
+              const baseName = (stateName || stateId).toString();
+              const breakingNewsHeadline = `${baseName.toUpperCase()} UNDER CONTEST!`;
+
+              VisualEffectsCoordinator.triggerBreakingNews(
+                breakingNewsHeadline,
+                fallbackPosition
+              );
             }
           }
         }


### PR DESCRIPTION
## Summary
- swap the contested-state cryptid sighting for a breaking news ticker that targets the map centroid with a safe fallback
- resolve breaking news overlay fallbacks to the right-hand panel and remove redundant particle spawning from the handler

## Testing
- npm run lint *(fails: repository contains pre-existing lint violations unrelated to this change)*
- bun test --coverage --coverage-reporter=text *(fails: known card resolution regression tests already failing on main)*

------
https://chatgpt.com/codex/tasks/task_e_68df6cb81fb08320a74b03d7faa2ed2c