### PR TITLE
Normalize pressure data for controlled states

### DIFF
--- a/src/systems/__tests__/cardResolution.regression.test.ts
+++ b/src/systems/__tests__/cardResolution.regression.test.ts
@@ -78,4 +78,37 @@ describe('resolveCardMVP regression', () => {
     expect(state?.pressureAi).toBe(0);
     expect(state?.pressurePlayer).toBe(0);
   });
+
+  it('clears ai pressure for ai-controlled states sourced from aiControlledStates', () => {
+    const gameState = createBaseSnapshot({
+      aiControlledStates: ['CA'],
+      states: [
+        {
+          id: 'CA',
+          name: 'California',
+          abbreviation: 'CA',
+          baseIP: 3,
+          baseDefense: 1,
+          defense: 1,
+          pressure: 4,
+          pressurePlayer: 0,
+          pressureAi: 4,
+          contested: false,
+          owner: 'ai',
+        },
+      ],
+    });
+    const card: GameCard = {
+      id: 'noop',
+      name: 'No-Op',
+      type: 'MEDIA',
+      faction: 'truth',
+      rarity: 'common',
+      cost: 0,
+    };
+
+    expect(() => {
+      resolveCardMVP(gameState, card, null, actor);
+    }).not.toThrow();
+  });
 });

--- a/src/systems/cardResolution.ts
+++ b/src/systems/cardResolution.ts
@@ -211,6 +211,14 @@ const toEngineState = (
     aiStates.add(id);
   }
 
+  for (const id of playerStates) {
+    pressureByState[id] = { P1: 0, P2: 0 };
+  }
+
+  for (const id of aiStates) {
+    pressureByState[id] = { P1: 0, P2: 0 };
+  }
+
   return {
     turn: snapshot.turn,
     currentPlayer: PLAYER_ID,


### PR DESCRIPTION
## Summary
- zero out pressure entries for any state marked as controlled when building the engine snapshot
- add a regression test covering AI-controlled states with stale pressure values

## Testing
- npm run lint *(fails: existing lint violations across unrelated files)*
- bun test --coverage --coverage-reporter=text *(fails: existing failing tests in resolveCardMVP suites)*

------
https://chatgpt.com/codex/tasks/task_e_68df741633d08320a3644b7057627e32