### PR TITLE
Add aurora and spin shield agendas with tests

### DIFF
--- a/docs/TECHNICAL_README.md
+++ b/docs/TECHNICAL_README.md
@@ -384,6 +384,7 @@ The secret agenda database now leans into the “Paranoid Times” tabloid-cookb
 | --- | --- | --- |
 | Bat Boy’s Brunch Brigade | Bat Boy sightings go brunch-core | Counts Appalachian control via `controlledStates` to confirm WV/KY/TN/PA brunch venues. |
 | Moonbeam Marmalade Slow-Cook | Lunar jam session | Reads `truthAbove80Streak` / `timeBasedGoalCounters` to require three glowing turns. |
+| Aurora Truth Choir | Polar foil-hood choir nights | Tracks `truthAbove80Streak` to demand a five-night streak above 80% Truth. |
 | UFO Retrieval Mise en Place | Crash-site mise en place | Filters `factionPlayHistory` for ZONE plays targeting desert crash states (NV/NM/AZ/UT). |
 | Tabloid Taste Test Kitchen | Recipe-column media blitz | Tallies MEDIA cards from `factionPlayHistory` to model serialized taste tests. |
 | Cryptid Potluck Planning | Monster potluck RSVPs | Uses `controlledStates` to corral cryptid-haunted states like WA/OR/WV/NJ/MT/NH. |
@@ -395,6 +396,7 @@ The secret agenda database now leans into the “Paranoid Times” tabloid-cookb
 | --- | --- | --- |
 | Capitol Cafeteria Stew | Beltway cafeteria chow | Requires `controlledStates` coverage of DC/VA/MD/CO ladles. |
 | Field-Ration Redactions | Press-release seasoning | Counts MEDIA plays from `factionPlayHistory` to keep the placemats censored. |
+| Spin Shield Network | Cue-card counter-chorus | Tallies DEFENSIVE card plays from `factionPlayHistory` to keep rebuttal grids aligned. |
 | Supply Chain Soup | Heartland ration routing | Monitors agricultural depot control (IA/NE/KS/MO/OK/AR) via `controlledStates`. |
 | UFO Recall Paperwork | Crash-site compliance | Uses `capturedStates` extracted from `factionPlayHistory` to confirm confiscations in NV/NM/AZ/UT. |
 | Cover-Up Casserole | Lid-on truth suppression | Leans on `truthBelow20Streak` / `timeBasedGoalCounters` for streak-style baking. |

--- a/src/data/__tests__/agendaDatabase.test.ts
+++ b/src/data/__tests__/agendaDatabase.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from 'bun:test';
+
+import { AGENDA_DATABASE, getRandomAgenda } from '../agendaDatabase';
+
+const TRUTH_AURORA_ID = 'truth_aurora_truth_choir';
+const GOV_SPIN_SHIELD_ID = 'gov_spin_shield_network';
+
+describe('secret agenda database additions', () => {
+  it('includes the Aurora Truth Choir agenda with streak-based progress', () => {
+    const agenda = AGENDA_DATABASE.find(entry => entry.id === TRUTH_AURORA_ID);
+    expect(agenda).toBeDefined();
+    expect(agenda?.target).toBe(5);
+    expect(agenda?.difficulty).toBe('legendary');
+
+    const report = agenda?.checkProgress({ truthAbove80Streak: 4, timeBasedGoalCounters: {} });
+    expect(report).toBeDefined();
+    expect(report?.progress).toBe(4);
+    expect(report?.stageId).toBe(`${TRUTH_AURORA_ID}-escalation`);
+  });
+
+  it('includes the Spin Shield Network agenda with defensive card tracking', () => {
+    const agenda = AGENDA_DATABASE.find(entry => entry.id === GOV_SPIN_SHIELD_ID);
+    expect(agenda).toBeDefined();
+    expect(agenda?.target).toBe(5);
+    expect(agenda?.difficulty).toBe('medium');
+
+    const report = agenda?.checkProgress({
+      factionPlayHistory: [
+        { card: { type: 'DEFENSIVE' } },
+        { card: { type: 'DEFENSIVE' } },
+        { card: { type: 'DEFENSIVE' } },
+        { card: { type: 'DEFENSIVE' } },
+      ],
+    });
+    expect(report).toBeDefined();
+    expect(report?.progress).toBe(4);
+    expect(report?.stageId).toBe(`${GOV_SPIN_SHIELD_ID}-escalation`);
+  });
+
+  it('rotates the new agendas through the random selector when forced', () => {
+    const truthExclusions = AGENDA_DATABASE
+      .filter(agenda => (agenda.faction === 'truth' || agenda.faction === 'both') && agenda.id !== TRUTH_AURORA_ID)
+      .map(agenda => agenda.id);
+    const truthAgenda = getRandomAgenda('truth', { excludeIds: truthExclusions });
+    expect(truthAgenda.id).toBe(TRUTH_AURORA_ID);
+
+    const governmentExclusions = AGENDA_DATABASE
+      .filter(agenda => (agenda.faction === 'government' || agenda.faction === 'both') && agenda.id !== GOV_SPIN_SHIELD_ID)
+      .map(agenda => agenda.id);
+    const governmentAgenda = getRandomAgenda('government', { excludeIds: governmentExclusions });
+    expect(governmentAgenda.id).toBe(GOV_SPIN_SHIELD_ID);
+  });
+});

--- a/src/data/agendaDatabase.ts
+++ b/src/data/agendaDatabase.ts
@@ -713,6 +713,46 @@ export const AGENDA_DATABASE: SecretAgenda[] = [
     flavorText: 'Donation perks include glow-in-the-dark crop circle blueprints.'
   }),
 
+  defineAgenda({
+    id: 'truth_aurora_truth_choir',
+    faction: 'truth',
+    category: 'influence',
+    title: 'Aurora Truth Choir',
+    headline: 'AURORA TRUTH CHOIR HARMONIZES FIVE NIGHTS STRAIGHT!',
+    operationName: 'Operation Polar Chorus',
+    issueTheme: 'Truth Momentum',
+    pullQuote: '“Hold the high note until the truth meter hums at full resonance.”',
+    artCue: {
+      icon: '/assets/tabloid-flash.svg',
+      texture: '/assets/tabloid-halftone.svg',
+      alt: 'Radiant aurora microphone graphic',
+    },
+    description:
+      'Keep the Truth meter above 80% for five consecutive turns so the aurora choir can beam whistleblower ballads across every midnight broadcast.',
+    target: 5,
+    difficulty: 'legendary',
+    stages: createAgendaStages('truth_aurora_truth_choir', 5, {
+      briefing: {
+        label: 'Choir Warm-Ups',
+        description: 'Sopranos rehearse foil-lined scales beneath the northern lights.',
+        requirement: 'Climb above 80% Truth for the opening performance.',
+      },
+      escalation: {
+        label: 'Encore Scheduling',
+        description: 'Every safehouse books repeat broadcasts as the streak continues.',
+        requirement: 'Sustain Truth above 80% for 3 consecutive turns.',
+        threshold: 3,
+      },
+      finale: {
+        label: 'Polar Ovation',
+        description: 'Five flawless nights shake surveillance drones out of alignment.',
+        requirement: 'Sustain Truth above 80% for 5 consecutive turns.',
+      },
+    }),
+    computeProgress: gameState => resolveStreak(gameState, 'truthAbove80Streak'),
+    flavorText: 'Program inserts double as emergency aurora-viewing visors.'
+  }),
+
   // GOVERNMENT FACTION AGENDAS
   defineAgenda({
     id: 'gov_capitol_stew',
@@ -1132,6 +1172,45 @@ export const AGENDA_DATABASE: SecretAgenda[] = [
     }),
     computeProgress: gameState => sumSuppressedTruthDelta(gameState),
     flavorText: 'Tote board numbers glow whenever a memory hole successfully swallows a rumor.'
+  }),
+
+  defineAgenda({
+    id: 'gov_spin_shield_network',
+    faction: 'government',
+    category: 'influence',
+    title: 'Spin Shield Network',
+    headline: 'DIRECTIVE 42-L: DEFENSIVE TALKING POINT GRID ONLINE!',
+    operationName: 'Operation Counter Chorus',
+    issueTheme: 'Information Discipline',
+    pullQuote: '“Rotate the cue cards clockwise after every rebuttal.”',
+    artCue: {
+      icon: '/assets/dossier-stamp.svg',
+      texture: '/assets/dossier-fibers.svg',
+      alt: 'Directive clearance sigil',
+    },
+    description:
+      'Deploy five DEFENSIVE cards so the spin shield can blanket nightly broadcasts with airtight rebuttal loops.',
+    target: 5,
+    difficulty: 'medium',
+    stages: createAgendaStages('gov_spin_shield_network', 5, {
+      briefing: {
+        label: 'Shield Calibration',
+        description: 'Briefing rooms script synchronized defensive counterpoints.',
+        requirement: 'Deploy the first DEFENSIVE rebuttal.',
+      },
+      escalation: {
+        label: 'Cue Card Rotation',
+        description: 'Talking point captains rehearse overlapping counter-choruses.',
+        requirement: 'Play 3 DEFENSIVE cards.',
+      },
+      finale: {
+        label: 'Full Spectrum Scramble',
+        description: 'Five-layer shield hums so loudly that rogue leaks lose traction.',
+        requirement: 'Play 5 DEFENSIVE cards.',
+      },
+    }),
+    computeProgress: gameState => countCardTypePlays(gameState, 'DEFENSIVE'),
+    flavorText: 'Each lectern hides an emergency fog machine for punctuation.'
   }),
 
   // SHARED/NEUTRAL AGENDAS

--- a/src/hooks/useGameState.ts
+++ b/src/hooks/useGameState.ts
@@ -407,7 +407,11 @@ const computeTruthStreaks = (
   };
 };
 
-const STREAK_AGENDA_IDS = new Set(['truth_moonbeam_marmalade', 'gov_coverup_casserole']);
+const STREAK_AGENDA_IDS = new Set([
+  'truth_moonbeam_marmalade',
+  'truth_aurora_truth_choir',
+  'gov_coverup_casserole',
+]);
 
 const DEFAULT_HOTSPOT_SOURCE: NonNullable<ParanormalHotspotPayload['source']> = 'neutral';
 


### PR DESCRIPTION
## Summary
- add the Aurora Truth Choir streak agenda for the Truth faction with themed copy and progress handling
- introduce the Spin Shield Network defensive-card agenda for the Government faction and include it in streak logging where needed
- update agenda documentation and add data tests to lock the new ids into the selector rotation

## Testing
- npm run lint *(fails: repository has pre-existing lint violations)*
- bun test --coverage --coverage-reporter=text

------
https://chatgpt.com/codex/tasks/task_e_68dfbb60187c83209f65ee802501c73f