### PR TITLE
Add shared article bank loader for newspaper content

### DIFF
--- a/src/engine/news/articleBank.ts
+++ b/src/engine/news/articleBank.ts
@@ -1,0 +1,63 @@
+import { z } from 'zod';
+
+const cardArticleSchema = z.object({
+  id: z.string(),
+  tone: z.string(),
+  tags: z.array(z.string()),
+  headline: z.string(),
+  subhead: z.string(),
+  byline: z.string(),
+  body: z.string(),
+  imagePrompt: z.string().optional(),
+});
+
+const articleFileSchema = z.object({
+  articles: z.array(cardArticleSchema),
+});
+
+export type CardArticle = z.infer<typeof cardArticleSchema>;
+
+export interface ArticleBank {
+  articles: CardArticle[];
+  byId: Map<string, CardArticle>;
+}
+
+let cachedArticleBank: Promise<ArticleBank> | null = null;
+
+async function importArticleData() {
+  const module = await import('../../../paranoid_times_card_articles_ALL.json');
+  return (module as { default?: unknown }).default ?? module;
+}
+
+export async function loadArticleBank(): Promise<ArticleBank> {
+  if (!cachedArticleBank) {
+    cachedArticleBank = importArticleData().then((rawData) => {
+      const { articles } = articleFileSchema.parse(rawData);
+      const byId = new Map<string, CardArticle>();
+
+      for (const article of articles) {
+        byId.set(article.id, article);
+      }
+
+      return { articles, byId } satisfies ArticleBank;
+    });
+  }
+
+  return cachedArticleBank;
+}
+
+export function getById(bank: ArticleBank, id: string | null | undefined): CardArticle | null {
+  if (!id) {
+    return null;
+  }
+
+  return bank.byId.get(id) ?? null;
+}
+
+export function has(bank: ArticleBank, id: string | null | undefined): boolean {
+  if (!id) {
+    return false;
+  }
+
+  return bank.byId.has(id);
+}


### PR DESCRIPTION
## Summary
- add a shared article bank module that loads and validates card article JSON data
- expose cached loading plus lookup helpers for use across engine and UI layers

## Testing
- npm run lint *(fails: existing lint violations in unrelated files)*
- bun test --coverage --coverage-reporter=text *(fails: existing test failures around resolveCardMVP and hotspot handling)*

------
https://chatgpt.com/codex/tasks/task_e_68e0bafeff6c832098f1513ad39898af