### PR TITLE
Align particle motifs with overlay animations

### DIFF
--- a/src/utils/visualEffects.ts
+++ b/src/utils/visualEffects.ts
@@ -9,7 +9,23 @@ export interface EffectPosition {
 export class VisualEffectsCoordinator {
   // Trigger particle effect at specific position
   static triggerParticleEffect(
-    type: 'deploy' | 'capture' | 'counter' | 'victory' | 'synergy' | 'bigwin' | 'stateloss' | 'chain' | 'stateevent' | 'flash' | 'broadcast' | 'cryptid',
+    type:
+      | 'deploy'
+      | 'capture'
+      | 'counter'
+      | 'victory'
+      | 'synergy'
+      | 'bigwin'
+      | 'stateloss'
+      | 'chain'
+      | 'stateevent'
+      | 'flash'
+      | 'broadcast'
+      | 'cryptid'
+      | 'ectoplasm'
+      | 'surveillanceRedaction'
+      | 'corkboardPins'
+      | 'hotspotFlare',
     position: EffectPosition
   ): void {
     window.dispatchEvent(new CustomEvent('cardDeployed', {
@@ -45,8 +61,10 @@ export class VisualEffectsCoordinator {
   static triggerSynergyActivation(
     bonusIP: number,
     position: EffectPosition,
-    effectType: 'synergy' | 'bigwin' | 'chain' = 'synergy',
-    comboName?: string
+    effectType: 'synergy' | 'bigwin' | 'chain' | 'corkboardPins' = 'synergy',
+    comboName?: string,
+    numberType: 'synergy' | 'combo' | 'chain' =
+      effectType === 'chain' ? 'chain' : effectType === 'bigwin' ? 'combo' : 'synergy'
   ): void {
     window.dispatchEvent(new CustomEvent('synergyActivation', {
       detail: {
@@ -54,7 +72,7 @@ export class VisualEffectsCoordinator {
         x: position.x,
         y: position.y,
         effectType,
-        numberType: effectType,
+        numberType,
         comboName
       }
     }));


### PR DESCRIPTION
## Summary
- group particle effects into reusable motif presets with themed palettes, motion profiles, and new effect types for ectoplasm, surveillance redactions, corkboard pins, and hotspot flares
- update CardAnimationLayer to request the new motifs with timed spawn offsets that sync with corkboard, surveillance, and hotspot overlays while honoring reduced-motion preferences
- extend the VisualEffectsCoordinator API so events can trigger the new motif-aware particle types

## Testing
- `npm run lint` *(fails: existing repository lint violations across legacy files)*
- `bun test --coverage --coverage-reporter=text`


------
https://chatgpt.com/codex/tasks/task_e_68df857f5a9c8320b586aa551dba0313