### PR TITLE
Replace tabloid relic rule file with themed expansion data

### DIFF
--- a/src/expansions/tabloidRelics/relics.rules.json
+++ b/src/expansions/tabloidRelics/relics.rules.json
@@ -1,95 +1,175 @@
-{
-  "version": 1,
-  "relics": [
-    {
-      "id": "inkwell_of_intrigue",
-      "label": "Inkwell of Intrigue",
-      "rarity": "common",
-      "duration": 2,
-      "priority": 40,
-      "trigger": {
-        "truthBelow": 45,
-        "comboTruthDeltaBelow": 0
-      },
-      "effects": {
-        "truthPerRound": 3
-      },
-      "summary": "+3% Truth each round while active.",
-      "detail": "Tabloid scribes weaponize scandal ink after a nightly slump.",
-      "clamp": {
-        "truth": { "max": 85 }
-      },
-      "amplify": {
-        "editorMultiplier": 1.4
-      }
+[
+  {
+    "id": "ufo_scoop",
+    "label": "UFO Scoop",
+    "rarity": "common",
+    "duration": 2,
+    "priority": 25,
+    "trigger": {
+      "playerMediaPlaysAtLeast": 1,
+      "eventTruthGainAtLeast": 6
     },
-    {
-      "id": "pressroom_lockdown",
-      "label": "Pressroom Lockdown",
-      "rarity": "uncommon",
-      "duration": 3,
-      "priority": 60,
-      "trigger": {
-        "ipBelow": 15,
-        "requiresFaction": "truth"
-      },
-      "effects": {
-        "ipPerRound": 3
-      },
-      "summary": "+3 IP buffer while the newsroom barricades itself.",
-      "detail": "Circulation security reroutes ad spend into your coffers.",
-      "clamp": {
-        "ip": { "min": 0 }
-      },
-      "amplify": {
-        "editorMultiplier": 1.2
-      }
+    "effects": {
+      "truthPerRound": 2,
+      "cardDrawBonus": 1
     },
-    {
-      "id": "red_string_reactor",
-      "label": "Red String Reactor",
-      "rarity": "rare",
-      "duration": 2,
-      "priority": 75,
-      "trigger": {
-        "playerMediaPlaysAtLeast": 2,
-        "eventTruthGainAtLeast": 8
-      },
-      "effects": {
-        "cardDrawBonus": 1,
-        "truthPerRound": 2
-      },
-      "summary": "Gain +1 card draw and +2% Truth for conspiracy-fueled spreads.",
-      "detail": "The corkboard glows when multiple exposés align in one issue.",
-      "clamp": {
-        "truth": { "max": 95 }
-      },
-      "amplify": {
-        "editorMultiplier": 1.3
-      }
-    },
-    {
-      "id": "black_budget_briefing",
-      "label": "Black Budget Briefing",
-      "rarity": "legendary",
-      "duration": 1,
-      "priority": 90,
-      "trigger": {
-        "aiIpAbove": 25,
-        "comboTruthDeltaBelow": -5
-      },
-      "effects": {
-        "ipPerRound": 5,
-        "truthPerRound": 4
-      },
-      "summary": "+5 IP and +4% Truth as clandestine backers panic-buy influence.",
-      "detail": "Shadow investors flood the newsroom when the opponent surges.",
-      "clamp": {
-        "truth": { "max": 100 }
-      },
-      "amplify": {
-        "editorMultiplier": 1.5
-      }
+    "summary": "Gain +1 card draw and +2% Truth for each round the scoop stays on presses.",
+    "detail": "Your newsroom breaks the saucer story first, turning every follow-up into a circulation boom.",
+    "clamp": {
+      "truth": { "max": 92 }
     }
-  ]
-}
+  },
+  {
+    "id": "cryptid_craze",
+    "label": "Cryptid Craze",
+    "rarity": "uncommon",
+    "duration": 3,
+    "priority": 40,
+    "trigger": {
+      "truthBelow": 60,
+      "playerMediaPlaysAtLeast": 2
+    },
+    "effects": {
+      "truthPerRound": 3
+    },
+    "summary": "+3% Truth each round as readers obsess over monster sightings.",
+    "detail": "Bigfoot fan clubs and chupacabra stans flood your tip lines with monetizable leads.",
+    "clamp": {
+      "truth": { "max": 96 }
+    }
+  },
+  {
+    "id": "halloween_spooktacular",
+    "label": "Halloween Spooktacular",
+    "rarity": "uncommon",
+    "duration": 2,
+    "priority": 55,
+    "trigger": {
+      "truthBelow": 70,
+      "ipBelow": 20,
+      "requiresFaction": "truth"
+    },
+    "effects": {
+      "truthPerRound": 4,
+      "ipPerRound": 2
+    },
+    "summary": "+4% Truth and +2 IP as haunted features terrify rival tabloids off the rack.",
+    "detail": "Pumpkin patch exposés and haunted mall guides convert seasonal panic into pure profit.",
+    "clamp": {
+      "truth": { "max": 98 },
+      "ip": { "min": 0 }
+    }
+  },
+  {
+    "id": "men_in_black_briefcase",
+    "label": "Men in Black Briefcase",
+    "rarity": "rare",
+    "duration": 2,
+    "priority": 70,
+    "trigger": {
+      "aiIpAbove": 25,
+      "comboTruthDeltaBelow": -3
+    },
+    "effects": {
+      "ipPerRound": 4,
+      "truthPerRound": 2
+    },
+    "summary": "+4 IP and +2% Truth as clandestine handlers leak hush money invoices.",
+    "detail": "Every confiscated briefcase comes with unredacted memos—and redistribution clauses you gladly violate.",
+    "clamp": {
+      "truth": { "max": 99 }
+    },
+    "amplify": {
+      "editorMultiplier": 1.25
+    }
+  },
+  {
+    "id": "mothman_press_conference",
+    "label": "Mothman Press Conference",
+    "rarity": "rare",
+    "duration": 3,
+    "priority": 65,
+    "trigger": {
+      "playerMediaPlaysAtLeast": 3,
+      "eventTruthGainAtLeast": 10
+    },
+    "effects": {
+      "truthPerRound": 3,
+      "cardDrawBonus": 1
+    },
+    "summary": "Draw +1 card and gain +3% Truth while the prophetic cryptid stays on stage.",
+    "detail": "Eyewitnesses line up to testify once Mothman endorses your coverage of looming disasters.",
+    "clamp": {
+      "truth": { "max": 97 }
+    },
+    "amplify": {
+      "editorMultiplier": 1.3
+    }
+  },
+  {
+    "id": "pumpkin_patch_press_pass",
+    "label": "Pumpkin Patch Press Pass",
+    "rarity": "common",
+    "duration": 2,
+    "priority": 20,
+    "trigger": {
+      "ipBelow": 18,
+      "requiresFaction": "truth"
+    },
+    "effects": {
+      "ipPerRound": 3
+    },
+    "summary": "+3 IP per round as seasonal advertisers compete for spooky placement.",
+    "detail": "Corn mazes and hayride sponsors underwrite your investigative pumpkin spice specials.",
+    "clamp": {
+      "ip": { "min": 0 }
+    }
+  },
+  {
+    "id": "midnight_static_broadcast",
+    "label": "Midnight Static Broadcast",
+    "rarity": "legendary",
+    "duration": 1,
+    "priority": 85,
+    "trigger": {
+      "aiAttackPlaysAtLeast": 2,
+      "truthBelow": 65
+    },
+    "effects": {
+      "truthPerRound": 6,
+      "ipPerRound": 4
+    },
+    "summary": "+6% Truth and +4 IP as pirate radio hijacks the airwaves with spectral evidence.",
+    "detail": "Ghostly callers patch through intercepted number-station logs implicating rival propagandists.",
+    "clamp": {
+      "truth": { "max": 100 }
+    },
+    "amplify": {
+      "editorMultiplier": 1.5
+    }
+  },
+  {
+    "id": "haunted_printing_press",
+    "label": "Haunted Printing Press",
+    "rarity": "legendary",
+    "duration": 2,
+    "priority": 95,
+    "trigger": {
+      "comboTruthDeltaBelow": -6,
+      "aiIpAbove": 30
+    },
+    "effects": {
+      "truthPerRound": 5,
+      "ipPerRound": 5,
+      "cardDrawBonus": 1
+    },
+    "summary": "+5% Truth, +5 IP, and +1 card draw while the possessed press spews spectral exclusives.",
+    "detail": "Each sheet emerges with ectoplasmic footnotes linking every cover-up to your rivals' donors.",
+    "clamp": {
+      "truth": { "max": 100 }
+    },
+    "amplify": {
+      "editorMultiplier": 1.6
+    }
+  }
+]


### PR DESCRIPTION
## Summary
- replace the tabloid relic rule file with the new themed entries (UFO Scoop, Cryptid Craze, Halloween Spooktacular, and more)

## Testing
- npm run lint *(fails: existing lint violations in unrelated files)*
- bun test --coverage --coverage-reporter=text *(fails: 2 existing tests failing in resolveCardMVP scenarios)*

------
https://chatgpt.com/codex/tasks/task_e_68dff6afe5a083209257ba818b3b0618