### PR TITLE
Add news article tests and front page coverage thresholds

### DIFF
--- a/bunfig.toml
+++ b/bunfig.toml
@@ -1,0 +1,3 @@
+[test]
+coverageSkipTestFiles = true
+coverageThreshold = { lines = 0.6, functions = 0.5, statements = 0.6, branches = 0.4 }

--- a/src/components/game/__tests__/TabloidNewspaperV2.frontPage.test.tsx
+++ b/src/components/game/__tests__/TabloidNewspaperV2.frontPage.test.tsx
@@ -1,0 +1,165 @@
+import { afterAll, afterEach, beforeAll, describe, expect, mock, test } from 'bun:test';
+import { Window } from 'happy-dom';
+
+import type { NarrativeIssue } from '@/engine/newspaper/IssueGenerator';
+import type { TabloidNewspaperProps } from '../TabloidNewspaperLegacy';
+
+const windowRef = new Window();
+
+const matchMediaStub = () => ({
+  matches: false,
+  addEventListener: () => {},
+  removeEventListener: () => {},
+});
+
+if (!('matchMedia' in windowRef)) {
+  (windowRef as unknown as { matchMedia: typeof matchMediaStub }).matchMedia = matchMediaStub;
+}
+
+globalThis.window = windowRef as unknown as typeof globalThis.window;
+globalThis.document = windowRef.document as unknown as Document;
+globalThis.navigator = windowRef.navigator as Navigator;
+globalThis.HTMLElement = windowRef.HTMLElement as unknown as typeof globalThis.HTMLElement;
+globalThis.CustomEvent = windowRef.CustomEvent as unknown as typeof globalThis.CustomEvent;
+
+const { render, screen, waitFor, cleanup } = await import('@testing-library/react');
+
+mock.module('@/lib/newspaperData', () => ({
+  loadNewspaperData: async () => ({
+    mastheads: ['The Paranoid Times'],
+    ads: [],
+    subheads: { generic: ['Officials refuse comment.'] },
+    bylines: ['By: Field Desk'],
+    sources: ['Source: Anonymous Courier'],
+    conspiracyCorner: [],
+    weather: ['Cloud cover classified.'],
+    attackVerbs: [],
+    mediaVerbs: [],
+    zoneVerbs: [],
+    stamps: { breaking: [], classified: [] },
+  }),
+  pick: <T,>(options: T[] | undefined, fallback: T): T => {
+    if (Array.isArray(options) && options.length) {
+      return options[0]!;
+    }
+    return fallback;
+  },
+  shuffle: <T,>(values: T[]): T[] => [...values],
+}));
+
+const generatedStory: NarrativeIssue['generatedStory'] = {
+  headline: 'Combined Headline Assembled',
+  subhead: 'Operatives align messaging across the theater.',
+  byline: 'By: Field Desk',
+  isFallback: false,
+  articles: [
+    {
+      cardId: 'card-1',
+      cardName: 'Alpha Agent',
+      cardType: 'attack',
+      player: 'human',
+      articleId: 'story-1',
+      headline: 'Side Story One',
+      subhead: 'Lead operatives breach the signal vault.',
+      byline: 'By: Operative Pulse',
+      body: ['Field team confirmed the breach before dawn.'],
+      tags: ['#Signal'],
+      imagePrompt: null,
+      isFallback: false,
+    },
+    {
+      cardId: 'card-2',
+      cardName: 'Beta Analyst',
+      cardType: 'media',
+      player: 'human',
+      articleId: 'story-2',
+      headline: 'Side Story Two',
+      subhead: 'Analysts flood feeds with decoded memos.',
+      byline: 'By: Resonance Bureau',
+      body: ['Network nodes amplify the recovered intel.'],
+      tags: ['#Broadcast'],
+      imagePrompt: null,
+      isFallback: false,
+    },
+    {
+      cardId: 'card-3',
+      cardName: 'Gamma Operative',
+      cardType: 'zone',
+      player: 'human',
+      articleId: 'story-3',
+      headline: 'Side Story Three',
+      subhead: 'Containment perimeter reroutes civilian traffic.',
+      byline: 'By: Field Desk',
+      body: ['Logistics teams confirm minimal collateral noise.'],
+      tags: ['#Containment'],
+      imagePrompt: null,
+      isFallback: false,
+    },
+  ],
+};
+
+const issue: NarrativeIssue = {
+  hero: null,
+  playerArticles: [],
+  oppositionArticles: [],
+  comboArticle: null,
+  byline: 'By: Field Desk',
+  sourceLine: 'Source: Anonymous Courier',
+  stamps: { breaking: null, classified: null },
+  supplements: { ads: [], conspiracies: [], weather: 'Cloud cover classified.' },
+  generatedStory,
+};
+
+mock.module('@/engine/newspaper/IssueGenerator', () => ({
+  generateIssue: async () => issue,
+}));
+
+mock.module('@/contexts/AudioContext', () => ({
+  useAudioContext: () => ({
+    play: () => {},
+  }),
+}));
+
+import TabloidNewspaperV2 from '../TabloidNewspaperV2';
+
+const baseProps: TabloidNewspaperProps = {
+  events: [],
+  playedCards: [],
+  faction: 'truth',
+  truth: 55,
+  onClose: () => {},
+  comboTruthDelta: 0,
+};
+
+beforeAll(() => {
+  globalThis.requestAnimationFrame = cb => setTimeout(() => cb(Date.now()), 0);
+  globalThis.cancelAnimationFrame = id => clearTimeout(id);
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+afterAll(() => {
+  delete (globalThis as { requestAnimationFrame?: typeof requestAnimationFrame }).requestAnimationFrame;
+  delete (globalThis as { cancelAnimationFrame?: typeof cancelAnimationFrame }).cancelAnimationFrame;
+});
+
+describe('TabloidNewspaperV2 front page integration', () => {
+  test('renders combined headline and three side dispatches', async () => {
+    render(<TabloidNewspaperV2 {...baseProps} />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Combined Headline Assembled')).toBeTruthy();
+    });
+
+    expect(screen.getByText('Operatives align messaging across the theater.')).toBeTruthy();
+
+    const sideStories = ['Side Story One', 'Side Story Two', 'Side Story Three'];
+    for (const headline of sideStories) {
+      expect(screen.getByText(headline)).toBeTruthy();
+    }
+
+    expect(screen.getAllByText(/Side Story/)).toHaveLength(3);
+  });
+});

--- a/src/engine/news/__tests__/articleBank.test.ts
+++ b/src/engine/news/__tests__/articleBank.test.ts
@@ -1,0 +1,59 @@
+import { afterEach, describe, expect, mock, test } from 'bun:test';
+
+import {
+  loadArticleBank,
+  getById,
+  has,
+  type CardArticle,
+  __setArticleBankLoader,
+  __resetArticleBankCache,
+} from '../articleBank';
+
+const sampleArticle = (overrides: Partial<CardArticle> = {}): CardArticle => ({
+  id: overrides.id ?? 'alpha',
+  tone: overrides.tone ?? 'truth',
+  tags: overrides.tags ?? ['#Signal'],
+  headline: overrides.headline ?? 'ALPHA SIGNAL DETECTED',
+  subhead: overrides.subhead ?? 'Operatives intercept classified broadcast.',
+  byline: overrides.byline ?? 'By: Field Unit 27-B/6',
+  body: overrides.body ?? 'Field report notes unusual readings across the grid.',
+  imagePrompt: overrides.imagePrompt,
+});
+
+afterEach(() => {
+  __resetArticleBankCache();
+});
+
+describe('loadArticleBank', () => {
+  test('successfully loads data and exposes lookup helpers', async () => {
+    const article = sampleArticle();
+    __setArticleBankLoader(async () => ({ articles: [article] }));
+
+    const bank = await loadArticleBank();
+
+    expect(bank.articles).toHaveLength(1);
+    expect(bank.byId.get(article.id)).toEqual(article);
+    expect(getById(bank, article.id)).toEqual(article);
+    expect(getById(bank, null)).toBeNull();
+    expect(has(bank, article.id)).toBe(true);
+    expect(has(bank, undefined)).toBe(false);
+  });
+
+  test('throws when the incoming data fails schema validation', async () => {
+    __setArticleBankLoader(async () => ({ invalid: true }));
+
+    await expect(loadArticleBank()).rejects.toThrow(/articles/i);
+  });
+
+  test('reuses the cached promise across multiple invocations', async () => {
+    const loader = mock(async () => ({ articles: [sampleArticle({ id: 'cached' })] }));
+    __setArticleBankLoader(loader);
+
+    const first = await loadArticleBank();
+    const second = await loadArticleBank();
+
+    expect(loader).toHaveBeenCalledTimes(1);
+    expect(second).toBe(first);
+    expect(has(second, 'cached')).toBe(true);
+  });
+});

--- a/src/engine/news/__tests__/mainStory.test.ts
+++ b/src/engine/news/__tests__/mainStory.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, test } from 'bun:test';
+
+import { generateMainStory } from '../mainStory';
+import type { ArticleBank, CardArticle } from '../articleBank';
+import type { StoryCardLike } from '../templates';
+
+const createArticle = (overrides: Partial<CardArticle> = {}): CardArticle => ({
+  id: overrides.id ?? 'card-alpha',
+  tone: overrides.tone ?? 'truth',
+  tags: overrides.tags ?? ['#Signal'],
+  headline: overrides.headline ?? 'ALPHA DISCOVERY CONFIRMED',
+  subhead: overrides.subhead ?? 'Operatives race to verify leaked intel.',
+  byline: overrides.byline ?? 'By: Field Unit 27-B/6',
+  body: overrides.body ?? 'Agents report unusual spikes across the grid.',
+  imagePrompt: overrides.imagePrompt,
+});
+
+const createBank = (articles: CardArticle[]): ArticleBank => ({
+  articles,
+  byId: new Map(articles.map(article => [article.id, article])),
+});
+
+const createCard = (overrides: Partial<StoryCardLike> & Pick<StoryCardLike, 'id'>): StoryCardLike => ({
+  id: overrides.id,
+  name: overrides.name ?? overrides.id,
+  faction: overrides.faction ?? 'truth',
+  tags: overrides.tags ?? [],
+});
+
+describe('generateMainStory', () => {
+  test('normalizes tone based on faction input', () => {
+    const truthCard = createCard({ id: 'truth-1', faction: 'Truth Coalition' });
+    const truthArticle = createArticle({ id: 'truth-1' });
+    const truthResult = generateMainStory({ bank: createBank([truthArticle]), cards: [truthCard], activeFaction: 'Truth Coalition' });
+
+    expect(truthResult.article.tone).toBe('truth');
+    expect(truthResult.debug.fallback).toBe(false);
+
+    const govCard = createCard({ id: 'gov-1', faction: 'GOV OPS' });
+    const govArticle = createArticle({ id: 'gov-1', tone: 'government', headline: 'DIRECTORATE RETAINS CONTROL' });
+    const govResult = generateMainStory({ bank: createBank([govArticle]), cards: [govCard], activeFaction: 'Gov Directorate' });
+
+    expect(govResult.article.tone).toBe('government');
+    expect(govResult.debug.fallback).toBe(false);
+  });
+
+  test('surfaces shared tags across cards in fallback stories', () => {
+    const cards = [
+      createCard({ id: 'alpha', name: 'Alpha Agent', tags: ['Mystery Signal', '#Network'] }),
+      createCard({ id: 'beta', name: 'Beta Analyst', tags: ['mystery signal', 'Countermeasure'] }),
+    ];
+
+    const result = generateMainStory({ bank: createBank([]), cards, activeFaction: 'Truth' });
+
+    expect(result.debug.fallback).toBe(true);
+    expect(result.debug.commonTags).toContain('#MysterySignal');
+    expect(result.article.tags).toContain('#MysterySignal');
+  });
+
+  test('builds a mythic fallback article when no cards provide headlines', () => {
+    const result = generateMainStory({ bank: createBank([]), cards: [], activeFaction: undefined });
+
+    expect(result.debug.fallback).toBe(true);
+    expect(result.debug.templateId).not.toBeNull();
+    expect(result.article.id).toMatch(/^generated-truth-/);
+    expect(result.article.headline).toBe(result.article.headline.toUpperCase());
+  });
+
+  test('produces deterministic output for identical inputs', () => {
+    const cards = [
+      createCard({ id: 'alpha', faction: 'truth', tags: ['Signal'] }),
+      createCard({ id: 'beta', faction: 'truth', tags: ['Counter'] }),
+    ];
+    const articles = [createArticle({ id: 'alpha', headline: 'ALPHA FIELD REPORT' })];
+    const bank = createBank(articles);
+
+    const first = generateMainStory({ bank, cards, activeFaction: 'truth' });
+    const second = generateMainStory({ bank, cards, activeFaction: 'truth' });
+
+    expect(second).toEqual(first);
+  });
+
+  test('falls back when referenced card articles are missing', () => {
+    const cards = [createCard({ id: 'missing', faction: 'gov force', tags: ['Containment'] })];
+
+    const result = generateMainStory({ bank: createBank([]), cards, activeFaction: 'gov force' });
+
+    expect(result.debug.fallback).toBe(true);
+    expect(result.article.tone).toBe('government');
+    expect(result.article.tags).toEqual(expect.arrayContaining(['#NarrativeContainment', '#OfficialChannel']));
+    expect(result.article.byline).toMatch(/By:/);
+  });
+});


### PR DESCRIPTION
## Summary
- inject a configurable loader into the article bank so the cache can be reset under test
- add focused tests for articleBank, mainStory, and the newspaper front page rendering
- configure Bun test coverage thresholds to track the new news modules

## Testing
- npm run lint *(fails: repository has pre-existing lint errors)*
- bun test --coverage --coverage-reporter=text

------
https://chatgpt.com/codex/tasks/task_e_68e0c174a27483208c7f040e9d94fd37