### PR TITLE
Refactor editors expansion to simple bonus/penalty model

### DIFF
--- a/src/expansions/editors/EditorsTypes.ts
+++ b/src/expansions/editors/EditorsTypes.ts
@@ -1,32 +1,21 @@
-export type EditorFaction = 'truth' | 'government' | 'neutral';
+export type EditorId = string;
 
-export type EditorHookPhase = 'onSetup' | 'onTurnStart' | 'onPlayCard';
+export type EditorEffect = {
+  start_ipDelta?: number;
+  onSetup_addCardIds?: string[];
+  onSetup_deckSizeDelta?: number;
+  round1_drawDelta?: number;
+  turnStart_scandalChance?: number;
+  scandal_effect?: 'randomDiscard:1';
+  onMediaPlay_truthDelta?: number;
+  attack_ipCostDelta?: number;
+};
 
-export interface EditorHookDefinition {
-  readonly id: string;
-  readonly label: string;
-  readonly description: string;
-}
-
-export type EditorHooksMap = Partial<Record<EditorHookPhase, readonly EditorHookDefinition[]>>;
-
-export interface EditorDefinition {
-  readonly id: string;
-  readonly slug: string;
-  readonly name: string;
-  readonly shortName: string;
-  readonly tagline: string;
-  readonly faction: EditorFaction;
-  readonly summary: string;
-  readonly hookSummary: string;
-  readonly recommendedHotspots?: readonly string[];
-  readonly hooks: EditorHooksMap;
-}
-
-export interface EditorsJson {
-  readonly editors: readonly EditorDefinition[];
-}
-
-export type EditorHookFor<Phase extends EditorHookPhase> = NonNullable<EditorHooksMap[Phase]> extends readonly (infer Hook)[]
-  ? Hook
-  : never;
+export type EditorDef = {
+  id: EditorId;
+  name: string;
+  portrait?: string;
+  flavor?: string;
+  bonus: EditorEffect;
+  penalty: EditorEffect;
+};

--- a/src/expansions/editors/EditorsUI.tsx
+++ b/src/expansions/editors/EditorsUI.tsx
@@ -10,8 +10,13 @@ import { EDITORS_EXPANSION_ID, isEditorsFeatureEnabled } from '@/data/expansions
 
 export { EDITORS_EXPANSION_ID } from '@/data/expansions/features';
 
-import type { EditorDefinition, EditorFaction, EditorHookDefinition, EditorHookPhase } from './EditorsTypes';
-import { getEditors, resolveActiveEditor, type EditorId } from './EditorsEngine';
+import type { EditorDef, EditorId } from './EditorsTypes';
+import {
+  describeEditorEffect,
+  getEditors,
+  resolveActiveEditor,
+  type EditorEffectKind,
+} from './EditorsEngine';
 
 export interface EditorsUIProps extends PropsWithChildren {
   readonly editorId?: EditorId | null;
@@ -21,161 +26,52 @@ export interface EditorsUIProps extends PropsWithChildren {
 
 const STORAGE_KEY = 'shadowgov:editors:last-selection';
 
-const PHASE_LABELS: Record<EditorHookPhase, string> = {
-  onSetup: 'Setup',
-  onTurnStart: 'Turn Start',
-  onPlayCard: 'On Play',
+const EFFECT_TITLES: Record<EditorEffectKind, string> = {
+  bonus: 'Bonus',
+  penalty: 'Tradeoff',
 };
 
-const PENALTY_KEYWORDS = [
-  'opponent',
-  'enemy',
-  'lock',
-  'locked',
-  'discard',
-  'tax',
-  'suppress',
-  'deny',
-  'burn',
-  'force',
-  'steal',
-  'reduce',
-  'lose',
-  'exhaust',
-  'penalty',
-  'sacrifice',
-];
-
-const HOOK_PHASES: readonly EditorHookPhase[] = ['onSetup', 'onTurnStart', 'onPlayCard'];
-
-export interface EditorEffectSummary {
-  readonly key: string;
-  readonly phase: EditorHookPhase;
-  readonly label: string;
-  readonly description: string;
-  readonly tone: 'bonus' | 'penalty';
-}
-
-export interface EditorEffectBuckets {
-  readonly bonuses: readonly EditorEffectSummary[];
-  readonly penalties: readonly EditorEffectSummary[];
-}
-
-const normalizeDescription = (description: string): string => description.toLowerCase();
-
-const classifyHookTone = (hook: EditorHookDefinition): 'bonus' | 'penalty' => {
-  const text = normalizeDescription(hook.description);
-  return PENALTY_KEYWORDS.some(keyword => text.includes(keyword)) ? 'penalty' : 'bonus';
+const EFFECT_BADGES: Record<EditorEffectKind, string> = {
+  bonus: 'bg-emerald-500/10 text-emerald-600 border-emerald-500/40',
+  penalty: 'bg-rose-500/10 text-rose-600 border-rose-500/40',
 };
 
-export const summarizeEditorEffects = (editor: EditorDefinition): EditorEffectBuckets => {
-  const bonuses: EditorEffectSummary[] = [];
-  const penalties: EditorEffectSummary[] = [];
-
-  HOOK_PHASES.forEach(phase => {
-    const hooksForPhase = editor.hooks?.[phase] ?? [];
-    hooksForPhase.forEach(hook => {
-      const tone = classifyHookTone(hook);
-      const entry: EditorEffectSummary = {
-        key: `${phase}:${hook.id}`,
-        phase,
-        label: hook.label,
-        description: hook.description,
-        tone,
-      };
-      if (tone === 'bonus') {
-        bonuses.push(entry);
-      } else {
-        penalties.push(entry);
-      }
-    });
-  });
-
-  return {
-    bonuses,
-    penalties,
-  };
-};
-
-const readStoredSelections = (): Partial<Record<'truth' | 'government' | 'neutral' | 'any', EditorId>> => {
-  if (typeof window === 'undefined') {
-    return {};
-  }
-  try {
-    const raw = window.localStorage.getItem(STORAGE_KEY);
-    if (!raw) {
-      return {};
-    }
-    const parsed = JSON.parse(raw) as Record<string, unknown>;
-    const result: Partial<Record<'truth' | 'government' | 'neutral' | 'any', EditorId>> = {};
-    for (const [key, value] of Object.entries(parsed)) {
-      if ((key === 'truth' || key === 'government' || key === 'neutral' || key === 'any') && typeof value === 'string') {
-        result[key] = value;
-      }
-    }
-    return result;
-  } catch (error) {
-    console.warn('[Editors] Failed to read stored selection', error);
-    return {};
-  }
-};
-
-const writeStoredSelections = (map: Partial<Record<'truth' | 'government' | 'neutral' | 'any', EditorId>>) => {
-  if (typeof window === 'undefined') {
+const rememberSelection = (editor: EditorDef | null) => {
+  if (!editor || typeof window === 'undefined') {
     return;
   }
   try {
-    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(map));
+    window.localStorage.setItem(STORAGE_KEY, editor.id);
   } catch (error) {
     console.warn('[Editors] Failed to persist selection', error);
   }
 };
 
-const rememberSelection = (editor: EditorDefinition | null) => {
-  if (!editor) {
-    return;
+const getStoredSelection = (): EditorId | null => {
+  if (typeof window === 'undefined') {
+    return null;
   }
-  const map = readStoredSelections();
-  map.any = editor.id;
-  map[editor.faction] = editor.id;
-  writeStoredSelections(map);
-};
-
-const getStoredSelection = (faction?: EditorFaction | 'any'): EditorId | null => {
-  const map = readStoredSelections();
-  if (!faction || faction === 'any') {
-    return map.any ?? null;
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    return raw ?? null;
+  } catch (error) {
+    console.warn('[Editors] Failed to read stored selection', error);
+    return null;
   }
-  return map[faction] ?? map.any ?? null;
-};
-
-const filterEditorsByFaction = (faction?: EditorFaction | 'any'): EditorDefinition[] => {
-  const editors = getEditors();
-  if (!faction || faction === 'any') {
-    return [...editors];
-  }
-  return editors.filter(editor => editor.faction === faction || editor.faction === 'neutral');
 };
 
 interface ChooseEditorOptions {
-  readonly faction?: EditorFaction | 'any';
   readonly defaultId?: EditorId | null;
   readonly allowSkip?: boolean;
 }
 
 interface EditorsChooseModalProps {
-  readonly editors: readonly EditorDefinition[];
+  readonly editors: readonly EditorDef[];
   readonly initialSelection?: EditorId | null;
-  readonly onConfirm: (editor: EditorDefinition | null) => void;
+  readonly onConfirm: (editor: EditorDef | null) => void;
   readonly onSkip?: () => void;
   readonly allowSkip: boolean;
 }
-
-const factionTone: Record<EditorFaction, string> = {
-  truth: 'bg-emerald-500/10 text-emerald-600 border-emerald-500/40',
-  government: 'bg-sky-500/10 text-sky-600 border-sky-500/40',
-  neutral: 'bg-amber-500/10 text-amber-600 border-amber-500/40',
-};
 
 const ensureHost = (): { container: HTMLElement; root: Root } => {
   if (typeof document === 'undefined') {
@@ -206,7 +102,18 @@ const teardownHost = () => {
 let activeHost: { container: HTMLElement; root: Root } | null = null;
 let activePromise: Promise<EditorId | null> | null = null;
 
-// [EDITORS_CHOOSE_MODAL]
+const renderEffectList = (editor: EditorDef, kind: EditorEffectKind): string[] => {
+  const effect = kind === 'bonus' ? editor.bonus : editor.penalty;
+  const described = describeEditorEffect(effect);
+  if (described.length > 0) {
+    return described;
+  }
+  if (kind === 'bonus') {
+    return ['No bonus'];
+  }
+  return ['No tradeoff'];
+};
+
 const EditorsChooseModal = ({ editors, initialSelection, onConfirm, onSkip, allowSkip }: EditorsChooseModalProps) => {
   const [selectedId, setSelectedId] = useState<EditorId | null>(() => {
     if (initialSelection && editors.some(editor => editor.id === initialSelection)) {
@@ -229,32 +136,24 @@ const EditorsChooseModal = ({ editors, initialSelection, onConfirm, onSkip, allo
     [editors, selectedId],
   );
 
-  const effectSummary = useMemo(() => (
-    selectedEditor ? summarizeEditorEffects(selectedEditor) : { bonuses: [], penalties: [] }
-  ), [selectedEditor]);
-
   return (
     <Dialog open>
       <DialogContent
-        className="max-w-4xl gap-0 border border-foreground/20 bg-background/95 p-0 shadow-xl"
+        className="max-w-3xl gap-0 border border-foreground/20 bg-background/95 p-0 shadow-xl"
         onPointerDownOutside={event => event.preventDefault()}
         onEscapeKeyDown={event => event.preventDefault()}
       >
         <DialogHeader className="space-y-1 border-b border-border bg-muted/40 px-6 py-4 text-left">
-          <DialogTitle className="text-2xl font-semibold tracking-tight">
-            Assign a Desk Editor
-          </DialogTitle>
+          <DialogTitle className="text-2xl font-semibold tracking-tight">Assign a Desk Editor</DialogTitle>
           <DialogDescription className="text-sm text-muted-foreground">
-            Choose an editor to tune your newsroom before the presses roll.
+            Choose an editor to adjust your newsroom before the presses roll.
           </DialogDescription>
         </DialogHeader>
         <div className="grid gap-6 px-6 pb-6 pt-4 md:grid-cols-[minmax(0,2fr)_minmax(0,1fr)]">
-          <ScrollArea className="h-[360px] rounded border border-border/40 bg-background/70">
+          <ScrollArea className="h-[340px] rounded border border-border/40 bg-background/70">
             <div className="grid gap-3 p-4">
               {editors.map(editor => {
                 const isSelected = selectedId === editor.id;
-                const tone = factionTone[editor.faction];
-                const summary = summarizeEditorEffects(editor);
                 return (
                   <button
                     key={editor.id}
@@ -268,47 +167,34 @@ const EditorsChooseModal = ({ editors, initialSelection, onConfirm, onSkip, allo
                     data-editor-id={editor.id}
                     data-state={isSelected ? 'selected' : 'idle'}
                   >
-                    <div className="flex flex-wrap items-start justify-between gap-3">
+                    <div className="flex items-start justify-between gap-3">
                       <div>
-                        <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">{editor.shortName}</p>
                         <h3 className="text-lg font-semibold leading-tight">{editor.name}</h3>
-                        <p className="text-sm text-muted-foreground">{editor.tagline}</p>
+                        {editor.flavor ? (
+                          <p className="text-sm italic text-muted-foreground">{editor.flavor}</p>
+                        ) : null}
                       </div>
-                      <Badge className={cn('border text-xs font-semibold uppercase tracking-wide', tone)}>
-                        {editor.faction}
+                      <Badge className="border border-foreground/40 bg-muted/40 text-xs font-semibold uppercase tracking-wide">
+                        Editors
                       </Badge>
                     </div>
-                    <p className="text-sm text-muted-foreground/90">{editor.summary}</p>
-                    {editor.hookSummary ? (
-                      <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground/80">
-                        Focus: <span className="font-normal normal-case text-muted-foreground">{editor.hookSummary}</span>
-                      </p>
-                    ) : null}
                     <div className="grid gap-3 md:grid-cols-2">
-                      {summary.bonuses.length > 0 ? (
-                        <div className="rounded border border-emerald-500/30 bg-emerald-500/10 p-3 text-emerald-700">
-                          <p className="text-xs font-semibold uppercase tracking-wide">Desk Bonuses</p>
-                          <ul className="mt-2 space-y-2 text-xs">
-                            {summary.bonuses.map(effect => (
-                              <li key={effect.key}>
-                                <span className="font-semibold">{PHASE_LABELS[effect.phase]}:</span> {effect.description}
-                              </li>
+                      {(['bonus', 'penalty'] as const).map(kind => (
+                        <div
+                          key={kind}
+                          className={cn(
+                            'rounded border p-3 text-sm',
+                            EFFECT_BADGES[kind],
+                          )}
+                        >
+                          <p className="text-xs font-semibold uppercase tracking-wide">{EFFECT_TITLES[kind]}</p>
+                          <ul className="mt-2 space-y-1 text-xs">
+                            {renderEffectList(editor, kind).map((line, index) => (
+                              <li key={`${kind}-${index}`}>{line}</li>
                             ))}
                           </ul>
                         </div>
-                      ) : null}
-                      {summary.penalties.length > 0 ? (
-                        <div className="rounded border border-rose-500/40 bg-rose-500/10 p-3 text-rose-700">
-                          <p className="text-xs font-semibold uppercase tracking-wide">Desk Tradeoffs</p>
-                          <ul className="mt-2 space-y-2 text-xs">
-                            {summary.penalties.map(effect => (
-                              <li key={effect.key}>
-                                <span className="font-semibold">{PHASE_LABELS[effect.phase]}:</span> {effect.description}
-                              </li>
-                            ))}
-                          </ul>
-                        </div>
-                      ) : null}
+                      ))}
                     </div>
                   </button>
                 );
@@ -321,41 +207,33 @@ const EditorsChooseModal = ({ editors, initialSelection, onConfirm, onSkip, allo
                 <div>
                   <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">Selected Editor</p>
                   <h4 className="text-lg font-semibold leading-tight">{selectedEditor.name}</h4>
-                  <p className="text-sm text-muted-foreground">{selectedEditor.summary}</p>
+                  {selectedEditor.flavor ? (
+                    <p className="text-sm italic text-muted-foreground">{selectedEditor.flavor}</p>
+                  ) : null}
                 </div>
-                {selectedEditor.recommendedHotspots?.length ? (
-                  <div className="rounded border border-border/40 bg-muted/20 p-3">
-                    <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">Favoured Hotspots</p>
-                    <p className="text-xs text-muted-foreground/90">
-                      {selectedEditor.recommendedHotspots.join(', ')}
-                    </p>
-                  </div>
-                ) : null}
                 <div className="space-y-3">
-                  {effectSummary.bonuses.length > 0 ? (
-                    <div>
-                      <p className="text-xs font-semibold uppercase tracking-wide text-emerald-600">Bonuses</p>
-                      <ul className="mt-1 space-y-1 text-xs text-emerald-700">
-                        {effectSummary.bonuses.map(effect => (
-                          <li key={effect.key}>
-                            <span className="font-semibold">{PHASE_LABELS[effect.phase]}:</span> {effect.description}
-                          </li>
+                  {(['bonus', 'penalty'] as const).map(kind => (
+                    <div key={kind}>
+                      <p
+                        className={cn(
+                          'text-xs font-semibold uppercase tracking-wide',
+                          kind === 'bonus' ? 'text-emerald-600' : 'text-rose-600',
+                        )}
+                      >
+                        {EFFECT_TITLES[kind]}
+                      </p>
+                      <ul
+                        className={cn(
+                          'mt-1 space-y-1 text-xs',
+                          kind === 'bonus' ? 'text-emerald-700' : 'text-rose-700',
+                        )}
+                      >
+                        {renderEffectList(selectedEditor, kind).map((line, index) => (
+                          <li key={`${kind}-detail-${index}`}>{line}</li>
                         ))}
                       </ul>
                     </div>
-                  ) : null}
-                  {effectSummary.penalties.length > 0 ? (
-                    <div>
-                      <p className="text-xs font-semibold uppercase tracking-wide text-rose-600">Tradeoffs</p>
-                      <ul className="mt-1 space-y-1 text-xs text-rose-700">
-                        {effectSummary.penalties.map(effect => (
-                          <li key={effect.key}>
-                            <span className="font-semibold">{PHASE_LABELS[effect.phase]}:</span> {effect.description}
-                          </li>
-                        ))}
-                      </ul>
-                    </div>
-                  ) : null}
+                  ))}
                 </div>
               </div>
             ) : (
@@ -364,12 +242,8 @@ const EditorsChooseModal = ({ editors, initialSelection, onConfirm, onSkip, allo
               </div>
             )}
             <div className="mt-auto flex flex-col gap-3">
-              <Button
-                className="w-full"
-                disabled={!selectedEditor}
-                onClick={() => onConfirm(selectedEditor ?? null)}
-              >
-                {selectedEditor ? `Start with ${selectedEditor.shortName}` : 'Select an Editor'}
+              <Button className="w-full" disabled={!selectedEditor} onClick={() => onConfirm(selectedEditor ?? null)}>
+                {selectedEditor ? `Start with ${selectedEditor.name}` : 'Select an Editor'}
               </Button>
               {allowSkip ? (
                 <Button variant="ghost" className="w-full" onClick={() => (onSkip ? onSkip() : onConfirm(null))}>
@@ -388,20 +262,21 @@ export const chooseEditor = (options: ChooseEditorOptions = {}): Promise<EditorI
   if (activePromise) {
     return activePromise;
   }
-  const { faction = 'any', defaultId, allowSkip = true } = options;
+  const { defaultId, allowSkip = true } = options;
   if (typeof document === 'undefined') {
     return Promise.resolve(null);
   }
 
-  const availableEditors = filterEditorsByFaction(faction);
+  const availableEditors = getEditors();
   if (availableEditors.length === 0) {
     return Promise.resolve(null);
   }
 
-  const storedSelection = getStoredSelection(faction);
-  const initialSelection = (defaultId ?? storedSelection) && availableEditors.some(editor => editor.id === (defaultId ?? storedSelection))
-    ? (defaultId ?? storedSelection)
-    : availableEditors[0]?.id ?? null;
+  const storedSelection = getStoredSelection();
+  const initialSelection = (defaultId ?? storedSelection) &&
+    availableEditors.some(editor => editor.id === (defaultId ?? storedSelection))
+      ? (defaultId ?? storedSelection)
+      : availableEditors[0]?.id ?? null;
 
   activePromise = new Promise<EditorId | null>((resolve) => {
     const host = ensureHost();
@@ -457,38 +332,31 @@ export const EditorsUI = ({ editorId, fallbackId, className, children }: Editors
       data-editor-id={editor.id}
     >
       <header className="flex flex-col gap-1">
-        <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">{editor.shortName}</p>
+        <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">Editor</p>
         <h2 className="text-lg font-semibold leading-tight">{editor.name}</h2>
-        <p className="text-sm text-muted-foreground">{editor.tagline}</p>
+        {editor.flavor ? <p className="text-sm italic text-muted-foreground">{editor.flavor}</p> : null}
       </header>
-      <p className="text-sm leading-relaxed text-muted-foreground/90">{editor.summary}</p>
-      <div className="space-y-3">
-        {editor.hookSummary ? (
-          <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground/80">
-            Hook Focus: <span className="font-normal normal-case text-muted-foreground">{editor.hookSummary}</span>
-          </p>
-        ) : null}
-        <ul className="list-disc space-y-1 pl-5 text-sm text-muted-foreground/90">
-          {(editor.hooks.onSetup ?? []).map(hook => (
-            <li key={hook.id}>
-              <span className="font-semibold">Setup:</span> {hook.description}
-            </li>
-          ))}
-          {(editor.hooks.onTurnStart ?? []).map(hook => (
-            <li key={hook.id}>
-              <span className="font-semibold">Turn Start:</span> {hook.description}
-            </li>
-          ))}
-          {(editor.hooks.onPlayCard ?? []).map(hook => (
-            <li key={hook.id}>
-              <span className="font-semibold">Play Card:</span> {hook.description}
-            </li>
-          ))}
-        </ul>
+      <div className="grid gap-3 md:grid-cols-2">
+        {(['bonus', 'penalty'] as const).map(kind => (
+          <div
+            key={kind}
+            className={cn(
+              'rounded border p-3 text-sm',
+              kind === 'bonus'
+                ? 'border-emerald-500/40 bg-emerald-500/10 text-emerald-700'
+                : 'border-rose-500/40 bg-rose-500/10 text-rose-700',
+            )}
+          >
+            <p className="text-xs font-semibold uppercase tracking-wide">{EFFECT_TITLES[kind]}</p>
+            <ul className="mt-2 space-y-1 text-xs">
+              {renderEffectList(editor, kind).map((line, index) => (
+                <li key={`${kind}-hud-${index}`}>{line}</li>
+              ))}
+            </ul>
+          </div>
+        ))}
       </div>
       {children ? <footer className="pt-2 text-xs text-muted-foreground/80">{children}</footer> : null}
     </section>
   );
 };
-
-export { PHASE_LABELS as EDITOR_PHASE_LABELS };

--- a/src/expansions/editors/editors.json
+++ b/src/expansions/editors/editors.json
@@ -1,119 +1,30 @@
-{
-  "editors": [
-    {
-      "id": "city-desk-cartographer",
-      "slug": "city-desk-cartographer",
-      "name": "City Desk Cartographer",
-      "shortName": "City Desk",
-      "tagline": "Maps the rumor grid before the presses heat up.",
-      "faction": "truth",
-      "summary": "Stabilizes the opening board state by scouting the layout grid and nudging early circulation in the right direction.",
-      "hookSummary": "Previews critical slots and shapes the first wave of assignments.",
-      "recommendedHotspots": ["new-york", "chicago", "washington-dc"],
-      "hooks": {
-        "onSetup": [
-          {
-            "id": "scout-the-grid",
-            "label": "Scout the Grid",
-            "description": "Preview the opening headline slot and tuck a spare lead for later."
-          }
-        ],
-        "onTurnStart": [
-          {
-            "id": "metro-ticker",
-            "label": "Metro Ticker",
-            "description": "Peek at the top Truth card each turn; you may keep or cycle it."
-          }
-        ]
-      }
-    },
-    {
-      "id": "night-shift-redactor",
-      "slug": "night-shift-redactor",
-      "name": "Night Shift Redactor",
-      "shortName": "Night Shift",
-      "tagline": "Stamps every revelation with a midnight disclaimer.",
-      "faction": "government",
-      "summary": "The agency-friendly desk that scrubs sensitive material and buries leads until dawn.",
-      "hookSummary": "Suppresses tempo plays while funneling evidence into the burn bin.",
-      "recommendedHotspots": ["pentagon", "langley", "quantico"],
-      "hooks": {
-        "onSetup": [
-          {
-            "id": "mandatory-redaction",
-            "label": "Mandatory Redaction",
-            "description": "Force both factions to discard and redraw one setup card."
-          }
-        ],
-        "onTurnStart": [
-          {
-            "id": "graveyard-shift",
-            "label": "Graveyard Shift",
-            "description": "Tax the opponent one Cover-Up whenever Public Frenzy is calm."
-          }
-        ],
-        "onPlayCard": [
-          {
-            "id": "stamp-it-denied",
-            "label": "Stamp it DENIED",
-            "description": "When you play a Response, flip an enemy bonus slot to locked until end of round."
-          }
-        ]
-      }
-    },
-    {
-      "id": "signal-jammer-bureau",
-      "slug": "signal-jammer-bureau",
-      "name": "Signal Jammer Bureau",
-      "shortName": "Signal Jammer",
-      "tagline": "Catches every weird broadcast before it hits the wire.",
-      "faction": "truth",
-      "summary": "A paranoiac desk that lives in the radio static, turning surprise transmissions into tactical intel.",
-      "hookSummary": "Rewards responsive play and amplifies chained reveals.",
-      "recommendedHotspots": ["roswell", "area-51", "estes-park"],
-      "hooks": {
-        "onTurnStart": [
-          {
-            "id": "frequency-scan",
-            "label": "Frequency Scan",
-            "description": "If Public Frenzy is 3+ gain a free Signal token; otherwise draw a clue fragment."
-          }
-        ],
-        "onPlayCard": [
-          {
-            "id": "jam-the-feed",
-            "label": "Jam the Feed",
-            "description": "After you play a Reaction headline, exhaust a Government support asset."
-          }
-        ]
-      }
-    },
-    {
-      "id": "florida-man-liaison",
-      "slug": "florida-man-liaison",
-      "name": "Florida Man Liaison",
-      "shortName": "Florida Bureau",
-      "tagline": "Files reports barefoot while the swamp is literally on fire.",
-      "faction": "truth",
-      "summary": "Leans into volatile hotspots and weaponises tabloid absurdity from the Sunshine State.",
-      "hookSummary": "Doubles down on hotspots that are already cooking and converts chaos into momentum.",
-      "recommendedHotspots": ["florida", "everglades", "key-west"],
-      "hooks": {
-        "onSetup": [
-          {
-            "id": "sunshine-surplus",
-            "label": "Sunshine Surplus",
-            "description": "Start with a Florida story pinned to the rumor board."
-          }
-        ],
-        "onPlayCard": [
-          {
-            "id": "headlines-on-fire",
-            "label": "Headlines on Fire",
-            "description": "When a hotspot is burning, upgrade the next Truth card you play this turn."
-          }
-        ]
-      }
-    }
-  ]
-}
+[
+  {
+    "id": "ed_muldrunk",
+    "name": "Fox Muldrunk",
+    "flavor": "\"Trust the hunch, ignore the paperwork.\"",
+    "bonus": { "onMediaPlay_truthDelta": 1 },
+    "penalty": { "start_ipDelta": -2 }
+  },
+  {
+    "id": "ed_floridaman",
+    "name": "Florida Man",
+    "flavor": "\"If it headlines, it’s fine.\"",
+    "bonus": { "turnStart_scandalChance": 0.1, "scandal_effect": "randomDiscard:1" },
+    "penalty": { "attack_ipCostDelta": 1 }
+  },
+  {
+    "id": "ed_el_visto",
+    "name": "El Visto",
+    "flavor": "\"Thank you, thank you very much.\"",
+    "bonus": { "onSetup_addCardIds": ["VEGAS_UFO_WEDDING"] },
+    "penalty": { "onSetup_deckSizeDelta": -1 }
+  },
+  {
+    "id": "ed_gonzo",
+    "name": "Hunter S. Thampson",
+    "flavor": "\"Buy the ticket, take the truth.\"",
+    "bonus": { "round1_drawDelta": 1 },
+    "penalty": { "attack_ipCostDelta": 1 }
+  }
+]

--- a/src/hooks/gameStateTypes.ts
+++ b/src/hooks/gameStateTypes.ts
@@ -8,7 +8,7 @@ import type { AIDifficulty } from '@/data/aiStrategy';
 import type { TurnPlay } from '@/game/combo.types';
 import type { HotspotKind, WeightedHotspotCandidate } from '@/systems/paranormalHotspots';
 import type { StateCombinationEffects } from '@/data/stateCombinations';
-import type { EditorDefinition, EditorId } from '@/expansions/editors/EditorsEngine';
+import type { EditorDef, EditorId } from '@/expansions/editors/EditorsEngine';
 import type { TabloidRelicRuntimeState } from '@/expansions/tabloidRelics/RelicTypes';
 
 export interface CardPlayRecord {
@@ -126,25 +126,16 @@ export interface GameState {
   activeCampaignArcs: ActiveCampaignArcState[];
   pendingArcEvents: PendingCampaignArcEvent[];
   editorId?: EditorId | null;
-  editorDef?: EditorDefinition | null;
+  editorDef?: EditorDef | null;
   editorRuntime?: GameEditorRuntimeState | null;
   preGameAdditions?: GameEditorPreGameAdditions | null;
   tabloidRelicsRuntime?: TabloidRelicRuntimeState | null;
 }
 
-export interface GameEditorScandalFlags {
-  readonly [flagId: string]: boolean;
-}
-
 export interface GameEditorRuntimeState {
   appliedSetup?: boolean;
   roundIndex?: number;
-  rngSeed?: number;
-  scandalFlags?: GameEditorScandalFlags;
-  deckSizeDelta?: {
-    player?: number;
-    ai?: number;
-  };
+  deckSizeDelta?: number;
 }
 
 export interface GameEditorPreGameAdditions {

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -43,14 +43,8 @@ import EnhancedNewspaper from '@/components/game/EnhancedNewspaper';
 import MinimizedHand from '@/components/game/MinimizedHand';
 import { VictoryConditions } from '@/components/game/VictoryConditions';
 import toast, { Toaster } from 'react-hot-toast';
-import {
-  chooseEditor,
-  isEditorsExpansionEnabled,
-  summarizeEditorEffects,
-  EDITOR_PHASE_LABELS,
-  type EditorEffectBuckets,
-} from '@/expansions/editors/EditorsUI';
-import type { EditorId } from '@/expansions/editors/EditorsEngine';
+import { chooseEditor, isEditorsExpansionEnabled } from '@/expansions/editors/EditorsUI';
+import { describeEditorEffect, type EditorId } from '@/expansions/editors/EditorsEngine';
 import type {
   ActiveCampaignArcState,
   ActiveParanormalHotspot,
@@ -745,11 +739,14 @@ const Index = () => {
     clearArchive: clearIntelArchive,
   } = useIntelArchive();
 
-  const editorEffects = useMemo<EditorEffectBuckets | null>(() => {
+  const editorEffects = useMemo(() => {
     if (!gameState.editorDef) {
       return null;
     }
-    return summarizeEditorEffects(gameState.editorDef);
+    return {
+      bonus: describeEditorEffect(gameState.editorDef.bonus),
+      penalty: describeEditorEffect(gameState.editorDef.penalty),
+    };
   }, [gameState.editorDef]);
 
   const [isObjectivesOpen, setIsObjectivesOpen] = useState(false);
@@ -2862,7 +2859,7 @@ const Index = () => {
                   )}
                   data-editor-id={gameState.editorDef.id}
                 >
-                  ✒️ Editor: {gameState.editorDef.shortName}
+                  ✒️ Editor: {gameState.editorDef.name}
                 </button>
               </PopoverTrigger>
               <PopoverContent
@@ -2873,43 +2870,28 @@ const Index = () => {
                   <div>
                     <p className="text-[10px] font-semibold uppercase tracking-[0.3em] text-newspaper-text/60">Desk Editor</p>
                     <h3 className="text-base font-semibold leading-tight">{gameState.editorDef.name}</h3>
-                    <p className="text-xs text-newspaper-text/70">{gameState.editorDef.tagline}</p>
+                    {gameState.editorDef.flavor ? (
+                      <p className="text-xs italic text-newspaper-text/70">{gameState.editorDef.flavor}</p>
+                    ) : null}
                   </div>
-                  {gameState.editorDef.hookSummary ? (
-                    <p className="text-[10px] font-semibold uppercase tracking-[0.3em] text-newspaper-text/60">
-                      Focus: <span className="font-normal normal-case text-newspaper-text">{gameState.editorDef.hookSummary}</span>
-                    </p>
-                  ) : null}
-                  {editorEffects?.bonuses?.length ? (
+                  {editorEffects?.bonus?.length ? (
                     <div>
                       <p className="text-[10px] font-semibold uppercase tracking-[0.3em] text-emerald-600">Bonuses</p>
                       <ul className="mt-1 space-y-1 text-xs text-emerald-700">
-                        {editorEffects.bonuses.map(effect => (
-                          <li key={effect.key}>
-                            <span className="font-semibold">{EDITOR_PHASE_LABELS[effect.phase]}:</span> {effect.description}
-                          </li>
+                        {editorEffects.bonus.map((line, index) => (
+                          <li key={`editor-bonus-${index}`}>{line}</li>
                         ))}
                       </ul>
                     </div>
                   ) : null}
-                  {editorEffects?.penalties?.length ? (
+                  {editorEffects?.penalty?.length ? (
                     <div>
                       <p className="text-[10px] font-semibold uppercase tracking-[0.3em] text-rose-600">Tradeoffs</p>
                       <ul className="mt-1 space-y-1 text-xs text-rose-700">
-                        {editorEffects.penalties.map(effect => (
-                          <li key={effect.key}>
-                            <span className="font-semibold">{EDITOR_PHASE_LABELS[effect.phase]}:</span> {effect.description}
-                          </li>
+                        {editorEffects.penalty.map((line, index) => (
+                          <li key={`editor-penalty-${index}`}>{line}</li>
                         ))}
                       </ul>
-                    </div>
-                  ) : null}
-                  {gameState.editorDef.recommendedHotspots?.length ? (
-                    <div className="rounded border border-newspaper-border/40 bg-newspaper-bg/40 p-3">
-                      <p className="text-[10px] font-semibold uppercase tracking-[0.3em] text-newspaper-text/60">Favoured Hotspots</p>
-                      <p className="text-[11px] text-newspaper-text/80">
-                        {gameState.editorDef.recommendedHotspots.join(', ')}
-                      </p>
                     </div>
                   ) : null}
                 </div>


### PR DESCRIPTION
## Summary
- replace the editors dataset and types with the agreed MVP bonus/penalty definitions
- add engine helpers that compute setup, turn-start, and play-time adjustments while updating the editor selection UI
- apply the editor modifiers during game setup, turn start, and card plays and surface the active editor in the HUD

## Testing
- npm run lint *(fails: repository contains pre-existing lint violations)*
- bun test --coverage --coverage-reporter=text


------
https://chatgpt.com/codex/tasks/task_e_68e029ac2c9c832083828ca58c6d6b28