### PR TITLE
Clear agenda buffer before starting a new campaign

### DIFF
--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -726,6 +726,7 @@ const Index = () => {
     archiveEdition,
     removeEditionFromArchive,
     agendaMoments,
+    clearAgendaMoments,
   } = usePressArchive();
   const {
     entries: intelArchiveEntries,
@@ -2001,6 +2002,7 @@ const Index = () => {
     setReadingEdition(null);
     setShowExtraEdition(false);
     setParanormalSightings([]);
+    clearAgendaMoments();
     await initGame(faction);
     setShowMenu(false);
     setShowIntro(false);


### PR DESCRIPTION
## Summary
- include `clearAgendaMoments` from the press archive hook on the index page
- clear any queued agenda moments before initializing a new campaign so the first paper uses fresh data

## Testing
- `npm run lint` *(fails: repository currently has pre-existing lint errors unrelated to this change)*
- `bun test --coverage --coverage-reporter=text` *(fails: repository currently has pre-existing test failures unrelated to this change)*

------
https://chatgpt.com/codex/tasks/task_e_68dfb783a02c832096c7b3def42b2b2f