### PR TITLE
Ensure agenda stage overlay stacks correctly

### DIFF
--- a/src/components/game/CardAnimationLayer.tsx
+++ b/src/components/game/CardAnimationLayer.tsx
@@ -366,7 +366,7 @@ const CardAnimationLayer: React.FC<CardAnimationLayerProps> = ({ children }) => 
 
       agendaStageTimeoutRef.current = window.setTimeout(() => {
         clearAgendaStageOverlay();
-      }, 2200);
+      }, 4200);
     };
 
     const handleFloatingNumber = (event: CustomEvent<{ value: number; type: 'ip' | 'truth' | 'damage' | 'synergy' | 'combo' | 'chain'; x: number; y: number }>) => {
@@ -584,7 +584,7 @@ const CardAnimationLayer: React.FC<CardAnimationLayerProps> = ({ children }) => 
       {/* Full-screen overlay for card animations */}
       <div
         id="card-play-layer"
-        className="fixed inset-0 pointer-events-none z-[40]"
+        className={`fixed inset-0 pointer-events-none ${agendaStageOverlay ? 'z-[70]' : 'z-[40]'}`}
         aria-hidden="true"
       >
         {children}


### PR DESCRIPTION
## Summary
- raise the card play layer z-index when the agenda stage overlay is active so it renders above other HUD elements
- extend the agenda stage dismissal timeout to keep the modal visible for an additional two seconds

## Testing
- npm run lint *(fails: repository has numerous pre-existing lint errors across multiple files)*
- bun test --coverage --coverage-reporter=text


------
https://chatgpt.com/codex/tasks/task_e_68dfa571b26483208c275e8fcbadef76