### PR TITLE
Add map visual effects toggle and guard map VFX triggers

### DIFF
--- a/src/components/game/EnhancedUSAMap.tsx
+++ b/src/components/game/EnhancedUSAMap.tsx
@@ -7,7 +7,7 @@ import * as topojson from 'topojson-client';
 import { geoAlbersUsa, geoPath } from 'd3-geo';
 import { AlertTriangle, Target, Shield } from 'lucide-react';
 import { VisualEffectsCoordinator } from '@/utils/visualEffects';
-import { areParanormalEffectsEnabled } from '@/state/settings';
+import { areMapVfxEnabled, areParanormalEffectsEnabled } from '@/state/settings';
 import { getHotspotIdleMessage } from '@/state/useGameLog';
 import type {
   ActiveStateBonus,
@@ -375,6 +375,7 @@ const EnhancedUSAMap: React.FC<EnhancedUSAMapProps> = ({
     const prefersReducedMotion = typeof window !== 'undefined'
       ? window.matchMedia?.('(prefers-reduced-motion: reduce)').matches
       : false;
+    const mapVfxEnabled = areMapVfxEnabled();
 
     const isGovernmentZoneTargeting = Boolean(governmentTarget?.active);
     const lockedStateId = governmentTarget?.stateId;
@@ -586,9 +587,13 @@ const EnhancedUSAMap: React.FC<EnhancedUSAMapProps> = ({
             }, 50);
             contestedAnimationTimeoutsRef.current.push(timeoutId);
 
-            if (typeof window !== 'undefined') {
-              const prefersReducedMotion = window.matchMedia?.('(prefers-reduced-motion: reduce)').matches;
-              if (areParanormalEffectsEnabled()) {
+            if (
+              typeof window !== 'undefined'
+              && mapVfxEnabled
+              && areParanormalEffectsEnabled()
+            ) {
+              const prefersReducedMotionSetting = window.matchMedia?.('(prefers-reduced-motion: reduce)').matches;
+              if (!prefersReducedMotionSetting) {
                 VisualEffectsCoordinator.triggerCryptidSighting({
                   position: {
                     x: svgRect.left + centroid[0],
@@ -596,8 +601,8 @@ const EnhancedUSAMap: React.FC<EnhancedUSAMapProps> = ({
                   },
                   stateId: stateKey,
                   stateName,
-                  footageQuality: prefersReducedMotion ? 'still' : Math.random() > 0.6 ? 'thermal' : 'grainy',
-                  reducedMotion: prefersReducedMotion,
+                  footageQuality: Math.random() > 0.6 ? 'thermal' : 'grainy',
+                  reducedMotion: prefersReducedMotionSetting,
                 });
               }
             }
@@ -614,6 +619,7 @@ const EnhancedUSAMap: React.FC<EnhancedUSAMapProps> = ({
           if (
             hotspotChanged &&
             typeof window !== 'undefined' &&
+            mapVfxEnabled &&
             areParanormalEffectsEnabled()
           ) {
             const prefersReducedMotionHotspot = window.matchMedia?.('(prefers-reduced-motion: reduce)').matches;

--- a/src/components/game/Options.tsx
+++ b/src/components/game/Options.tsx
@@ -109,6 +109,7 @@ interface GameSettings {
   drawMode: 'standard' | 'classic' | 'momentum' | 'catchup' | 'fast';
   uiTheme: 'tabloid_bw' | 'government_classic';
   paranormalEffectsEnabled: boolean;
+  mapVfxEnabled: boolean;
   uiScale: number;
 }
 
@@ -147,6 +148,7 @@ const Options = ({ onClose, onBackToMainMenu, onSaveGame }: OptionsProps) => {
       drawMode: 'standard',
       uiTheme,
       paranormalEffectsEnabled: true,
+      mapVfxEnabled: true,
       uiScale: DEFAULT_UI_SCALE,
     };
 
@@ -167,6 +169,9 @@ const Options = ({ onClose, onBackToMainMenu, onSaveGame }: OptionsProps) => {
           secretAgendasEnabled: typeof rest.secretAgendasEnabled === 'boolean'
             ? rest.secretAgendasEnabled
             : baseSettings.secretAgendasEnabled,
+          mapVfxEnabled: typeof rest.mapVfxEnabled === 'boolean'
+            ? rest.mapVfxEnabled
+            : baseSettings.mapVfxEnabled,
         };
 
         if (typeof document !== 'undefined') {
@@ -399,6 +404,7 @@ const Options = ({ onClose, onBackToMainMenu, onSaveGame }: OptionsProps) => {
       drawMode: 'standard',
       uiTheme: 'tabloid_bw',
       paranormalEffectsEnabled: true,
+      mapVfxEnabled: true,
       uiScale: DEFAULT_UI_SCALE,
     };
 
@@ -811,6 +817,14 @@ const Options = ({ onClose, onBackToMainMenu, onSaveGame }: OptionsProps) => {
                 <Switch
                   checked={settings.paranormalEffectsEnabled}
                   onCheckedChange={checked => updateSettings({ paranormalEffectsEnabled: checked })}
+                />
+              </div>
+
+              <div className="flex items-center justify-between">
+                <label className="text-sm font-medium text-newspaper-text">Map Visual Effects</label>
+                <Switch
+                  checked={settings.mapVfxEnabled}
+                  onCheckedChange={checked => updateSettings({ mapVfxEnabled: checked })}
                 />
               </div>
 

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -50,7 +50,7 @@ import type {
 } from '@/hooks/gameStateTypes';
 import { getStateByAbbreviation, getStateById } from '@/data/usaStates';
 import type { ParanormalSighting } from '@/types/paranormal';
-import { areParanormalEffectsEnabled } from '@/state/settings';
+import { areMapVfxEnabled, areParanormalEffectsEnabled } from '@/state/settings';
 import type { GameCard } from '@/rules/mvp';
 import type { GameEvent } from '@/data/eventDatabase';
 import { EVENT_DATABASE } from '@/data/eventDatabase';
@@ -1070,7 +1070,9 @@ const Index = () => {
           reducedMotion,
           source: currentEvent?.faction,
         });
-        VisualEffectsCoordinator.triggerParticleEffect('broadcast', broadcastPosition);
+        if (!reducedMotion && areMapVfxEnabled()) {
+          VisualEffectsCoordinator.triggerParticleEffect('broadcast', broadcastPosition);
+        }
         if (stage === 'finale') {
           VisualEffectsCoordinator.triggerTruthFlash(broadcastPosition);
         }
@@ -1111,16 +1113,22 @@ const Index = () => {
             stateId: currentEvent.paranormalHotspot.stateId,
             stateAbbreviation: currentEvent.paranormalHotspot.stateId,
           }) ?? VisualEffectsCoordinator.getScreenCenter();
-        VisualEffectsCoordinator.triggerParanormalHotspot({
-          position: hotspotPosition,
-          stateId: currentEvent.paranormalHotspot.stateId ?? hotspotStateName,
-          stateName: hotspotStateName,
-          label: currentEvent.paranormalHotspot.label ?? currentEvent.title,
-          icon: currentEvent.paranormalHotspot.icon ?? '👻',
-          source: currentEvent.paranormalHotspot.source ?? 'neutral',
-          defenseBoost: currentEvent.paranormalHotspot.defenseBoost,
-          truthReward: currentEvent.paranormalHotspot.truthReward,
-        });
+        if (
+          !reducedMotion
+          && areMapVfxEnabled()
+          && areParanormalEffectsEnabled()
+        ) {
+          VisualEffectsCoordinator.triggerParanormalHotspot({
+            position: hotspotPosition,
+            stateId: currentEvent.paranormalHotspot.stateId ?? hotspotStateName,
+            stateName: hotspotStateName,
+            label: currentEvent.paranormalHotspot.label ?? currentEvent.title,
+            icon: currentEvent.paranormalHotspot.icon ?? '👻',
+            source: currentEvent.paranormalHotspot.source ?? 'neutral',
+            defenseBoost: currentEvent.paranormalHotspot.defenseBoost,
+            truthReward: currentEvent.paranormalHotspot.truthReward,
+          });
+        }
 
         const timestamp = Date.now();
         pushSighting({
@@ -1370,7 +1378,9 @@ const Index = () => {
       },
       (type, x, y) => {
         // Particle effect callback
-        VisualEffectsCoordinator.triggerParticleEffect(type as any, { x, y });
+        if (!prefersReducedMotion && areMapVfxEnabled()) {
+          VisualEffectsCoordinator.triggerParticleEffect(type as any, { x, y });
+        }
       },
       (value, type, x, y) => {
         // Floating number callback
@@ -1447,6 +1457,7 @@ const Index = () => {
     getTotalBonusIP,
     audio,
     setGameState,
+    prefersReducedMotion,
   ]);
 
   useEffect(() => {

--- a/src/state/settings.ts
+++ b/src/state/settings.ts
@@ -2,6 +2,29 @@ import type { Difficulty } from "../ai";
 
 const OPTIONS_STORAGE_KEY = "gameSettings";
 
+type StoredGameSettings = {
+  paranormalEffectsEnabled?: unknown;
+  mapVfxEnabled?: unknown;
+};
+
+const readStoredGameSettings = (): StoredGameSettings | null => {
+  if (typeof localStorage === "undefined") {
+    return null;
+  }
+
+  try {
+    const stored = localStorage.getItem(OPTIONS_STORAGE_KEY);
+    if (!stored) {
+      return null;
+    }
+
+    return JSON.parse(stored) as StoredGameSettings;
+  } catch (error) {
+    console.warn("Failed to read stored game settings:", error);
+    return null;
+  }
+};
+
 export function getDifficulty(): Difficulty {
   const storage = typeof localStorage !== "undefined" ? localStorage : null;
   const raw = storage?.getItem("shadowgov:difficulty") ?? "NORMAL";
@@ -29,23 +52,17 @@ export function setDifficultyFromLabel(label: string) {
 }
 
 export function areParanormalEffectsEnabled(): boolean {
-  if (typeof localStorage === "undefined") {
-    return true;
+  const stored = readStoredGameSettings();
+  if (stored && typeof stored.paranormalEffectsEnabled === "boolean") {
+    return stored.paranormalEffectsEnabled;
   }
+  return true;
+}
 
-  try {
-    const stored = localStorage.getItem(OPTIONS_STORAGE_KEY);
-    if (!stored) {
-      return true;
-    }
-
-    const parsed = JSON.parse(stored) as { paranormalEffectsEnabled?: unknown } | null;
-    if (parsed && typeof parsed.paranormalEffectsEnabled === "boolean") {
-      return parsed.paranormalEffectsEnabled;
-    }
-  } catch (error) {
-    console.warn("Failed to read paranormal effects setting: ", error);
+export function areMapVfxEnabled(): boolean {
+  const stored = readStoredGameSettings();
+  if (stored && typeof stored.mapVfxEnabled === "boolean") {
+    return stored.mapVfxEnabled;
   }
-
   return true;
 }


### PR DESCRIPTION
## Summary
- add a persisted `mapVfxEnabled` option with a settings toggle
- expose `areMapVfxEnabled()` and reuse shared storage parsing helpers
- guard map particle, hotspot, and cryptid effects behind the new toggle and reduced-motion checks

## Testing
- npm run lint *(fails: existing lint violations across repository)*
- bun test --coverage --coverage-reporter=text *(fails: existing card resolution regression tests)*

------
https://chatgpt.com/codex/tasks/task_e_68df6f3f0f7c832092e401329d7ea88e