### PR TITLE
Fix playCardAnimated hook dependencies

### DIFF
--- a/src/hooks/useGameState.ts
+++ b/src/hooks/useGameState.ts
@@ -3111,7 +3111,7 @@ export const useGameState = (aiDifficultyOverride?: AIDifficulty) => {
         emitEditorToastMessages(pendingEditorToasts);
       }
     }
-  }, [achievements, resolveCardEffects, triggerCapturedStateEvents, gameState, animateCard]);
+  }, [achievements, resolveCardEffects, triggerCapturedStateEvents, gameState]);
 
 
   const selectCard = useCallback((cardId: string | null) => {


### PR DESCRIPTION
## Summary
- remove the nonexistent animateCard reference from the playCardAnimated hook dependency list

## Testing
- npm run lint *(fails: existing lint errors unrelated to change)*
- bun test --coverage --coverage-reporter=text *(fails: existing test failures related to environment and known regressions)*

------
https://chatgpt.com/codex/tasks/task_e_68dfebda93a88320aad2c78b7e7caf11