### PR TITLE
Fix campaign hotspot positioning lookup

### DIFF
--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -1108,10 +1108,18 @@ const Index = () => {
       const hotspotTagline = buildCampaignHotspotTagline({ arc, event: currentEvent, stage });
       if (hotspotTagline && currentEvent?.paranormalHotspot) {
         const hotspotStateName = resolveEventStateName(currentEvent) ?? 'Unknown Site';
+        const rawStateId = currentEvent.paranormalHotspot.stateId;
+        const normalizedStateId = rawStateId?.trim();
+        const resolvedState = normalizedStateId
+          ? getStateById(normalizedStateId)
+            ?? getStateByAbbreviation(normalizedStateId.toUpperCase())
+          : undefined;
+        const hotspotStateAbbreviation = resolvedState?.abbreviation
+          ?? normalizedStateId?.toUpperCase();
         const hotspotPosition =
           VisualEffectsCoordinator.getStateCenterPosition({
             stateId: currentEvent.paranormalHotspot.stateId,
-            stateAbbreviation: currentEvent.paranormalHotspot.stateId,
+            stateAbbreviation: hotspotStateAbbreviation,
           }) ?? VisualEffectsCoordinator.getScreenCenter();
         if (
           !reducedMotion
@@ -1120,7 +1128,9 @@ const Index = () => {
         ) {
           VisualEffectsCoordinator.triggerParanormalHotspot({
             position: hotspotPosition,
-            stateId: currentEvent.paranormalHotspot.stateId ?? hotspotStateName,
+            stateId: hotspotStateAbbreviation
+              ?? currentEvent.paranormalHotspot.stateId
+              ?? hotspotStateName,
             stateName: hotspotStateName,
             label: currentEvent.paranormalHotspot.label ?? currentEvent.title,
             icon: currentEvent.paranormalHotspot.icon ?? '👻',


### PR DESCRIPTION
## Summary
- resolve campaign hotspot state abbreviations before triggering campaign hotspot visuals
- use the resolved abbreviation when dispatching the paranormal hotspot effect to keep overlays centered

## Testing
- npm run lint *(fails: pre-existing lint violations throughout repository)*
- bun test --coverage --coverage-reporter=text

------
https://chatgpt.com/codex/tasks/task_e_68df8e89b7d483209921cd71e3ff23e0