### PR TITLE
Add automated card tagging tooling and apply tags

### DIFF
--- a/__tests__/tagCards.test.ts
+++ b/__tests__/tagCards.test.ts
@@ -1,0 +1,101 @@
+import { processCard } from '../scripts/tagCards';
+
+describe('tagCards processCard', () => {
+  it('ensures faction and type tags are present for Truth Attack cards', () => {
+    const result = processCard('core_truth_MVP_balanced.json', {
+      name: 'Test Assault',
+      type: 'ATTACK',
+      faction: 'TRUTH',
+      power: 5,
+    });
+
+    expect(result.tags).toEqual(expect.arrayContaining(['attack', 'truth']));
+  });
+
+  it('adds expansion tags for cryptid cards', () => {
+    const result = processCard('cryptids.json', {
+      name: 'Forest Watch',
+      type: 'ZONE',
+      faction: 'TRUTH',
+    });
+
+    expect(result.tags).toEqual(expect.arrayContaining(['cryptid', 'truth', 'zone']));
+  });
+
+  it('applies cryptid rally heuristics', () => {
+    const result = processCard('cryptids.json', {
+      name: 'Bigfoot Plaza Rally',
+      type: 'ZONE',
+      faction: 'TRUTH',
+    });
+
+    expect(result.tags).toEqual(
+      expect.arrayContaining(['bigfoot', 'cryptid', 'location', 'protest', 'truth', 'zone'])
+    );
+  });
+
+  it('tags Elvis media appropriately', () => {
+    const result = processCard('core_truth_MVP_balanced.json', {
+      name: 'Elvis Broadcast',
+      type: 'MEDIA',
+      faction: 'TRUTH',
+    });
+
+    expect(result.tags).toEqual(expect.arrayContaining(['elvis', 'media', 'truth']));
+  });
+
+  it('tags Area 51 Hangar as a location', () => {
+    const result = processCard('core_government_MVP_balanced.json', {
+      name: 'Area 51 Hangar',
+      type: 'ZONE',
+      faction: 'GOV',
+    });
+
+    expect(result.tags).toEqual(expect.arrayContaining(['area51', 'government', 'location', 'zone']));
+  });
+
+  it('tags Haunted Lighthouse as haunted location', () => {
+    const result = processCard('halloween_spooktacular_with_temp_image.json', {
+      name: 'Haunted Lighthouse',
+      type: 'ZONE',
+      faction: 'TRUTH',
+    });
+
+    expect(result.tags).toEqual(
+      expect.arrayContaining(['ghost', 'haunted', 'halloween', 'location', 'truth', 'zone'])
+    );
+  });
+
+  it('is idempotent when run multiple times', () => {
+    const card = {
+      name: 'Elvis Broadcast',
+      type: 'MEDIA' as const,
+      faction: 'TRUTH' as const,
+    };
+
+    const once = processCard('core_truth_MVP_balanced.json', card);
+    const twice = processCard('core_truth_MVP_balanced.json', once);
+
+    expect(twice.tags).toEqual(once.tags);
+  });
+
+  it('does not mutate unrelated fields', () => {
+    const card = {
+      id: 'card-123',
+      name: 'Control Report',
+      type: 'MEDIA' as const,
+      faction: 'GOV' as const,
+      flavor: 'Stay vigilant.',
+    };
+
+    const result = processCard('core_government_MVP_balanced.json', card);
+
+    expect(result).toMatchObject({
+      id: 'card-123',
+      name: 'Control Report',
+      flavor: 'Stay vigilant.',
+    });
+    expect(result.tags).toEqual(expect.arrayContaining(['bureaucracy', 'coverup', 'government', 'media']));
+  });
+});
+

--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -1,0 +1,14 @@
+/** @type {import('jest').Config} */
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  testMatch: ['**/__tests__/**/*.test.ts'],
+  testPathIgnorePatterns: ['/node_modules/', '<rootDir>/src/'],
+  transform: {
+    '^.+\\.(ts|tsx)$': ['ts-jest', { tsconfig: 'tsconfig.jest.json' }],
+  },
+  moduleNameMapper: {
+    '^(\\.{1,2}/.*)\\.js$': '$1',
+  },
+};
+

--- a/package-lock.json
+++ b/package-lock.json
@@ -68,6 +68,7 @@
         "@eslint/js": "^9.32.0",
         "@tailwindcss/typography": "^0.5.16",
         "@testing-library/react": "^16.3.0",
+        "@types/jest": "^29.5.12",
         "@types/node": "^22.16.5",
         "@types/react": "^18.3.23",
         "@types/react-dom": "^18.3.7",
@@ -78,12 +79,15 @@
         "eslint-plugin-react-refresh": "^0.4.20",
         "globals": "^15.15.0",
         "happy-dom": "^19.0.2",
+        "jest": "^29.7.0",
         "jsdom": "^27.0.0",
         "lovable-tagger": "^1.1.9",
         "postcss": "^8.5.6",
         "react-test-renderer": "^18.3.1",
         "tailwindcss": "^3.4.17",
+        "ts-jest": "^29.3.4",
         "ts-node": "^10.9.2",
+        "tsx": "^4.19.2",
         "typescript": "^5.8.3",
         "typescript-eslint": "^8.38.0",
         "vite": "^5.4.19"
@@ -162,7 +166,6 @@
       "integrity": "sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/helper-validator-identifier": "^7.27.1",
         "js-tokens": "^4.0.0",
@@ -172,10 +175,167 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@babel/compat-data": {
+      "version": "7.28.4",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.28.4.tgz",
+      "integrity": "sha512-YsmSKC29MJwf0gF8Rjjrg5LQCmyh+j/nD8/eP7f+BeoQTKYqs9RoWbjGOdy0+1Ekr68RJZMUOPVQaQisnIo4Rw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/core": {
+      "version": "7.28.4",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.28.4.tgz",
+      "integrity": "sha512-2BCOP7TN8M+gVDj7/ht3hsaO/B/n5oDbiAyyvnRlNOs+u1o+JWNYTQrmpuNp1/Wq2gcFrI01JAW+paEKDMx/CA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.27.1",
+        "@babel/generator": "^7.28.3",
+        "@babel/helper-compilation-targets": "^7.27.2",
+        "@babel/helper-module-transforms": "^7.28.3",
+        "@babel/helpers": "^7.28.4",
+        "@babel/parser": "^7.28.4",
+        "@babel/template": "^7.27.2",
+        "@babel/traverse": "^7.28.4",
+        "@babel/types": "^7.28.4",
+        "@jridgewell/remapping": "^2.3.5",
+        "convert-source-map": "^2.0.0",
+        "debug": "^4.1.0",
+        "gensync": "^1.0.0-beta.2",
+        "json5": "^2.2.3",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/babel"
+      }
+    },
+    "node_modules/@babel/core/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/@babel/generator": {
+      "version": "7.28.3",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.28.3.tgz",
+      "integrity": "sha512-3lSpxGgvnmZznmBkCRnVREPUFJv2wrv9iAoFDvADJc0ypmdOxdUtcLeBgBJ6zE0PMeTKnxeQzyk0xTBq4Ep7zw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.28.3",
+        "@babel/types": "^7.28.2",
+        "@jridgewell/gen-mapping": "^0.3.12",
+        "@jridgewell/trace-mapping": "^0.3.28",
+        "jsesc": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets": {
+      "version": "7.27.2",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.27.2.tgz",
+      "integrity": "sha512-2+1thGUUWWjLTYTHZWK1n8Yga0ijBz1XAhUXcKy81rd5g6yh7hGqMp45v7cadSbEHc9G3OTv45SyneRN3ps4DQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/compat-data": "^7.27.2",
+        "@babel/helper-validator-option": "^7.27.1",
+        "browserslist": "^4.24.0",
+        "lru-cache": "^5.1.1",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets/node_modules/lru-cache": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/@babel/helper-globals": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.28.0.tgz",
+      "integrity": "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-imports": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.27.1.tgz",
+      "integrity": "sha512-0gSFWUPNXNopqtIPQvlD5WgXYI5GY2kP2cCvoT8kczjbfcfuIljTbcWrulD1CIPIX2gt1wghbDy08yE1p+/r3w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/traverse": "^7.27.1",
+        "@babel/types": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-transforms": {
+      "version": "7.28.3",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.28.3.tgz",
+      "integrity": "sha512-gytXUbs8k2sXS9PnQptz5o0QnpLL51SwASIORY6XaBKF88nsOT0Zw9szLqlSGQDP/4TljBAD5y98p2U1fqkdsw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-module-imports": "^7.27.1",
+        "@babel/helper-validator-identifier": "^7.27.1",
+        "@babel/traverse": "^7.28.3"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/helper-plugin-utils": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.27.1.tgz",
+      "integrity": "sha512-1gn1Up5YXka3YYAHGKpbideQ5Yjf1tDa9qYcgysz+cNCXukyLl6DjPXhD3VRwSb8c0J9tA4b2+rHEZtc6R0tlw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
     "node_modules/@babel/helper-string-parser": {
-      "version": "7.25.9",
-      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.25.9.tgz",
-      "integrity": "sha512-4A/SCr/2KLd5jrtOMFzaKjVtAei3+2r/NChoBNoZ3EyP/+GlhoaEGoWOZUmFmoITP7zOJyHIMm+DYRd8o3PvHA==",
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
+      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -192,20 +352,283 @@
         "node": ">=6.9.0"
       }
     },
-    "node_modules/@babel/parser": {
-      "version": "7.25.9",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.25.9.tgz",
-      "integrity": "sha512-aI3jjAAO1fh7vY/pBGsn1i9LDbRP43+asrRlkPuTXW5yHXtd1NgTEMudbBoDDxrf1daEEfPJqR+JBMakzrR4Dg==",
+    "node_modules/@babel/helper-validator-option": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.27.1.tgz",
+      "integrity": "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helpers": {
+      "version": "7.28.4",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.28.4.tgz",
+      "integrity": "sha512-HFN59MmQXGHVyYadKLVumYsA9dBFun/ldYxipEjzA4196jpLZd8UjEEBLkbEkvfYreDqJhZxYAWFPtrfhNpj4w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.25.9"
+        "@babel/template": "^7.27.2",
+        "@babel/types": "^7.28.4"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.28.4",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.28.4.tgz",
+      "integrity": "sha512-yZbBqeM6TkpP9du/I2pUZnJsRMGGvOuIrhjzC1AwHwW+6he4mni6Bp/m8ijn0iOuZuPI2BfkCoSRunpyjnrQKg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.28.4"
       },
       "bin": {
         "parser": "bin/babel-parser.js"
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-async-generators": {
+      "version": "7.8.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-async-generators/-/plugin-syntax-async-generators-7.8.4.tgz",
+      "integrity": "sha512-tycmZxkGfZaxhMRbXlPXuVFpdWlXpir2W4AMhSJgRKzk/eDlIXOhb2LHWoLpDF7TEHylV5zNhykX6KAgHJmTNw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-bigint": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-bigint/-/plugin-syntax-bigint-7.8.3.tgz",
+      "integrity": "sha512-wnTnFlG+YxQm3vDxpGE57Pj0srRU4sHE/mDkt1qv2YJJSeUAec2ma4WLUnUPeKjyrfntVwe/N6dCXpU+zL3Npg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-class-properties": {
+      "version": "7.12.13",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-class-properties/-/plugin-syntax-class-properties-7.12.13.tgz",
+      "integrity": "sha512-fm4idjKla0YahUNgFNLCB0qySdsoPiZP3iQE3rky0mBUtMZ23yDJ9SJdg6dXTSDnulOVqiF3Hgr9nbXvXTQZYA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.12.13"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-class-static-block": {
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-class-static-block/-/plugin-syntax-class-static-block-7.14.5.tgz",
+      "integrity": "sha512-b+YyPmr6ldyNnM6sqYeMWE+bgJcJpO6yS4QD7ymxgH34GBPNDM/THBh8iunyvKIZztiwLH4CJZ0RxTk9emgpjw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.14.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-import-attributes": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-attributes/-/plugin-syntax-import-attributes-7.27.1.tgz",
+      "integrity": "sha512-oFT0FrKHgF53f4vOsZGi2Hh3I35PfSmVs4IBFLFj4dnafP+hIWDLg3VyKmUHfLoLHlyxY4C7DGtmHuJgn+IGww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-import-meta": {
+      "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-meta/-/plugin-syntax-import-meta-7.10.4.tgz",
+      "integrity": "sha512-Yqfm+XDx0+Prh3VSeEQCPU81yC+JWZ2pDPFSS4ZdpfZhp4MkFMaDC1UqseovEKwSUpnIL7+vK+Clp7bfh0iD7g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.10.4"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-json-strings": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-json-strings/-/plugin-syntax-json-strings-7.8.3.tgz",
+      "integrity": "sha512-lY6kdGpWHvjoe2vk4WrAapEuBR69EMxZl+RoGRhrFGNYVK8mOPAW8VfbT/ZgrFbXlDNiiaxQnAtgVCZ6jv30EA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-jsx": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.27.1.tgz",
+      "integrity": "sha512-y8YTNIeKoyhGd9O0Jiyzyyqk8gdjnumGTQPsz0xOZOQ2RmkVJeZ1vmmfIvFEKqucBG6axJGBZDE/7iI5suUI/w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-logical-assignment-operators": {
+      "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-logical-assignment-operators/-/plugin-syntax-logical-assignment-operators-7.10.4.tgz",
+      "integrity": "sha512-d8waShlpFDinQ5MtvGU9xDAOzKH47+FFoney2baFIoMr952hKOLp1HR7VszoZvOsV/4+RRszNY7D17ba0te0ig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.10.4"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-nullish-coalescing-operator": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-nullish-coalescing-operator/-/plugin-syntax-nullish-coalescing-operator-7.8.3.tgz",
+      "integrity": "sha512-aSff4zPII1u2QD7y+F8oDsz19ew4IGEJg9SVW+bqwpwtfFleiQDMdzA/R+UlWDzfnHFCxxleFT0PMIrR36XLNQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-numeric-separator": {
+      "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-numeric-separator/-/plugin-syntax-numeric-separator-7.10.4.tgz",
+      "integrity": "sha512-9H6YdfkcK/uOnY/K7/aA2xpzaAgkQn37yzWUMRK7OaPOqOpGS1+n0H5hxT9AUw9EsSjPW8SVyMJwYRtWs3X3ug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.10.4"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-object-rest-spread": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-object-rest-spread/-/plugin-syntax-object-rest-spread-7.8.3.tgz",
+      "integrity": "sha512-XoqMijGZb9y3y2XskN+P1wUGiVwWZ5JmoDRwx5+3GmEplNyVM2s2Dg8ILFQm8rWM48orGy5YpI5Bl8U1y7ydlA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-optional-catch-binding": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-optional-catch-binding/-/plugin-syntax-optional-catch-binding-7.8.3.tgz",
+      "integrity": "sha512-6VPD0Pc1lpTqw0aKoeRTMiB+kWhAoT24PA+ksWSBrFtl5SIRVpZlwN3NNPQjehA2E/91FV3RjLWoVTglWcSV3Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-optional-chaining": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-optional-chaining/-/plugin-syntax-optional-chaining-7.8.3.tgz",
+      "integrity": "sha512-KoK9ErH1MBlCPxV0VANkXW2/dw4vlbGDrFgz8bmUsBGYkFRcbRwMh6cIJubdPrkxRwuGdtCk0v/wPTKbQgBjkg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-private-property-in-object": {
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-private-property-in-object/-/plugin-syntax-private-property-in-object-7.14.5.tgz",
+      "integrity": "sha512-0wVnp9dxJ72ZUJDV27ZfbSj6iHLoytYZmh3rFcxNnvsJF3ktkzLDZPy/mA17HGsaQT3/DQsWYX1f1QGWkCoVUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.14.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-top-level-await": {
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-top-level-await/-/plugin-syntax-top-level-await-7.14.5.tgz",
+      "integrity": "sha512-hx++upLv5U1rgYfwe1xBQUhRmU41NEvpUvrp8jkrSCdvGSnM5/qdRMtylJ6PG5OFkBaHkbTAKTnd3/YyESRHFw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.14.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-typescript": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.27.1.tgz",
+      "integrity": "sha512-xfYCBMxveHrRMnAWl1ZlPXOZjzkN82THFvLhQhFXFt81Z5HnN+EtUkZhv/zcKpmT3fzmWZB0ywiBrbC3vogbwQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/runtime": {
@@ -217,19 +640,60 @@
         "node": ">=6.9.0"
       }
     },
-    "node_modules/@babel/types": {
-      "version": "7.25.9",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.25.9.tgz",
-      "integrity": "sha512-OwS2CM5KocvQ/k7dFJa8i5bNGJP0hXWfVCfDkqRFP1IreH1JDC7wG6eCYCi0+McbfT8OR/kNqsI0UU0xP9H6PQ==",
+    "node_modules/@babel/template": {
+      "version": "7.27.2",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.27.2.tgz",
+      "integrity": "sha512-LPDZ85aEJyYSd18/DkjNh4/y1ntkE5KwUHWTiqgRxruuZL2F1yuHligVHLvcHY2vMHXttKFpJn6LwfI7cw7ODw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-string-parser": "^7.25.9",
-        "@babel/helper-validator-identifier": "^7.25.9"
+        "@babel/code-frame": "^7.27.1",
+        "@babel/parser": "^7.27.2",
+        "@babel/types": "^7.27.1"
       },
       "engines": {
         "node": ">=6.9.0"
       }
+    },
+    "node_modules/@babel/traverse": {
+      "version": "7.28.4",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.28.4.tgz",
+      "integrity": "sha512-YEzuboP2qvQavAcjgQNVgsvHIDv6ZpwXvcvjmyySP2DIMuByS/6ioU5G9pYrWHM6T2YDfc7xga9iNzYOs12CFQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.27.1",
+        "@babel/generator": "^7.28.3",
+        "@babel/helper-globals": "^7.28.0",
+        "@babel/parser": "^7.28.4",
+        "@babel/template": "^7.27.2",
+        "@babel/types": "^7.28.4",
+        "debug": "^4.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.28.4",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.28.4.tgz",
+      "integrity": "sha512-bkFqkLhh3pMBUQQkpVgWDWq/lqzc2678eUyDlTBhRqhCHFguYYGM0Efga7tYk4TogG/3x0EEl66/OQ+WGbWB/Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.27.1",
+        "@babel/helper-validator-identifier": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bcoe/v8-coverage": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz",
+      "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@cspotcode/source-map-support": {
       "version": "0.8.1",
@@ -750,6 +1214,23 @@
         "node": ">=12"
       }
     },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.10.tgz",
+      "integrity": "sha512-AVTSBhTX8Y/Fz6OmIVBip9tJzZEUcY8WLh7I59+upa5/GPhh2/aM6bvOMQySspnCCHvFi79kMtdJS1w0DXAeag==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@esbuild/sunos-x64": {
       "version": "0.21.5",
       "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
@@ -1102,33 +1583,536 @@
         "node": ">=12"
       }
     },
-    "node_modules/@jridgewell/gen-mapping": {
-      "version": "0.3.5",
-      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.5.tgz",
-      "integrity": "sha512-IzL8ZoEDIBRWEzlCcRhOaCupYyN5gdIK+Q6fbFdPDg6HqX6jpkItn7DFIpW9LQzXG6Df9sA7+OKnq0qlz/GaQg==",
-      "license": "MIT",
+    "node_modules/@istanbuljs/load-nyc-config": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@istanbuljs/load-nyc-config/-/load-nyc-config-1.1.0.tgz",
+      "integrity": "sha512-VjeHSlIzpv/NyD3N0YuHfXOPDIixcA1q2ZV98wsMqcYlPmv2n3Yb2lYP9XMElnaFVXg5A7YLTeLu6V84uQDjmQ==",
+      "dev": true,
+      "license": "ISC",
       "dependencies": {
-        "@jridgewell/set-array": "^1.2.1",
-        "@jridgewell/sourcemap-codec": "^1.4.10",
-        "@jridgewell/trace-mapping": "^0.3.24"
+        "camelcase": "^5.3.1",
+        "find-up": "^4.1.0",
+        "get-package-type": "^0.1.0",
+        "js-yaml": "^3.13.1",
+        "resolve-from": "^5.0.0"
       },
       "engines": {
-        "node": ">=6.0.0"
+        "node": ">=8"
+      }
+    },
+    "node_modules/@istanbuljs/load-nyc-config/node_modules/argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "sprintf-js": "~1.0.2"
+      }
+    },
+    "node_modules/@istanbuljs/load-nyc-config/node_modules/find-up": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+      "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^5.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@istanbuljs/load-nyc-config/node_modules/js-yaml": {
+      "version": "3.14.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
+      "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/@istanbuljs/load-nyc-config/node_modules/locate-path": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+      "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@istanbuljs/load-nyc-config/node_modules/p-limit": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-try": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@istanbuljs/load-nyc-config/node_modules/p-locate": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+      "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@istanbuljs/load-nyc-config/node_modules/resolve-from": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
+      "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@istanbuljs/schema": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.3.tgz",
+      "integrity": "sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@jest/console": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/console/-/console-29.7.0.tgz",
+      "integrity": "sha512-5Ni4CU7XHQi32IJ398EEP4RrB8eV09sXP2ROqD4bksHrnTree52PsxvX8tpL8LvTZ3pFzXyPbNQReSN41CAhOg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "^29.6.3",
+        "@types/node": "*",
+        "chalk": "^4.0.0",
+        "jest-message-util": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "slash": "^3.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jest/core": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/core/-/core-29.7.0.tgz",
+      "integrity": "sha512-n7aeXWKMnGtDA48y8TLWJPJmLmmZ642Ceo78cYWEpiD7FzDgmNDV/GCVRorPABdXLJZ/9wzzgZAlHjXjxDHGsg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/console": "^29.7.0",
+        "@jest/reporters": "^29.7.0",
+        "@jest/test-result": "^29.7.0",
+        "@jest/transform": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "@types/node": "*",
+        "ansi-escapes": "^4.2.1",
+        "chalk": "^4.0.0",
+        "ci-info": "^3.2.0",
+        "exit": "^0.1.2",
+        "graceful-fs": "^4.2.9",
+        "jest-changed-files": "^29.7.0",
+        "jest-config": "^29.7.0",
+        "jest-haste-map": "^29.7.0",
+        "jest-message-util": "^29.7.0",
+        "jest-regex-util": "^29.6.3",
+        "jest-resolve": "^29.7.0",
+        "jest-resolve-dependencies": "^29.7.0",
+        "jest-runner": "^29.7.0",
+        "jest-runtime": "^29.7.0",
+        "jest-snapshot": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "jest-validate": "^29.7.0",
+        "jest-watcher": "^29.7.0",
+        "micromatch": "^4.0.4",
+        "pretty-format": "^29.7.0",
+        "slash": "^3.0.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      },
+      "peerDependencies": {
+        "node-notifier": "^8.0.1 || ^9.0.0 || ^10.0.0"
+      },
+      "peerDependenciesMeta": {
+        "node-notifier": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@jest/core/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@jest/core/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@jest/core/node_modules/pretty-format": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
+      "integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/schemas": "^29.6.3",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^18.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jest/core/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@jest/environment": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-29.7.0.tgz",
+      "integrity": "sha512-aQIfHDq33ExsN4jP1NWGXhxgQ/wixs60gDiKO+XVMd8Mn0NWPWgc34ZQDTb2jKaUWQ7MuwoitXAsN2XVXNMpAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/fake-timers": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "@types/node": "*",
+        "jest-mock": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jest/expect": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/expect/-/expect-29.7.0.tgz",
+      "integrity": "sha512-8uMeAMycttpva3P1lBHB8VciS9V0XAr3GymPpipdyQXbBcuhkLQOSe8E/p92RyAdToS6ZD1tFkX+CkhoECE0dQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "expect": "^29.7.0",
+        "jest-snapshot": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jest/expect-utils": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/expect-utils/-/expect-utils-29.7.0.tgz",
+      "integrity": "sha512-GlsNBWiFQFCVi9QVSx7f5AgMeLxe9YCCs5PuP2O2LdjDAA8Jh9eX7lA1Jq/xdXw3Wb3hyvlFNfZIfcRetSzYcA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "jest-get-type": "^29.6.3"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jest/fake-timers": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-29.7.0.tgz",
+      "integrity": "sha512-q4DH1Ha4TTFPdxLsqDXK1d3+ioSL7yL5oCMJZgDYm6i+6CygW5E5xVr/D1HdsGxjt1ZWSfUAs9OxSB/BNelWrQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "^29.6.3",
+        "@sinonjs/fake-timers": "^10.0.2",
+        "@types/node": "*",
+        "jest-message-util": "^29.7.0",
+        "jest-mock": "^29.7.0",
+        "jest-util": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jest/globals": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/globals/-/globals-29.7.0.tgz",
+      "integrity": "sha512-mpiz3dutLbkW2MNFubUGUEVLkTGiqW6yLVTA+JbP6fI6J5iL9Y0Nlg8k95pcF8ctKwCS7WVxteBs29hhfAotzQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/environment": "^29.7.0",
+        "@jest/expect": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "jest-mock": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jest/reporters": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/reporters/-/reporters-29.7.0.tgz",
+      "integrity": "sha512-DApq0KJbJOEzAFYjHADNNxAE3KbhxQB1y5Kplb5Waqw6zVbuWatSnMjE5gs8FUgEPmNsnZA3NCWl9NG0ia04Pg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@bcoe/v8-coverage": "^0.2.3",
+        "@jest/console": "^29.7.0",
+        "@jest/test-result": "^29.7.0",
+        "@jest/transform": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "@jridgewell/trace-mapping": "^0.3.18",
+        "@types/node": "*",
+        "chalk": "^4.0.0",
+        "collect-v8-coverage": "^1.0.0",
+        "exit": "^0.1.2",
+        "glob": "^7.1.3",
+        "graceful-fs": "^4.2.9",
+        "istanbul-lib-coverage": "^3.0.0",
+        "istanbul-lib-instrument": "^6.0.0",
+        "istanbul-lib-report": "^3.0.0",
+        "istanbul-lib-source-maps": "^4.0.0",
+        "istanbul-reports": "^3.1.3",
+        "jest-message-util": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "jest-worker": "^29.7.0",
+        "slash": "^3.0.0",
+        "string-length": "^4.0.1",
+        "strip-ansi": "^6.0.0",
+        "v8-to-istanbul": "^9.0.1"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      },
+      "peerDependencies": {
+        "node-notifier": "^8.0.1 || ^9.0.0 || ^10.0.0"
+      },
+      "peerDependenciesMeta": {
+        "node-notifier": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@jest/reporters/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@jest/reporters/node_modules/glob": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "deprecated": "Glob versions prior to v9 are no longer supported",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@jest/reporters/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@jest/schemas": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.6.3.tgz",
+      "integrity": "sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sinclair/typebox": "^0.27.8"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jest/source-map": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/@jest/source-map/-/source-map-29.6.3.tgz",
+      "integrity": "sha512-MHjT95QuipcPrpLM+8JMSzFx6eHp5Bm+4XeFDJlwsvVBjmKNiIAvasGK2fxz2WbGRlnvqehFbh07MMa7n3YJnw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.18",
+        "callsites": "^3.0.0",
+        "graceful-fs": "^4.2.9"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jest/test-result": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-29.7.0.tgz",
+      "integrity": "sha512-Fdx+tv6x1zlkJPcWXmMDAG2HBnaR9XPSd5aDWQVsfrZmLVT3lU1cwyxLgRmXR9yrq4NBoEm9BMsfgFzTQAbJYA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/console": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "@types/istanbul-lib-coverage": "^2.0.0",
+        "collect-v8-coverage": "^1.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jest/test-sequencer": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/test-sequencer/-/test-sequencer-29.7.0.tgz",
+      "integrity": "sha512-GQwJ5WZVrKnOJuiYiAF52UNUJXgTZx1NHjFSEB0qEMmSZKAkdMoIzw/Cj6x6NF4AvV23AUqDpFzQkN/eYCYTxw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/test-result": "^29.7.0",
+        "graceful-fs": "^4.2.9",
+        "jest-haste-map": "^29.7.0",
+        "slash": "^3.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jest/transform": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/transform/-/transform-29.7.0.tgz",
+      "integrity": "sha512-ok/BTPFzFKVMwO5eOHRrvnBVHdRy9IrsrW1GpMaQ9MCnilNLXQKmAX8s1YXDFaai9xJpac2ySzV0YeRRECr2Vw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.11.6",
+        "@jest/types": "^29.6.3",
+        "@jridgewell/trace-mapping": "^0.3.18",
+        "babel-plugin-istanbul": "^6.1.1",
+        "chalk": "^4.0.0",
+        "convert-source-map": "^2.0.0",
+        "fast-json-stable-stringify": "^2.1.0",
+        "graceful-fs": "^4.2.9",
+        "jest-haste-map": "^29.7.0",
+        "jest-regex-util": "^29.6.3",
+        "jest-util": "^29.7.0",
+        "micromatch": "^4.0.4",
+        "pirates": "^4.0.4",
+        "slash": "^3.0.0",
+        "write-file-atomic": "^4.0.2"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jest/types": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/@jest/types/-/types-29.6.3.tgz",
+      "integrity": "sha512-u3UPsIilWKOM3F9CXtrG8LEJmNxwoCQC/XVj4IKYXvvpx7QIi/Kg1LI5uDmDpKlac62NUtX7eLjRh+jVZcLOzw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/schemas": "^29.6.3",
+        "@types/istanbul-lib-coverage": "^2.0.0",
+        "@types/istanbul-reports": "^3.0.0",
+        "@types/node": "*",
+        "@types/yargs": "^17.0.8",
+        "chalk": "^4.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/remapping": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
+      "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
       }
     },
     "node_modules/@jridgewell/resolve-uri": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
       "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6.0.0"
-      }
-    },
-    "node_modules/@jridgewell/set-array": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.2.1.tgz",
-      "integrity": "sha512-R8gLRTZeyp03ymzP/6Lil/28tGeGEzhx1q2k703KGWRAI1VdvPIXdG70VJc2pAMw3NA6JKL5hhFu1sJX0Mnn/A==",
       "license": "MIT",
       "engines": {
         "node": ">=6.0.0"
@@ -1141,9 +2125,9 @@
       "license": "MIT"
     },
     "node_modules/@jridgewell/trace-mapping": {
-      "version": "0.3.25",
-      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.25.tgz",
-      "integrity": "sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==",
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
       "license": "MIT",
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
@@ -2789,6 +3773,33 @@
         "win32"
       ]
     },
+    "node_modules/@sinclair/typebox": {
+      "version": "0.27.8",
+      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.8.tgz",
+      "integrity": "sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@sinonjs/commons": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-3.0.1.tgz",
+      "integrity": "sha512-K3mCHKQ9sVh8o1C9cxkwxaOmXoAMlDxC1mYyHrjqOWEcBjYr76t96zL2zlj5dUGZ3HSw240X1qgH3Mjf1yJWpQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "type-detect": "4.0.8"
+      }
+    },
+    "node_modules/@sinonjs/fake-timers": {
+      "version": "10.3.0",
+      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-10.3.0.tgz",
+      "integrity": "sha512-V4BG07kuYSUkTCSBHG8G8TNhM+F19jXFWnQtzj+we8DrkpSBCee9Z3Ms8yiGer/dlmhe35/Xdgyo3/0rQKg7YA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@sinonjs/commons": "^3.0.0"
+      }
+    },
     "node_modules/@swc/core": {
       "version": "1.13.2",
       "resolved": "https://registry.npmjs.org/@swc/core/-/core-1.13.2.tgz",
@@ -3155,6 +4166,51 @@
       "license": "MIT",
       "peer": true
     },
+    "node_modules/@types/babel__core": {
+      "version": "7.20.5",
+      "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
+      "integrity": "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.20.7",
+        "@babel/types": "^7.20.7",
+        "@types/babel__generator": "*",
+        "@types/babel__template": "*",
+        "@types/babel__traverse": "*"
+      }
+    },
+    "node_modules/@types/babel__generator": {
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.27.0.tgz",
+      "integrity": "sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/@types/babel__template": {
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.4.4.tgz",
+      "integrity": "sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.1.0",
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/@types/babel__traverse": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.28.0.tgz",
+      "integrity": "sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.28.2"
+      }
+    },
     "node_modules/@types/d3-array": {
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.1.tgz",
@@ -3225,6 +4281,82 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/graceful-fs": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@types/graceful-fs/-/graceful-fs-4.1.9.tgz",
+      "integrity": "sha512-olP3sd1qOEe5dXTSaFvQG+02VdRXcdytWLAZsAq1PecU8uqQAhkrnbli7DagjtXKW/Bl7YJbUsa8MPcuc8LHEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/istanbul-lib-coverage": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.6.tgz",
+      "integrity": "sha512-2QF/t/auWm0lsy8XtKVPG19v3sSOQlJe/YHZgfjb/KBBHOGSV+J2q/S671rcq9uTBrLAXmZpqJiaQbMT+zNU1w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/istanbul-lib-report": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/istanbul-lib-report/-/istanbul-lib-report-3.0.3.tgz",
+      "integrity": "sha512-NQn7AHQnk/RSLOxrBbGyJM/aVQ+pjj5HCgasFxc0K/KhoATfQ/47AyUl15I2yBUpihjmas+a+VJBOqecrFH+uA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/istanbul-lib-coverage": "*"
+      }
+    },
+    "node_modules/@types/istanbul-reports": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.4.tgz",
+      "integrity": "sha512-pk2B1NWalF9toCRu6gjBzR69syFjP4Od8WRAX+0mmf9lAjCRicLOWc+ZrxZHx/0XRjotgkF9t6iaMJ+aXcOdZQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/istanbul-lib-report": "*"
+      }
+    },
+    "node_modules/@types/jest": {
+      "version": "29.5.14",
+      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-29.5.14.tgz",
+      "integrity": "sha512-ZN+4sdnLUbo8EVvVc2ao0GFW6oVrQRPn4K2lglySj7APvSrgzxHiNNK99us4WDMi57xxA2yggblIAMNhXOotLQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "expect": "^29.0.0",
+        "pretty-format": "^29.0.0"
+      }
+    },
+    "node_modules/@types/jest/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@types/jest/node_modules/pretty-format": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
+      "integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/schemas": "^29.6.3",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^18.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
@@ -3270,10 +4402,34 @@
         "@types/react": "^18.0.0"
       }
     },
+    "node_modules/@types/stack-utils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.3.tgz",
+      "integrity": "sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/whatwg-mimetype": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/@types/whatwg-mimetype/-/whatwg-mimetype-3.0.2.tgz",
       "integrity": "sha512-c2AKvDT8ToxLIOUlN51gTiHXflsfIFisS4pO7pDPoKouJCESkhZnEy623gwP9laCy5lnLDAw1vAzu2vM2YLOrA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/yargs": {
+      "version": "17.0.33",
+      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.33.tgz",
+      "integrity": "sha512-WpxBCKWPLr4xSsHgz511rFJAM+wS28w2zEO1QDNY5zM/S8ok70NNfztH0xwhqKyaK0OHCbN98LDAZuy1ctxDkA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/yargs-parser": "*"
+      }
+    },
+    "node_modules/@types/yargs-parser": {
+      "version": "21.0.3",
+      "resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-21.0.3.tgz",
+      "integrity": "sha512-I4q9QU9MQv4oEOz4tAHJtNz1cwuLxn2F3xcc2iV5WdqLPpUnj30aUuxt1mAxYTG+oe8CZMV/+6rU4S4gRDzqtQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -3612,6 +4768,22 @@
         "url": "https://github.com/sponsors/epoberezkin"
       }
     },
+    "node_modules/ansi-escapes": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
+      "integrity": "sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "type-fest": "^0.21.3"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/ansi-regex": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.1.0.tgz",
@@ -3732,6 +4904,132 @@
         "postcss": "^8.1.0"
       }
     },
+    "node_modules/babel-jest": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-29.7.0.tgz",
+      "integrity": "sha512-BrvGY3xZSwEcCzKvKsCi2GgHqDqsYkOP4/by5xCgIwGXQxIEh+8ew3gmrE1y7XRR6LHZIj6yLYnUi/mm2KXKBg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/transform": "^29.7.0",
+        "@types/babel__core": "^7.1.14",
+        "babel-plugin-istanbul": "^6.1.1",
+        "babel-preset-jest": "^29.6.3",
+        "chalk": "^4.0.0",
+        "graceful-fs": "^4.2.9",
+        "slash": "^3.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.8.0"
+      }
+    },
+    "node_modules/babel-plugin-istanbul": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-6.1.1.tgz",
+      "integrity": "sha512-Y1IQok9821cC9onCx5otgFfRm7Lm+I+wwxOx738M/WLPZ9Q42m4IG5W0FNX8WLL2gYMZo3JkuXIH2DOpWM+qwA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.0.0",
+        "@istanbuljs/load-nyc-config": "^1.0.0",
+        "@istanbuljs/schema": "^0.1.2",
+        "istanbul-lib-instrument": "^5.0.4",
+        "test-exclude": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/babel-plugin-istanbul/node_modules/istanbul-lib-instrument": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-5.2.1.tgz",
+      "integrity": "sha512-pzqtp31nLv/XFOzXGuvhCb8qhjmTVo5vjVk19XE4CRlSWz0KoeJ3bw9XsA7nOp9YBf4qHjwBxkDzKcME/J29Yg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@babel/core": "^7.12.3",
+        "@babel/parser": "^7.14.7",
+        "@istanbuljs/schema": "^0.1.2",
+        "istanbul-lib-coverage": "^3.2.0",
+        "semver": "^6.3.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/babel-plugin-istanbul/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/babel-plugin-jest-hoist": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-29.6.3.tgz",
+      "integrity": "sha512-ESAc/RJvGTFEzRwOTT4+lNDk/GNHMkKbNzsvT0qKRfDyyYTskxB5rnU2njIDYVxXCBHHEI1c0YwHob3WaYujOg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/template": "^7.3.3",
+        "@babel/types": "^7.3.3",
+        "@types/babel__core": "^7.1.14",
+        "@types/babel__traverse": "^7.0.6"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/babel-preset-current-node-syntax": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/babel-preset-current-node-syntax/-/babel-preset-current-node-syntax-1.2.0.tgz",
+      "integrity": "sha512-E/VlAEzRrsLEb2+dv8yp3bo4scof3l9nR4lrld+Iy5NyVqgVYUJnDAmunkhPMisRI32Qc4iRiz425d8vM++2fg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/plugin-syntax-async-generators": "^7.8.4",
+        "@babel/plugin-syntax-bigint": "^7.8.3",
+        "@babel/plugin-syntax-class-properties": "^7.12.13",
+        "@babel/plugin-syntax-class-static-block": "^7.14.5",
+        "@babel/plugin-syntax-import-attributes": "^7.24.7",
+        "@babel/plugin-syntax-import-meta": "^7.10.4",
+        "@babel/plugin-syntax-json-strings": "^7.8.3",
+        "@babel/plugin-syntax-logical-assignment-operators": "^7.10.4",
+        "@babel/plugin-syntax-nullish-coalescing-operator": "^7.8.3",
+        "@babel/plugin-syntax-numeric-separator": "^7.10.4",
+        "@babel/plugin-syntax-object-rest-spread": "^7.8.3",
+        "@babel/plugin-syntax-optional-catch-binding": "^7.8.3",
+        "@babel/plugin-syntax-optional-chaining": "^7.8.3",
+        "@babel/plugin-syntax-private-property-in-object": "^7.14.5",
+        "@babel/plugin-syntax-top-level-await": "^7.14.5"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0 || ^8.0.0-0"
+      }
+    },
+    "node_modules/babel-preset-jest": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-29.6.3.tgz",
+      "integrity": "sha512-0B3bhxR6snWXJZtR/RliHTDPRgn1sNHOR0yVtq/IiQFyuOVjFS+wuio/R4gSNkyYmKmJB4wGZv2NZanmKmTnNA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "babel-plugin-jest-hoist": "^29.6.3",
+        "babel-preset-current-node-syntax": "^1.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
@@ -3816,10 +5114,50 @@
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
       }
     },
+    "node_modules/bs-logger": {
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/bs-logger/-/bs-logger-0.2.6.tgz",
+      "integrity": "sha512-pd8DCoxmbgc7hyPKOvxtqNcjYoOsABPQdcCUjGp3d42VR2CX1ORhk2A87oqqu5R1kk+76nsxZupkmyd+MVtCog==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-json-stable-stringify": "2.x"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/bser": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/bser/-/bser-2.1.1.tgz",
+      "integrity": "sha512-gQxTNE/GAfIIrmHLUE3oJyp5FO6HRBfhjnw4/wMmA63ZGDJnWBmgY/lyQBpnDUkGmAhbSe39tx2d/iTOAfglwQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "node-int64": "^0.4.0"
+      }
+    },
+    "node_modules/buffer-from": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
+      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/callsites": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
       "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/camelcase": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+      "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -3873,6 +5211,16 @@
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
+    "node_modules/char-regex": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/char-regex/-/char-regex-1.0.2.tgz",
+      "integrity": "sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/chokidar": {
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
@@ -3909,6 +5257,29 @@
         "node": ">= 6"
       }
     },
+    "node_modules/ci-info": {
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.9.0.tgz",
+      "integrity": "sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/sibiraj-s"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cjs-module-lexer": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.4.3.tgz",
+      "integrity": "sha512-9z8TZaGM1pfswYeXrUpzPrkx8UnWYdhJclsiYMm6x/w5+nN+8Tf/LnAgfLGQCm59qAOxU8WwHEq2vNwF6i4j+Q==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/class-variance-authority": {
       "version": "0.7.1",
       "resolved": "https://registry.npmjs.org/class-variance-authority/-/class-variance-authority-0.7.1.tgz",
@@ -3918,6 +5289,84 @@
       },
       "funding": {
         "url": "https://polar.sh/cva"
+      }
+    },
+    "node_modules/cliui": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/cliui/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cliui/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cliui/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cliui/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cliui/node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
     },
     "node_modules/clsx": {
@@ -3944,6 +5393,24 @@
         "react": "^18 || ^19 || ^19.0.0-rc",
         "react-dom": "^18 || ^19 || ^19.0.0-rc"
       }
+    },
+    "node_modules/co": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
+      "integrity": "sha512-QVb0dM5HvG+uaxitm8wONl7jltx8dqhfU33DcqtOZcLSVIKSDDLDi7+0LbAKiyI8hD9u42m2YxXSkMGWThaecQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "iojs": ">= 1.0.0",
+        "node": ">= 0.12.0"
+      }
+    },
+    "node_modules/collect-v8-coverage": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/collect-v8-coverage/-/collect-v8-coverage-1.0.2.tgz",
+      "integrity": "sha512-lHl4d5/ONEbLlJvaJNtsF/Lz+WvB07u2ycqTYbdrq7UypDXailES4valYb2eWiJFxZlVmpGekfqoxQhzyFdT4Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/color-convert": {
       "version": "2.0.1",
@@ -3978,6 +5445,35 @@
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/create-jest": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/create-jest/-/create-jest-29.7.0.tgz",
+      "integrity": "sha512-Adz2bdH0Vq3F53KEMJOoftQFutWCukm6J24wbPWRO4k1kMY7gS7ds/uoJkNuV8wDCtWWnuwGcJwpWcih+zEW1Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "^29.6.3",
+        "chalk": "^4.0.0",
+        "exit": "^0.1.2",
+        "graceful-fs": "^4.2.9",
+        "jest-config": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "prompts": "^2.0.1"
+      },
+      "bin": {
+        "create-jest": "bin/create-jest.js"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
     },
     "node_modules/create-require": {
       "version": "1.1.1",
@@ -4244,12 +5740,37 @@
       "integrity": "sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==",
       "license": "MIT"
     },
+    "node_modules/dedent": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/dedent/-/dedent-1.7.0.tgz",
+      "integrity": "sha512-HGFtf8yhuhGhqO07SV79tRp+br4MnbdjeVxotpn1QBl30pcLLCQjX5b2295ll0fv8RKDKsmWYrl05usHM9CewQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "babel-plugin-macros": "^3.1.0"
+      },
+      "peerDependenciesMeta": {
+        "babel-plugin-macros": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/deep-is": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/deepmerge": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
+      "integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/dequal": {
       "version": "2.0.3",
@@ -4260,6 +5781,16 @@
       "peer": true,
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/detect-newline": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-3.1.0.tgz",
+      "integrity": "sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/detect-node-es": {
@@ -4282,6 +5813,16 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.3.1"
+      }
+    },
+    "node_modules/diff-sequences": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-29.6.3.tgz",
+      "integrity": "sha512-EjePK1srD3P08o2j4f0ExnylqRs5B9tJjcp9t1krH2qRi8CCdsYfwe9JgSLurFBWwq4uOlipzfk5fHNvwFKr8Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
     "node_modules/dlv": {
@@ -4349,6 +5890,19 @@
         "embla-carousel": "8.6.0"
       }
     },
+    "node_modules/emittery": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/emittery/-/emittery-0.13.1.tgz",
+      "integrity": "sha512-DeWwawk6r5yR9jFgnDKYt4sLS0LmHJJi3ZOnb5/JdbYwj3nW+FxQnHIjhBKz8YLC7oRNPVM9NQ47I3CVx34eqQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/emittery?sponsor=1"
+      }
+    },
     "node_modules/emoji-regex": {
       "version": "9.2.2",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
@@ -4366,6 +5920,16 @@
       },
       "funding": {
         "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/error-ex": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.4.tgz",
+      "integrity": "sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-arrayish": "^0.2.1"
       }
     },
     "node_modules/esbuild": {
@@ -4562,6 +6126,20 @@
         "url": "https://opencollective.com/eslint"
       }
     },
+    "node_modules/esprima": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "bin": {
+        "esparse": "bin/esparse.js",
+        "esvalidate": "bin/esvalidate.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/esquery": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.6.0.tgz",
@@ -4623,6 +6201,63 @@
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
       "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
       "license": "MIT"
+    },
+    "node_modules/execa": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
+      "integrity": "sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cross-spawn": "^7.0.3",
+        "get-stream": "^6.0.0",
+        "human-signals": "^2.1.0",
+        "is-stream": "^2.0.0",
+        "merge-stream": "^2.0.0",
+        "npm-run-path": "^4.0.1",
+        "onetime": "^5.1.2",
+        "signal-exit": "^3.0.3",
+        "strip-final-newline": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/execa?sponsor=1"
+      }
+    },
+    "node_modules/execa/node_modules/signal-exit": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/exit": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
+      "integrity": "sha512-Zk/eNKV2zbjpKzrsQ+n1G6poVbErQxJ0LBOJXaKZ1EViLzH+hrLu9cdXI4zw9dBQJslwBEpbQ2P1oS7nDxs6jQ==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/expect": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/expect/-/expect-29.7.0.tgz",
+      "integrity": "sha512-2Zks0hf1VLFYI1kbh0I5jP3KHHyCHpkfyHBzsSXRFgl/Bg9mWYfMW8oD+PdMPlEwy5HNsR9JutYy6pMeOh61nw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/expect-utils": "^29.7.0",
+        "jest-get-type": "^29.6.3",
+        "jest-matcher-utils": "^29.7.0",
+        "jest-message-util": "^29.7.0",
+        "jest-util": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
@@ -4689,6 +6324,16 @@
       "license": "ISC",
       "dependencies": {
         "reusify": "^1.0.4"
+      }
+    },
+    "node_modules/fb-watchman": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/fb-watchman/-/fb-watchman-2.0.2.tgz",
+      "integrity": "sha512-p5161BqbuCaSnB8jIbzQHOlpgsPmK5rJVDfDKO91Axs5NC1uu3HRQm6wt9cd9/+GtQQIO53JdGXXoyDpTAsgYA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bser": "2.1.1"
       }
     },
     "node_modules/file-entry-cache": {
@@ -4811,6 +6456,13 @@
         }
       }
     },
+    "node_modules/fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -4834,6 +6486,26 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/gensync": {
+      "version": "1.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
+      "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
     "node_modules/get-nonce": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/get-nonce/-/get-nonce-1.0.1.tgz",
@@ -4841,6 +6513,42 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/get-package-type": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/get-package-type/-/get-package-type-0.1.0.tgz",
+      "integrity": "sha512-pjzuKtY64GYfWizNAJ0fr9VqttZkNiK2iS430LtIHzjBEr6bX8Am2zm4sW4Ro5wjWW5cAlRL1qAMTcXbjNAO2Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/get-stream": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
+      "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/get-tsconfig": {
+      "version": "4.10.1",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.10.1.tgz",
+      "integrity": "sha512-auHyJ4AgMz7vgS8Hp3N6HXSmlMdUyhSUrfBF16w153rxtLIEOE+HGqaBppczZvnHLqQJfiHotCYpNhl0lUROFQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "resolve-pkg-maps": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
       }
     },
     "node_modules/glob": {
@@ -4921,12 +6629,41 @@
         "csstype": "^3.0.10"
       }
     },
+    "node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/graphemer": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/graphemer/-/graphemer-1.4.0.tgz",
       "integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/handlebars": {
+      "version": "4.7.8",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.8.tgz",
+      "integrity": "sha512-vafaFqs8MZkRrSX7sFVUdo3ap/eNiLnb4IakshzvP56X5Nr1iGKAIqdX6tMlm6HcNRIkr6AxO5jFEoJzzpT8aQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "minimist": "^1.2.5",
+        "neo-async": "^2.6.2",
+        "source-map": "^0.6.1",
+        "wordwrap": "^1.0.0"
+      },
+      "bin": {
+        "handlebars": "bin/handlebars"
+      },
+      "engines": {
+        "node": ">=0.4.7"
+      },
+      "optionalDependencies": {
+        "uglify-js": "^3.1.4"
+      }
     },
     "node_modules/happy-dom": {
       "version": "19.0.2",
@@ -4988,6 +6725,13 @@
         "node": ">=18"
       }
     },
+    "node_modules/html-escaper": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/http-proxy-agent": {
       "version": "7.0.2",
       "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
@@ -5014,6 +6758,16 @@
       },
       "engines": {
         "node": ">= 14"
+      }
+    },
+    "node_modules/human-signals": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
+      "integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=10.17.0"
       }
     },
     "node_modules/iconv-lite": {
@@ -5056,6 +6810,26 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/import-local": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/import-local/-/import-local-3.2.0.tgz",
+      "integrity": "sha512-2SPlun1JUPWoM6t3F0dw0FkCF/jWY8kttcY4f599GLTSjh2OCuuhdTkJQsEcZzBqbXZGKMK2OqW1oZsjtf/gQA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pkg-dir": "^4.2.0",
+        "resolve-cwd": "^3.0.0"
+      },
+      "bin": {
+        "import-local-fixture": "fixtures/cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/imurmurhash": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
@@ -5065,6 +6839,25 @@
       "engines": {
         "node": ">=0.8.19"
       }
+    },
+    "node_modules/inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
+      "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/input-otp": {
       "version": "1.4.2",
@@ -5084,6 +6877,13 @@
       "engines": {
         "node": ">=12"
       }
+    },
+    "node_modules/is-arrayish": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+      "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/is-binary-path": {
       "version": "2.1.0",
@@ -5130,6 +6930,16 @@
         "node": ">=8"
       }
     },
+    "node_modules/is-generator-fn": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-generator-fn/-/is-generator-fn-2.1.0.tgz",
+      "integrity": "sha512-cTIB4yPYL/Grw0EaSzASzg6bBy9gqCofvWN8okThAYIxKJZC+udlRAmGbM0XLeniEJSs8uEgHPGuHSe1XsOLSQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/is-glob": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
@@ -5158,11 +6968,95 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/is-stream": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+      "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "license": "ISC"
+    },
+    "node_modules/istanbul-lib-coverage": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+      "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-instrument": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-6.0.3.tgz",
+      "integrity": "sha512-Vtgk7L/R2JHyyGW07spoFlB8/lpjiOLTjMdms6AFMraYt3BaJauod/NGrfnVG/y4Ix1JEuMRPDPEj2ua+zz1/Q==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@babel/core": "^7.23.9",
+        "@babel/parser": "^7.23.9",
+        "@istanbuljs/schema": "^0.1.3",
+        "istanbul-lib-coverage": "^3.2.0",
+        "semver": "^7.5.4"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-lib-report": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+      "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "istanbul-lib-coverage": "^3.0.0",
+        "make-dir": "^4.0.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-lib-source-maps": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-4.0.1.tgz",
+      "integrity": "sha512-n3s8EwkdFIJCG3BPKBYvskgXGoy88ARzvegkitk60NxRdwltLOTaH7CUiMRXvwYorl0Q712iEjcWB+fK/MrWVw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "debug": "^4.1.1",
+        "istanbul-lib-coverage": "^3.0.0",
+        "source-map": "^0.6.1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-reports": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
+      "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "html-escaper": "^2.0.0",
+        "istanbul-lib-report": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/jackspeak": {
       "version": "3.4.3",
@@ -5177,6 +7071,885 @@
       },
       "optionalDependencies": {
         "@pkgjs/parseargs": "^0.11.0"
+      }
+    },
+    "node_modules/jest": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest/-/jest-29.7.0.tgz",
+      "integrity": "sha512-NIy3oAFp9shda19hy4HK0HRTWKtPJmGdnvywu01nOqNC2vZg+Z+fvJDxpMQA88eb2I9EcafcdjYgsDthnYTvGw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/core": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "import-local": "^3.0.2",
+        "jest-cli": "^29.7.0"
+      },
+      "bin": {
+        "jest": "bin/jest.js"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      },
+      "peerDependencies": {
+        "node-notifier": "^8.0.1 || ^9.0.0 || ^10.0.0"
+      },
+      "peerDependenciesMeta": {
+        "node-notifier": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jest-changed-files": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-29.7.0.tgz",
+      "integrity": "sha512-fEArFiwf1BpQ+4bXSprcDc3/x4HSzL4al2tozwVpDFpsxALjLYdyiIK4e5Vz66GQJIbXJ82+35PtysofptNX2w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "execa": "^5.0.0",
+        "jest-util": "^29.7.0",
+        "p-limit": "^3.1.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-circus": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-circus/-/jest-circus-29.7.0.tgz",
+      "integrity": "sha512-3E1nCMgipcTkCocFwM90XXQab9bS+GMsjdpmPrlelaxwD93Ad8iVEjX/vvHPdLPnFf+L40u+5+iutRdA1N9myw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/environment": "^29.7.0",
+        "@jest/expect": "^29.7.0",
+        "@jest/test-result": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "@types/node": "*",
+        "chalk": "^4.0.0",
+        "co": "^4.6.0",
+        "dedent": "^1.0.0",
+        "is-generator-fn": "^2.0.0",
+        "jest-each": "^29.7.0",
+        "jest-matcher-utils": "^29.7.0",
+        "jest-message-util": "^29.7.0",
+        "jest-runtime": "^29.7.0",
+        "jest-snapshot": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "p-limit": "^3.1.0",
+        "pretty-format": "^29.7.0",
+        "pure-rand": "^6.0.0",
+        "slash": "^3.0.0",
+        "stack-utils": "^2.0.3"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-circus/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/jest-circus/node_modules/pretty-format": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
+      "integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/schemas": "^29.6.3",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^18.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-cli": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-29.7.0.tgz",
+      "integrity": "sha512-OVVobw2IubN/GSYsxETi+gOe7Ka59EFMR/twOU3Jb2GnKKeMGJB5SGUUrEz3SFVmJASUdZUzy83sLNNQ2gZslg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/core": "^29.7.0",
+        "@jest/test-result": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "chalk": "^4.0.0",
+        "create-jest": "^29.7.0",
+        "exit": "^0.1.2",
+        "import-local": "^3.0.2",
+        "jest-config": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "jest-validate": "^29.7.0",
+        "yargs": "^17.3.1"
+      },
+      "bin": {
+        "jest": "bin/jest.js"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      },
+      "peerDependencies": {
+        "node-notifier": "^8.0.1 || ^9.0.0 || ^10.0.0"
+      },
+      "peerDependenciesMeta": {
+        "node-notifier": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jest-config": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-config/-/jest-config-29.7.0.tgz",
+      "integrity": "sha512-uXbpfeQ7R6TZBqI3/TxCU4q4ttk3u0PJeC+E0zbfSoSjq6bJ7buBPxzQPL0ifrkY4DNu4JUdk0ImlBUYi840eQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.11.6",
+        "@jest/test-sequencer": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "babel-jest": "^29.7.0",
+        "chalk": "^4.0.0",
+        "ci-info": "^3.2.0",
+        "deepmerge": "^4.2.2",
+        "glob": "^7.1.3",
+        "graceful-fs": "^4.2.9",
+        "jest-circus": "^29.7.0",
+        "jest-environment-node": "^29.7.0",
+        "jest-get-type": "^29.6.3",
+        "jest-regex-util": "^29.6.3",
+        "jest-resolve": "^29.7.0",
+        "jest-runner": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "jest-validate": "^29.7.0",
+        "micromatch": "^4.0.4",
+        "parse-json": "^5.2.0",
+        "pretty-format": "^29.7.0",
+        "slash": "^3.0.0",
+        "strip-json-comments": "^3.1.1"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      },
+      "peerDependencies": {
+        "@types/node": "*",
+        "ts-node": ">=9.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "ts-node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jest-config/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/jest-config/node_modules/glob": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "deprecated": "Glob versions prior to v9 are no longer supported",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/jest-config/node_modules/pretty-format": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
+      "integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/schemas": "^29.6.3",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^18.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-diff": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-29.7.0.tgz",
+      "integrity": "sha512-LMIgiIrhigmPrs03JHpxUh2yISK3vLFPkAodPeo0+BuF7wA2FoQbkEg1u8gBYBThncu7e1oEDUfIXVuTqLRUjw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^4.0.0",
+        "diff-sequences": "^29.6.3",
+        "jest-get-type": "^29.6.3",
+        "pretty-format": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-diff/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/jest-diff/node_modules/pretty-format": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
+      "integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/schemas": "^29.6.3",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^18.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-docblock": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-29.7.0.tgz",
+      "integrity": "sha512-q617Auw3A612guyaFgsbFeYpNP5t2aoUNLwBUbc/0kD1R4t9ixDbyFTHd1nok4epoVFpr7PmeWHrhvuV3XaJ4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "detect-newline": "^3.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-each": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-each/-/jest-each-29.7.0.tgz",
+      "integrity": "sha512-gns+Er14+ZrEoC5fhOfYCY1LOHHr0TI+rQUHZS8Ttw2l7gl+80eHc/gFf2Ktkw0+SIACDTeWvpFcv3B04VembQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "^29.6.3",
+        "chalk": "^4.0.0",
+        "jest-get-type": "^29.6.3",
+        "jest-util": "^29.7.0",
+        "pretty-format": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-each/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/jest-each/node_modules/pretty-format": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
+      "integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/schemas": "^29.6.3",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^18.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-environment-node": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-29.7.0.tgz",
+      "integrity": "sha512-DOSwCRqXirTOyheM+4d5YZOrWcdu0LNZ87ewUoywbcb2XR4wKgqiG8vNeYwhjFMbEkfju7wx2GYH0P2gevGvFw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/environment": "^29.7.0",
+        "@jest/fake-timers": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "@types/node": "*",
+        "jest-mock": "^29.7.0",
+        "jest-util": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-get-type": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-29.6.3.tgz",
+      "integrity": "sha512-zrteXnqYxfQh7l5FHyL38jL39di8H8rHoecLH3JNxH3BwOrBsNeabdap5e0I23lD4HHI8W5VFBZqG4Eaq5LNcw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-haste-map": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-29.7.0.tgz",
+      "integrity": "sha512-fP8u2pyfqx0K1rGn1R9pyE0/KTn+G7PxktWidOBTqFPLYX0b9ksaMFkhK5vrS3DVun09pckLdlx90QthlW7AmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "^29.6.3",
+        "@types/graceful-fs": "^4.1.3",
+        "@types/node": "*",
+        "anymatch": "^3.0.3",
+        "fb-watchman": "^2.0.0",
+        "graceful-fs": "^4.2.9",
+        "jest-regex-util": "^29.6.3",
+        "jest-util": "^29.7.0",
+        "jest-worker": "^29.7.0",
+        "micromatch": "^4.0.4",
+        "walker": "^1.0.8"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "^2.3.2"
+      }
+    },
+    "node_modules/jest-leak-detector": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-29.7.0.tgz",
+      "integrity": "sha512-kYA8IJcSYtST2BY9I+SMC32nDpBT3J2NvWJx8+JCuCdl/CR1I4EKUJROiP8XtCcxqgTTBGJNdbB1A8XRKbTetw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "jest-get-type": "^29.6.3",
+        "pretty-format": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-leak-detector/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/jest-leak-detector/node_modules/pretty-format": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
+      "integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/schemas": "^29.6.3",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^18.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-matcher-utils": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-29.7.0.tgz",
+      "integrity": "sha512-sBkD+Xi9DtcChsI3L3u0+N0opgPYnCRPtGcQYrgXmR+hmt/fYfWAL0xRXYU8eWOdfuLgBe0YCW3AFtnRLagq/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^4.0.0",
+        "jest-diff": "^29.7.0",
+        "jest-get-type": "^29.6.3",
+        "pretty-format": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-matcher-utils/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/jest-matcher-utils/node_modules/pretty-format": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
+      "integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/schemas": "^29.6.3",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^18.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-message-util": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-29.7.0.tgz",
+      "integrity": "sha512-GBEV4GRADeP+qtB2+6u61stea8mGcOT4mCtrYISZwfu9/ISHFJ/5zOMXYbpBE9RsS5+Gb63DW4FgmnKJ79Kf6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.12.13",
+        "@jest/types": "^29.6.3",
+        "@types/stack-utils": "^2.0.0",
+        "chalk": "^4.0.0",
+        "graceful-fs": "^4.2.9",
+        "micromatch": "^4.0.4",
+        "pretty-format": "^29.7.0",
+        "slash": "^3.0.0",
+        "stack-utils": "^2.0.3"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-message-util/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/jest-message-util/node_modules/pretty-format": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
+      "integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/schemas": "^29.6.3",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^18.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-mock": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-29.7.0.tgz",
+      "integrity": "sha512-ITOMZn+UkYS4ZFh83xYAOzWStloNzJFO2s8DWrE4lhtGD+AorgnbkiKERe4wQVBydIGPx059g6riW5Btp6Llnw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "^29.6.3",
+        "@types/node": "*",
+        "jest-util": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-pnp-resolver": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/jest-pnp-resolver/-/jest-pnp-resolver-1.2.3.tgz",
+      "integrity": "sha512-+3NpwQEnRoIBtx4fyhblQDPgJI0H1IEIkX7ShLUjPGA7TtUTvI1oiKi3SR4oBR0hQhQR80l4WAe5RrXBwWMA8w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      },
+      "peerDependencies": {
+        "jest-resolve": "*"
+      },
+      "peerDependenciesMeta": {
+        "jest-resolve": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jest-regex-util": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-29.6.3.tgz",
+      "integrity": "sha512-KJJBsRCyyLNWCNBOvZyRDnAIfUiRJ8v+hOBQYGn8gDyF3UegwiP4gwRR3/SDa42g1YbVycTidUF3rKjyLFDWbg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-resolve": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-29.7.0.tgz",
+      "integrity": "sha512-IOVhZSrg+UvVAshDSDtHyFCCBUl/Q3AAJv8iZ6ZjnZ74xzvwuzLXid9IIIPgTnY62SJjfuupMKZsZQRsCvxEgA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^4.0.0",
+        "graceful-fs": "^4.2.9",
+        "jest-haste-map": "^29.7.0",
+        "jest-pnp-resolver": "^1.2.2",
+        "jest-util": "^29.7.0",
+        "jest-validate": "^29.7.0",
+        "resolve": "^1.20.0",
+        "resolve.exports": "^2.0.0",
+        "slash": "^3.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-resolve-dependencies": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-29.7.0.tgz",
+      "integrity": "sha512-un0zD/6qxJ+S0et7WxeI3H5XSe9lTBBR7bOHCHXkKR6luG5mwDDlIzVQ0V5cZCuoTgEdcdwzTghYkTWfubi+nA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "jest-regex-util": "^29.6.3",
+        "jest-snapshot": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-runner": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-29.7.0.tgz",
+      "integrity": "sha512-fsc4N6cPCAahybGBfTRcq5wFR6fpLznMg47sY5aDpsoejOcVYFb07AHuSnR0liMcPTgBsA3ZJL6kFOjPdoNipQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/console": "^29.7.0",
+        "@jest/environment": "^29.7.0",
+        "@jest/test-result": "^29.7.0",
+        "@jest/transform": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "@types/node": "*",
+        "chalk": "^4.0.0",
+        "emittery": "^0.13.1",
+        "graceful-fs": "^4.2.9",
+        "jest-docblock": "^29.7.0",
+        "jest-environment-node": "^29.7.0",
+        "jest-haste-map": "^29.7.0",
+        "jest-leak-detector": "^29.7.0",
+        "jest-message-util": "^29.7.0",
+        "jest-resolve": "^29.7.0",
+        "jest-runtime": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "jest-watcher": "^29.7.0",
+        "jest-worker": "^29.7.0",
+        "p-limit": "^3.1.0",
+        "source-map-support": "0.5.13"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-runtime": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-29.7.0.tgz",
+      "integrity": "sha512-gUnLjgwdGqW7B4LvOIkbKs9WGbn+QLqRQQ9juC6HndeDiezIwhDP+mhMwHWCEcfQ5RUXa6OPnFF8BJh5xegwwQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/environment": "^29.7.0",
+        "@jest/fake-timers": "^29.7.0",
+        "@jest/globals": "^29.7.0",
+        "@jest/source-map": "^29.6.3",
+        "@jest/test-result": "^29.7.0",
+        "@jest/transform": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "@types/node": "*",
+        "chalk": "^4.0.0",
+        "cjs-module-lexer": "^1.0.0",
+        "collect-v8-coverage": "^1.0.0",
+        "glob": "^7.1.3",
+        "graceful-fs": "^4.2.9",
+        "jest-haste-map": "^29.7.0",
+        "jest-message-util": "^29.7.0",
+        "jest-mock": "^29.7.0",
+        "jest-regex-util": "^29.6.3",
+        "jest-resolve": "^29.7.0",
+        "jest-snapshot": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "slash": "^3.0.0",
+        "strip-bom": "^4.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-runtime/node_modules/glob": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "deprecated": "Glob versions prior to v9 are no longer supported",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/jest-snapshot": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-29.7.0.tgz",
+      "integrity": "sha512-Rm0BMWtxBcioHr1/OX5YCP8Uov4riHvKPknOGs804Zg9JGZgmIBkbtlxJC/7Z4msKYVbIJtfU+tKb8xlYNfdkw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.11.6",
+        "@babel/generator": "^7.7.2",
+        "@babel/plugin-syntax-jsx": "^7.7.2",
+        "@babel/plugin-syntax-typescript": "^7.7.2",
+        "@babel/types": "^7.3.3",
+        "@jest/expect-utils": "^29.7.0",
+        "@jest/transform": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "babel-preset-current-node-syntax": "^1.0.0",
+        "chalk": "^4.0.0",
+        "expect": "^29.7.0",
+        "graceful-fs": "^4.2.9",
+        "jest-diff": "^29.7.0",
+        "jest-get-type": "^29.6.3",
+        "jest-matcher-utils": "^29.7.0",
+        "jest-message-util": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "natural-compare": "^1.4.0",
+        "pretty-format": "^29.7.0",
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-snapshot/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/jest-snapshot/node_modules/pretty-format": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
+      "integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/schemas": "^29.6.3",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^18.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-util": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-29.7.0.tgz",
+      "integrity": "sha512-z6EbKajIpqGKU56y5KBUgy1dt1ihhQJgWzUlZHArA/+X2ad7Cb5iF+AK1EWVL/Bo7Rz9uurpqw6SiBCefUbCGA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "^29.6.3",
+        "@types/node": "*",
+        "chalk": "^4.0.0",
+        "ci-info": "^3.2.0",
+        "graceful-fs": "^4.2.9",
+        "picomatch": "^2.2.3"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-validate": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-29.7.0.tgz",
+      "integrity": "sha512-ZB7wHqaRGVw/9hST/OuFUReG7M8vKeq0/J2egIGLdvjHCmYqGARhzXmtgi+gVeZ5uXFF219aOc3Ls2yLg27tkw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "^29.6.3",
+        "camelcase": "^6.2.0",
+        "chalk": "^4.0.0",
+        "jest-get-type": "^29.6.3",
+        "leven": "^3.1.0",
+        "pretty-format": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-validate/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/jest-validate/node_modules/camelcase": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
+      "integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/jest-validate/node_modules/pretty-format": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
+      "integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/schemas": "^29.6.3",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^18.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-watcher": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-29.7.0.tgz",
+      "integrity": "sha512-49Fg7WXkU3Vl2h6LbLtMQ/HyB6rXSIX7SqvBLQmssRBGN9I0PNvPmAmCWSOY6SOvrjhI/F7/bGAv9RtnsPA03g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/test-result": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "@types/node": "*",
+        "ansi-escapes": "^4.2.1",
+        "chalk": "^4.0.0",
+        "emittery": "^0.13.1",
+        "jest-util": "^29.7.0",
+        "string-length": "^4.0.1"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-worker": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-29.7.0.tgz",
+      "integrity": "sha512-eIz2msL/EzL9UFTFFx7jBTkeZfku0yUAyZZZmJ93H2TYEiroIx2PQjEXcwYtYl8zXCxb+PAmA2hLIt/6ZEkPHw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "jest-util": "^29.7.0",
+        "merge-stream": "^2.0.0",
+        "supports-color": "^8.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-worker/node_modules/supports-color": {
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+      "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
       }
     },
     "node_modules/jiti": {
@@ -5257,10 +8030,30 @@
         "node": ">=18"
       }
     },
+    "node_modules/jsesc": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
+      "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "jsesc": "bin/jsesc"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/json-buffer": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
       "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-parse-even-better-errors": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
+      "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
       "dev": true,
       "license": "MIT"
     },
@@ -5278,6 +8071,19 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/json5": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "json5": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/keyv": {
       "version": "4.5.4",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
@@ -5286,6 +8092,26 @@
       "license": "MIT",
       "dependencies": {
         "json-buffer": "3.0.1"
+      }
+    },
+    "node_modules/kleur": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/kleur/-/kleur-3.0.3.tgz",
+      "integrity": "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/leven": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/leven/-/leven-3.1.0.tgz",
+      "integrity": "sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/levn": {
@@ -5353,6 +8179,13 @@
       "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
       "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==",
       "dev": true
+    },
+    "node_modules/lodash.memoize": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
+      "integrity": "sha512-t7j+NzmgnQzTAYXcsHYLgimltOV1MXHtlOWf6GjL9Kj8GK5FInw5JotxvbOs+IvV1/Dzo04/fCGfLVs7aXb4Ag==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
@@ -5858,6 +8691,22 @@
         "@jridgewell/sourcemap-codec": "^1.5.0"
       }
     },
+    "node_modules/make-dir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+      "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/make-error": {
       "version": "1.3.6",
       "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
@@ -5865,12 +8714,29 @@
       "devOptional": true,
       "license": "ISC"
     },
+    "node_modules/makeerror": {
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/makeerror/-/makeerror-1.0.12.tgz",
+      "integrity": "sha512-JmqCvUhmt43madlpFzG4BQzG2Z3m6tvQDNKdClZnO3VbIudJYmxsT0FNJMeiB2+JTSlTQTSbU8QdesVmwJcmLg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tmpl": "1.0.5"
+      }
+    },
     "node_modules/mdn-data": {
       "version": "2.12.2",
       "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.12.2.tgz",
       "integrity": "sha512-IEn+pegP1aManZuckezWCO+XZQDplx1366JoVhTpMpBB1sPey/SbveZQUosKiKiGYjg1wH4pMlNgXbCiYgihQA==",
       "dev": true,
       "license": "CC0-1.0"
+    },
+    "node_modules/merge-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
+      "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/merge2": {
       "version": "1.4.1",
@@ -5894,6 +8760,16 @@
         "node": ">=8.6"
       }
     },
+    "node_modules/mimic-fn": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
+      "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/minimatch": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
@@ -5905,6 +8781,16 @@
       },
       "engines": {
         "node": "*"
+      }
+    },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/minipass": {
@@ -5974,6 +8860,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/neo-async": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
+      "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/next-themes": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/next-themes/-/next-themes-0.3.0.tgz",
@@ -5983,6 +8876,13 @@
         "react": "^16.8 || ^17 || ^18",
         "react-dom": "^16.8 || ^17 || ^18"
       }
+    },
+    "node_modules/node-int64": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
+      "integrity": "sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/node-releases": {
       "version": "2.0.19",
@@ -6010,6 +8910,19 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/npm-run-path": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
+      "integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
@@ -6026,6 +8939,32 @@
       "license": "MIT",
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/onetime": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
+      "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mimic-fn": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/optionator": {
@@ -6078,6 +9017,16 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/p-try": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/package-json-from-dist": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
@@ -6095,6 +9044,25 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/parse-json": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
+      "integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.0.0",
+        "error-ex": "^1.3.1",
+        "json-parse-even-better-errors": "^2.3.0",
+        "lines-and-columns": "^1.1.6"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/parse5": {
@@ -6118,6 +9086,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/path-key": {
@@ -6185,6 +9163,75 @@
       "license": "MIT",
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/pkg-dir": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz",
+      "integrity": "sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "find-up": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/pkg-dir/node_modules/find-up": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+      "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^5.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/pkg-dir/node_modules/locate-path": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+      "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/pkg-dir/node_modules/p-limit": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-try": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/pkg-dir/node_modules/p-locate": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+      "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/postcss": {
@@ -6389,6 +9436,20 @@
       "license": "MIT",
       "peer": true
     },
+    "node_modules/prompts": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.4.2.tgz",
+      "integrity": "sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "kleur": "^3.0.3",
+        "sisteransi": "^1.0.5"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/prop-types": {
       "version": "15.8.1",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
@@ -6415,6 +9476,23 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/pure-rand": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-6.1.0.tgz",
+      "integrity": "sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/dubzzz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fast-check"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/queue-microtask": {
       "version": "1.2.3",
@@ -6738,6 +9816,16 @@
         "decimal.js-light": "^2.4.1"
       }
     },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/require-from-string": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
@@ -6765,6 +9853,29 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/resolve-cwd": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-cwd/-/resolve-cwd-3.0.0.tgz",
+      "integrity": "sha512-OrZaX2Mb+rJCpH/6CpSqt9xFVpN++x01XnN2ie9g6P5/3xelLAkXWVADpdz1IHD/KFfEXyE6V0U01OQ3UO2rEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "resolve-from": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/resolve-cwd/node_modules/resolve-from": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
+      "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/resolve-from": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
@@ -6773,6 +9884,26 @@
       "license": "MIT",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/resolve-pkg-maps": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
+      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+      }
+    },
+    "node_modules/resolve.exports": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/resolve.exports/-/resolve.exports-2.0.3.tgz",
+      "integrity": "sha512-OcXjMsGdhL4XnbShKpAcSqPMzQoYkYyhbEaeSko47MjRP9NfEQMhZkXL1DoFlt9LWQn4YttrdnV6X2OiyzBi+A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/reusify": {
@@ -6926,6 +10057,23 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/sisteransi": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
+      "integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/slash": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
+      "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/sonner": {
       "version": "1.7.4",
       "resolved": "https://registry.npmjs.org/sonner/-/sonner-1.7.4.tgz",
@@ -6936,6 +10084,16 @@
         "react-dom": "^18.0.0 || ^19.0.0 || ^19.0.0-rc"
       }
     },
+    "node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -6943,6 +10101,84 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/source-map-support": {
+      "version": "0.5.13",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.13.tgz",
+      "integrity": "sha512-SHSKFHadjVA5oR4PPqhtAVdcBWwRYVd6g6cAXnIbRiIwc2EhPrTuKUBdSLvlEKyIP3GCf89fltvcZiP9MMFA1w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "source-map": "^0.6.0"
+      }
+    },
+    "node_modules/sprintf-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/stack-utils": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-2.0.6.tgz",
+      "integrity": "sha512-XlkWvfIm6RmsWtNJx+uqtKLS8eqFbxUg0ZzLXqY0caEy9l7hruX8IpiDnjsLavoBgqCCR71TqWO8MaXYheJ3RQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "escape-string-regexp": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/stack-utils/node_modules/escape-string-regexp": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz",
+      "integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-length": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/string-length/-/string-length-4.0.2.tgz",
+      "integrity": "sha512-+l6rNN5fYHNhZZy41RXsYptCjA2Igmq4EG7kZAYFQI1E1VTXarr6ZPXBg6eq7Y6eK4FEhY6AJlyuFIb/v/S0VQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "char-regex": "^1.0.2",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/string-length/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-length/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/string-width": {
@@ -7039,6 +10275,26 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/strip-bom": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-4.0.0.tgz",
+      "integrity": "sha512-3xurFv5tEgii33Zi8Jtp55wEIILR9eh34FAW00PZf+JnSsTmV/ioewSgQl97JHvgjoRGwPShsWm+IdrxB35d0w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-final-newline": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
+      "integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/strip-json-comments": {
@@ -7164,6 +10420,43 @@
         "tailwindcss": ">=3.0.0 || insiders"
       }
     },
+    "node_modules/test-exclude": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-6.0.0.tgz",
+      "integrity": "sha512-cAGWPIyOHU6zlmg88jwm7VRyXnMN7iV68OGAbYDk/Mh/xC/pzVPlQtY6ngoIH/5/tciuhGfvESU8GrHrcxD56w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "@istanbuljs/schema": "^0.1.2",
+        "glob": "^7.1.4",
+        "minimatch": "^3.0.4"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/test-exclude/node_modules/glob": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "deprecated": "Glob versions prior to v9 are no longer supported",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/thenify": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.1.tgz",
@@ -7210,6 +10503,13 @@
       "integrity": "sha512-XHhPmHxphLi+LGbH0G/O7dmUH9V65OY20R7vH8gETHsp5AZCjBk9l8sqmRKLaGOxnETU7XNSDUPtewAy/K6jbA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/tmpl": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.5.tgz",
+      "integrity": "sha512-3f0uOEAQwIqGuWW2MVzYg8fV/QNnc/IpuJNG837rLuczAaLVHslWHZQj4IGiEl5Hs3kkbhwL9Ab7Hrsmuj+Smw==",
+      "dev": true,
+      "license": "BSD-3-Clause"
     },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
@@ -7288,6 +10588,72 @@
       "integrity": "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==",
       "license": "Apache-2.0"
     },
+    "node_modules/ts-jest": {
+      "version": "29.4.4",
+      "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-29.4.4.tgz",
+      "integrity": "sha512-ccVcRABct5ZELCT5U0+DZwkXMCcOCLi2doHRrKy1nK/s7J7bch6TzJMsrY09WxgUUIP/ITfmcDS8D2yl63rnXw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bs-logger": "^0.2.6",
+        "fast-json-stable-stringify": "^2.1.0",
+        "handlebars": "^4.7.8",
+        "json5": "^2.2.3",
+        "lodash.memoize": "^4.1.2",
+        "make-error": "^1.3.6",
+        "semver": "^7.7.2",
+        "type-fest": "^4.41.0",
+        "yargs-parser": "^21.1.1"
+      },
+      "bin": {
+        "ts-jest": "cli.js"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || ^18.0.0 || >=20.0.0"
+      },
+      "peerDependencies": {
+        "@babel/core": ">=7.0.0-beta.0 <8",
+        "@jest/transform": "^29.0.0 || ^30.0.0",
+        "@jest/types": "^29.0.0 || ^30.0.0",
+        "babel-jest": "^29.0.0 || ^30.0.0",
+        "jest": "^29.0.0 || ^30.0.0",
+        "jest-util": "^29.0.0 || ^30.0.0",
+        "typescript": ">=4.3 <6"
+      },
+      "peerDependenciesMeta": {
+        "@babel/core": {
+          "optional": true
+        },
+        "@jest/transform": {
+          "optional": true
+        },
+        "@jest/types": {
+          "optional": true
+        },
+        "babel-jest": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "jest-util": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ts-jest/node_modules/type-fest": {
+      "version": "4.41.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
+      "integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
+      "dev": true,
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/ts-node": {
       "version": "10.9.2",
       "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz",
@@ -7345,6 +10711,493 @@
       "integrity": "sha512-jWVzBLplnCmoaTr13V9dYbiQ99wvZRd0vNWaDRg+aVYRcjDF3nDksxFDE/+fkXnKhpnUUkmx5pK/v8mCtLVqZA==",
       "license": "0BSD"
     },
+    "node_modules/tsx": {
+      "version": "4.20.6",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.20.6.tgz",
+      "integrity": "sha512-ytQKuwgmrrkDTFP4LjR0ToE2nqgy886GpvRSpU0JAnrdBYppuY5rLkRUYPU1yCryb24SsKBTL/hlDQAEFVwtZg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.25.0",
+        "get-tsconfig": "^4.7.5"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.10.tgz",
+      "integrity": "sha512-0NFWnA+7l41irNuaSVlLfgNT12caWJVLzp5eAVhZ0z1qpxbockccEt3s+149rE64VUI3Ml2zt8Nv5JVc4QXTsw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/android-arm": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.10.tgz",
+      "integrity": "sha512-dQAxF1dW1C3zpeCDc5KqIYuZ1tgAdRXNoZP7vkBIRtKZPYe2xVr/d3SkirklCHudW1B45tGiUlz2pUWDfbDD4w==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/android-arm64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.10.tgz",
+      "integrity": "sha512-LSQa7eDahypv/VO6WKohZGPSJDq5OVOo3UoFR1E4t4Gj1W7zEQMUhI+lo81H+DtB+kP+tDgBp+M4oNCwp6kffg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/android-x64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.10.tgz",
+      "integrity": "sha512-MiC9CWdPrfhibcXwr39p9ha1x0lZJ9KaVfvzA0Wxwz9ETX4v5CHfF09bx935nHlhi+MxhA63dKRRQLiVgSUtEg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.10.tgz",
+      "integrity": "sha512-JC74bdXcQEpW9KkV326WpZZjLguSZ3DfS8wrrvPMHgQOIEIG/sPXEN/V8IssoJhbefLRcRqw6RQH2NnpdprtMA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/darwin-x64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.10.tgz",
+      "integrity": "sha512-tguWg1olF6DGqzws97pKZ8G2L7Ig1vjDmGTwcTuYHbuU6TTjJe5FXbgs5C1BBzHbJ2bo1m3WkQDbWO2PvamRcg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.10.tgz",
+      "integrity": "sha512-3ZioSQSg1HT2N05YxeJWYR+Libe3bREVSdWhEEgExWaDtyFbbXWb49QgPvFH8u03vUPX10JhJPcz7s9t9+boWg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.10.tgz",
+      "integrity": "sha512-LLgJfHJk014Aa4anGDbh8bmI5Lk+QidDmGzuC2D+vP7mv/GeSN+H39zOf7pN5N8p059FcOfs2bVlrRr4SK9WxA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-arm": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.10.tgz",
+      "integrity": "sha512-oR31GtBTFYCqEBALI9r6WxoU/ZofZl962pouZRTEYECvNF/dtXKku8YXcJkhgK/beU+zedXfIzHijSRapJY3vg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-arm64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.10.tgz",
+      "integrity": "sha512-5luJWN6YKBsawd5f9i4+c+geYiVEw20FVW5x0v1kEMWNq8UctFjDiMATBxLvmmHA4bf7F6hTRaJgtghFr9iziQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-ia32": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.10.tgz",
+      "integrity": "sha512-NrSCx2Kim3EnnWgS4Txn0QGt0Xipoumb6z6sUtl5bOEZIVKhzfyp/Lyw4C1DIYvzeW/5mWYPBFJU3a/8Yr75DQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-loong64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.10.tgz",
+      "integrity": "sha512-xoSphrd4AZda8+rUDDfD9J6FUMjrkTz8itpTITM4/xgerAZZcFW7Dv+sun7333IfKxGG8gAq+3NbfEMJfiY+Eg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.10.tgz",
+      "integrity": "sha512-ab6eiuCwoMmYDyTnyptoKkVS3k8fy/1Uvq7Dj5czXI6DF2GqD2ToInBI0SHOp5/X1BdZ26RKc5+qjQNGRBelRA==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.10.tgz",
+      "integrity": "sha512-NLinzzOgZQsGpsTkEbdJTCanwA5/wozN9dSgEl12haXJBzMTpssebuXR42bthOF3z7zXFWH1AmvWunUCkBE4EA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.10.tgz",
+      "integrity": "sha512-FE557XdZDrtX8NMIeA8LBJX3dC2M8VGXwfrQWU7LB5SLOajfJIxmSdyL/gU1m64Zs9CBKvm4UAuBp5aJ8OgnrA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-s390x": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.10.tgz",
+      "integrity": "sha512-3BBSbgzuB9ajLoVZk0mGu+EHlBwkusRmeNYdqmznmMc9zGASFjSsxgkNsqmXugpPk00gJ0JNKh/97nxmjctdew==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-x64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.10.tgz",
+      "integrity": "sha512-QSX81KhFoZGwenVyPoberggdW1nrQZSvfVDAIUXr3WqLRZGZqWk/P4T8p2SP+de2Sr5HPcvjhcJzEiulKgnxtA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.10.tgz",
+      "integrity": "sha512-AKQM3gfYfSW8XRk8DdMCzaLUFB15dTrZfnX8WXQoOUpUBQ+NaAFCP1kPS/ykbbGYz7rxn0WS48/81l9hFl3u4A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.10.tgz",
+      "integrity": "sha512-7RTytDPGU6fek/hWuN9qQpeGPBZFfB4zZgcz2VK2Z5VpdUxEI8JKYsg3JfO0n/Z1E/6l05n0unDCNc4HnhQGig==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.10.tgz",
+      "integrity": "sha512-5Se0VM9Wtq797YFn+dLimf2Zx6McttsH2olUBsDml+lm0GOCRVebRWUvDtkY4BWYv/3NgzS8b/UM3jQNh5hYyw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.10.tgz",
+      "integrity": "sha512-XkA4frq1TLj4bEMB+2HnI0+4RnjbuGZfet2gs/LNs5Hc7D89ZQBHQ0gL2ND6Lzu1+QVkjp3x1gIcPKzRNP8bXw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/sunos-x64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.10.tgz",
+      "integrity": "sha512-fswk3XT0Uf2pGJmOpDB7yknqhVkJQkAQOcW/ccVOtfx05LkbWOaRAtn5SaqXypeKQra1QaEa841PgrSL9ubSPQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/win32-arm64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.10.tgz",
+      "integrity": "sha512-ah+9b59KDTSfpaCg6VdJoOQvKjI33nTaQr4UluQwW7aEwZQsbMCfTmfEO4VyewOxx4RaDT/xCy9ra2GPWmO7Kw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/win32-ia32": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.10.tgz",
+      "integrity": "sha512-QHPDbKkrGO8/cz9LKVnJU22HOi4pxZnZhhA2HYHez5Pz4JeffhDjf85E57Oyco163GnzNCVkZK0b/n4Y0UHcSw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/win32-x64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.10.tgz",
+      "integrity": "sha512-9KpxSVFCu0iK1owoez6aC/s/EdUQLDN3adTxGCqxMVhrPDj6bt5dbrHDXUuq+Bs2vATFBBrQS5vdQ/Ed2P+nbw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/esbuild": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.10.tgz",
+      "integrity": "sha512-9RiGKvCwaqxO2owP61uQ4BgNborAQskMR6QusfWzQqv7AZOg5oGehdY2pRJMTKuwxd1IDBP4rSbI5lHzU7SMsQ==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.25.10",
+        "@esbuild/android-arm": "0.25.10",
+        "@esbuild/android-arm64": "0.25.10",
+        "@esbuild/android-x64": "0.25.10",
+        "@esbuild/darwin-arm64": "0.25.10",
+        "@esbuild/darwin-x64": "0.25.10",
+        "@esbuild/freebsd-arm64": "0.25.10",
+        "@esbuild/freebsd-x64": "0.25.10",
+        "@esbuild/linux-arm": "0.25.10",
+        "@esbuild/linux-arm64": "0.25.10",
+        "@esbuild/linux-ia32": "0.25.10",
+        "@esbuild/linux-loong64": "0.25.10",
+        "@esbuild/linux-mips64el": "0.25.10",
+        "@esbuild/linux-ppc64": "0.25.10",
+        "@esbuild/linux-riscv64": "0.25.10",
+        "@esbuild/linux-s390x": "0.25.10",
+        "@esbuild/linux-x64": "0.25.10",
+        "@esbuild/netbsd-arm64": "0.25.10",
+        "@esbuild/netbsd-x64": "0.25.10",
+        "@esbuild/openbsd-arm64": "0.25.10",
+        "@esbuild/openbsd-x64": "0.25.10",
+        "@esbuild/openharmony-arm64": "0.25.10",
+        "@esbuild/sunos-x64": "0.25.10",
+        "@esbuild/win32-arm64": "0.25.10",
+        "@esbuild/win32-ia32": "0.25.10",
+        "@esbuild/win32-x64": "0.25.10"
+      }
+    },
     "node_modules/type-check": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
@@ -7356,6 +11209,29 @@
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/type-detect": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/type-fest": {
+      "version": "0.21.3",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
+      "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
+      "dev": true,
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/typescript": {
@@ -7394,6 +11270,20 @@
       "peerDependencies": {
         "eslint": "^8.57.0 || ^9.0.0",
         "typescript": ">=4.8.4 <5.9.0"
+      }
+    },
+    "node_modules/uglify-js": {
+      "version": "3.19.3",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.19.3.tgz",
+      "integrity": "sha512-v3Xu+yuwBXisp6QYTcH4UbH+xYJXqnq2m/LtQVWKWzYc1iehYnLixoQDN9FH6/j9/oybfd6W9Ghwkl8+UMKTKQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "optional": true,
+      "bin": {
+        "uglifyjs": "bin/uglifyjs"
+      },
+      "engines": {
+        "node": ">=0.8.0"
       }
     },
     "node_modules/undici-types": {
@@ -7515,6 +11405,21 @@
       "devOptional": true,
       "license": "MIT"
     },
+    "node_modules/v8-to-istanbul": {
+      "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-9.3.0.tgz",
+      "integrity": "sha512-kiGUalWN+rgBJ/1OHZsBtU4rXZOfj/7rKQxULKlIzwzQSvMJUUNgPwJEEh7gU6xEVxC0ahoOBvN2YI8GH6FNgA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.12",
+        "@types/istanbul-lib-coverage": "^2.0.1",
+        "convert-source-map": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10.12.0"
+      }
+    },
     "node_modules/vaul": {
       "version": "0.9.9",
       "resolved": "https://registry.npmjs.org/vaul/-/vaul-0.9.9.tgz",
@@ -7623,6 +11528,16 @@
         "node": ">=18"
       }
     },
+    "node_modules/walker": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/walker/-/walker-1.0.8.tgz",
+      "integrity": "sha512-ts/8E8l5b7kY0vlWLewOkDXMmPdLcVV4GmOQLyxuSswIJsweeFZtAsMF7k1Nszz+TYBQrlYRmzOnr398y1JemQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "makeerror": "1.0.12"
+      }
+    },
     "node_modules/webidl-conversions": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.0.tgz",
@@ -7694,6 +11609,13 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/wordwrap": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+      "integrity": "sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/wrap-ansi": {
       "version": "8.1.0",
@@ -7783,6 +11705,34 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/write-file-atomic": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-4.0.2.tgz",
+      "integrity": "sha512-7KxauUdBmSdWnmpaGFg+ppNjKF8uNLry8LyzjauQDOVONfFLNKrKvQOxZ/VuTIcS/gge/YNahf5RIIQWTSarlg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "imurmurhash": "^0.1.4",
+        "signal-exit": "^3.0.7"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/write-file-atomic/node_modules/signal-exit": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/ws": {
       "version": "8.18.3",
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
@@ -7822,6 +11772,23 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yallist": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/yaml": {
       "version": "2.6.0",
       "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.6.0.tgz",
@@ -7832,6 +11799,80 @@
       },
       "engines": {
         "node": ">= 14"
+      }
+    },
+    "node_modules/yargs": {
+      "version": "17.7.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^8.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yargs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yargs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/yargs/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yargs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/yn": {

--- a/package.json
+++ b/package.json
@@ -13,6 +13,8 @@
     "predev": "node scripts/generate-extension-index.mjs",
     "prebuild": "node scripts/generate-extension-index.mjs",
     "ingest:core": "ts-node scripts/splitCoreToBatches.ts",
+    "tag:cards": "tsx scripts/tagCards.ts",
+    "tag:check": "tsx scripts/tagCards.ts --check",
     "validate:mvp": "bun scripts/validate-mvp-batch.ts",
     "ai:tune": "node --loader ts-node/esm --experimental-specifier-resolution=node tools/ai-simulation.ts"
   },
@@ -94,6 +96,10 @@
     "tailwindcss": "^3.4.17",
     "ts-node": "^10.9.2",
     "typescript": "^5.8.3",
+    "@types/jest": "^29.5.12",
+    "jest": "^29.7.0",
+    "ts-jest": "^29.3.4",
+    "tsx": "^4.19.2",
     "typescript-eslint": "^8.38.0",
     "vite": "^5.4.19"
   }

--- a/public/extensions/cryptids.json
+++ b/public/extensions/cryptids.json
@@ -11,5257 +11,5905 @@
   ],
   "count": 300,
   "cards": [
-  {
-    "schemaVersion": 2,
-    "id": "CRY-TS-001",
-    "faction": "truth",
-    "name": "Cryptid Field Research",
-    "type": "ZONE",
-    "rarity": "uncommon",
-    "effects": {
-      "pressureDelta": 2
-    },
-    "tags": [
-      "cryptid"
-    ],
-    "cost": 5,
-    "flavor": "\"CLASSIFIED INTELLIGENCE: Cryptid looked straight into the lens.\""
-  },
-  {
-    "schemaVersion": 2,
-    "id": "CRY-TS-002",
-    "faction": "truth",
-    "name": "Ultra Disclosure Protocol",
-    "type": "MEDIA",
-    "rarity": "legendary",
-    "effects": {
-      "truthDelta": 4
-    },
-    "tags": [
-      "cryptid"
-    ],
-    "cost": 6,
-    "flavor": "\"CLASSIFIED INTELLIGENCE: Tabloid headline writes itself.\""
-  },
-  {
-    "schemaVersion": 2,
-    "id": "CRY-TS-003",
-    "faction": "truth",
-    "name": "Bigfoot Expedition",
-    "type": "ZONE",
-    "rarity": "uncommon",
-    "effects": {
-      "pressureDelta": 2
-    },
-    "tags": [
-      "cryptid"
-    ],
-    "cost": 5,
-    "flavor": "\"CLASSIFIED INTELLIGENCE: Experts disagree; the crowd screams yes.\""
-  },
-  {
-    "schemaVersion": 2,
-    "id": "CRY-TS-004",
-    "faction": "truth",
-    "name": "Alien Abduction Support Group",
-    "type": "ATTACK",
-    "rarity": "uncommon",
-    "effects": {
-      "ipDelta": {
-        "opponent": 2
-      }
-    },
-    "tags": [
-      "cryptid"
-    ],
-    "cost": 3,
-    "flavor": "\"CLASSIFIED INTELLIGENCE: Alien looked straight into the lens.\""
-  },
-  {
-    "schemaVersion": 2,
-    "id": "CRY-TS-005",
-    "faction": "truth",
-    "name": "UFO Hotline Network",
-    "type": "MEDIA",
-    "rarity": "uncommon",
-    "effects": {
-      "truthDelta": 2
-    },
-    "tags": [
-      "cryptid"
-    ],
-    "cost": 4,
-    "flavor": "\"CLASSIFIED INTELLIGENCE: UFO looked straight into the lens.\""
-  },
-  {
-    "schemaVersion": 2,
-    "id": "CRY-TS-006",
-    "faction": "truth",
-    "name": "Mothman Prophecies",
-    "type": "ATTACK",
-    "rarity": "rare",
-    "effects": {
-      "ipDelta": {
-        "opponent": 3
+    {
+      "schemaVersion": 2,
+      "id": "CRY-TS-001",
+      "faction": "truth",
+      "name": "Cryptid Field Research",
+      "type": "ZONE",
+      "rarity": "uncommon",
+      "effects": {
+        "pressureDelta": 2
       },
-      "discardOpponent": 1
+      "tags": [
+        "cryptid",
+        "truth",
+        "zone"
+      ],
+      "cost": 5,
+      "flavor": "\"CLASSIFIED INTELLIGENCE: Cryptid looked straight into the lens.\""
     },
-    "tags": [
-      "cryptid"
-    ],
-    "cost": 4,
-    "flavor": "\"CLASSIFIED INTELLIGENCE: Pixels enhanced: chills confirmed.\""
-  },
-  {
-    "schemaVersion": 2,
-    "id": "CRY-TS-007",
-    "faction": "truth",
-    "name": "Chupacabra Sighting Report",
-    "type": "ATTACK",
-    "rarity": "uncommon",
-    "effects": {
-      "ipDelta": {
-        "opponent": 2
-      }
-    },
-    "tags": [
-      "cryptid"
-    ],
-    "cost": 3,
-    "flavor": "\"CLASSIFIED INTELLIGENCE: Chupacabra looked straight into the lens.\""
-  },
-  {
-    "schemaVersion": 2,
-    "id": "CRY-TS-008",
-    "faction": "truth",
-    "name": "Lake Monster Sonar Evidence",
-    "type": "ATTACK",
-    "rarity": "uncommon",
-    "effects": {
-      "ipDelta": {
-        "opponent": 2
-      }
-    },
-    "tags": [
-      "cryptid"
-    ],
-    "cost": 3,
-    "flavor": "\"CLASSIFIED INTELLIGENCE: Experts disagree; the crowd screams yes.\""
-  },
-  {
-    "schemaVersion": 2,
-    "id": "CRY-TS-009",
-    "faction": "truth",
-    "name": "Ancient Astronaut Theory",
-    "type": "MEDIA",
-    "rarity": "rare",
-    "effects": {
-      "truthDelta": 3
-    },
-    "tags": [
-      "cryptid"
-    ],
-    "cost": 5,
-    "flavor": "\"CLASSIFIED INTELLIGENCE: We brought snacks and a camcorder.\""
-  },
-  {
-    "schemaVersion": 2,
-    "id": "CRY-TS-010",
-    "faction": "truth",
-    "name": "Roswell Survivor Testimony",
-    "type": "MEDIA",
-    "rarity": "rare",
-    "effects": {
-      "truthDelta": 3
-    },
-    "tags": [
-      "cryptid"
-    ],
-    "cost": 5,
-    "flavor": "\"CLASSIFIED INTELLIGENCE: Roswell looked straight into the lens.\""
-  },
-  {
-    "schemaVersion": 2,
-    "id": "CRY-TS-011",
-    "faction": "truth",
-    "name": "Area 51 Infiltration",
-    "type": "ATTACK",
-    "rarity": "legendary",
-    "effects": {
-      "ipDelta": {
-        "opponent": 4
+    {
+      "schemaVersion": 2,
+      "id": "CRY-TS-002",
+      "faction": "truth",
+      "name": "Ultra Disclosure Protocol",
+      "type": "MEDIA",
+      "rarity": "legendary",
+      "effects": {
+        "truthDelta": 4
       },
-      "discardOpponent": 2
+      "tags": [
+        "cryptid",
+        "media",
+        "truth"
+      ],
+      "cost": 6,
+      "flavor": "\"CLASSIFIED INTELLIGENCE: Tabloid headline writes itself.\""
     },
-    "tags": [
-      "cryptid"
-    ],
-    "cost": 5,
-    "flavor": "\"CLASSIFIED INTELLIGENCE: Experts disagree; the crowd screams yes.\""
-  },
-  {
-    "schemaVersion": 2,
-    "id": "CRY-TS-012",
-    "faction": "truth",
-    "name": "Jersey Devil Hunt",
-    "type": "ATTACK",
-    "rarity": "common",
-    "effects": {
-      "ipDelta": {
-        "opponent": 1
-      }
-    },
-    "tags": [
-      "cryptid"
-    ],
-    "cost": 2,
-    "flavor": "\"CLASSIFIED INTELLIGENCE: Pixels enhanced: chills confirmed.\""
-  },
-  {
-    "schemaVersion": 2,
-    "id": "CRY-TS-013",
-    "faction": "truth",
-    "name": "Skunk Ape Footage",
-    "type": "MEDIA",
-    "rarity": "uncommon",
-    "effects": {
-      "truthDelta": 2
-    },
-    "tags": [
-      "cryptid"
-    ],
-    "cost": 4,
-    "flavor": "\"CLASSIFIED INTELLIGENCE: Pixels enhanced: chills confirmed.\""
-  },
-  {
-    "schemaVersion": 2,
-    "id": "CRY-TS-014",
-    "faction": "truth",
-    "name": "Beast of Bray Road Tracking",
-    "type": "ATTACK",
-    "rarity": "uncommon",
-    "effects": {
-      "ipDelta": {
-        "opponent": 2
-      }
-    },
-    "tags": [
-      "cryptid"
-    ],
-    "cost": 3,
-    "flavor": "\"CLASSIFIED INTELLIGENCE: Tabloid headline writes itself.\""
-  },
-  {
-    "schemaVersion": 2,
-    "id": "CRY-TS-015",
-    "faction": "truth",
-    "name": "Phantom Kangaroo Tracking Network",
-    "type": "ZONE",
-    "rarity": "uncommon",
-    "effects": {
-      "pressureDelta": 2
-    },
-    "tags": [
-      "cryptid"
-    ],
-    "cost": 5,
-    "flavor": "\"CLASSIFIED INTELLIGENCE: Experts disagree; the crowd screams yes.\""
-  },
-  {
-    "schemaVersion": 2,
-    "id": "CRY-TS-016",
-    "faction": "truth",
-    "name": "Fouke Monster Evidence",
-    "type": "ATTACK",
-    "rarity": "uncommon",
-    "effects": {
-      "ipDelta": {
-        "opponent": 2
-      }
-    },
-    "tags": [
-      "cryptid"
-    ],
-    "cost": 3,
-    "flavor": "\"CLASSIFIED INTELLIGENCE: Tabloid headline writes itself.\""
-  },
-  {
-    "schemaVersion": 2,
-    "id": "CRY-TS-017",
-    "faction": "truth",
-    "name": "Thunderbird Sightings Database",
-    "type": "ATTACK",
-    "rarity": "rare",
-    "effects": {
-      "ipDelta": {
-        "opponent": 3
+    {
+      "schemaVersion": 2,
+      "id": "CRY-TS-003",
+      "faction": "truth",
+      "name": "Bigfoot Expedition",
+      "type": "ZONE",
+      "rarity": "uncommon",
+      "effects": {
+        "pressureDelta": 2
       },
-      "discardOpponent": 1
+      "tags": [
+        "bigfoot",
+        "cryptid",
+        "truth",
+        "zone"
+      ],
+      "cost": 5,
+      "flavor": "\"CLASSIFIED INTELLIGENCE: Experts disagree; the crowd screams yes.\""
     },
-    "tags": [
-      "cryptid"
-    ],
-    "cost": 4,
-    "flavor": "\"CLASSIFIED INTELLIGENCE: Experts disagree; the crowd screams yes.\""
-  },
-  {
-    "schemaVersion": 2,
-    "id": "CRY-TS-018",
-    "faction": "truth",
-    "name": "Shadow People Documentation",
-    "type": "ATTACK",
-    "rarity": "uncommon",
-    "effects": {
-      "ipDelta": {
-        "opponent": 2
-      }
-    },
-    "tags": [
-      "cryptid"
-    ],
-    "cost": 3,
-    "flavor": "\"CLASSIFIED INTELLIGENCE: Tabloid headline writes itself.\""
-  },
-  {
-    "schemaVersion": 2,
-    "id": "CRY-TS-019",
-    "faction": "truth",
-    "name": "Hopkinsville Goblins Testimony",
-    "type": "MEDIA",
-    "rarity": "uncommon",
-    "effects": {
-      "truthDelta": 2
-    },
-    "tags": [
-      "cryptid"
-    ],
-    "cost": 4,
-    "flavor": "\"CLASSIFIED INTELLIGENCE: Hopkinsville looked straight into the lens.\""
-  },
-  {
-    "schemaVersion": 2,
-    "id": "CRY-TS-020",
-    "faction": "truth",
-    "name": "Lizard People Exposé",
-    "type": "ATTACK",
-    "rarity": "legendary",
-    "effects": {
-      "ipDelta": {
-        "opponent": 4
+    {
+      "schemaVersion": 2,
+      "id": "CRY-TS-004",
+      "faction": "truth",
+      "name": "Alien Abduction Support Group",
+      "type": "ATTACK",
+      "rarity": "uncommon",
+      "effects": {
+        "ipDelta": {
+          "opponent": 2
+        }
       },
-      "discardOpponent": 2
+      "tags": [
+        "alien",
+        "attack",
+        "cryptid",
+        "truth"
+      ],
+      "cost": 3,
+      "flavor": "\"CLASSIFIED INTELLIGENCE: Alien looked straight into the lens.\""
     },
-    "tags": [
-      "cryptid"
-    ],
-    "cost": 5,
-    "flavor": "\"CLASSIFIED INTELLIGENCE: Lizard looked straight into the lens.\""
-  },
-  {
-    "schemaVersion": 2,
-    "id": "CRY-TS-021",
-    "faction": "truth",
-    "name": "Hollow Earth Expedition",
-    "type": "ZONE",
-    "rarity": "rare",
-    "effects": {
-      "pressureDelta": 3
-    },
-    "tags": [
-      "cryptid"
-    ],
-    "cost": 6,
-    "flavor": "\"CLASSIFIED INTELLIGENCE: Tabloid headline writes itself.\""
-  },
-  {
-    "schemaVersion": 2,
-    "id": "CRY-TS-022",
-    "faction": "truth",
-    "name": "Time Traveler Interview",
-    "type": "MEDIA",
-    "rarity": "legendary",
-    "effects": {
-      "truthDelta": 4
-    },
-    "tags": [
-      "cryptid"
-    ],
-    "cost": 6,
-    "flavor": "\"CLASSIFIED INTELLIGENCE: Tabloid headline writes itself.\""
-  },
-  {
-    "schemaVersion": 2,
-    "id": "CRY-TS-023",
-    "faction": "truth",
-    "name": "UFO Crash Retrieval Team",
-    "type": "MEDIA",
-    "rarity": "uncommon",
-    "effects": {
-      "truthDelta": 2
-    },
-    "tags": [
-      "cryptid"
-    ],
-    "cost": 4,
-    "flavor": "\"CLASSIFIED INTELLIGENCE: Pixels enhanced: chills confirmed.\""
-  },
-  {
-    "schemaVersion": 2,
-    "id": "CRY-TS-024",
-    "faction": "truth",
-    "name": "Interdimensional Portal Research",
-    "type": "MEDIA",
-    "rarity": "uncommon",
-    "effects": {
-      "truthDelta": 2
-    },
-    "tags": [
-      "cryptid"
-    ],
-    "cost": 4,
-    "flavor": "\"CLASSIFIED INTELLIGENCE: Interdimensional looked straight into the lens.\""
-  },
-  {
-    "schemaVersion": 2,
-    "id": "CRY-TS-025",
-    "faction": "truth",
-    "name": "Phantom Black Dog Network",
-    "type": "ZONE",
-    "rarity": "uncommon",
-    "effects": {
-      "pressureDelta": 2
-    },
-    "tags": [
-      "cryptid"
-    ],
-    "cost": 5,
-    "flavor": "\"CLASSIFIED INTELLIGENCE: Phantom looked straight into the lens.\""
-  },
-  {
-    "schemaVersion": 2,
-    "id": "CRY-TS-026",
-    "faction": "truth",
-    "name": "Yeti Hair Analysis",
-    "type": "MEDIA",
-    "rarity": "uncommon",
-    "effects": {
-      "truthDelta": 2
-    },
-    "tags": [
-      "cryptid"
-    ],
-    "cost": 4,
-    "flavor": "\"CLASSIFIED INTELLIGENCE: Tabloid headline writes itself.\""
-  },
-  {
-    "schemaVersion": 2,
-    "id": "CRY-TS-027",
-    "faction": "truth",
-    "name": "Skinwalker Ranch Investigation",
-    "type": "ATTACK",
-    "rarity": "rare",
-    "effects": {
-      "ipDelta": {
-        "opponent": 3
+    {
+      "schemaVersion": 2,
+      "id": "CRY-TS-005",
+      "faction": "truth",
+      "name": "UFO Hotline Network",
+      "type": "MEDIA",
+      "rarity": "uncommon",
+      "effects": {
+        "truthDelta": 2
       },
-      "discardOpponent": 1
+      "tags": [
+        "cryptid",
+        "media",
+        "truth",
+        "ufo"
+      ],
+      "cost": 4,
+      "flavor": "\"CLASSIFIED INTELLIGENCE: UFO looked straight into the lens.\""
     },
-    "tags": [
-      "cryptid"
-    ],
-    "cost": 4,
-    "flavor": "\"CLASSIFIED INTELLIGENCE: Tabloid headline writes itself.\""
-  },
-  {
-    "schemaVersion": 2,
-    "id": "CRY-TS-028",
-    "faction": "truth",
-    "name": "Dover Demon Witness Testimony",
-    "type": "MEDIA",
-    "rarity": "uncommon",
-    "effects": {
-      "truthDelta": 2
-    },
-    "tags": [
-      "cryptid"
-    ],
-    "cost": 4,
-    "flavor": "\"CLASSIFIED INTELLIGENCE: Experts disagree; the crowd screams yes.\""
-  },
-  {
-    "schemaVersion": 2,
-    "id": "CRY-TS-029",
-    "faction": "truth",
-    "name": "Real Alien Autopsy Leak",
-    "type": "MEDIA",
-    "rarity": "rare",
-    "effects": {
-      "truthDelta": 3
-    },
-    "tags": [
-      "cryptid"
-    ],
-    "cost": 5,
-    "flavor": "\"CLASSIFIED INTELLIGENCE: Real looked straight into the lens.\""
-  },
-  {
-    "schemaVersion": 2,
-    "id": "CRY-TS-030",
-    "faction": "truth",
-    "name": "Cattle Mutilation Pattern Analysis",
-    "type": "ZONE",
-    "rarity": "uncommon",
-    "effects": {
-      "pressureDelta": 2
-    },
-    "tags": [
-      "cryptid"
-    ],
-    "cost": 5,
-    "flavor": "\"CLASSIFIED INTELLIGENCE: Tabloid headline writes itself.\""
-  },
-  {
-    "schemaVersion": 2,
-    "id": "CRY-TS-031",
-    "faction": "truth",
-    "name": "Crop Circle Decoder Ring",
-    "type": "MEDIA",
-    "rarity": "uncommon",
-    "effects": {
-      "truthDelta": 2
-    },
-    "tags": [
-      "cryptid"
-    ],
-    "cost": 4,
-    "flavor": "\"CLASSIFIED INTELLIGENCE: Experts disagree; the crowd screams yes.\""
-  },
-  {
-    "schemaVersion": 2,
-    "id": "CRY-TS-032",
-    "faction": "truth",
-    "name": "1897 Phantom Airship Reports",
-    "type": "MEDIA",
-    "rarity": "uncommon",
-    "effects": {
-      "truthDelta": 2
-    },
-    "tags": [
-      "cryptid"
-    ],
-    "cost": 4,
-    "flavor": "\"CLASSIFIED INTELLIGENCE: Pixels enhanced: chills confirmed.\""
-  },
-  {
-    "schemaVersion": 2,
-    "id": "CRY-TS-033",
-    "faction": "truth",
-    "name": "Beast of Bladenboro Hunt",
-    "type": "ATTACK",
-    "rarity": "uncommon",
-    "effects": {
-      "ipDelta": {
-        "opponent": 2
-      }
-    },
-    "tags": [
-      "cryptid"
-    ],
-    "cost": 3,
-    "flavor": "\"CLASSIFIED INTELLIGENCE: Pixels enhanced: chills confirmed.\""
-  },
-  {
-    "schemaVersion": 2,
-    "id": "CRY-TS-034",
-    "faction": "truth",
-    "name": "Washington Sea Serpent Sonar",
-    "type": "ZONE",
-    "rarity": "uncommon",
-    "effects": {
-      "pressureDelta": 2
-    },
-    "tags": [
-      "cryptid"
-    ],
-    "cost": 5,
-    "flavor": "\"CLASSIFIED INTELLIGENCE: Experts disagree; the crowd screams yes.\""
-  },
-  {
-    "schemaVersion": 2,
-    "id": "CRY-TS-035",
-    "faction": "truth",
-    "name": "Moon-Eyed People Archaeological Site",
-    "type": "ZONE",
-    "rarity": "rare",
-    "effects": {
-      "pressureDelta": 3
-    },
-    "tags": [
-      "cryptid"
-    ],
-    "cost": 6,
-    "flavor": "\"CLASSIFIED INTELLIGENCE: Tabloid headline writes itself.\""
-  },
-  {
-    "schemaVersion": 2,
-    "id": "CRY-TS-036",
-    "faction": "truth",
-    "name": "Giant Pacific Octopus Encounter",
-    "type": "ZONE",
-    "rarity": "rare",
-    "effects": {
-      "pressureDelta": 3
-    },
-    "tags": [
-      "cryptid"
-    ],
-    "cost": 6,
-    "flavor": "\"CLASSIFIED INTELLIGENCE: Tabloid headline writes itself.\""
-  },
-  {
-    "schemaVersion": 2,
-    "id": "CRY-TS-037",
-    "faction": "truth",
-    "name": "Remote Viewing Leak",
-    "type": "MEDIA",
-    "rarity": "rare",
-    "effects": {
-      "truthDelta": 3
-    },
-    "tags": [
-      "cryptid"
-    ],
-    "cost": 5,
-    "flavor": "\"CLASSIFIED INTELLIGENCE: We brought snacks and a camcorder.\""
-  },
-  {
-    "schemaVersion": 2,
-    "id": "CRY-TS-038",
-    "faction": "truth",
-    "name": "Invisible Aircraft Photos",
-    "type": "MEDIA",
-    "rarity": "legendary",
-    "effects": {
-      "truthDelta": 4
-    },
-    "tags": [
-      "cryptid"
-    ],
-    "cost": 6,
-    "flavor": "\"CLASSIFIED INTELLIGENCE: We brought snacks and a camcorder.\""
-  },
-  {
-    "schemaVersion": 2,
-    "id": "CRY-TS-039",
-    "faction": "truth",
-    "name": "Missing Time Survivor Network",
-    "type": "MEDIA",
-    "rarity": "rare",
-    "effects": {
-      "truthDelta": 3
-    },
-    "tags": [
-      "cryptid"
-    ],
-    "cost": 5,
-    "flavor": "\"CLASSIFIED INTELLIGENCE: Experts disagree; the crowd screams yes.\""
-  },
-  {
-    "schemaVersion": 2,
-    "id": "CRY-TS-040",
-    "faction": "truth",
-    "name": "Grey Alien Eyewitness Testimony",
-    "type": "MEDIA",
-    "rarity": "rare",
-    "effects": {
-      "truthDelta": 3
-    },
-    "tags": [
-      "cryptid"
-    ],
-    "cost": 5,
-    "flavor": "\"CLASSIFIED INTELLIGENCE: Pixels enhanced: chills confirmed.\""
-  },
-  {
-    "schemaVersion": 2,
-    "id": "CRY-TS-041",
-    "faction": "truth",
-    "name": "Reality Breach Detector",
-    "type": "MEDIA",
-    "rarity": "legendary",
-    "effects": {
-      "truthDelta": 4
-    },
-    "tags": [
-      "cryptid"
-    ],
-    "cost": 6,
-    "flavor": "\"CLASSIFIED INTELLIGENCE: We brought snacks and a camcorder.\""
-  },
-  {
-    "schemaVersion": 2,
-    "id": "CRY-TS-042",
-    "faction": "truth",
-    "name": "Paranormal Investigation Society",
-    "type": "MEDIA",
-    "rarity": "uncommon",
-    "effects": {
-      "truthDelta": 2
-    },
-    "tags": [
-      "cryptid"
-    ],
-    "cost": 4,
-    "flavor": "\"CLASSIFIED INTELLIGENCE: Tabloid headline writes itself.\""
-  },
-  {
-    "schemaVersion": 2,
-    "id": "CRY-TS-043",
-    "faction": "truth",
-    "name": "Alien Implant Removal Clinic",
-    "type": "ZONE",
-    "rarity": "rare",
-    "effects": {
-      "pressureDelta": 3
-    },
-    "tags": [
-      "cryptid"
-    ],
-    "cost": 6,
-    "flavor": "\"CLASSIFIED INTELLIGENCE: Experts disagree; the crowd screams yes.\""
-  },
-  {
-    "schemaVersion": 2,
-    "id": "CRY-TS-044",
-    "faction": "truth",
-    "name": "Consciousness Expansion Workshop",
-    "type": "MEDIA",
-    "rarity": "rare",
-    "effects": {
-      "truthDelta": 3
-    },
-    "tags": [
-      "cryptid"
-    ],
-    "cost": 5,
-    "flavor": "\"CLASSIFIED INTELLIGENCE: Tabloid headline writes itself.\""
-  },
-  {
-    "schemaVersion": 2,
-    "id": "CRY-TS-045",
-    "faction": "truth",
-    "name": "Multidimensional Gateway",
-    "type": "MEDIA",
-    "rarity": "legendary",
-    "effects": {
-      "truthDelta": 4
-    },
-    "tags": [
-      "cryptid"
-    ],
-    "cost": 6,
-    "flavor": "\"CLASSIFIED INTELLIGENCE: Tabloid headline writes itself.\""
-  },
-  {
-    "schemaVersion": 2,
-    "id": "CRY-TS-046",
-    "faction": "truth",
-    "name": "Moon Landing Hoax Evidence",
-    "type": "MEDIA",
-    "rarity": "uncommon",
-    "effects": {
-      "truthDelta": 2
-    },
-    "tags": [
-      "cryptid"
-    ],
-    "cost": 4,
-    "flavor": "\"CLASSIFIED INTELLIGENCE: Experts disagree; the crowd screams yes.\""
-  },
-  {
-    "schemaVersion": 2,
-    "id": "CRY-TS-047",
-    "faction": "truth",
-    "name": "Memory Recovery Session",
-    "type": "MEDIA",
-    "rarity": "rare",
-    "effects": {
-      "truthDelta": 3
-    },
-    "tags": [
-      "cryptid"
-    ],
-    "cost": 5,
-    "flavor": "\"CLASSIFIED INTELLIGENCE: Tabloid headline writes itself.\""
-  },
-  {
-    "schemaVersion": 2,
-    "id": "CRY-TS-048",
-    "faction": "truth",
-    "name": "Shadow Government Infiltration",
-    "type": "ATTACK",
-    "rarity": "legendary",
-    "effects": {
-      "ipDelta": {
-        "opponent": 4
+    {
+      "schemaVersion": 2,
+      "id": "CRY-TS-006",
+      "faction": "truth",
+      "name": "Mothman Prophecies",
+      "type": "ATTACK",
+      "rarity": "rare",
+      "effects": {
+        "ipDelta": {
+          "opponent": 3
+        },
+        "discardOpponent": 1
       },
-      "discardOpponent": 2
-    },
-    "tags": [
-      "cryptid"
-    ],
-    "cost": 5,
-    "flavor": "\"CLASSIFIED INTELLIGENCE: Pixels enhanced: chills confirmed.\""
-  },
-  {
-    "schemaVersion": 2,
-    "id": "CRY-TS-049",
-    "faction": "truth",
-    "name": "Operation Paperclip Files",
-    "type": "MEDIA",
-    "rarity": "rare",
-    "effects": {
-      "truthDelta": 3
-    },
-    "tags": [
-      "cryptid"
-    ],
-    "cost": 5,
-    "flavor": "\"CLASSIFIED INTELLIGENCE: Pixels enhanced: chills confirmed.\""
-  },
-  {
-    "schemaVersion": 2,
-    "id": "CRY-TS-050",
-    "faction": "truth",
-    "name": "Holographic Universe Theory",
-    "type": "MEDIA",
-    "rarity": "uncommon",
-    "effects": {
-      "truthDelta": 2
-    },
-    "tags": [
-      "cryptid"
-    ],
-    "cost": 4,
-    "flavor": "\"CLASSIFIED INTELLIGENCE: Tabloid headline writes itself.\""
-  },
-  {
-    "schemaVersion": 2,
-    "id": "CRY-TS-051",
-    "faction": "truth",
-    "name": "Cryptid DNA Evidence Database",
-    "type": "MEDIA",
-    "rarity": "rare",
-    "effects": {
-      "truthDelta": 3
-    },
-    "tags": [
-      "cryptid"
-    ],
-    "cost": 5,
-    "flavor": "\"CLASSIFIED INTELLIGENCE: Experts disagree; the crowd screams yes.\""
-  },
-  {
-    "schemaVersion": 2,
-    "id": "CRY-TS-052",
-    "faction": "truth",
-    "name": "Phantom Satellite Tracking",
-    "type": "MEDIA",
-    "rarity": "rare",
-    "effects": {
-      "truthDelta": 3
-    },
-    "tags": [
-      "cryptid"
-    ],
-    "cost": 5,
-    "flavor": "\"CLASSIFIED INTELLIGENCE: We brought snacks and a camcorder.\""
-  },
-  {
-    "schemaVersion": 2,
-    "id": "CRY-TS-053",
-    "faction": "truth",
-    "name": "Consciousness Upload Technology",
-    "type": "MEDIA",
-    "rarity": "uncommon",
-    "effects": {
-      "truthDelta": 2
-    },
-    "tags": [
-      "cryptid"
-    ],
-    "cost": 4,
-    "flavor": "\"CLASSIFIED INTELLIGENCE: We brought snacks and a camcorder.\""
-  },
-  {
-    "schemaVersion": 2,
-    "id": "CRY-TS-054",
-    "faction": "truth",
-    "name": "Multidimensional Broadcast Network",
-    "type": "ZONE",
-    "rarity": "legendary",
-    "effects": {
-      "pressureDelta": 4
-    },
-    "tags": [
-      "cryptid"
-    ],
-    "cost": 7,
-    "flavor": "\"CLASSIFIED INTELLIGENCE: We brought snacks and a camcorder.\""
-  },
-  {
-    "schemaVersion": 2,
-    "id": "CRY-TS-055",
-    "faction": "truth",
-    "name": "Crystal Wi-Fi Chakra Network",
-    "type": "MEDIA",
-    "rarity": "uncommon",
-    "effects": {
-      "truthDelta": 2
-    },
-    "tags": [
-      "cryptid"
-    ],
-    "cost": 4,
-    "flavor": "\"CLASSIFIED INTELLIGENCE: Tabloid headline writes itself.\""
-  },
-  {
-    "schemaVersion": 2,
-    "id": "CRY-TS-056",
-    "faction": "truth",
-    "name": "Late Night AM Radio",
-    "type": "MEDIA",
-    "rarity": "uncommon",
-    "effects": {
-      "truthDelta": 2
-    },
-    "tags": [
-      "cryptid"
-    ],
-    "cost": 4,
-    "flavor": "\"CLASSIFIED INTELLIGENCE: Experts disagree; the crowd screams yes.\""
-  },
-  {
-    "schemaVersion": 2,
-    "id": "CRY-TS-057",
-    "faction": "truth",
-    "name": "Viral Thread Storm",
-    "type": "MEDIA",
-    "rarity": "rare",
-    "effects": {
-      "truthDelta": 3
-    },
-    "tags": [
-      "cryptid"
-    ],
-    "cost": 5,
-    "flavor": "\"CLASSIFIED INTELLIGENCE: Pixels enhanced: chills confirmed.\""
-  },
-  {
-    "schemaVersion": 2,
-    "id": "CRY-TS-058",
-    "faction": "truth",
-    "name": "Bigfoot Field Operations",
-    "type": "ZONE",
-    "rarity": "rare",
-    "effects": {
-      "pressureDelta": 3
-    },
-    "tags": [
-      "cryptid"
-    ],
-    "cost": 6,
-    "flavor": "\"CLASSIFIED INTELLIGENCE: Bigfoot looked straight into the lens.\""
-  },
-  {
-    "schemaVersion": 2,
-    "id": "CRY-TS-059",
-    "faction": "truth",
-    "name": "Mothman Omen Network",
-    "type": "ATTACK",
-    "rarity": "uncommon",
-    "effects": {
-      "ipDelta": {
-        "opponent": 2
-      }
-    },
-    "tags": [
-      "cryptid"
-    ],
-    "cost": 3,
-    "flavor": "\"CLASSIFIED INTELLIGENCE: Experts disagree; the crowd screams yes.\""
-  },
-  {
-    "schemaVersion": 2,
-    "id": "CRY-TS-060",
-    "faction": "truth",
-    "name": "Essential Oils Mind Shield",
-    "type": "MEDIA",
-    "rarity": "uncommon",
-    "effects": {
-      "truthDelta": 2
-    },
-    "tags": [
-      "cryptid"
-    ],
-    "cost": 4,
-    "flavor": "\"CLASSIFIED INTELLIGENCE: Pixels enhanced: chills confirmed.\""
-  },
-  {
-    "schemaVersion": 2,
-    "id": "CRY-TS-061",
-    "faction": "truth",
-    "name": "Healing Crystal Array",
-    "type": "MEDIA",
-    "rarity": "uncommon",
-    "effects": {
-      "truthDelta": 2
-    },
-    "tags": [
-      "cryptid"
-    ],
-    "cost": 4,
-    "flavor": "\"CLASSIFIED INTELLIGENCE: Healing looked straight into the lens.\""
-  },
-  {
-    "schemaVersion": 2,
-    "id": "CRY-TS-062",
-    "faction": "truth",
-    "name": "Really Long YouTube Videos",
-    "type": "MEDIA",
-    "rarity": "uncommon",
-    "effects": {
-      "truthDelta": 2
-    },
-    "tags": [
-      "cryptid"
-    ],
-    "cost": 4,
-    "flavor": "\"CLASSIFIED INTELLIGENCE: Pixels enhanced: chills confirmed.\""
-  },
-  {
-    "schemaVersion": 2,
-    "id": "CRY-TS-063",
-    "faction": "truth",
-    "name": "Whistleblower Protection Network",
-    "type": "MEDIA",
-    "rarity": "rare",
-    "effects": {
-      "truthDelta": 3
-    },
-    "tags": [
-      "cryptid"
-    ],
-    "cost": 5,
-    "flavor": "\"CLASSIFIED INTELLIGENCE: Pixels enhanced: chills confirmed.\""
-  },
-  {
-    "schemaVersion": 2,
-    "id": "CRY-TS-064",
-    "faction": "truth",
-    "name": "Anonymous Leak Platform",
-    "type": "MEDIA",
-    "rarity": "rare",
-    "effects": {
-      "truthDelta": 3
-    },
-    "tags": [
-      "cryptid"
-    ],
-    "cost": 5,
-    "flavor": "\"CLASSIFIED INTELLIGENCE: Tabloid headline writes itself.\""
-  },
-  {
-    "schemaVersion": 2,
-    "id": "CRY-TS-065",
-    "faction": "truth",
-    "name": "Flat Earth Conference",
-    "type": "MEDIA",
-    "rarity": "uncommon",
-    "effects": {
-      "truthDelta": 2
-    },
-    "tags": [
-      "cryptid"
-    ],
-    "cost": 4,
-    "flavor": "\"CLASSIFIED INTELLIGENCE: Flat looked straight into the lens.\""
-  },
-  {
-    "schemaVersion": 2,
-    "id": "CRY-TS-066",
-    "faction": "truth",
-    "name": "Chemtrail Detection Kit",
-    "type": "ZONE",
-    "rarity": "uncommon",
-    "effects": {
-      "pressureDelta": 2
-    },
-    "tags": [
-      "cryptid"
-    ],
-    "cost": 5,
-    "flavor": "\"CLASSIFIED INTELLIGENCE: We brought snacks and a camcorder.\""
-  },
-  {
-    "schemaVersion": 2,
-    "id": "CRY-TS-067",
-    "faction": "truth",
-    "name": "Vaccine Truth Bomb Campaign",
-    "type": "ZONE",
-    "rarity": "rare",
-    "effects": {
-      "pressureDelta": 3
-    },
-    "tags": [
-      "cryptid"
-    ],
-    "cost": 6,
-    "flavor": "\"CLASSIFIED INTELLIGENCE: Tabloid headline writes itself.\""
-  },
-  {
-    "schemaVersion": 2,
-    "id": "CRY-TS-068",
-    "faction": "truth",
-    "name": "Alabama Cryptid Mass Sighting",
-    "type": "ATTACK",
-    "rarity": "common",
-    "effects": {
-      "ipDelta": {
-        "opponent": 1
-      }
-    },
-    "tags": [
-      "cryptid",
-      "alabama",
-      "alabama-cryptid"
-    ],
-    "cost": 2,
-    "flavor": "\"CLASSIFIED INTELLIGENCE: The locals swear alabama cryptid waved back.\""
-  },
-  {
-    "schemaVersion": 2,
-    "id": "CRY-TS-069",
-    "faction": "truth",
-    "name": "Tizheruk Mass Sighting",
-    "type": "ZONE",
-    "rarity": "common",
-    "effects": {
-      "pressureDelta": 1
-    },
-    "tags": [
-      "cryptid",
-      "alaska",
-      "tizheruk"
-    ],
-    "cost": 4,
-    "flavor": "\"CLASSIFIED INTELLIGENCE: The locals swear tizheruk waved back.\""
-  },
-  {
-    "schemaVersion": 2,
-    "id": "CRY-TS-070",
-    "faction": "truth",
-    "name": "Thunderbird Mass Sighting",
-    "type": "ATTACK",
-    "rarity": "common",
-    "effects": {
-      "ipDelta": {
-        "opponent": 1
-      }
-    },
-    "tags": [
-      "cryptid",
-      "arizona",
-      "thunderbird"
-    ],
-    "cost": 2,
-    "flavor": "\"CLASSIFIED INTELLIGENCE: The locals swear thunderbird waved back.\""
-  },
-  {
-    "schemaVersion": 2,
-    "id": "CRY-TS-071",
-    "faction": "truth",
-    "name": "Fouke Monster Mass Sighting",
-    "type": "ATTACK",
-    "rarity": "common",
-    "effects": {
-      "ipDelta": {
-        "opponent": 1
-      }
-    },
-    "tags": [
-      "cryptid",
-      "arkansas",
-      "fouke-monster"
-    ],
-    "cost": 2,
-    "flavor": "\"CLASSIFIED INTELLIGENCE: The locals swear fouke monster waved back.\""
-  },
-  {
-    "schemaVersion": 2,
-    "id": "CRY-TS-072",
-    "faction": "truth",
-    "name": "Bigfoot Mass Sighting",
-    "type": "ZONE",
-    "rarity": "common",
-    "effects": {
-      "pressureDelta": 1
-    },
-    "tags": [
-      "cryptid",
-      "california",
-      "bigfoot"
-    ],
-    "cost": 4,
-    "flavor": "\"CLASSIFIED INTELLIGENCE: The locals swear bigfoot waved back.\""
-  },
-  {
-    "schemaVersion": 2,
-    "id": "CRY-TS-073",
-    "faction": "truth",
-    "name": "Colorado Cryptid Mass Sighting",
-    "type": "ATTACK",
-    "rarity": "common",
-    "effects": {
-      "ipDelta": {
-        "opponent": 1
-      }
-    },
-    "tags": [
-      "cryptid",
-      "colorado",
-      "colorado-cryptid"
-    ],
-    "cost": 2,
-    "flavor": "\"CLASSIFIED INTELLIGENCE: The locals swear colorado cryptid waved back.\""
-  },
-  {
-    "schemaVersion": 2,
-    "id": "CRY-TS-074",
-    "faction": "truth",
-    "name": "Connecticut Cryptid Mass Sighting",
-    "type": "ATTACK",
-    "rarity": "common",
-    "effects": {
-      "ipDelta": {
-        "opponent": 1
-      }
-    },
-    "tags": [
-      "cryptid",
-      "connecticut",
-      "connecticut-cryptid"
-    ],
-    "cost": 2,
-    "flavor": "\"CLASSIFIED INTELLIGENCE: The locals swear connecticut cryptid waved back.\""
-  },
-  {
-    "schemaVersion": 2,
-    "id": "CRY-TS-075",
-    "faction": "truth",
-    "name": "Delaware Cryptid Mass Sighting",
-    "type": "ZONE",
-    "rarity": "common",
-    "effects": {
-      "pressureDelta": 1
-    },
-    "tags": [
-      "cryptid",
-      "delaware",
-      "delaware-cryptid"
-    ],
-    "cost": 4,
-    "flavor": "\"CLASSIFIED INTELLIGENCE: The locals swear delaware cryptid waved back.\""
-  },
-  {
-    "schemaVersion": 2,
-    "id": "CRY-TS-076",
-    "faction": "truth",
-    "name": "Skunk Ape Mass Sighting",
-    "type": "ZONE",
-    "rarity": "common",
-    "effects": {
-      "pressureDelta": 1
-    },
-    "tags": [
-      "cryptid",
-      "florida",
-      "skunk-ape"
-    ],
-    "cost": 4,
-    "flavor": "\"CLASSIFIED INTELLIGENCE: The locals swear skunk ape waved back.\""
-  },
-  {
-    "schemaVersion": 2,
-    "id": "CRY-TS-077",
-    "faction": "truth",
-    "name": "Georgia Cryptid Mass Sighting",
-    "type": "ZONE",
-    "rarity": "common",
-    "effects": {
-      "pressureDelta": 1
-    },
-    "tags": [
-      "cryptid",
-      "georgia",
-      "georgia-cryptid"
-    ],
-    "cost": 4,
-    "flavor": "\"CLASSIFIED INTELLIGENCE: The locals swear georgia cryptid waved back.\""
-  },
-  {
-    "schemaVersion": 2,
-    "id": "CRY-TS-078",
-    "faction": "truth",
-    "name": "Hawaii Cryptid Mass Sighting",
-    "type": "ZONE",
-    "rarity": "common",
-    "effects": {
-      "pressureDelta": 1
-    },
-    "tags": [
-      "cryptid",
-      "hawaii",
-      "hawaii-cryptid"
-    ],
-    "cost": 4,
-    "flavor": "\"CLASSIFIED INTELLIGENCE: The locals swear hawaii cryptid waved back.\""
-  },
-  {
-    "schemaVersion": 2,
-    "id": "CRY-TS-079",
-    "faction": "truth",
-    "name": "Idaho Cryptid Mass Sighting",
-    "type": "ZONE",
-    "rarity": "common",
-    "effects": {
-      "pressureDelta": 1
-    },
-    "tags": [
-      "cryptid",
-      "idaho",
-      "idaho-cryptid"
-    ],
-    "cost": 4,
-    "flavor": "\"CLASSIFIED INTELLIGENCE: The locals swear idaho cryptid waved back.\""
-  },
-  {
-    "schemaVersion": 2,
-    "id": "CRY-TS-080",
-    "faction": "truth",
-    "name": "Enfield Horror Mass Sighting",
-    "type": "ZONE",
-    "rarity": "common",
-    "effects": {
-      "pressureDelta": 1
-    },
-    "tags": [
-      "cryptid",
-      "illinois",
-      "enfield-horror"
-    ],
-    "cost": 4,
-    "flavor": "\"CLASSIFIED INTELLIGENCE: The locals swear enfield horror waved back.\""
-  },
-  {
-    "schemaVersion": 2,
-    "id": "CRY-TS-081",
-    "faction": "truth",
-    "name": "Indiana Cryptid Mass Sighting",
-    "type": "ZONE",
-    "rarity": "common",
-    "effects": {
-      "pressureDelta": 1
-    },
-    "tags": [
-      "cryptid",
-      "indiana",
-      "indiana-cryptid"
-    ],
-    "cost": 4,
-    "flavor": "\"CLASSIFIED INTELLIGENCE: The locals swear indiana cryptid waved back.\""
-  },
-  {
-    "schemaVersion": 2,
-    "id": "CRY-TS-082",
-    "faction": "truth",
-    "name": "Iowa Cryptid Mass Sighting",
-    "type": "ZONE",
-    "rarity": "common",
-    "effects": {
-      "pressureDelta": 1
-    },
-    "tags": [
-      "cryptid",
-      "iowa",
-      "iowa-cryptid"
-    ],
-    "cost": 4,
-    "flavor": "\"CLASSIFIED INTELLIGENCE: The locals swear iowa cryptid waved back.\""
-  },
-  {
-    "schemaVersion": 2,
-    "id": "CRY-TS-083",
-    "faction": "truth",
-    "name": "Kansas Cryptid Mass Sighting",
-    "type": "ZONE",
-    "rarity": "common",
-    "effects": {
-      "pressureDelta": 1
-    },
-    "tags": [
-      "cryptid",
-      "kansas",
-      "kansas-cryptid"
-    ],
-    "cost": 4,
-    "flavor": "\"CLASSIFIED INTELLIGENCE: The locals swear kansas cryptid waved back.\""
-  },
-  {
-    "schemaVersion": 2,
-    "id": "CRY-TS-084",
-    "faction": "truth",
-    "name": "Kelly–Hopkinsville Goblins Mass Sighting",
-    "type": "ZONE",
-    "rarity": "common",
-    "effects": {
-      "pressureDelta": 1
-    },
-    "tags": [
-      "cryptid",
-      "kentucky",
-      "kelly–hopkinsville-goblins"
-    ],
-    "cost": 4,
-    "flavor": "\"CLASSIFIED INTELLIGENCE: The locals swear kelly–hopkinsville goblins waved back.\""
-  },
-  {
-    "schemaVersion": 2,
-    "id": "CRY-TS-085",
-    "faction": "truth",
-    "name": "Rougarou Mass Sighting",
-    "type": "ZONE",
-    "rarity": "common",
-    "effects": {
-      "pressureDelta": 1
-    },
-    "tags": [
-      "cryptid",
-      "louisiana",
-      "rougarou"
-    ],
-    "cost": 4,
-    "flavor": "\"CLASSIFIED INTELLIGENCE: The locals swear rougarou waved back.\""
-  },
-  {
-    "schemaVersion": 2,
-    "id": "CRY-TS-086",
-    "faction": "truth",
-    "name": "Maine Cryptid Mass Sighting",
-    "type": "ZONE",
-    "rarity": "common",
-    "effects": {
-      "pressureDelta": 1
-    },
-    "tags": [
-      "cryptid",
-      "maine",
-      "maine-cryptid"
-    ],
-    "cost": 4,
-    "flavor": "\"CLASSIFIED INTELLIGENCE: The locals swear maine cryptid waved back.\""
-  },
-  {
-    "schemaVersion": 2,
-    "id": "CRY-TS-087",
-    "faction": "truth",
-    "name": "Snallygaster Mass Sighting",
-    "type": "ZONE",
-    "rarity": "common",
-    "effects": {
-      "pressureDelta": 1
-    },
-    "tags": [
-      "cryptid",
-      "maryland",
-      "snallygaster"
-    ],
-    "cost": 4,
-    "flavor": "\"CLASSIFIED INTELLIGENCE: The locals swear snallygaster waved back.\""
-  },
-  {
-    "schemaVersion": 2,
-    "id": "CRY-TS-088",
-    "faction": "truth",
-    "name": "Dover Demon Mass Sighting",
-    "type": "ZONE",
-    "rarity": "common",
-    "effects": {
-      "pressureDelta": 1
-    },
-    "tags": [
-      "cryptid",
-      "massachusetts",
-      "dover-demon"
-    ],
-    "cost": 4,
-    "flavor": "\"CLASSIFIED INTELLIGENCE: The locals swear dover demon waved back.\""
-  },
-  {
-    "schemaVersion": 2,
-    "id": "CRY-TS-089",
-    "faction": "truth",
-    "name": "Dogman Mass Sighting",
-    "type": "ZONE",
-    "rarity": "common",
-    "effects": {
-      "pressureDelta": 1
-    },
-    "tags": [
-      "cryptid",
-      "michigan",
-      "dogman"
-    ],
-    "cost": 4,
-    "flavor": "\"CLASSIFIED INTELLIGENCE: The locals swear dogman waved back.\""
-  },
-  {
-    "schemaVersion": 2,
-    "id": "CRY-TS-090",
-    "faction": "truth",
-    "name": "Wendigo Mass Sighting",
-    "type": "ATTACK",
-    "rarity": "common",
-    "effects": {
-      "ipDelta": {
-        "opponent": 1
-      }
-    },
-    "tags": [
-      "cryptid",
-      "minnesota",
-      "wendigo"
-    ],
-    "cost": 2,
-    "flavor": "\"CLASSIFIED INTELLIGENCE: The locals swear wendigo waved back.\""
-  },
-  {
-    "schemaVersion": 2,
-    "id": "CRY-TS-091",
-    "faction": "truth",
-    "name": "Mississippi Cryptid Mass Sighting",
-    "type": "ZONE",
-    "rarity": "common",
-    "effects": {
-      "pressureDelta": 1
-    },
-    "tags": [
-      "cryptid",
-      "mississippi",
-      "mississippi-cryptid"
-    ],
-    "cost": 4,
-    "flavor": "\"CLASSIFIED INTELLIGENCE: The locals swear mississippi cryptid waved back.\""
-  },
-  {
-    "schemaVersion": 2,
-    "id": "CRY-TS-092",
-    "faction": "truth",
-    "name": "Missouri Cryptid Mass Sighting",
-    "type": "ZONE",
-    "rarity": "common",
-    "effects": {
-      "pressureDelta": 1
-    },
-    "tags": [
-      "cryptid",
-      "missouri",
-      "missouri-cryptid"
-    ],
-    "cost": 4,
-    "flavor": "\"CLASSIFIED INTELLIGENCE: The locals swear missouri cryptid waved back.\""
-  },
-  {
-    "schemaVersion": 2,
-    "id": "CRY-TS-093",
-    "faction": "truth",
-    "name": "Shunka Warakin Mass Sighting",
-    "type": "ZONE",
-    "rarity": "common",
-    "effects": {
-      "pressureDelta": 1
-    },
-    "tags": [
-      "cryptid",
-      "montana",
-      "shunka-warakin"
-    ],
-    "cost": 4,
-    "flavor": "\"CLASSIFIED INTELLIGENCE: The locals swear shunka warakin waved back.\""
-  },
-  {
-    "schemaVersion": 2,
-    "id": "CRY-TS-094",
-    "faction": "truth",
-    "name": "Nebraska Cryptid Mass Sighting",
-    "type": "ZONE",
-    "rarity": "common",
-    "effects": {
-      "pressureDelta": 1
-    },
-    "tags": [
-      "cryptid",
-      "nebraska",
-      "nebraska-cryptid"
-    ],
-    "cost": 4,
-    "flavor": "\"CLASSIFIED INTELLIGENCE: The locals swear nebraska cryptid waved back.\""
-  },
-  {
-    "schemaVersion": 2,
-    "id": "CRY-TS-095",
-    "faction": "truth",
-    "name": "Tahoe Tessie Mass Sighting",
-    "type": "ZONE",
-    "rarity": "common",
-    "effects": {
-      "pressureDelta": 1
-    },
-    "tags": [
-      "cryptid",
-      "nevada",
-      "tahoe-tessie"
-    ],
-    "cost": 4,
-    "flavor": "\"CLASSIFIED INTELLIGENCE: The locals swear tahoe tessie waved back.\""
-  },
-  {
-    "schemaVersion": 2,
-    "id": "CRY-TS-096",
-    "faction": "truth",
-    "name": "Wood Devils Mass Sighting",
-    "type": "ZONE",
-    "rarity": "common",
-    "effects": {
-      "pressureDelta": 1
-    },
-    "tags": [
-      "cryptid",
-      "new-hampshire",
-      "wood-devils"
-    ],
-    "cost": 4,
-    "flavor": "\"CLASSIFIED INTELLIGENCE: The locals swear wood devils waved back.\""
-  },
-  {
-    "schemaVersion": 2,
-    "id": "CRY-TS-097",
-    "faction": "truth",
-    "name": "Jersey Devil Mass Sighting",
-    "type": "ATTACK",
-    "rarity": "common",
-    "effects": {
-      "ipDelta": {
-        "opponent": 1
-      }
-    },
-    "tags": [
-      "cryptid",
-      "new-jersey",
-      "jersey-devil"
-    ],
-    "cost": 2,
-    "flavor": "\"CLASSIFIED INTELLIGENCE: The locals swear jersey devil waved back.\""
-  },
-  {
-    "schemaVersion": 2,
-    "id": "CRY-TS-098",
-    "faction": "truth",
-    "name": "Skinwalkers Mass Sighting",
-    "type": "ATTACK",
-    "rarity": "common",
-    "effects": {
-      "ipDelta": {
-        "opponent": 1
-      }
-    },
-    "tags": [
-      "cryptid",
-      "new-mexico",
-      "skinwalkers"
-    ],
-    "cost": 2,
-    "flavor": "\"CLASSIFIED INTELLIGENCE: The locals swear skinwalkers waved back.\""
-  },
-  {
-    "schemaVersion": 2,
-    "id": "CRY-TS-099",
-    "faction": "truth",
-    "name": "Montauk Monster Mass Sighting",
-    "type": "ZONE",
-    "rarity": "common",
-    "effects": {
-      "pressureDelta": 1
-    },
-    "tags": [
-      "cryptid",
-      "new-york",
-      "montauk-monster"
-    ],
-    "cost": 4,
-    "flavor": "\"CLASSIFIED INTELLIGENCE: The locals swear montauk monster waved back.\""
-  },
-  {
-    "schemaVersion": 2,
-    "id": "CRY-TS-100",
-    "faction": "truth",
-    "name": "North Carolina Cryptid Mass Sighting",
-    "type": "ZONE",
-    "rarity": "common",
-    "effects": {
-      "pressureDelta": 1
-    },
-    "tags": [
-      "cryptid",
-      "north-carolina",
-      "north-carolina-cryptid"
-    ],
-    "cost": 4,
-    "flavor": "\"CLASSIFIED INTELLIGENCE: The locals swear north carolina cryptid waved back.\""
-  },
-  {
-    "schemaVersion": 2,
-    "id": "CRY-TS-101",
-    "faction": "truth",
-    "name": "North Dakota Cryptid Mass Sighting",
-    "type": "ZONE",
-    "rarity": "common",
-    "effects": {
-      "pressureDelta": 1
-    },
-    "tags": [
-      "cryptid",
-      "north-dakota",
-      "north-dakota-cryptid"
-    ],
-    "cost": 4,
-    "flavor": "\"CLASSIFIED INTELLIGENCE: The locals swear north dakota cryptid waved back.\""
-  },
-  {
-    "schemaVersion": 2,
-    "id": "CRY-TS-102",
-    "faction": "truth",
-    "name": "Loveland Frogman Mass Sighting",
-    "type": "ZONE",
-    "rarity": "common",
-    "effects": {
-      "pressureDelta": 1
-    },
-    "tags": [
-      "cryptid",
-      "ohio",
-      "loveland-frogman"
-    ],
-    "cost": 4,
-    "flavor": "\"CLASSIFIED INTELLIGENCE: The locals swear loveland frogman waved back.\""
-  },
-  {
-    "schemaVersion": 2,
-    "id": "CRY-TS-103",
-    "faction": "truth",
-    "name": "Oklahoma Cryptid Mass Sighting",
-    "type": "ZONE",
-    "rarity": "common",
-    "effects": {
-      "pressureDelta": 1
-    },
-    "tags": [
-      "cryptid",
-      "oklahoma",
-      "oklahoma-cryptid"
-    ],
-    "cost": 4,
-    "flavor": "\"CLASSIFIED INTELLIGENCE: The locals swear oklahoma cryptid waved back.\""
-  },
-  {
-    "schemaVersion": 2,
-    "id": "CRY-TS-104",
-    "faction": "truth",
-    "name": "Bigfoot Mass Sighting",
-    "type": "ZONE",
-    "rarity": "common",
-    "effects": {
-      "pressureDelta": 1
-    },
-    "tags": [
-      "cryptid",
-      "oregon",
-      "bigfoot"
-    ],
-    "cost": 4,
-    "flavor": "\"CLASSIFIED INTELLIGENCE: The locals swear bigfoot waved back.\""
-  },
-  {
-    "schemaVersion": 2,
-    "id": "CRY-TS-105",
-    "faction": "truth",
-    "name": "Pennsylvania Cryptid Mass Sighting",
-    "type": "ZONE",
-    "rarity": "common",
-    "effects": {
-      "pressureDelta": 1
-    },
-    "tags": [
-      "cryptid",
-      "pennsylvania",
-      "pennsylvania-cryptid"
-    ],
-    "cost": 4,
-    "flavor": "\"CLASSIFIED INTELLIGENCE: The locals swear pennsylvania cryptid waved back.\""
-  },
-  {
-    "schemaVersion": 2,
-    "id": "CRY-TS-106",
-    "faction": "truth",
-    "name": "Rhode Island Cryptid Mass Sighting",
-    "type": "ZONE",
-    "rarity": "common",
-    "effects": {
-      "pressureDelta": 1
-    },
-    "tags": [
-      "cryptid",
-      "rhode-island",
-      "rhode-island-cryptid"
-    ],
-    "cost": 4,
-    "flavor": "\"CLASSIFIED INTELLIGENCE: The locals swear rhode island cryptid waved back.\""
-  },
-  {
-    "schemaVersion": 2,
-    "id": "CRY-TS-107",
-    "faction": "truth",
-    "name": "South Carolina Cryptid Mass Sighting",
-    "type": "ZONE",
-    "rarity": "common",
-    "effects": {
-      "pressureDelta": 1
-    },
-    "tags": [
-      "cryptid",
-      "south-carolina",
-      "south-carolina-cryptid"
-    ],
-    "cost": 4,
-    "flavor": "\"CLASSIFIED INTELLIGENCE: The locals swear south carolina cryptid waved back.\""
-  },
-  {
-    "schemaVersion": 2,
-    "id": "CRY-TS-108",
-    "faction": "truth",
-    "name": "South Dakota Cryptid Mass Sighting",
-    "type": "ZONE",
-    "rarity": "common",
-    "effects": {
-      "pressureDelta": 1
-    },
-    "tags": [
-      "cryptid",
-      "south-dakota",
-      "south-dakota-cryptid"
-    ],
-    "cost": 4,
-    "flavor": "\"CLASSIFIED INTELLIGENCE: The locals swear south dakota cryptid waved back.\""
-  },
-  {
-    "schemaVersion": 2,
-    "id": "CRY-TS-109",
-    "faction": "truth",
-    "name": "Tennessee Cryptid Mass Sighting",
-    "type": "ZONE",
-    "rarity": "common",
-    "effects": {
-      "pressureDelta": 1
-    },
-    "tags": [
-      "cryptid",
-      "tennessee",
-      "tennessee-cryptid"
-    ],
-    "cost": 4,
-    "flavor": "\"CLASSIFIED INTELLIGENCE: The locals swear tennessee cryptid waved back.\""
-  },
-  {
-    "schemaVersion": 2,
-    "id": "CRY-TS-110",
-    "faction": "truth",
-    "name": "Chupacabra Mass Sighting",
-    "type": "ATTACK",
-    "rarity": "common",
-    "effects": {
-      "ipDelta": {
-        "opponent": 1
-      }
-    },
-    "tags": [
-      "cryptid",
-      "texas",
-      "chupacabra"
-    ],
-    "cost": 2,
-    "flavor": "\"CLASSIFIED INTELLIGENCE: The locals swear chupacabra waved back.\""
-  },
-  {
-    "schemaVersion": 2,
-    "id": "CRY-TS-111",
-    "faction": "truth",
-    "name": "Utah Cryptid Mass Sighting",
-    "type": "ZONE",
-    "rarity": "common",
-    "effects": {
-      "pressureDelta": 1
-    },
-    "tags": [
-      "cryptid",
-      "utah",
-      "utah-cryptid"
-    ],
-    "cost": 4,
-    "flavor": "\"CLASSIFIED INTELLIGENCE: The locals swear utah cryptid waved back.\""
-  },
-  {
-    "schemaVersion": 2,
-    "id": "CRY-TS-112",
-    "faction": "truth",
-    "name": "Champ Mass Sighting",
-    "type": "ZONE",
-    "rarity": "common",
-    "effects": {
-      "pressureDelta": 1
-    },
-    "tags": [
-      "cryptid",
-      "vermont",
-      "champ"
-    ],
-    "cost": 4,
-    "flavor": "\"CLASSIFIED INTELLIGENCE: The locals swear champ waved back.\""
-  },
-  {
-    "schemaVersion": 2,
-    "id": "CRY-TS-113",
-    "faction": "truth",
-    "name": "Virginia Cryptid Mass Sighting",
-    "type": "ZONE",
-    "rarity": "common",
-    "effects": {
-      "pressureDelta": 1
-    },
-    "tags": [
-      "cryptid",
-      "virginia",
-      "virginia-cryptid"
-    ],
-    "cost": 4,
-    "flavor": "\"CLASSIFIED INTELLIGENCE: The locals swear virginia cryptid waved back.\""
-  },
-  {
-    "schemaVersion": 2,
-    "id": "CRY-TS-114",
-    "faction": "truth",
-    "name": "Bigfoot Mass Sighting",
-    "type": "ZONE",
-    "rarity": "common",
-    "effects": {
-      "pressureDelta": 1
-    },
-    "tags": [
-      "cryptid",
-      "washington",
-      "bigfoot"
-    ],
-    "cost": 4,
-    "flavor": "\"CLASSIFIED INTELLIGENCE: The locals swear bigfoot waved back.\""
-  },
-  {
-    "schemaVersion": 2,
-    "id": "CRY-TS-115",
-    "faction": "truth",
-    "name": "Mothman Mass Sighting",
-    "type": "ATTACK",
-    "rarity": "common",
-    "effects": {
-      "ipDelta": {
-        "opponent": 1
-      }
-    },
-    "tags": [
-      "cryptid",
-      "west-virginia",
-      "mothman"
-    ],
-    "cost": 2,
-    "flavor": "\"CLASSIFIED INTELLIGENCE: The locals swear mothman waved back.\""
-  },
-  {
-    "schemaVersion": 2,
-    "id": "CRY-TS-116",
-    "faction": "truth",
-    "name": "Beast of Bray Road Mass Sighting",
-    "type": "ATTACK",
-    "rarity": "common",
-    "effects": {
-      "ipDelta": {
-        "opponent": 1
-      }
-    },
-    "tags": [
-      "cryptid",
-      "wisconsin",
-      "beast-of-bray-road"
-    ],
-    "cost": 2,
-    "flavor": "\"CLASSIFIED INTELLIGENCE: The locals swear beast of bray road waved back.\""
-  },
-  {
-    "schemaVersion": 2,
-    "id": "CRY-TS-117",
-    "faction": "truth",
-    "name": "Wyoming Cryptid Mass Sighting",
-    "type": "ZONE",
-    "rarity": "common",
-    "effects": {
-      "pressureDelta": 1
-    },
-    "tags": [
-      "cryptid",
-      "wyoming",
-      "wyoming-cryptid"
-    ],
-    "cost": 4,
-    "flavor": "\"CLASSIFIED INTELLIGENCE: The locals swear wyoming cryptid waved back.\""
-  },
-  {
-    "schemaVersion": 2,
-    "id": "CRY-TS-118",
-    "faction": "truth",
-    "name": "Chupacabra Panic Wave",
-    "type": "ATTACK",
-    "rarity": "common",
-    "effects": {
-      "ipDelta": {
-        "opponent": 1
-      }
-    },
-    "tags": [
-      "chupacabra",
-      "cryptid"
-    ],
-    "cost": 2,
-    "flavor": "\"CLASSIFIED INTELLIGENCE: Eyewitnesses report chills and grainy footage.\""
-  },
-  {
-    "schemaVersion": 2,
-    "id": "CRY-TS-119",
-    "faction": "truth",
-    "name": "Tizheruk Panic Wave",
-    "type": "ATTACK",
-    "rarity": "common",
-    "effects": {
-      "ipDelta": {
-        "opponent": 1
-      }
-    },
-    "tags": [
-      "tizheruk",
-      "cryptid"
-    ],
-    "cost": 2,
-    "flavor": "\"CLASSIFIED INTELLIGENCE: Eyewitnesses report chills and grainy footage.\""
-  },
-  {
-    "schemaVersion": 2,
-    "id": "CRY-TS-120",
-    "faction": "truth",
-    "name": "Wendigo Watch Patrols",
-    "type": "ATTACK",
-    "rarity": "common",
-    "effects": {
-      "ipDelta": {
-        "opponent": 1
-      }
-    },
-    "tags": [
-      "wendigo",
-      "cryptid"
-    ],
-    "cost": 2,
-    "flavor": "\"CLASSIFIED INTELLIGENCE: Eyewitnesses report chills and grainy footage.\""
-  },
-  {
-    "schemaVersion": 2,
-    "id": "CRY-TS-121",
-    "faction": "truth",
-    "name": "Loveland Frogman Watch Patrols",
-    "type": "MEDIA",
-    "rarity": "common",
-    "effects": {
-      "truthDelta": 1
-    },
-    "tags": [
-      "loveland-frogman",
-      "cryptid"
-    ],
-    "cost": 3,
-    "flavor": "\"CLASSIFIED INTELLIGENCE: Eyewitnesses report chills and grainy footage.\""
-  },
-  {
-    "schemaVersion": 2,
-    "id": "CRY-TS-122",
-    "faction": "truth",
-    "name": "Bigfoot Panic Wave",
-    "type": "ATTACK",
-    "rarity": "common",
-    "effects": {
-      "ipDelta": {
-        "opponent": 1
-      }
-    },
-    "tags": [
-      "bigfoot",
-      "cryptid"
-    ],
-    "cost": 2,
-    "flavor": "\"CLASSIFIED INTELLIGENCE: Eyewitnesses report chills and grainy footage.\""
-  },
-  {
-    "schemaVersion": 2,
-    "id": "CRY-TS-123",
-    "faction": "truth",
-    "name": "Dogman Panic Wave",
-    "type": "ATTACK",
-    "rarity": "common",
-    "effects": {
-      "ipDelta": {
-        "opponent": 1
-      }
-    },
-    "tags": [
-      "dogman",
-      "cryptid"
-    ],
-    "cost": 2,
-    "flavor": "\"CLASSIFIED INTELLIGENCE: Eyewitnesses report chills and grainy footage.\""
-  },
-  {
-    "schemaVersion": 2,
-    "id": "CRY-TS-124",
-    "faction": "truth",
-    "name": "Rougarou Watch Patrols",
-    "type": "MEDIA",
-    "rarity": "common",
-    "effects": {
-      "truthDelta": 1
-    },
-    "tags": [
-      "rougarou",
-      "cryptid"
-    ],
-    "cost": 3,
-    "flavor": "\"CLASSIFIED INTELLIGENCE: Eyewitnesses report chills and grainy footage.\""
-  },
-  {
-    "schemaVersion": 2,
-    "id": "CRY-TS-125",
-    "faction": "truth",
-    "name": "Tahoe Tessie Panic Wave",
-    "type": "ATTACK",
-    "rarity": "common",
-    "effects": {
-      "ipDelta": {
-        "opponent": 1
-      }
-    },
-    "tags": [
-      "tahoe-tessie",
-      "cryptid"
-    ],
-    "cost": 2,
-    "flavor": "\"CLASSIFIED INTELLIGENCE: Eyewitnesses report chills and grainy footage.\""
-  },
-  {
-    "schemaVersion": 2,
-    "id": "CRY-TS-126",
-    "faction": "truth",
-    "name": "Beast of Bray Road Watch Patrols",
-    "type": "ATTACK",
-    "rarity": "common",
-    "effects": {
-      "ipDelta": {
-        "opponent": 1
-      }
-    },
-    "tags": [
-      "beast-of-bray-road",
-      "cryptid"
-    ],
-    "cost": 2,
-    "flavor": "\"CLASSIFIED INTELLIGENCE: Eyewitnesses report chills and grainy footage.\""
-  },
-  {
-    "schemaVersion": 2,
-    "id": "CRY-TS-127",
-    "faction": "truth",
-    "name": "Wendigo Watch Patrols",
-    "type": "ATTACK",
-    "rarity": "common",
-    "effects": {
-      "ipDelta": {
-        "opponent": 1
-      }
-    },
-    "tags": [
-      "wendigo",
-      "cryptid"
-    ],
-    "cost": 2,
-    "flavor": "\"CLASSIFIED INTELLIGENCE: Eyewitnesses report chills and grainy footage.\""
-  },
-  {
-    "schemaVersion": 2,
-    "id": "CRY-TS-128",
-    "faction": "truth",
-    "name": "Dover Demon Panic Wave",
-    "type": "ATTACK",
-    "rarity": "common",
-    "effects": {
-      "ipDelta": {
-        "opponent": 1
-      }
-    },
-    "tags": [
-      "dover-demon",
-      "cryptid"
-    ],
-    "cost": 2,
-    "flavor": "\"CLASSIFIED INTELLIGENCE: Eyewitnesses report chills and grainy footage.\""
-  },
-  {
-    "schemaVersion": 2,
-    "id": "CRY-TS-129",
-    "faction": "truth",
-    "name": "Tizheruk Watch Patrols",
-    "type": "MEDIA",
-    "rarity": "common",
-    "effects": {
-      "truthDelta": 1
-    },
-    "tags": [
-      "tizheruk",
-      "cryptid"
-    ],
-    "cost": 3,
-    "flavor": "\"CLASSIFIED INTELLIGENCE: Eyewitnesses report chills and grainy footage.\""
-  },
-  {
-    "schemaVersion": 2,
-    "id": "CRY-TS-130",
-    "faction": "truth",
-    "name": "Fouke Monster Watch Patrols",
-    "type": "MEDIA",
-    "rarity": "common",
-    "effects": {
-      "truthDelta": 1
-    },
-    "tags": [
-      "fouke-monster",
-      "cryptid"
-    ],
-    "cost": 3,
-    "flavor": "\"CLASSIFIED INTELLIGENCE: Eyewitnesses report chills and grainy footage.\""
-  },
-  {
-    "schemaVersion": 2,
-    "id": "CRY-TS-131",
-    "faction": "truth",
-    "name": "Jersey Devil Panic Wave",
-    "type": "ATTACK",
-    "rarity": "common",
-    "effects": {
-      "ipDelta": {
-        "opponent": 1
-      }
-    },
-    "tags": [
-      "jersey-devil",
-      "cryptid"
-    ],
-    "cost": 2,
-    "flavor": "\"CLASSIFIED INTELLIGENCE: Eyewitnesses report chills and grainy footage.\""
-  },
-  {
-    "schemaVersion": 2,
-    "id": "CRY-TS-132",
-    "faction": "truth",
-    "name": "Tizheruk Panic Wave",
-    "type": "ATTACK",
-    "rarity": "common",
-    "effects": {
-      "ipDelta": {
-        "opponent": 1
-      }
-    },
-    "tags": [
-      "tizheruk",
-      "cryptid"
-    ],
-    "cost": 2,
-    "flavor": "\"CLASSIFIED INTELLIGENCE: Eyewitnesses report chills and grainy footage.\""
-  },
-  {
-    "schemaVersion": 2,
-    "id": "CRY-TS-133",
-    "faction": "truth",
-    "name": "Tahoe Tessie Panic Wave",
-    "type": "ATTACK",
-    "rarity": "common",
-    "effects": {
-      "ipDelta": {
-        "opponent": 1
-      }
-    },
-    "tags": [
-      "tahoe-tessie",
-      "cryptid"
-    ],
-    "cost": 2,
-    "flavor": "\"CLASSIFIED INTELLIGENCE: Eyewitnesses report chills and grainy footage.\""
-  },
-  {
-    "schemaVersion": 2,
-    "id": "CRY-TS-134",
-    "faction": "truth",
-    "name": "Fouke Monster Panic Wave",
-    "type": "ATTACK",
-    "rarity": "common",
-    "effects": {
-      "ipDelta": {
-        "opponent": 1
-      }
-    },
-    "tags": [
-      "fouke-monster",
-      "cryptid"
-    ],
-    "cost": 2,
-    "flavor": "\"CLASSIFIED INTELLIGENCE: Eyewitnesses report chills and grainy footage.\""
-  },
-  {
-    "schemaVersion": 2,
-    "id": "CRY-TS-135",
-    "faction": "truth",
-    "name": "Snallygaster Watch Patrols",
-    "type": "MEDIA",
-    "rarity": "common",
-    "effects": {
-      "truthDelta": 1
-    },
-    "tags": [
-      "snallygaster",
-      "cryptid"
-    ],
-    "cost": 3,
-    "flavor": "\"CLASSIFIED INTELLIGENCE: Eyewitnesses report chills and grainy footage.\""
-  },
-  {
-    "schemaVersion": 2,
-    "id": "CRY-TS-136",
-    "faction": "truth",
-    "name": "Chupacabra Panic Wave",
-    "type": "ATTACK",
-    "rarity": "common",
-    "effects": {
-      "ipDelta": {
-        "opponent": 1
-      }
-    },
-    "tags": [
-      "chupacabra",
-      "cryptid"
-    ],
-    "cost": 2,
-    "flavor": "\"CLASSIFIED INTELLIGENCE: Eyewitnesses report chills and grainy footage.\""
-  },
-  {
-    "schemaVersion": 2,
-    "id": "CRY-TS-137",
-    "faction": "truth",
-    "name": "Shunka Warakin Panic Wave",
-    "type": "ATTACK",
-    "rarity": "common",
-    "effects": {
-      "ipDelta": {
-        "opponent": 1
-      }
-    },
-    "tags": [
-      "shunka-warakin",
-      "cryptid"
-    ],
-    "cost": 2,
-    "flavor": "\"CLASSIFIED INTELLIGENCE: Eyewitnesses report chills and grainy footage.\""
-  },
-  {
-    "schemaVersion": 2,
-    "id": "CRY-TS-138",
-    "faction": "truth",
-    "name": "Tizheruk Panic Wave",
-    "type": "ATTACK",
-    "rarity": "common",
-    "effects": {
-      "ipDelta": {
-        "opponent": 1
-      }
-    },
-    "tags": [
-      "tizheruk",
-      "cryptid"
-    ],
-    "cost": 2,
-    "flavor": "\"CLASSIFIED INTELLIGENCE: Eyewitnesses report chills and grainy footage.\""
-  },
-  {
-    "schemaVersion": 2,
-    "id": "CRY-TS-139",
-    "faction": "truth",
-    "name": "Fouke Monster Panic Wave",
-    "type": "ATTACK",
-    "rarity": "common",
-    "effects": {
-      "ipDelta": {
-        "opponent": 1
-      }
-    },
-    "tags": [
-      "fouke-monster",
-      "cryptid"
-    ],
-    "cost": 2,
-    "flavor": "\"CLASSIFIED INTELLIGENCE: Eyewitnesses report chills and grainy footage.\""
-  },
-  {
-    "schemaVersion": 2,
-    "id": "CRY-TS-140",
-    "faction": "truth",
-    "name": "Dover Demon Panic Wave",
-    "type": "ATTACK",
-    "rarity": "common",
-    "effects": {
-      "ipDelta": {
-        "opponent": 1
-      }
-    },
-    "tags": [
-      "dover-demon",
-      "cryptid"
-    ],
-    "cost": 2,
-    "flavor": "\"CLASSIFIED INTELLIGENCE: Eyewitnesses report chills and grainy footage.\""
-  },
-  {
-    "schemaVersion": 2,
-    "id": "CRY-TS-141",
-    "faction": "truth",
-    "name": "Shunka Warakin Panic Wave",
-    "type": "ATTACK",
-    "rarity": "common",
-    "effects": {
-      "ipDelta": {
-        "opponent": 1
-      }
-    },
-    "tags": [
-      "shunka-warakin",
-      "cryptid"
-    ],
-    "cost": 2,
-    "flavor": "\"CLASSIFIED INTELLIGENCE: Eyewitnesses report chills and grainy footage.\""
-  },
-  {
-    "schemaVersion": 2,
-    "id": "CRY-TS-142",
-    "faction": "truth",
-    "name": "Champ Watch Patrols",
-    "type": "MEDIA",
-    "rarity": "common",
-    "effects": {
-      "truthDelta": 1
-    },
-    "tags": [
-      "champ",
-      "cryptid"
-    ],
-    "cost": 3,
-    "flavor": "\"CLASSIFIED INTELLIGENCE: Eyewitnesses report chills and grainy footage.\""
-  },
-  {
-    "schemaVersion": 2,
-    "id": "CRY-TS-143",
-    "faction": "truth",
-    "name": "Loveland Frogman Watch Patrols",
-    "type": "MEDIA",
-    "rarity": "common",
-    "effects": {
-      "truthDelta": 1
-    },
-    "tags": [
-      "loveland-frogman",
-      "cryptid"
-    ],
-    "cost": 3,
-    "flavor": "\"CLASSIFIED INTELLIGENCE: Eyewitnesses report chills and grainy footage.\""
-  },
-  {
-    "schemaVersion": 2,
-    "id": "CRY-TS-144",
-    "faction": "truth",
-    "name": "Montauk Monster Panic Wave",
-    "type": "ATTACK",
-    "rarity": "common",
-    "effects": {
-      "ipDelta": {
-        "opponent": 1
-      }
-    },
-    "tags": [
-      "montauk-monster",
-      "cryptid"
-    ],
-    "cost": 2,
-    "flavor": "\"CLASSIFIED INTELLIGENCE: Eyewitnesses report chills and grainy footage.\""
-  },
-  {
-    "schemaVersion": 2,
-    "id": "CRY-TS-145",
-    "faction": "truth",
-    "name": "Dogman Panic Wave",
-    "type": "ATTACK",
-    "rarity": "common",
-    "effects": {
-      "ipDelta": {
-        "opponent": 1
-      }
-    },
-    "tags": [
-      "dogman",
-      "cryptid"
-    ],
-    "cost": 2,
-    "flavor": "\"CLASSIFIED INTELLIGENCE: Eyewitnesses report chills and grainy footage.\""
-  },
-  {
-    "schemaVersion": 2,
-    "id": "CRY-TS-146",
-    "faction": "truth",
-    "name": "Tizheruk Panic Wave",
-    "type": "ATTACK",
-    "rarity": "common",
-    "effects": {
-      "ipDelta": {
-        "opponent": 1
-      }
-    },
-    "tags": [
-      "tizheruk",
-      "cryptid"
-    ],
-    "cost": 2,
-    "flavor": "\"CLASSIFIED INTELLIGENCE: Eyewitnesses report chills and grainy footage.\""
-  },
-  {
-    "schemaVersion": 2,
-    "id": "CRY-TS-147",
-    "faction": "truth",
-    "name": "Dover Demon Panic Wave",
-    "type": "ATTACK",
-    "rarity": "common",
-    "effects": {
-      "ipDelta": {
-        "opponent": 1
-      }
-    },
-    "tags": [
-      "dover-demon",
-      "cryptid"
-    ],
-    "cost": 2,
-    "flavor": "\"CLASSIFIED INTELLIGENCE: Eyewitnesses report chills and grainy footage.\""
-  },
-  {
-    "schemaVersion": 2,
-    "id": "CRY-TS-148",
-    "faction": "truth",
-    "name": "Snallygaster Watch Patrols",
-    "type": "MEDIA",
-    "rarity": "common",
-    "effects": {
-      "truthDelta": 1
-    },
-    "tags": [
-      "snallygaster",
-      "cryptid"
-    ],
-    "cost": 3,
-    "flavor": "\"CLASSIFIED INTELLIGENCE: Eyewitnesses report chills and grainy footage.\""
-  },
-  {
-    "schemaVersion": 2,
-    "id": "CRY-TS-149",
-    "faction": "truth",
-    "name": "Rougarou Panic Wave",
-    "type": "ATTACK",
-    "rarity": "common",
-    "effects": {
-      "ipDelta": {
-        "opponent": 1
-      }
-    },
-    "tags": [
-      "rougarou",
-      "cryptid"
-    ],
-    "cost": 2,
-    "flavor": "\"CLASSIFIED INTELLIGENCE: Eyewitnesses report chills and grainy footage.\""
-  },
-  {
-    "schemaVersion": 2,
-    "id": "CRY-TS-150",
-    "faction": "truth",
-    "name": "Montauk Monster Panic Wave",
-    "type": "ATTACK",
-    "rarity": "common",
-    "effects": {
-      "ipDelta": {
-        "opponent": 1
-      }
-    },
-    "tags": [
-      "montauk-monster",
-      "cryptid"
-    ],
-    "cost": 2,
-    "flavor": "\"CLASSIFIED INTELLIGENCE: Eyewitnesses report chills and grainy footage.\""
-  },
-  {
-    "schemaVersion": 2,
-    "id": "CRY-GV-001",
-    "faction": "government",
-    "name": "Men in Black Sweep",
-    "type": "ATTACK",
-    "rarity": "rare",
-    "effects": {
-      "ipDelta": {
-        "opponent": 3
+      "tags": [
+        "attack",
+        "cryptid",
+        "mothman",
+        "truth"
+      ],
+      "cost": 4,
+      "flavor": "\"CLASSIFIED INTELLIGENCE: Pixels enhanced: chills confirmed.\""
+    },
+    {
+      "schemaVersion": 2,
+      "id": "CRY-TS-007",
+      "faction": "truth",
+      "name": "Chupacabra Sighting Report",
+      "type": "ATTACK",
+      "rarity": "uncommon",
+      "effects": {
+        "ipDelta": {
+          "opponent": 2
+        }
       },
-      "discardOpponent": 1
+      "tags": [
+        "attack",
+        "bureaucracy",
+        "coverup",
+        "cryptid",
+        "media",
+        "truth"
+      ],
+      "cost": 3,
+      "flavor": "\"CLASSIFIED INTELLIGENCE: Chupacabra looked straight into the lens.\""
     },
-    "tags": [
-      "cryptid"
-    ],
-    "cost": 4,
-    "flavor": "\"CLASSIFIED INTELLIGENCE: Situation normal—memo drafted and archived.\""
-  },
-  {
-    "schemaVersion": 2,
-    "id": "CRY-GV-002",
-    "faction": "government",
-    "name": "Weather Machine Alpha",
-    "type": "ZONE",
-    "rarity": "uncommon",
-    "effects": {
-      "pressureDelta": 2
-    },
-    "tags": [
-      "cryptid"
-    ],
-    "cost": 5,
-    "flavor": "\"CLASSIFIED INTELLIGENCE: Situation normal—memo drafted and archived.\""
-  },
-  {
-    "schemaVersion": 2,
-    "id": "CRY-GV-003",
-    "faction": "government",
-    "name": "Project Grand Mandela",
-    "type": "MEDIA",
-    "rarity": "rare",
-    "effects": {
-      "truthDelta": -3
-    },
-    "tags": [
-      "cryptid"
-    ],
-    "cost": 5,
-    "flavor": "\"CLASSIFIED INTELLIGENCE: Awaiting lab results; likely weather and shadows.\""
-  },
-  {
-    "schemaVersion": 2,
-    "id": "CRY-GV-004",
-    "faction": "government",
-    "name": "Chemtrail Deployment",
-    "type": "ZONE",
-    "rarity": "uncommon",
-    "effects": {
-      "pressureDelta": 2
-    },
-    "tags": [
-      "cryptid"
-    ],
-    "cost": 5,
-    "flavor": "\"CLASSIFIED INTELLIGENCE: Public guidance issued; no chemtrail detected.\""
-  },
-  {
-    "schemaVersion": 2,
-    "id": "CRY-GV-005",
-    "faction": "government",
-    "name": "Area 51 Security",
-    "type": "ZONE",
-    "rarity": "common",
-    "effects": {
-      "pressureDelta": 1
-    },
-    "tags": [
-      "cryptid"
-    ],
-    "cost": 4,
-    "flavor": "\"CLASSIFIED INTELLIGENCE: Filed under routine wildlife misidentification.\""
-  },
-  {
-    "schemaVersion": 2,
-    "id": "CRY-GV-006",
-    "faction": "government",
-    "name": "Fake Alien Invasion",
-    "type": "ZONE",
-    "rarity": "legendary",
-    "effects": {
-      "pressureDelta": 4
-    },
-    "tags": [
-      "cryptid"
-    ],
-    "cost": 7,
-    "flavor": "\"CLASSIFIED INTELLIGENCE: Field note logged; further action unnecessary.\""
-  },
-  {
-    "schemaVersion": 2,
-    "id": "CRY-GV-007",
-    "faction": "government",
-    "name": "Roswell Cover Story",
-    "type": "MEDIA",
-    "rarity": "uncommon",
-    "effects": {
-      "truthDelta": -2
-    },
-    "tags": [
-      "cryptid"
-    ],
-    "cost": 4,
-    "flavor": "\"CLASSIFIED INTELLIGENCE: Public guidance issued; no roswell detected.\""
-  },
-  {
-    "schemaVersion": 2,
-    "id": "CRY-GV-008",
-    "faction": "government",
-    "name": "Disinformation Bureau",
-    "type": "MEDIA",
-    "rarity": "rare",
-    "effects": {
-      "truthDelta": -3
-    },
-    "tags": [
-      "cryptid"
-    ],
-    "cost": 5,
-    "flavor": "\"CLASSIFIED INTELLIGENCE: Awaiting lab results; likely weather and shadows.\""
-  },
-  {
-    "schemaVersion": 2,
-    "id": "CRY-GV-009",
-    "faction": "government",
-    "name": "Bigfoot Suit Factory",
-    "type": "ZONE",
-    "rarity": "uncommon",
-    "effects": {
-      "pressureDelta": 2
-    },
-    "tags": [
-      "cryptid"
-    ],
-    "cost": 5,
-    "flavor": "\"CLASSIFIED INTELLIGENCE: Field note logged; further action unnecessary.\""
-  },
-  {
-    "schemaVersion": 2,
-    "id": "CRY-GV-010",
-    "faction": "government",
-    "name": "Project Blue Beam",
-    "type": "ATTACK",
-    "rarity": "legendary",
-    "effects": {
-      "ipDelta": {
-        "opponent": 4
+    {
+      "schemaVersion": 2,
+      "id": "CRY-TS-008",
+      "faction": "truth",
+      "name": "Lake Monster Sonar Evidence",
+      "type": "ATTACK",
+      "rarity": "uncommon",
+      "effects": {
+        "ipDelta": {
+          "opponent": 2
+        }
       },
-      "discardOpponent": 2
+      "tags": [
+        "attack",
+        "cryptid",
+        "truth"
+      ],
+      "cost": 3,
+      "flavor": "\"CLASSIFIED INTELLIGENCE: Experts disagree; the crowd screams yes.\""
     },
-    "tags": [
-      "cryptid"
-    ],
-    "cost": 5,
-    "flavor": "\"CLASSIFIED INTELLIGENCE: Filed under routine wildlife misidentification.\""
-  },
-  {
-    "schemaVersion": 2,
-    "id": "CRY-GV-011",
-    "faction": "government",
-    "name": "Mothman Relocation Program",
-    "type": "ATTACK",
-    "rarity": "rare",
-    "effects": {
-      "ipDelta": {
-        "opponent": 3
+    {
+      "schemaVersion": 2,
+      "id": "CRY-TS-009",
+      "faction": "truth",
+      "name": "Ancient Astronaut Theory",
+      "type": "MEDIA",
+      "rarity": "rare",
+      "effects": {
+        "truthDelta": 3
       },
-      "discardOpponent": 1
+      "tags": [
+        "cryptid",
+        "media",
+        "truth"
+      ],
+      "cost": 5,
+      "flavor": "\"CLASSIFIED INTELLIGENCE: We brought snacks and a camcorder.\""
     },
-    "tags": [
-      "cryptid"
-    ],
-    "cost": 4,
-    "flavor": "\"CLASSIFIED INTELLIGENCE: Awaiting lab results; likely weather and shadows.\""
-  },
-  {
-    "schemaVersion": 2,
-    "id": "CRY-GV-012",
-    "faction": "government",
-    "name": "Chupacabra Protocol",
-    "type": "ATTACK",
-    "rarity": "uncommon",
-    "effects": {
-      "ipDelta": {
-        "opponent": 2
-      }
-    },
-    "tags": [
-      "cryptid"
-    ],
-    "cost": 3,
-    "flavor": "\"CLASSIFIED INTELLIGENCE: Filed under routine wildlife misidentification.\""
-  },
-  {
-    "schemaVersion": 2,
-    "id": "CRY-GV-013",
-    "faction": "government",
-    "name": "Cryptid Containment Unit",
-    "type": "MEDIA",
-    "rarity": "common",
-    "effects": {
-      "truthDelta": -1
-    },
-    "tags": [
-      "cryptid"
-    ],
-    "cost": 3,
-    "flavor": "\"CLASSIFIED INTELLIGENCE: Awaiting lab results; likely weather and shadows.\""
-  },
-  {
-    "schemaVersion": 2,
-    "id": "CRY-GV-014",
-    "faction": "government",
-    "name": "Jersey Devil Task Force",
-    "type": "ATTACK",
-    "rarity": "common",
-    "effects": {
-      "ipDelta": {
-        "opponent": 1
-      }
-    },
-    "tags": [
-      "cryptid"
-    ],
-    "cost": 2,
-    "flavor": "\"CLASSIFIED INTELLIGENCE: Public guidance issued; no jersey devil detected.\""
-  },
-  {
-    "schemaVersion": 2,
-    "id": "CRY-GV-015",
-    "faction": "government",
-    "name": "Lake Monster Drainage",
-    "type": "ATTACK",
-    "rarity": "uncommon",
-    "effects": {
-      "ipDelta": {
-        "opponent": 2
-      }
-    },
-    "tags": [
-      "cryptid"
-    ],
-    "cost": 3,
-    "flavor": "\"CLASSIFIED INTELLIGENCE: Public guidance issued; no lake detected.\""
-  },
-  {
-    "schemaVersion": 2,
-    "id": "CRY-GV-016",
-    "faction": "government",
-    "name": "Men in Beige",
-    "type": "ATTACK",
-    "rarity": "common",
-    "effects": {
-      "ipDelta": {
-        "opponent": 1
-      }
-    },
-    "tags": [
-      "cryptid"
-    ],
-    "cost": 2,
-    "flavor": "\"CLASSIFIED INTELLIGENCE: Filed under routine wildlife misidentification.\""
-  },
-  {
-    "schemaVersion": 2,
-    "id": "CRY-GV-017",
-    "faction": "government",
-    "name": "Swamp Gas Generator",
-    "type": "ZONE",
-    "rarity": "uncommon",
-    "effects": {
-      "pressureDelta": 2
-    },
-    "tags": [
-      "cryptid"
-    ],
-    "cost": 5,
-    "flavor": "\"CLASSIFIED INTELLIGENCE: Situation normal—memo drafted and archived.\""
-  },
-  {
-    "schemaVersion": 2,
-    "id": "CRY-GV-018",
-    "faction": "government",
-    "name": "Deniability Protocols",
-    "type": "ZONE",
-    "rarity": "uncommon",
-    "effects": {
-      "pressureDelta": 2
-    },
-    "tags": [
-      "cryptid"
-    ],
-    "cost": 5,
-    "flavor": "\"CLASSIFIED INTELLIGENCE: Field note logged; further action unnecessary.\""
-  },
-  {
-    "schemaVersion": 2,
-    "id": "CRY-GV-019",
-    "faction": "government",
-    "name": "Black Helicopters",
-    "type": "ATTACK",
-    "rarity": "rare",
-    "effects": {
-      "ipDelta": {
-        "opponent": 3
+    {
+      "schemaVersion": 2,
+      "id": "CRY-TS-010",
+      "faction": "truth",
+      "name": "Roswell Survivor Testimony",
+      "type": "MEDIA",
+      "rarity": "rare",
+      "effects": {
+        "truthDelta": 3
       },
-      "discardOpponent": 1
+      "tags": [
+        "cryptid",
+        "media",
+        "roswell",
+        "truth"
+      ],
+      "cost": 5,
+      "flavor": "\"CLASSIFIED INTELLIGENCE: Roswell looked straight into the lens.\""
     },
-    "tags": [
-      "cryptid"
-    ],
-    "cost": 4,
-    "flavor": "\"CLASSIFIED INTELLIGENCE: Public guidance issued; no black detected.\""
-  },
-  {
-    "schemaVersion": 2,
-    "id": "CRY-GV-020",
-    "faction": "government",
-    "name": "Cryptozoology Department",
-    "type": "ZONE",
-    "rarity": "uncommon",
-    "effects": {
-      "pressureDelta": 2
-    },
-    "tags": [
-      "cryptid"
-    ],
-    "cost": 5,
-    "flavor": "\"CLASSIFIED INTELLIGENCE: Field note logged; further action unnecessary.\""
-  },
-  {
-    "schemaVersion": 2,
-    "id": "CRY-GV-021",
-    "faction": "government",
-    "name": "Flatwoods Incident",
-    "type": "ZONE",
-    "rarity": "uncommon",
-    "effects": {
-      "pressureDelta": 2
-    },
-    "tags": [
-      "cryptid"
-    ],
-    "cost": 5,
-    "flavor": "\"CLASSIFIED INTELLIGENCE: Awaiting lab results; likely weather and shadows.\""
-  },
-  {
-    "schemaVersion": 2,
-    "id": "CRY-GV-022",
-    "faction": "government",
-    "name": "Skunk Ape Safari",
-    "type": "ZONE",
-    "rarity": "common",
-    "effects": {
-      "pressureDelta": 1
-    },
-    "tags": [
-      "cryptid"
-    ],
-    "cost": 4,
-    "flavor": "\"CLASSIFIED INTELLIGENCE: Field note logged; further action unnecessary.\""
-  },
-  {
-    "schemaVersion": 2,
-    "id": "CRY-GV-023",
-    "faction": "government",
-    "name": "Thunderbird Tracking",
-    "type": "ATTACK",
-    "rarity": "uncommon",
-    "effects": {
-      "ipDelta": {
-        "opponent": 2
-      }
-    },
-    "tags": [
-      "cryptid"
-    ],
-    "cost": 3,
-    "flavor": "\"CLASSIFIED INTELLIGENCE: Public guidance issued; no thunderbird detected.\""
-  },
-  {
-    "schemaVersion": 2,
-    "id": "CRY-GV-024",
-    "faction": "government",
-    "name": "Shadow People Census",
-    "type": "ATTACK",
-    "rarity": "uncommon",
-    "effects": {
-      "ipDelta": {
-        "opponent": 2
-      }
-    },
-    "tags": [
-      "cryptid"
-    ],
-    "cost": 3,
-    "flavor": "\"CLASSIFIED INTELLIGENCE: Public guidance issued; no shadow detected.\""
-  },
-  {
-    "schemaVersion": 2,
-    "id": "CRY-GV-025",
-    "faction": "government",
-    "name": "Hopkinsville Goblins",
-    "type": "ZONE",
-    "rarity": "rare",
-    "effects": {
-      "pressureDelta": 3
-    },
-    "tags": [
-      "cryptid"
-    ],
-    "cost": 6,
-    "flavor": "\"CLASSIFIED INTELLIGENCE: Situation normal—memo drafted and archived.\""
-  },
-  {
-    "schemaVersion": 2,
-    "id": "CRY-GV-026",
-    "faction": "government",
-    "name": "Lizard Person Council",
-    "type": "MEDIA",
-    "rarity": "legendary",
-    "effects": {
-      "truthDelta": -4
-    },
-    "tags": [
-      "cryptid"
-    ],
-    "cost": 6,
-    "flavor": "\"CLASSIFIED INTELLIGENCE: Situation normal—memo drafted and archived.\""
-  },
-  {
-    "schemaVersion": 2,
-    "id": "CRY-GV-027",
-    "faction": "government",
-    "name": "Hollow Earth Drilling",
-    "type": "ZONE",
-    "rarity": "rare",
-    "effects": {
-      "pressureDelta": 3
-    },
-    "tags": [
-      "cryptid"
-    ],
-    "cost": 6,
-    "flavor": "\"CLASSIFIED INTELLIGENCE: Situation normal—memo drafted and archived.\""
-  },
-  {
-    "schemaVersion": 2,
-    "id": "CRY-GV-028",
-    "faction": "government",
-    "name": "Time Travel Bureau",
-    "type": "MEDIA",
-    "rarity": "uncommon",
-    "effects": {
-      "truthDelta": -2
-    },
-    "tags": [
-      "cryptid"
-    ],
-    "cost": 4,
-    "flavor": "\"CLASSIFIED INTELLIGENCE: Public guidance issued; no time detected.\""
-  },
-  {
-    "schemaVersion": 2,
-    "id": "CRY-GV-029",
-    "faction": "government",
-    "name": "Flying Saucer Hangar",
-    "type": "ZONE",
-    "rarity": "rare",
-    "effects": {
-      "pressureDelta": 3
-    },
-    "tags": [
-      "cryptid"
-    ],
-    "cost": 6,
-    "flavor": "\"CLASSIFIED INTELLIGENCE: Filed under routine wildlife misidentification.\""
-  },
-  {
-    "schemaVersion": 2,
-    "id": "CRY-GV-030",
-    "faction": "government",
-    "name": "Interdimensional Gate",
-    "type": "ZONE",
-    "rarity": "rare",
-    "effects": {
-      "pressureDelta": 3
-    },
-    "tags": [
-      "cryptid"
-    ],
-    "cost": 6,
-    "flavor": "\"CLASSIFIED INTELLIGENCE: Filed under routine wildlife misidentification.\""
-  },
-  {
-    "schemaVersion": 2,
-    "id": "CRY-GV-031",
-    "faction": "government",
-    "name": "Yeti Expedition Hoax",
-    "type": "ZONE",
-    "rarity": "uncommon",
-    "effects": {
-      "pressureDelta": 2
-    },
-    "tags": [
-      "cryptid"
-    ],
-    "cost": 5,
-    "flavor": "\"CLASSIFIED INTELLIGENCE: Field note logged; further action unnecessary.\""
-  },
-  {
-    "schemaVersion": 2,
-    "id": "CRY-GV-032",
-    "faction": "government",
-    "name": "Skinwalker Ranch Buyout",
-    "type": "ATTACK",
-    "rarity": "uncommon",
-    "effects": {
-      "ipDelta": {
-        "opponent": 2
-      }
-    },
-    "tags": [
-      "cryptid"
-    ],
-    "cost": 3,
-    "flavor": "\"CLASSIFIED INTELLIGENCE: Field note logged; further action unnecessary.\""
-  },
-  {
-    "schemaVersion": 2,
-    "id": "CRY-GV-033",
-    "faction": "government",
-    "name": "Dover Demon Debunking",
-    "type": "ZONE",
-    "rarity": "uncommon",
-    "effects": {
-      "pressureDelta": 2
-    },
-    "tags": [
-      "cryptid"
-    ],
-    "cost": 5,
-    "flavor": "\"CLASSIFIED INTELLIGENCE: Filed under routine wildlife misidentification.\""
-  },
-  {
-    "schemaVersion": 2,
-    "id": "CRY-GV-034",
-    "faction": "government",
-    "name": "Alien Autopsy Studio",
-    "type": "ZONE",
-    "rarity": "rare",
-    "effects": {
-      "pressureDelta": 3
-    },
-    "tags": [
-      "cryptid"
-    ],
-    "cost": 6,
-    "flavor": "\"CLASSIFIED INTELLIGENCE: Filed under routine wildlife misidentification.\""
-  },
-  {
-    "schemaVersion": 2,
-    "id": "CRY-GV-035",
-    "faction": "government",
-    "name": "Cattle Mutilation Labs",
-    "type": "ZONE",
-    "rarity": "uncommon",
-    "effects": {
-      "pressureDelta": 2
-    },
-    "tags": [
-      "cryptid"
-    ],
-    "cost": 5,
-    "flavor": "\"CLASSIFIED INTELLIGENCE: Filed under routine wildlife misidentification.\""
-  },
-  {
-    "schemaVersion": 2,
-    "id": "CRY-GV-036",
-    "faction": "government",
-    "name": "Crop Circle Artists Guild",
-    "type": "ZONE",
-    "rarity": "uncommon",
-    "effects": {
-      "pressureDelta": 2
-    },
-    "tags": [
-      "cryptid"
-    ],
-    "cost": 5,
-    "flavor": "\"CLASSIFIED INTELLIGENCE: Awaiting lab results; likely weather and shadows.\""
-  },
-  {
-    "schemaVersion": 2,
-    "id": "CRY-GV-037",
-    "faction": "government",
-    "name": "Phantom Airships",
-    "type": "ZONE",
-    "rarity": "common",
-    "effects": {
-      "pressureDelta": 1
-    },
-    "tags": [
-      "cryptid"
-    ],
-    "cost": 4,
-    "flavor": "\"CLASSIFIED INTELLIGENCE: Field note logged; further action unnecessary.\""
-  },
-  {
-    "schemaVersion": 2,
-    "id": "CRY-GV-038",
-    "faction": "government",
-    "name": "Washington Sea Serpent",
-    "type": "ZONE",
-    "rarity": "uncommon",
-    "effects": {
-      "pressureDelta": 2
-    },
-    "tags": [
-      "cryptid"
-    ],
-    "cost": 5,
-    "flavor": "\"CLASSIFIED INTELLIGENCE: Awaiting lab results; likely weather and shadows.\""
-  },
-  {
-    "schemaVersion": 2,
-    "id": "CRY-GV-039",
-    "faction": "government",
-    "name": "Moon-Eyed People Census",
-    "type": "ZONE",
-    "rarity": "uncommon",
-    "effects": {
-      "pressureDelta": 2
-    },
-    "tags": [
-      "cryptid"
-    ],
-    "cost": 5,
-    "flavor": "\"CLASSIFIED INTELLIGENCE: Public guidance issued; no moon-eyed detected.\""
-  },
-  {
-    "schemaVersion": 2,
-    "id": "CRY-GV-040",
-    "faction": "government",
-    "name": "Giant Octopus Cover-up",
-    "type": "MEDIA",
-    "rarity": "rare",
-    "effects": {
-      "truthDelta": -3
-    },
-    "tags": [
-      "cryptid"
-    ],
-    "cost": 5,
-    "flavor": "\"CLASSIFIED INTELLIGENCE: Public guidance issued; no giant detected.\""
-  },
-  {
-    "schemaVersion": 2,
-    "id": "CRY-GV-041",
-    "faction": "government",
-    "name": "Psychic Spying Program",
-    "type": "ZONE",
-    "rarity": "uncommon",
-    "effects": {
-      "pressureDelta": 2
-    },
-    "tags": [
-      "cryptid"
-    ],
-    "cost": 5,
-    "flavor": "\"CLASSIFIED INTELLIGENCE: Field note logged; further action unnecessary.\""
-  },
-  {
-    "schemaVersion": 2,
-    "id": "CRY-GV-042",
-    "faction": "government",
-    "name": "Invisible Aircraft Project",
-    "type": "MEDIA",
-    "rarity": "legendary",
-    "effects": {
-      "truthDelta": -4
-    },
-    "tags": [
-      "cryptid"
-    ],
-    "cost": 6,
-    "flavor": "\"CLASSIFIED INTELLIGENCE: Public guidance issued; no invisible detected.\""
-  },
-  {
-    "schemaVersion": 2,
-    "id": "CRY-GV-043",
-    "faction": "government",
-    "name": "Missing Time Protocol",
-    "type": "ATTACK",
-    "rarity": "uncommon",
-    "effects": {
-      "ipDelta": {
-        "opponent": 2
-      }
-    },
-    "tags": [
-      "cryptid"
-    ],
-    "cost": 3,
-    "flavor": "\"CLASSIFIED INTELLIGENCE: Situation normal—memo drafted and archived.\""
-  },
-  {
-    "schemaVersion": 2,
-    "id": "CRY-GV-044",
-    "faction": "government",
-    "name": "Greys Employment Program",
-    "type": "ZONE",
-    "rarity": "uncommon",
-    "effects": {
-      "pressureDelta": 2
-    },
-    "tags": [
-      "cryptid"
-    ],
-    "cost": 5,
-    "flavor": "\"CLASSIFIED INTELLIGENCE: Filed under routine wildlife misidentification.\""
-  },
-  {
-    "schemaVersion": 2,
-    "id": "CRY-GV-045",
-    "faction": "government",
-    "name": "Reality Anchor Array",
-    "type": "MEDIA",
-    "rarity": "rare",
-    "effects": {
-      "truthDelta": -3
-    },
-    "tags": [
-      "cryptid"
-    ],
-    "cost": 5,
-    "flavor": "\"CLASSIFIED INTELLIGENCE: Situation normal—memo drafted and archived.\""
-  },
-  {
-    "schemaVersion": 2,
-    "id": "CRY-GV-046",
-    "faction": "government",
-    "name": "Dimension X Portal",
-    "type": "ZONE",
-    "rarity": "uncommon",
-    "effects": {
-      "pressureDelta": 2
-    },
-    "tags": [
-      "cryptid"
-    ],
-    "cost": 5,
-    "flavor": "\"CLASSIFIED INTELLIGENCE: Situation normal—memo drafted and archived.\""
-  },
-  {
-    "schemaVersion": 2,
-    "id": "CRY-GV-047",
-    "faction": "government",
-    "name": "Cryptid Rehabilitation Center",
-    "type": "ZONE",
-    "rarity": "common",
-    "effects": {
-      "pressureDelta": 1
-    },
-    "tags": [
-      "cryptid"
-    ],
-    "cost": 4,
-    "flavor": "\"CLASSIFIED INTELLIGENCE: Situation normal—memo drafted and archived.\""
-  },
-  {
-    "schemaVersion": 2,
-    "id": "CRY-GV-048",
-    "faction": "government",
-    "name": "Mind Probe Study",
-    "type": "ATTACK",
-    "rarity": "uncommon",
-    "effects": {
-      "ipDelta": {
-        "opponent": 2
-      }
-    },
-    "tags": [
-      "cryptid"
-    ],
-    "cost": 3,
-    "flavor": "\"CLASSIFIED INTELLIGENCE: Filed under routine wildlife misidentification.\""
-  },
-  {
-    "schemaVersion": 2,
-    "id": "CRY-GV-049",
-    "faction": "government",
-    "name": "Subliminal Broadcast Network",
-    "type": "ZONE",
-    "rarity": "rare",
-    "effects": {
-      "pressureDelta": 3
-    },
-    "tags": [
-      "cryptid"
-    ],
-    "cost": 6,
-    "flavor": "\"CLASSIFIED INTELLIGENCE: Situation normal—memo drafted and archived.\""
-  },
-  {
-    "schemaVersion": 2,
-    "id": "CRY-GV-050",
-    "faction": "government",
-    "name": "Fake Moon Landing Set",
-    "type": "ZONE",
-    "rarity": "uncommon",
-    "effects": {
-      "pressureDelta": 2
-    },
-    "tags": [
-      "cryptid"
-    ],
-    "cost": 5,
-    "flavor": "\"CLASSIFIED INTELLIGENCE: Filed under routine wildlife misidentification.\""
-  },
-  {
-    "schemaVersion": 2,
-    "id": "CRY-GV-051",
-    "faction": "government",
-    "name": "Neuralyzer Deployment",
-    "type": "MEDIA",
-    "rarity": "uncommon",
-    "effects": {
-      "truthDelta": -2
-    },
-    "tags": [
-      "cryptid"
-    ],
-    "cost": 4,
-    "flavor": "\"CLASSIFIED INTELLIGENCE: Public guidance issued; no neuralyzer detected.\""
-  },
-  {
-    "schemaVersion": 2,
-    "id": "CRY-GV-052",
-    "faction": "government",
-    "name": "Shadow Government HQ",
-    "type": "ATTACK",
-    "rarity": "legendary",
-    "effects": {
-      "ipDelta": {
-        "opponent": 4
+    {
+      "schemaVersion": 2,
+      "id": "CRY-TS-011",
+      "faction": "truth",
+      "name": "Area 51 Infiltration",
+      "type": "ATTACK",
+      "rarity": "legendary",
+      "effects": {
+        "ipDelta": {
+          "opponent": 4
+        },
+        "discardOpponent": 2
       },
-      "discardOpponent": 2
+      "tags": [
+        "area51",
+        "attack",
+        "cryptid",
+        "truth"
+      ],
+      "cost": 5,
+      "flavor": "\"CLASSIFIED INTELLIGENCE: Experts disagree; the crowd screams yes.\""
     },
-    "tags": [
-      "cryptid"
-    ],
-    "cost": 5,
-    "flavor": "\"CLASSIFIED INTELLIGENCE: Field note logged; further action unnecessary.\""
-  },
-  {
-    "schemaVersion": 2,
-    "id": "CRY-GV-053",
-    "faction": "government",
-    "name": "Operation Paperclip II",
-    "type": "MEDIA",
-    "rarity": "uncommon",
-    "effects": {
-      "truthDelta": -2
-    },
-    "tags": [
-      "cryptid"
-    ],
-    "cost": 4,
-    "flavor": "\"CLASSIFIED INTELLIGENCE: Public guidance issued; no operation detected.\""
-  },
-  {
-    "schemaVersion": 2,
-    "id": "CRY-GV-054",
-    "faction": "government",
-    "name": "Holographic UFO Display",
-    "type": "MEDIA",
-    "rarity": "uncommon",
-    "effects": {
-      "truthDelta": -2
-    },
-    "tags": [
-      "cryptid"
-    ],
-    "cost": 4,
-    "flavor": "\"CLASSIFIED INTELLIGENCE: Public guidance issued; no holographic detected.\""
-  },
-  {
-    "schemaVersion": 2,
-    "id": "CRY-GV-055",
-    "faction": "government",
-    "name": "Cryptid Breeding Program",
-    "type": "MEDIA",
-    "rarity": "rare",
-    "effects": {
-      "truthDelta": -3
-    },
-    "tags": [
-      "cryptid"
-    ],
-    "cost": 5,
-    "flavor": "\"CLASSIFIED INTELLIGENCE: Situation normal—memo drafted and archived.\""
-  },
-  {
-    "schemaVersion": 2,
-    "id": "CRY-GV-056",
-    "faction": "government",
-    "name": "False Flag Cryptid Attack",
-    "type": "ATTACK",
-    "rarity": "legendary",
-    "effects": {
-      "ipDelta": {
-        "opponent": 4
+    {
+      "schemaVersion": 2,
+      "id": "CRY-TS-012",
+      "faction": "truth",
+      "name": "Jersey Devil Hunt",
+      "type": "ATTACK",
+      "rarity": "common",
+      "effects": {
+        "ipDelta": {
+          "opponent": 1
+        }
       },
-      "discardOpponent": 2
+      "tags": [
+        "attack",
+        "cryptid",
+        "truth"
+      ],
+      "cost": 2,
+      "flavor": "\"CLASSIFIED INTELLIGENCE: Pixels enhanced: chills confirmed.\""
     },
-    "tags": [
-      "cryptid"
-    ],
-    "cost": 5,
-    "flavor": "\"CLASSIFIED INTELLIGENCE: Filed under routine wildlife misidentification.\""
-  },
-  {
-    "schemaVersion": 2,
-    "id": "CRY-GV-057",
-    "faction": "government",
-    "name": "Extraterrestrial Non-Disclosure Treaty",
-    "type": "ZONE",
-    "rarity": "uncommon",
-    "effects": {
-      "pressureDelta": 2
-    },
-    "tags": [
-      "cryptid"
-    ],
-    "cost": 5,
-    "flavor": "\"CLASSIFIED INTELLIGENCE: Field note logged; further action unnecessary.\""
-  },
-  {
-    "schemaVersion": 2,
-    "id": "CRY-GV-058",
-    "faction": "government",
-    "name": "Quantum Bigfoot Experiment",
-    "type": "ZONE",
-    "rarity": "rare",
-    "effects": {
-      "pressureDelta": 3
-    },
-    "tags": [
-      "cryptid"
-    ],
-    "cost": 6,
-    "flavor": "\"CLASSIFIED INTELLIGENCE: Filed under routine wildlife misidentification.\""
-  },
-  {
-    "schemaVersion": 2,
-    "id": "CRY-GV-059",
-    "faction": "government",
-    "name": "Interdimensional Customs",
-    "type": "ZONE",
-    "rarity": "uncommon",
-    "effects": {
-      "pressureDelta": 2
-    },
-    "tags": [
-      "cryptid"
-    ],
-    "cost": 5,
-    "flavor": "\"CLASSIFIED INTELLIGENCE: Filed under routine wildlife misidentification.\""
-  },
-  {
-    "schemaVersion": 2,
-    "id": "CRY-GV-060",
-    "faction": "government",
-    "name": "Cosmic Horror Containment",
-    "type": "MEDIA",
-    "rarity": "rare",
-    "effects": {
-      "truthDelta": -3
-    },
-    "tags": [
-      "cryptid"
-    ],
-    "cost": 5,
-    "flavor": "\"CLASSIFIED INTELLIGENCE: Public guidance issued; no cosmic detected.\""
-  },
-  {
-    "schemaVersion": 2,
-    "id": "CRY-GV-061",
-    "faction": "government",
-    "name": "Reptilian Shapeshifter Agent",
-    "type": "ATTACK",
-    "rarity": "uncommon",
-    "effects": {
-      "ipDelta": {
-        "opponent": 2
-      }
-    },
-    "tags": [
-      "cryptid"
-    ],
-    "cost": 3,
-    "flavor": "\"CLASSIFIED INTELLIGENCE: Situation normal—memo drafted and archived.\""
-  },
-  {
-    "schemaVersion": 2,
-    "id": "CRY-GV-062",
-    "faction": "government",
-    "name": "Memory Modification Clinic",
-    "type": "ATTACK",
-    "rarity": "rare",
-    "effects": {
-      "ipDelta": {
-        "opponent": 3
+    {
+      "schemaVersion": 2,
+      "id": "CRY-TS-013",
+      "faction": "truth",
+      "name": "Skunk Ape Footage",
+      "type": "MEDIA",
+      "rarity": "uncommon",
+      "effects": {
+        "truthDelta": 2
       },
-      "discardOpponent": 1
-    },
-    "tags": [
-      "cryptid"
-    ],
-    "cost": 4,
-    "flavor": "\"CLASSIFIED INTELLIGENCE: Situation normal—memo drafted and archived.\""
-  },
-  {
-    "schemaVersion": 2,
-    "id": "CRY-GV-063",
-    "faction": "government",
-    "name": "Psy-Ops Division",
-    "type": "MEDIA",
-    "rarity": "uncommon",
-    "effects": {
-      "truthDelta": -2
-    },
-    "tags": [
-      "cryptid"
-    ],
-    "cost": 4,
-    "flavor": "\"CLASSIFIED INTELLIGENCE: Situation normal—memo drafted and archived.\""
-  },
-  {
-    "schemaVersion": 2,
-    "id": "CRY-GV-064",
-    "faction": "government",
-    "name": "Cryptid Witness Protection",
-    "type": "MEDIA",
-    "rarity": "uncommon",
-    "effects": {
-      "truthDelta": -2
-    },
-    "tags": [
-      "cryptid"
-    ],
-    "cost": 4,
-    "flavor": "\"CLASSIFIED INTELLIGENCE: Public guidance issued; no cryptid detected.\""
-  },
-  {
-    "schemaVersion": 2,
-    "id": "CRY-GV-065",
-    "faction": "government",
-    "name": "Underground Bunker Network",
-    "type": "ZONE",
-    "rarity": "uncommon",
-    "effects": {
-      "pressureDelta": 2
-    },
-    "tags": [
-      "cryptid"
-    ],
-    "cost": 5,
-    "flavor": "\"CLASSIFIED INTELLIGENCE: Filed under routine wildlife misidentification.\""
-  },
-  {
-    "schemaVersion": 2,
-    "id": "CRY-GV-066",
-    "faction": "government",
-    "name": "Orbital Mind Control Platform",
-    "type": "ZONE",
-    "rarity": "uncommon",
-    "effects": {
-      "pressureDelta": 2
-    },
-    "tags": [
-      "cryptid"
-    ],
-    "cost": 5,
-    "flavor": "\"CLASSIFIED INTELLIGENCE: Awaiting lab results; likely weather and shadows.\""
-  },
-  {
-    "schemaVersion": 2,
-    "id": "CRY-GV-067",
-    "faction": "government",
-    "name": "Temporal Loop Device",
-    "type": "MEDIA",
-    "rarity": "rare",
-    "effects": {
-      "truthDelta": -3
-    },
-    "tags": [
-      "cryptid"
-    ],
-    "cost": 5,
-    "flavor": "\"CLASSIFIED INTELLIGENCE: Awaiting lab results; likely weather and shadows.\""
-  },
-  {
-    "schemaVersion": 2,
-    "id": "CRY-GV-068",
-    "faction": "government",
-    "name": "Anomalous Materials Division",
-    "type": "ZONE",
-    "rarity": "uncommon",
-    "effects": {
-      "pressureDelta": 2
-    },
-    "tags": [
-      "cryptid"
-    ],
-    "cost": 5,
-    "flavor": "\"CLASSIFIED INTELLIGENCE: Field note logged; further action unnecessary.\""
-  },
-  {
-    "schemaVersion": 2,
-    "id": "CRY-GV-069",
-    "faction": "government",
-    "name": "Phantom Helicopter Squadron",
-    "type": "ZONE",
-    "rarity": "common",
-    "effects": {
-      "pressureDelta": 1
-    },
-    "tags": [
-      "cryptid"
-    ],
-    "cost": 4,
-    "flavor": "\"CLASSIFIED INTELLIGENCE: Public guidance issued; no phantom detected.\""
-  },
-  {
-    "schemaVersion": 2,
-    "id": "CRY-GV-070",
-    "faction": "government",
-    "name": "Reality Distortion Field",
-    "type": "ZONE",
-    "rarity": "uncommon",
-    "effects": {
-      "pressureDelta": 2
-    },
-    "tags": [
-      "cryptid"
-    ],
-    "cost": 5,
-    "flavor": "\"CLASSIFIED INTELLIGENCE: Awaiting lab results; likely weather and shadows.\""
-  },
-  {
-    "schemaVersion": 2,
-    "id": "CRY-GV-071",
-    "faction": "government",
-    "name": "Cryptid DNA Database",
-    "type": "ZONE",
-    "rarity": "rare",
-    "effects": {
-      "pressureDelta": 3
-    },
-    "tags": [
-      "cryptid"
-    ],
-    "cost": 6,
-    "flavor": "\"CLASSIFIED INTELLIGENCE: Filed under routine wildlife misidentification.\""
-  },
-  {
-    "schemaVersion": 2,
-    "id": "CRY-GV-072",
-    "faction": "government",
-    "name": "Phantom Satellite Grid",
-    "type": "ZONE",
-    "rarity": "rare",
-    "effects": {
-      "pressureDelta": 3
-    },
-    "tags": [
-      "cryptid"
-    ],
-    "cost": 6,
-    "flavor": "\"CLASSIFIED INTELLIGENCE: Field note logged; further action unnecessary.\""
-  },
-  {
-    "schemaVersion": 2,
-    "id": "CRY-GV-073",
-    "faction": "government",
-    "name": "Consciousness Transfer Lab",
-    "type": "ATTACK",
-    "rarity": "uncommon",
-    "effects": {
-      "ipDelta": {
-        "opponent": 2
-      }
-    },
-    "tags": [
-      "cryptid"
-    ],
-    "cost": 3,
-    "flavor": "\"CLASSIFIED INTELLIGENCE: Awaiting lab results; likely weather and shadows.\""
-  },
-  {
-    "schemaVersion": 2,
-    "id": "CRY-GV-074",
-    "faction": "government",
-    "name": "Multidimensional Embassy",
-    "type": "ZONE",
-    "rarity": "uncommon",
-    "effects": {
-      "pressureDelta": 2
-    },
-    "tags": [
-      "cryptid"
-    ],
-    "cost": 5,
-    "flavor": "\"CLASSIFIED INTELLIGENCE: Filed under routine wildlife misidentification.\""
-  },
-  {
-    "schemaVersion": 2,
-    "id": "CRY-GV-075",
-    "faction": "government",
-    "name": "Alabama Wildlife Advisory",
-    "type": "MEDIA",
-    "rarity": "common",
-    "effects": {
-      "truthDelta": -1
-    },
-    "tags": [
-      "cryptid",
-      "alabama",
-      "advisory"
-    ],
-    "cost": 3,
-    "flavor": "\"CLASSIFIED INTELLIGENCE: Public bulletin: Do not feed the alabama cryptid.\""
-  },
-  {
-    "schemaVersion": 2,
-    "id": "CRY-GV-076",
-    "faction": "government",
-    "name": "Alaska Wildlife Advisory",
-    "type": "MEDIA",
-    "rarity": "common",
-    "effects": {
-      "truthDelta": -1
-    },
-    "tags": [
-      "cryptid",
-      "alaska",
-      "advisory"
-    ],
-    "cost": 3,
-    "flavor": "\"CLASSIFIED INTELLIGENCE: Public bulletin: Do not feed the tizheruk.\""
-  },
-  {
-    "schemaVersion": 2,
-    "id": "CRY-GV-077",
-    "faction": "government",
-    "name": "Arizona Wildlife Advisory",
-    "type": "ATTACK",
-    "rarity": "common",
-    "effects": {
-      "ipDelta": {
-        "opponent": 1
-      }
-    },
-    "tags": [
-      "cryptid",
-      "arizona",
-      "advisory"
-    ],
-    "cost": 2,
-    "flavor": "\"CLASSIFIED INTELLIGENCE: Public bulletin: Do not feed the thunderbird.\""
-  },
-  {
-    "schemaVersion": 2,
-    "id": "CRY-GV-078",
-    "faction": "government",
-    "name": "Arkansas Wildlife Advisory",
-    "type": "MEDIA",
-    "rarity": "common",
-    "effects": {
-      "truthDelta": -1
-    },
-    "tags": [
-      "cryptid",
-      "arkansas",
-      "advisory"
-    ],
-    "cost": 3,
-    "flavor": "\"CLASSIFIED INTELLIGENCE: Public bulletin: Do not feed the fouke monster.\""
-  },
-  {
-    "schemaVersion": 2,
-    "id": "CRY-GV-079",
-    "faction": "government",
-    "name": "California Wildlife Advisory",
-    "type": "ZONE",
-    "rarity": "common",
-    "effects": {
-      "pressureDelta": 1
-    },
-    "tags": [
-      "cryptid",
-      "california",
-      "advisory"
-    ],
-    "cost": 4,
-    "flavor": "\"CLASSIFIED INTELLIGENCE: Public bulletin: Do not feed the bigfoot.\""
-  },
-  {
-    "schemaVersion": 2,
-    "id": "CRY-GV-080",
-    "faction": "government",
-    "name": "Colorado Wildlife Advisory",
-    "type": "ZONE",
-    "rarity": "common",
-    "effects": {
-      "pressureDelta": 1
-    },
-    "tags": [
-      "cryptid",
-      "colorado",
-      "advisory"
-    ],
-    "cost": 4,
-    "flavor": "\"CLASSIFIED INTELLIGENCE: Public bulletin: Do not feed the colorado cryptid.\""
-  },
-  {
-    "schemaVersion": 2,
-    "id": "CRY-GV-081",
-    "faction": "government",
-    "name": "Connecticut Wildlife Advisory",
-    "type": "MEDIA",
-    "rarity": "common",
-    "effects": {
-      "truthDelta": -1
-    },
-    "tags": [
-      "cryptid",
-      "connecticut",
-      "advisory"
-    ],
-    "cost": 3,
-    "flavor": "\"CLASSIFIED INTELLIGENCE: Public bulletin: Do not feed the connecticut cryptid.\""
-  },
-  {
-    "schemaVersion": 2,
-    "id": "CRY-GV-082",
-    "faction": "government",
-    "name": "Delaware Wildlife Advisory",
-    "type": "MEDIA",
-    "rarity": "common",
-    "effects": {
-      "truthDelta": -1
-    },
-    "tags": [
-      "cryptid",
-      "delaware",
-      "advisory"
-    ],
-    "cost": 3,
-    "flavor": "\"CLASSIFIED INTELLIGENCE: Public bulletin: Do not feed the delaware cryptid.\""
-  },
-  {
-    "schemaVersion": 2,
-    "id": "CRY-GV-083",
-    "faction": "government",
-    "name": "Florida Wildlife Advisory",
-    "type": "MEDIA",
-    "rarity": "common",
-    "effects": {
-      "truthDelta": -1
-    },
-    "tags": [
-      "cryptid",
-      "florida",
-      "advisory"
-    ],
-    "cost": 3,
-    "flavor": "\"CLASSIFIED INTELLIGENCE: Public bulletin: Do not feed the skunk ape.\""
-  },
-  {
-    "schemaVersion": 2,
-    "id": "CRY-GV-084",
-    "faction": "government",
-    "name": "Georgia Wildlife Advisory",
-    "type": "MEDIA",
-    "rarity": "common",
-    "effects": {
-      "truthDelta": -1
-    },
-    "tags": [
-      "cryptid",
-      "georgia",
-      "advisory"
-    ],
-    "cost": 3,
-    "flavor": "\"CLASSIFIED INTELLIGENCE: Public bulletin: Do not feed the georgia cryptid.\""
-  },
-  {
-    "schemaVersion": 2,
-    "id": "CRY-GV-085",
-    "faction": "government",
-    "name": "Hawaii Wildlife Advisory",
-    "type": "MEDIA",
-    "rarity": "common",
-    "effects": {
-      "truthDelta": -1
-    },
-    "tags": [
-      "cryptid",
-      "hawaii",
-      "advisory"
-    ],
-    "cost": 3,
-    "flavor": "\"CLASSIFIED INTELLIGENCE: Public bulletin: Do not feed the hawaii cryptid.\""
-  },
-  {
-    "schemaVersion": 2,
-    "id": "CRY-GV-086",
-    "faction": "government",
-    "name": "Idaho Wildlife Advisory",
-    "type": "MEDIA",
-    "rarity": "common",
-    "effects": {
-      "truthDelta": -1
-    },
-    "tags": [
-      "cryptid",
-      "idaho",
-      "advisory"
-    ],
-    "cost": 3,
-    "flavor": "\"CLASSIFIED INTELLIGENCE: Public bulletin: Do not feed the idaho cryptid.\""
-  },
-  {
-    "schemaVersion": 2,
-    "id": "CRY-GV-087",
-    "faction": "government",
-    "name": "Illinois Wildlife Advisory",
-    "type": "ZONE",
-    "rarity": "common",
-    "effects": {
-      "pressureDelta": 1
-    },
-    "tags": [
-      "cryptid",
-      "illinois",
-      "advisory"
-    ],
-    "cost": 4,
-    "flavor": "\"CLASSIFIED INTELLIGENCE: Public bulletin: Do not feed the enfield horror.\""
-  },
-  {
-    "schemaVersion": 2,
-    "id": "CRY-GV-088",
-    "faction": "government",
-    "name": "Indiana Wildlife Advisory",
-    "type": "MEDIA",
-    "rarity": "common",
-    "effects": {
-      "truthDelta": -1
-    },
-    "tags": [
-      "cryptid",
-      "indiana",
-      "advisory"
-    ],
-    "cost": 3,
-    "flavor": "\"CLASSIFIED INTELLIGENCE: Public bulletin: Do not feed the indiana cryptid.\""
-  },
-  {
-    "schemaVersion": 2,
-    "id": "CRY-GV-089",
-    "faction": "government",
-    "name": "Iowa Wildlife Advisory",
-    "type": "MEDIA",
-    "rarity": "common",
-    "effects": {
-      "truthDelta": -1
-    },
-    "tags": [
-      "cryptid",
-      "iowa",
-      "advisory"
-    ],
-    "cost": 3,
-    "flavor": "\"CLASSIFIED INTELLIGENCE: Public bulletin: Do not feed the iowa cryptid.\""
-  },
-  {
-    "schemaVersion": 2,
-    "id": "CRY-GV-090",
-    "faction": "government",
-    "name": "Kansas Wildlife Advisory",
-    "type": "MEDIA",
-    "rarity": "common",
-    "effects": {
-      "truthDelta": -1
-    },
-    "tags": [
-      "cryptid",
-      "kansas",
-      "advisory"
-    ],
-    "cost": 3,
-    "flavor": "\"CLASSIFIED INTELLIGENCE: Public bulletin: Do not feed the kansas cryptid.\""
-  },
-  {
-    "schemaVersion": 2,
-    "id": "CRY-GV-091",
-    "faction": "government",
-    "name": "Kentucky Wildlife Advisory",
-    "type": "MEDIA",
-    "rarity": "common",
-    "effects": {
-      "truthDelta": -1
-    },
-    "tags": [
-      "cryptid",
-      "kentucky",
-      "advisory"
-    ],
-    "cost": 3,
-    "flavor": "\"CLASSIFIED INTELLIGENCE: Public bulletin: Do not feed the kelly–hopkinsville goblins.\""
-  },
-  {
-    "schemaVersion": 2,
-    "id": "CRY-GV-092",
-    "faction": "government",
-    "name": "Louisiana Wildlife Advisory",
-    "type": "MEDIA",
-    "rarity": "common",
-    "effects": {
-      "truthDelta": -1
-    },
-    "tags": [
-      "cryptid",
-      "louisiana",
-      "advisory"
-    ],
-    "cost": 3,
-    "flavor": "\"CLASSIFIED INTELLIGENCE: Public bulletin: Do not feed the rougarou.\""
-  },
-  {
-    "schemaVersion": 2,
-    "id": "CRY-GV-093",
-    "faction": "government",
-    "name": "Maine Wildlife Advisory",
-    "type": "MEDIA",
-    "rarity": "common",
-    "effects": {
-      "truthDelta": -1
-    },
-    "tags": [
-      "cryptid",
-      "maine",
-      "advisory"
-    ],
-    "cost": 3,
-    "flavor": "\"CLASSIFIED INTELLIGENCE: Public bulletin: Do not feed the maine cryptid.\""
-  },
-  {
-    "schemaVersion": 2,
-    "id": "CRY-GV-094",
-    "faction": "government",
-    "name": "Maryland Wildlife Advisory",
-    "type": "MEDIA",
-    "rarity": "common",
-    "effects": {
-      "truthDelta": -1
-    },
-    "tags": [
-      "cryptid",
-      "maryland",
-      "advisory"
-    ],
-    "cost": 3,
-    "flavor": "\"CLASSIFIED INTELLIGENCE: Public bulletin: Do not feed the snallygaster.\""
-  },
-  {
-    "schemaVersion": 2,
-    "id": "CRY-GV-095",
-    "faction": "government",
-    "name": "Massachusetts Wildlife Advisory",
-    "type": "MEDIA",
-    "rarity": "common",
-    "effects": {
-      "truthDelta": -1
-    },
-    "tags": [
-      "cryptid",
-      "massachusetts",
-      "advisory"
-    ],
-    "cost": 3,
-    "flavor": "\"CLASSIFIED INTELLIGENCE: Public bulletin: Do not feed the dover demon.\""
-  },
-  {
-    "schemaVersion": 2,
-    "id": "CRY-GV-096",
-    "faction": "government",
-    "name": "Michigan Wildlife Advisory",
-    "type": "MEDIA",
-    "rarity": "common",
-    "effects": {
-      "truthDelta": -1
-    },
-    "tags": [
-      "cryptid",
-      "michigan",
-      "advisory"
-    ],
-    "cost": 3,
-    "flavor": "\"CLASSIFIED INTELLIGENCE: Public bulletin: Do not feed the dogman.\""
-  },
-  {
-    "schemaVersion": 2,
-    "id": "CRY-GV-097",
-    "faction": "government",
-    "name": "Minnesota Wildlife Advisory",
-    "type": "ATTACK",
-    "rarity": "common",
-    "effects": {
-      "ipDelta": {
-        "opponent": 1
-      }
-    },
-    "tags": [
-      "cryptid",
-      "minnesota",
-      "advisory"
-    ],
-    "cost": 2,
-    "flavor": "\"CLASSIFIED INTELLIGENCE: Public bulletin: Do not feed the wendigo.\""
-  },
-  {
-    "schemaVersion": 2,
-    "id": "CRY-GV-098",
-    "faction": "government",
-    "name": "Mississippi Wildlife Advisory",
-    "type": "MEDIA",
-    "rarity": "common",
-    "effects": {
-      "truthDelta": -1
-    },
-    "tags": [
-      "cryptid",
-      "mississippi",
-      "advisory"
-    ],
-    "cost": 3,
-    "flavor": "\"CLASSIFIED INTELLIGENCE: Public bulletin: Do not feed the mississippi cryptid.\""
-  },
-  {
-    "schemaVersion": 2,
-    "id": "CRY-GV-099",
-    "faction": "government",
-    "name": "Missouri Wildlife Advisory",
-    "type": "MEDIA",
-    "rarity": "common",
-    "effects": {
-      "truthDelta": -1
-    },
-    "tags": [
-      "cryptid",
-      "missouri",
-      "advisory"
-    ],
-    "cost": 3,
-    "flavor": "\"CLASSIFIED INTELLIGENCE: Public bulletin: Do not feed the missouri cryptid.\""
-  },
-  {
-    "schemaVersion": 2,
-    "id": "CRY-GV-100",
-    "faction": "government",
-    "name": "Montana Wildlife Advisory",
-    "type": "MEDIA",
-    "rarity": "common",
-    "effects": {
-      "truthDelta": -1
-    },
-    "tags": [
-      "cryptid",
-      "montana",
-      "advisory"
-    ],
-    "cost": 3,
-    "flavor": "\"CLASSIFIED INTELLIGENCE: Public bulletin: Do not feed the shunka warakin.\""
-  },
-  {
-    "schemaVersion": 2,
-    "id": "CRY-GV-101",
-    "faction": "government",
-    "name": "Nebraska Wildlife Advisory",
-    "type": "MEDIA",
-    "rarity": "common",
-    "effects": {
-      "truthDelta": -1
-    },
-    "tags": [
-      "cryptid",
-      "nebraska",
-      "advisory"
-    ],
-    "cost": 3,
-    "flavor": "\"CLASSIFIED INTELLIGENCE: Public bulletin: Do not feed the nebraska cryptid.\""
-  },
-  {
-    "schemaVersion": 2,
-    "id": "CRY-GV-102",
-    "faction": "government",
-    "name": "Nevada Wildlife Advisory",
-    "type": "MEDIA",
-    "rarity": "common",
-    "effects": {
-      "truthDelta": -1
-    },
-    "tags": [
-      "cryptid",
-      "nevada",
-      "advisory"
-    ],
-    "cost": 3,
-    "flavor": "\"CLASSIFIED INTELLIGENCE: Public bulletin: Do not feed the tahoe tessie.\""
-  },
-  {
-    "schemaVersion": 2,
-    "id": "CRY-GV-103",
-    "faction": "government",
-    "name": "New Hampshire Wildlife Advisory",
-    "type": "MEDIA",
-    "rarity": "common",
-    "effects": {
-      "truthDelta": -1
-    },
-    "tags": [
-      "cryptid",
-      "new-hampshire",
-      "advisory"
-    ],
-    "cost": 3,
-    "flavor": "\"CLASSIFIED INTELLIGENCE: Public bulletin: Do not feed the wood devils.\""
-  },
-  {
-    "schemaVersion": 2,
-    "id": "CRY-GV-104",
-    "faction": "government",
-    "name": "New Jersey Wildlife Advisory",
-    "type": "ATTACK",
-    "rarity": "common",
-    "effects": {
-      "ipDelta": {
-        "opponent": 1
-      }
-    },
-    "tags": [
-      "cryptid",
-      "new-jersey",
-      "advisory"
-    ],
-    "cost": 2,
-    "flavor": "\"CLASSIFIED INTELLIGENCE: Public bulletin: Do not feed the jersey devil.\""
-  },
-  {
-    "schemaVersion": 2,
-    "id": "CRY-GV-105",
-    "faction": "government",
-    "name": "New Mexico Wildlife Advisory",
-    "type": "ATTACK",
-    "rarity": "common",
-    "effects": {
-      "ipDelta": {
-        "opponent": 1
-      }
-    },
-    "tags": [
-      "cryptid",
-      "new-mexico",
-      "advisory"
-    ],
-    "cost": 2,
-    "flavor": "\"CLASSIFIED INTELLIGENCE: Public bulletin: Do not feed the skinwalkers.\""
-  },
-  {
-    "schemaVersion": 2,
-    "id": "CRY-GV-106",
-    "faction": "government",
-    "name": "New York Wildlife Advisory",
-    "type": "MEDIA",
-    "rarity": "common",
-    "effects": {
-      "truthDelta": -1
-    },
-    "tags": [
-      "cryptid",
-      "new-york",
-      "advisory"
-    ],
-    "cost": 3,
-    "flavor": "\"CLASSIFIED INTELLIGENCE: Public bulletin: Do not feed the montauk monster.\""
-  },
-  {
-    "schemaVersion": 2,
-    "id": "CRY-GV-107",
-    "faction": "government",
-    "name": "North Carolina Wildlife Advisory",
-    "type": "MEDIA",
-    "rarity": "common",
-    "effects": {
-      "truthDelta": -1
-    },
-    "tags": [
-      "cryptid",
-      "north-carolina",
-      "advisory"
-    ],
-    "cost": 3,
-    "flavor": "\"CLASSIFIED INTELLIGENCE: Public bulletin: Do not feed the north carolina cryptid.\""
-  },
-  {
-    "schemaVersion": 2,
-    "id": "CRY-GV-108",
-    "faction": "government",
-    "name": "North Dakota Wildlife Advisory",
-    "type": "MEDIA",
-    "rarity": "common",
-    "effects": {
-      "truthDelta": -1
-    },
-    "tags": [
-      "cryptid",
-      "north-dakota",
-      "advisory"
-    ],
-    "cost": 3,
-    "flavor": "\"CLASSIFIED INTELLIGENCE: Public bulletin: Do not feed the north dakota cryptid.\""
-  },
-  {
-    "schemaVersion": 2,
-    "id": "CRY-GV-109",
-    "faction": "government",
-    "name": "Ohio Wildlife Advisory",
-    "type": "MEDIA",
-    "rarity": "common",
-    "effects": {
-      "truthDelta": -1
-    },
-    "tags": [
-      "cryptid",
-      "ohio",
-      "advisory"
-    ],
-    "cost": 3,
-    "flavor": "\"CLASSIFIED INTELLIGENCE: Public bulletin: Do not feed the loveland frogman.\""
-  },
-  {
-    "schemaVersion": 2,
-    "id": "CRY-GV-110",
-    "faction": "government",
-    "name": "Oklahoma Wildlife Advisory",
-    "type": "MEDIA",
-    "rarity": "common",
-    "effects": {
-      "truthDelta": -1
-    },
-    "tags": [
-      "cryptid",
-      "oklahoma",
-      "advisory"
-    ],
-    "cost": 3,
-    "flavor": "\"CLASSIFIED INTELLIGENCE: Public bulletin: Do not feed the oklahoma cryptid.\""
-  },
-  {
-    "schemaVersion": 2,
-    "id": "CRY-GV-111",
-    "faction": "government",
-    "name": "Oregon Wildlife Advisory",
-    "type": "MEDIA",
-    "rarity": "common",
-    "effects": {
-      "truthDelta": -1
-    },
-    "tags": [
-      "cryptid",
-      "oregon",
-      "advisory"
-    ],
-    "cost": 3,
-    "flavor": "\"CLASSIFIED INTELLIGENCE: Public bulletin: Do not feed the bigfoot.\""
-  },
-  {
-    "schemaVersion": 2,
-    "id": "CRY-GV-112",
-    "faction": "government",
-    "name": "Pennsylvania Wildlife Advisory",
-    "type": "MEDIA",
-    "rarity": "common",
-    "effects": {
-      "truthDelta": -1
-    },
-    "tags": [
-      "cryptid",
-      "pennsylvania",
-      "advisory"
-    ],
-    "cost": 3,
-    "flavor": "\"CLASSIFIED INTELLIGENCE: Public bulletin: Do not feed the pennsylvania cryptid.\""
-  },
-  {
-    "schemaVersion": 2,
-    "id": "CRY-GV-113",
-    "faction": "government",
-    "name": "Rhode Island Wildlife Advisory",
-    "type": "MEDIA",
-    "rarity": "common",
-    "effects": {
-      "truthDelta": -1
-    },
-    "tags": [
-      "cryptid",
-      "rhode-island",
-      "advisory"
-    ],
-    "cost": 3,
-    "flavor": "\"CLASSIFIED INTELLIGENCE: Public bulletin: Do not feed the rhode island cryptid.\""
-  },
-  {
-    "schemaVersion": 2,
-    "id": "CRY-GV-114",
-    "faction": "government",
-    "name": "South Carolina Wildlife Advisory",
-    "type": "MEDIA",
-    "rarity": "common",
-    "effects": {
-      "truthDelta": -1
-    },
-    "tags": [
-      "cryptid",
-      "south-carolina",
-      "advisory"
-    ],
-    "cost": 3,
-    "flavor": "\"CLASSIFIED INTELLIGENCE: Public bulletin: Do not feed the south carolina cryptid.\""
-  },
-  {
-    "schemaVersion": 2,
-    "id": "CRY-GV-115",
-    "faction": "government",
-    "name": "South Dakota Wildlife Advisory",
-    "type": "MEDIA",
-    "rarity": "common",
-    "effects": {
-      "truthDelta": -1
-    },
-    "tags": [
-      "cryptid",
-      "south-dakota",
-      "advisory"
-    ],
-    "cost": 3,
-    "flavor": "\"CLASSIFIED INTELLIGENCE: Public bulletin: Do not feed the south dakota cryptid.\""
-  },
-  {
-    "schemaVersion": 2,
-    "id": "CRY-GV-116",
-    "faction": "government",
-    "name": "Tennessee Wildlife Advisory",
-    "type": "MEDIA",
-    "rarity": "common",
-    "effects": {
-      "truthDelta": -1
-    },
-    "tags": [
-      "cryptid",
-      "tennessee",
-      "advisory"
-    ],
-    "cost": 3,
-    "flavor": "\"CLASSIFIED INTELLIGENCE: Public bulletin: Do not feed the tennessee cryptid.\""
-  },
-  {
-    "schemaVersion": 2,
-    "id": "CRY-GV-117",
-    "faction": "government",
-    "name": "Texas Wildlife Advisory",
-    "type": "ATTACK",
-    "rarity": "common",
-    "effects": {
-      "ipDelta": {
-        "opponent": 1
-      }
-    },
-    "tags": [
-      "cryptid",
-      "texas",
-      "advisory"
-    ],
-    "cost": 2,
-    "flavor": "\"CLASSIFIED INTELLIGENCE: Public bulletin: Do not feed the chupacabra.\""
-  },
-  {
-    "schemaVersion": 2,
-    "id": "CRY-GV-118",
-    "faction": "government",
-    "name": "Utah Wildlife Advisory",
-    "type": "MEDIA",
-    "rarity": "common",
-    "effects": {
-      "truthDelta": -1
-    },
-    "tags": [
-      "cryptid",
-      "utah",
-      "advisory"
-    ],
-    "cost": 3,
-    "flavor": "\"CLASSIFIED INTELLIGENCE: Public bulletin: Do not feed the utah cryptid.\""
-  },
-  {
-    "schemaVersion": 2,
-    "id": "CRY-GV-119",
-    "faction": "government",
-    "name": "Vermont Wildlife Advisory",
-    "type": "MEDIA",
-    "rarity": "common",
-    "effects": {
-      "truthDelta": -1
-    },
-    "tags": [
-      "cryptid",
-      "vermont",
-      "advisory"
-    ],
-    "cost": 3,
-    "flavor": "\"CLASSIFIED INTELLIGENCE: Public bulletin: Do not feed the champ.\""
-  },
-  {
-    "schemaVersion": 2,
-    "id": "CRY-GV-120",
-    "faction": "government",
-    "name": "Virginia Wildlife Advisory",
-    "type": "MEDIA",
-    "rarity": "common",
-    "effects": {
-      "truthDelta": -1
-    },
-    "tags": [
-      "cryptid",
-      "virginia",
-      "advisory"
-    ],
-    "cost": 3,
-    "flavor": "\"CLASSIFIED INTELLIGENCE: Public bulletin: Do not feed the virginia cryptid.\""
-  },
-  {
-    "schemaVersion": 2,
-    "id": "CRY-GV-121",
-    "faction": "government",
-    "name": "Washington Wildlife Advisory",
-    "type": "MEDIA",
-    "rarity": "common",
-    "effects": {
-      "truthDelta": -1
-    },
-    "tags": [
-      "cryptid",
-      "washington",
-      "advisory"
-    ],
-    "cost": 3,
-    "flavor": "\"CLASSIFIED INTELLIGENCE: Public bulletin: Do not feed the bigfoot.\""
-  },
-  {
-    "schemaVersion": 2,
-    "id": "CRY-GV-122",
-    "faction": "government",
-    "name": "West Virginia Wildlife Advisory",
-    "type": "ATTACK",
-    "rarity": "common",
-    "effects": {
-      "ipDelta": {
-        "opponent": 1
-      }
-    },
-    "tags": [
-      "cryptid",
-      "west-virginia",
-      "advisory"
-    ],
-    "cost": 2,
-    "flavor": "\"CLASSIFIED INTELLIGENCE: Public bulletin: Do not feed the mothman.\""
-  },
-  {
-    "schemaVersion": 2,
-    "id": "CRY-GV-123",
-    "faction": "government",
-    "name": "Wisconsin Wildlife Advisory",
-    "type": "ATTACK",
-    "rarity": "common",
-    "effects": {
-      "ipDelta": {
-        "opponent": 1
-      }
-    },
-    "tags": [
-      "cryptid",
-      "wisconsin",
-      "advisory"
-    ],
-    "cost": 2,
-    "flavor": "\"CLASSIFIED INTELLIGENCE: Public bulletin: Do not feed the beast of bray road.\""
-  },
-  {
-    "schemaVersion": 2,
-    "id": "CRY-GV-124",
-    "faction": "government",
-    "name": "Wyoming Wildlife Advisory",
-    "type": "MEDIA",
-    "rarity": "common",
-    "effects": {
-      "truthDelta": -1
-    },
-    "tags": [
-      "cryptid",
-      "wyoming",
-      "advisory"
-    ],
-    "cost": 3,
-    "flavor": "\"CLASSIFIED INTELLIGENCE: Public bulletin: Do not feed the wyoming cryptid.\""
-  },
-  {
-    "schemaVersion": 2,
-    "id": "CRY-GV-125",
-    "faction": "government",
-    "name": "Chupacabra Area Closure",
-    "type": "ATTACK",
-    "rarity": "common",
-    "effects": {
-      "ipDelta": {
-        "opponent": 1
-      }
-    },
-    "tags": [
-      "chupacabra",
-      "cryptid"
-    ],
-    "cost": 2,
-    "flavor": "\"CLASSIFIED INTELLIGENCE: Standard operating procedure, nothing to see.\""
-  },
-  {
-    "schemaVersion": 2,
-    "id": "CRY-GV-126",
-    "faction": "government",
-    "name": "Skunk Ape Area Closure",
-    "type": "ZONE",
-    "rarity": "common",
-    "effects": {
-      "pressureDelta": 1
-    },
-    "tags": [
-      "skunk-ape",
-      "cryptid"
-    ],
-    "cost": 4,
-    "flavor": "\"CLASSIFIED INTELLIGENCE: Standard operating procedure, nothing to see.\""
-  },
-  {
-    "schemaVersion": 2,
-    "id": "CRY-GV-127",
-    "faction": "government",
-    "name": "Snallygaster Perimeter Lockdown",
-    "type": "MEDIA",
-    "rarity": "common",
-    "effects": {
-      "truthDelta": -1
-    },
-    "tags": [
-      "snallygaster",
-      "cryptid"
-    ],
-    "cost": 3,
-    "flavor": "\"CLASSIFIED INTELLIGENCE: Standard operating procedure, nothing to see.\""
-  },
-  {
-    "schemaVersion": 2,
-    "id": "CRY-GV-128",
-    "faction": "government",
-    "name": "Snallygaster Budget Audit",
-    "type": "ATTACK",
-    "rarity": "common",
-    "effects": {
-      "ipDelta": {
-        "opponent": 1
-      }
-    },
-    "tags": [
-      "snallygaster",
-      "cryptid"
-    ],
-    "cost": 2,
-    "flavor": "\"CLASSIFIED INTELLIGENCE: Standard operating procedure, nothing to see.\""
-  },
-  {
-    "schemaVersion": 2,
-    "id": "CRY-GV-129",
-    "faction": "government",
-    "name": "Bigfoot Area Closure",
-    "type": "ZONE",
-    "rarity": "common",
-    "effects": {
-      "pressureDelta": 1
-    },
-    "tags": [
-      "bigfoot",
-      "cryptid"
-    ],
-    "cost": 4,
-    "flavor": "\"CLASSIFIED INTELLIGENCE: Standard operating procedure, nothing to see.\""
-  },
-  {
-    "schemaVersion": 2,
-    "id": "CRY-GV-130",
-    "faction": "government",
-    "name": "Thunderbird Area Closure",
-    "type": "ATTACK",
-    "rarity": "common",
-    "effects": {
-      "ipDelta": {
-        "opponent": 1
-      }
-    },
-    "tags": [
-      "thunderbird",
-      "cryptid"
-    ],
-    "cost": 2,
-    "flavor": "\"CLASSIFIED INTELLIGENCE: Standard operating procedure, nothing to see.\""
-  },
-  {
-    "schemaVersion": 2,
-    "id": "CRY-GV-131",
-    "faction": "government",
-    "name": "Montauk Monster Area Closure",
-    "type": "ZONE",
-    "rarity": "common",
-    "effects": {
-      "pressureDelta": 1
-    },
-    "tags": [
-      "montauk-monster",
-      "cryptid"
-    ],
-    "cost": 4,
-    "flavor": "\"CLASSIFIED INTELLIGENCE: Standard operating procedure, nothing to see.\""
-  },
-  {
-    "schemaVersion": 2,
-    "id": "CRY-GV-132",
-    "faction": "government",
-    "name": "Dogman Area Closure",
-    "type": "ZONE",
-    "rarity": "common",
-    "effects": {
-      "pressureDelta": 1
-    },
-    "tags": [
-      "dogman",
-      "cryptid"
-    ],
-    "cost": 4,
-    "flavor": "\"CLASSIFIED INTELLIGENCE: Standard operating procedure, nothing to see.\""
-  },
-  {
-    "schemaVersion": 2,
-    "id": "CRY-GV-133",
-    "faction": "government",
-    "name": "Champ Budget Audit",
-    "type": "ATTACK",
-    "rarity": "common",
-    "effects": {
-      "ipDelta": {
-        "opponent": 1
-      }
-    },
-    "tags": [
-      "champ",
-      "cryptid"
-    ],
-    "cost": 2,
-    "flavor": "\"CLASSIFIED INTELLIGENCE: Standard operating procedure, nothing to see.\""
-  },
-  {
-    "schemaVersion": 2,
-    "id": "CRY-GV-134",
-    "faction": "government",
-    "name": "Montauk Monster Area Closure",
-    "type": "ZONE",
-    "rarity": "common",
-    "effects": {
-      "pressureDelta": 1
-    },
-    "tags": [
-      "montauk-monster",
-      "cryptid"
-    ],
-    "cost": 4,
-    "flavor": "\"CLASSIFIED INTELLIGENCE: Standard operating procedure, nothing to see.\""
-  },
-  {
-    "schemaVersion": 2,
-    "id": "CRY-GV-135",
-    "faction": "government",
-    "name": "Dover Demon Area Closure",
-    "type": "ZONE",
-    "rarity": "common",
-    "effects": {
-      "pressureDelta": 1
-    },
-    "tags": [
-      "dover-demon",
-      "cryptid"
-    ],
-    "cost": 4,
-    "flavor": "\"CLASSIFIED INTELLIGENCE: Standard operating procedure, nothing to see.\""
-  },
-  {
-    "schemaVersion": 2,
-    "id": "CRY-GV-136",
-    "faction": "government",
-    "name": "Tahoe Tessie Area Closure",
-    "type": "ZONE",
-    "rarity": "common",
-    "effects": {
-      "pressureDelta": 1
-    },
-    "tags": [
-      "tahoe-tessie",
-      "cryptid"
-    ],
-    "cost": 4,
-    "flavor": "\"CLASSIFIED INTELLIGENCE: Standard operating procedure, nothing to see.\""
-  },
-  {
-    "schemaVersion": 2,
-    "id": "CRY-GV-137",
-    "faction": "government",
-    "name": "Beast of Bray Road Budget Audit",
-    "type": "ATTACK",
-    "rarity": "common",
-    "effects": {
-      "ipDelta": {
-        "opponent": 1
-      }
-    },
-    "tags": [
-      "beast-of-bray-road",
-      "cryptid"
-    ],
-    "cost": 2,
-    "flavor": "\"CLASSIFIED INTELLIGENCE: Standard operating procedure, nothing to see.\""
-  },
-  {
-    "schemaVersion": 2,
-    "id": "CRY-GV-138",
-    "faction": "government",
-    "name": "Thunderbird Perimeter Lockdown",
-    "type": "ATTACK",
-    "rarity": "common",
-    "effects": {
-      "ipDelta": {
-        "opponent": 1
-      }
-    },
-    "tags": [
-      "thunderbird",
-      "cryptid"
-    ],
-    "cost": 2,
-    "flavor": "\"CLASSIFIED INTELLIGENCE: Standard operating procedure, nothing to see.\""
-  },
-  {
-    "schemaVersion": 2,
-    "id": "CRY-GV-139",
-    "faction": "government",
-    "name": "Rougarou Perimeter Lockdown",
-    "type": "MEDIA",
-    "rarity": "common",
-    "effects": {
-      "truthDelta": -1
-    },
-    "tags": [
-      "rougarou",
-      "cryptid"
-    ],
-    "cost": 3,
-    "flavor": "\"CLASSIFIED INTELLIGENCE: Standard operating procedure, nothing to see.\""
-  },
-  {
-    "schemaVersion": 2,
-    "id": "CRY-GV-140",
-    "faction": "government",
-    "name": "Jersey Devil Area Closure",
-    "type": "ATTACK",
-    "rarity": "common",
-    "effects": {
-      "ipDelta": {
-        "opponent": 1
-      }
-    },
-    "tags": [
-      "jersey-devil",
-      "cryptid"
-    ],
-    "cost": 2,
-    "flavor": "\"CLASSIFIED INTELLIGENCE: Standard operating procedure, nothing to see.\""
-  },
-  {
-    "schemaVersion": 2,
-    "id": "CRY-GV-141",
-    "faction": "government",
-    "name": "Dogman Area Closure",
-    "type": "ZONE",
-    "rarity": "common",
-    "effects": {
-      "pressureDelta": 1
-    },
-    "tags": [
-      "dogman",
-      "cryptid"
-    ],
-    "cost": 4,
-    "flavor": "\"CLASSIFIED INTELLIGENCE: Standard operating procedure, nothing to see.\""
-  },
-  {
-    "schemaVersion": 2,
-    "id": "CRY-GV-142",
-    "faction": "government",
-    "name": "Wendigo Perimeter Lockdown",
-    "type": "ATTACK",
-    "rarity": "common",
-    "effects": {
-      "ipDelta": {
-        "opponent": 1
-      }
-    },
-    "tags": [
-      "wendigo",
-      "cryptid"
-    ],
-    "cost": 2,
-    "flavor": "\"CLASSIFIED INTELLIGENCE: Standard operating procedure, nothing to see.\""
-  },
-  {
-    "schemaVersion": 2,
-    "id": "CRY-GV-143",
-    "faction": "government",
-    "name": "Shunka Warakin Area Closure",
-    "type": "ZONE",
-    "rarity": "common",
-    "effects": {
-      "pressureDelta": 1
-    },
-    "tags": [
-      "shunka-warakin",
-      "cryptid"
-    ],
-    "cost": 4,
-    "flavor": "\"CLASSIFIED INTELLIGENCE: Standard operating procedure, nothing to see.\""
-  },
-  {
-    "schemaVersion": 2,
-    "id": "CRY-GV-144",
-    "faction": "government",
-    "name": "Dover Demon Budget Audit",
-    "type": "ATTACK",
-    "rarity": "common",
-    "effects": {
-      "ipDelta": {
-        "opponent": 1
-      }
-    },
-    "tags": [
-      "dover-demon",
-      "cryptid"
-    ],
-    "cost": 2,
-    "flavor": "\"CLASSIFIED INTELLIGENCE: Standard operating procedure, nothing to see.\""
-  },
-  {
-    "schemaVersion": 2,
-    "id": "CRY-GV-145",
-    "faction": "government",
-    "name": "Thunderbird Perimeter Lockdown",
-    "type": "ATTACK",
-    "rarity": "common",
-    "effects": {
-      "ipDelta": {
-        "opponent": 1
-      }
-    },
-    "tags": [
-      "thunderbird",
-      "cryptid"
-    ],
-    "cost": 2,
-    "flavor": "\"CLASSIFIED INTELLIGENCE: Standard operating procedure, nothing to see.\""
-  },
-  {
-    "schemaVersion": 2,
-    "id": "CRY-GV-146",
-    "faction": "government",
-    "name": "Skunk Ape Area Closure",
-    "type": "ZONE",
-    "rarity": "common",
-    "effects": {
-      "pressureDelta": 1
-    },
-    "tags": [
-      "skunk-ape",
-      "cryptid"
-    ],
-    "cost": 4,
-    "flavor": "\"CLASSIFIED INTELLIGENCE: Standard operating procedure, nothing to see.\""
-  },
-  {
-    "schemaVersion": 2,
-    "id": "CRY-GV-147",
-    "faction": "government",
-    "name": "Rougarou Budget Audit",
-    "type": "ATTACK",
-    "rarity": "common",
-    "effects": {
-      "ipDelta": {
-        "opponent": 1
-      }
-    },
-    "tags": [
-      "rougarou",
-      "cryptid"
-    ],
-    "cost": 2,
-    "flavor": "\"CLASSIFIED INTELLIGENCE: Standard operating procedure, nothing to see.\""
-  },
-  {
-    "schemaVersion": 2,
-    "id": "CRY-GV-148",
-    "faction": "government",
-    "name": "Chupacabra Budget Audit",
-    "type": "ATTACK",
-    "rarity": "common",
-    "effects": {
-      "ipDelta": {
-        "opponent": 1
-      }
-    },
-    "tags": [
-      "chupacabra",
-      "cryptid"
-    ],
-    "cost": 2,
-    "flavor": "\"CLASSIFIED INTELLIGENCE: Standard operating procedure, nothing to see.\""
-  },
-  {
-    "schemaVersion": 2,
-    "id": "CRY-GV-149",
-    "faction": "government",
-    "name": "Dover Demon Budget Audit",
-    "type": "ATTACK",
-    "rarity": "common",
-    "effects": {
-      "ipDelta": {
-        "opponent": 1
-      }
-    },
-    "tags": [
-      "dover-demon",
-      "cryptid"
-    ],
-    "cost": 2,
-    "flavor": "\"CLASSIFIED INTELLIGENCE: Standard operating procedure, nothing to see.\""
-  },
-  {
-    "schemaVersion": 2,
-    "id": "CRY-GV-150",
-    "faction": "government",
-    "name": "Jersey Devil Perimeter Lockdown",
-    "type": "ATTACK",
-    "rarity": "common",
-    "effects": {
-      "ipDelta": {
-        "opponent": 1
-      }
-    },
-    "tags": [
-      "jersey-devil",
-      "cryptid"
-    ],
-    "cost": 2,
-    "flavor": "\"CLASSIFIED INTELLIGENCE: Standard operating procedure, nothing to see.\""
-  }
-]
+      "tags": [
+        "cryptid",
+        "media",
+        "truth"
+      ],
+      "cost": 4,
+      "flavor": "\"CLASSIFIED INTELLIGENCE: Pixels enhanced: chills confirmed.\""
+    },
+    {
+      "schemaVersion": 2,
+      "id": "CRY-TS-014",
+      "faction": "truth",
+      "name": "Beast of Bray Road Tracking",
+      "type": "ATTACK",
+      "rarity": "uncommon",
+      "effects": {
+        "ipDelta": {
+          "opponent": 2
+        }
+      },
+      "tags": [
+        "attack",
+        "cryptid",
+        "truth"
+      ],
+      "cost": 3,
+      "flavor": "\"CLASSIFIED INTELLIGENCE: Tabloid headline writes itself.\""
+    },
+    {
+      "schemaVersion": 2,
+      "id": "CRY-TS-015",
+      "faction": "truth",
+      "name": "Phantom Kangaroo Tracking Network",
+      "type": "ZONE",
+      "rarity": "uncommon",
+      "effects": {
+        "pressureDelta": 2
+      },
+      "tags": [
+        "cryptid",
+        "truth",
+        "zone"
+      ],
+      "cost": 5,
+      "flavor": "\"CLASSIFIED INTELLIGENCE: Experts disagree; the crowd screams yes.\""
+    },
+    {
+      "schemaVersion": 2,
+      "id": "CRY-TS-016",
+      "faction": "truth",
+      "name": "Fouke Monster Evidence",
+      "type": "ATTACK",
+      "rarity": "uncommon",
+      "effects": {
+        "ipDelta": {
+          "opponent": 2
+        }
+      },
+      "tags": [
+        "attack",
+        "cryptid",
+        "truth"
+      ],
+      "cost": 3,
+      "flavor": "\"CLASSIFIED INTELLIGENCE: Tabloid headline writes itself.\""
+    },
+    {
+      "schemaVersion": 2,
+      "id": "CRY-TS-017",
+      "faction": "truth",
+      "name": "Thunderbird Sightings Database",
+      "type": "ATTACK",
+      "rarity": "rare",
+      "effects": {
+        "ipDelta": {
+          "opponent": 3
+        },
+        "discardOpponent": 1
+      },
+      "tags": [
+        "attack",
+        "cryptid",
+        "truth"
+      ],
+      "cost": 4,
+      "flavor": "\"CLASSIFIED INTELLIGENCE: Experts disagree; the crowd screams yes.\""
+    },
+    {
+      "schemaVersion": 2,
+      "id": "CRY-TS-018",
+      "faction": "truth",
+      "name": "Shadow People Documentation",
+      "type": "ATTACK",
+      "rarity": "uncommon",
+      "effects": {
+        "ipDelta": {
+          "opponent": 2
+        }
+      },
+      "tags": [
+        "attack",
+        "cryptid",
+        "truth"
+      ],
+      "cost": 3,
+      "flavor": "\"CLASSIFIED INTELLIGENCE: Tabloid headline writes itself.\""
+    },
+    {
+      "schemaVersion": 2,
+      "id": "CRY-TS-019",
+      "faction": "truth",
+      "name": "Hopkinsville Goblins Testimony",
+      "type": "MEDIA",
+      "rarity": "uncommon",
+      "effects": {
+        "truthDelta": 2
+      },
+      "tags": [
+        "cryptid",
+        "media",
+        "truth"
+      ],
+      "cost": 4,
+      "flavor": "\"CLASSIFIED INTELLIGENCE: Hopkinsville looked straight into the lens.\""
+    },
+    {
+      "schemaVersion": 2,
+      "id": "CRY-TS-020",
+      "faction": "truth",
+      "name": "Lizard People Exposé",
+      "type": "ATTACK",
+      "rarity": "legendary",
+      "effects": {
+        "ipDelta": {
+          "opponent": 4
+        },
+        "discardOpponent": 2
+      },
+      "tags": [
+        "attack",
+        "cryptid",
+        "truth"
+      ],
+      "cost": 5,
+      "flavor": "\"CLASSIFIED INTELLIGENCE: Lizard looked straight into the lens.\""
+    },
+    {
+      "schemaVersion": 2,
+      "id": "CRY-TS-021",
+      "faction": "truth",
+      "name": "Hollow Earth Expedition",
+      "type": "ZONE",
+      "rarity": "rare",
+      "effects": {
+        "pressureDelta": 3
+      },
+      "tags": [
+        "cryptid",
+        "truth",
+        "zone"
+      ],
+      "cost": 6,
+      "flavor": "\"CLASSIFIED INTELLIGENCE: Tabloid headline writes itself.\""
+    },
+    {
+      "schemaVersion": 2,
+      "id": "CRY-TS-022",
+      "faction": "truth",
+      "name": "Time Traveler Interview",
+      "type": "MEDIA",
+      "rarity": "legendary",
+      "effects": {
+        "truthDelta": 4
+      },
+      "tags": [
+        "cryptid",
+        "media",
+        "truth"
+      ],
+      "cost": 6,
+      "flavor": "\"CLASSIFIED INTELLIGENCE: Tabloid headline writes itself.\""
+    },
+    {
+      "schemaVersion": 2,
+      "id": "CRY-TS-023",
+      "faction": "truth",
+      "name": "UFO Crash Retrieval Team",
+      "type": "MEDIA",
+      "rarity": "uncommon",
+      "effects": {
+        "truthDelta": 2
+      },
+      "tags": [
+        "cryptid",
+        "media",
+        "truth",
+        "ufo"
+      ],
+      "cost": 4,
+      "flavor": "\"CLASSIFIED INTELLIGENCE: Pixels enhanced: chills confirmed.\""
+    },
+    {
+      "schemaVersion": 2,
+      "id": "CRY-TS-024",
+      "faction": "truth",
+      "name": "Interdimensional Portal Research",
+      "type": "MEDIA",
+      "rarity": "uncommon",
+      "effects": {
+        "truthDelta": 2
+      },
+      "tags": [
+        "cryptid",
+        "media",
+        "truth"
+      ],
+      "cost": 4,
+      "flavor": "\"CLASSIFIED INTELLIGENCE: Interdimensional looked straight into the lens.\""
+    },
+    {
+      "schemaVersion": 2,
+      "id": "CRY-TS-025",
+      "faction": "truth",
+      "name": "Phantom Black Dog Network",
+      "type": "ZONE",
+      "rarity": "uncommon",
+      "effects": {
+        "pressureDelta": 2
+      },
+      "tags": [
+        "cryptid",
+        "truth",
+        "zone"
+      ],
+      "cost": 5,
+      "flavor": "\"CLASSIFIED INTELLIGENCE: Phantom looked straight into the lens.\""
+    },
+    {
+      "schemaVersion": 2,
+      "id": "CRY-TS-026",
+      "faction": "truth",
+      "name": "Yeti Hair Analysis",
+      "type": "MEDIA",
+      "rarity": "uncommon",
+      "effects": {
+        "truthDelta": 2
+      },
+      "tags": [
+        "cryptid",
+        "media",
+        "truth"
+      ],
+      "cost": 4,
+      "flavor": "\"CLASSIFIED INTELLIGENCE: Tabloid headline writes itself.\""
+    },
+    {
+      "schemaVersion": 2,
+      "id": "CRY-TS-027",
+      "faction": "truth",
+      "name": "Skinwalker Ranch Investigation",
+      "type": "ATTACK",
+      "rarity": "rare",
+      "effects": {
+        "ipDelta": {
+          "opponent": 3
+        },
+        "discardOpponent": 1
+      },
+      "tags": [
+        "attack",
+        "cryptid",
+        "truth"
+      ],
+      "cost": 4,
+      "flavor": "\"CLASSIFIED INTELLIGENCE: Tabloid headline writes itself.\""
+    },
+    {
+      "schemaVersion": 2,
+      "id": "CRY-TS-028",
+      "faction": "truth",
+      "name": "Dover Demon Witness Testimony",
+      "type": "MEDIA",
+      "rarity": "uncommon",
+      "effects": {
+        "truthDelta": 2
+      },
+      "tags": [
+        "cryptid",
+        "media",
+        "truth"
+      ],
+      "cost": 4,
+      "flavor": "\"CLASSIFIED INTELLIGENCE: Experts disagree; the crowd screams yes.\""
+    },
+    {
+      "schemaVersion": 2,
+      "id": "CRY-TS-029",
+      "faction": "truth",
+      "name": "Real Alien Autopsy Leak",
+      "type": "MEDIA",
+      "rarity": "rare",
+      "effects": {
+        "truthDelta": 3
+      },
+      "tags": [
+        "alien",
+        "cryptid",
+        "media",
+        "truth"
+      ],
+      "cost": 5,
+      "flavor": "\"CLASSIFIED INTELLIGENCE: Real looked straight into the lens.\""
+    },
+    {
+      "schemaVersion": 2,
+      "id": "CRY-TS-030",
+      "faction": "truth",
+      "name": "Cattle Mutilation Pattern Analysis",
+      "type": "ZONE",
+      "rarity": "uncommon",
+      "effects": {
+        "pressureDelta": 2
+      },
+      "tags": [
+        "cryptid",
+        "truth",
+        "zone"
+      ],
+      "cost": 5,
+      "flavor": "\"CLASSIFIED INTELLIGENCE: Tabloid headline writes itself.\""
+    },
+    {
+      "schemaVersion": 2,
+      "id": "CRY-TS-031",
+      "faction": "truth",
+      "name": "Crop Circle Decoder Ring",
+      "type": "MEDIA",
+      "rarity": "uncommon",
+      "effects": {
+        "truthDelta": 2
+      },
+      "tags": [
+        "cryptid",
+        "media",
+        "truth"
+      ],
+      "cost": 4,
+      "flavor": "\"CLASSIFIED INTELLIGENCE: Experts disagree; the crowd screams yes.\""
+    },
+    {
+      "schemaVersion": 2,
+      "id": "CRY-TS-032",
+      "faction": "truth",
+      "name": "1897 Phantom Airship Reports",
+      "type": "MEDIA",
+      "rarity": "uncommon",
+      "effects": {
+        "truthDelta": 2
+      },
+      "tags": [
+        "cryptid",
+        "media",
+        "truth"
+      ],
+      "cost": 4,
+      "flavor": "\"CLASSIFIED INTELLIGENCE: Pixels enhanced: chills confirmed.\""
+    },
+    {
+      "schemaVersion": 2,
+      "id": "CRY-TS-033",
+      "faction": "truth",
+      "name": "Beast of Bladenboro Hunt",
+      "type": "ATTACK",
+      "rarity": "uncommon",
+      "effects": {
+        "ipDelta": {
+          "opponent": 2
+        }
+      },
+      "tags": [
+        "attack",
+        "cryptid",
+        "truth"
+      ],
+      "cost": 3,
+      "flavor": "\"CLASSIFIED INTELLIGENCE: Pixels enhanced: chills confirmed.\""
+    },
+    {
+      "schemaVersion": 2,
+      "id": "CRY-TS-034",
+      "faction": "truth",
+      "name": "Washington Sea Serpent Sonar",
+      "type": "ZONE",
+      "rarity": "uncommon",
+      "effects": {
+        "pressureDelta": 2
+      },
+      "tags": [
+        "cryptid",
+        "truth",
+        "zone"
+      ],
+      "cost": 5,
+      "flavor": "\"CLASSIFIED INTELLIGENCE: Experts disagree; the crowd screams yes.\""
+    },
+    {
+      "schemaVersion": 2,
+      "id": "CRY-TS-035",
+      "faction": "truth",
+      "name": "Moon-Eyed People Archaeological Site",
+      "type": "ZONE",
+      "rarity": "rare",
+      "effects": {
+        "pressureDelta": 3
+      },
+      "tags": [
+        "cryptid",
+        "truth",
+        "zone"
+      ],
+      "cost": 6,
+      "flavor": "\"CLASSIFIED INTELLIGENCE: Tabloid headline writes itself.\""
+    },
+    {
+      "schemaVersion": 2,
+      "id": "CRY-TS-036",
+      "faction": "truth",
+      "name": "Giant Pacific Octopus Encounter",
+      "type": "ZONE",
+      "rarity": "rare",
+      "effects": {
+        "pressureDelta": 3
+      },
+      "tags": [
+        "cryptid",
+        "truth",
+        "zone"
+      ],
+      "cost": 6,
+      "flavor": "\"CLASSIFIED INTELLIGENCE: Tabloid headline writes itself.\""
+    },
+    {
+      "schemaVersion": 2,
+      "id": "CRY-TS-037",
+      "faction": "truth",
+      "name": "Remote Viewing Leak",
+      "type": "MEDIA",
+      "rarity": "rare",
+      "effects": {
+        "truthDelta": 3
+      },
+      "tags": [
+        "cryptid",
+        "media",
+        "truth"
+      ],
+      "cost": 5,
+      "flavor": "\"CLASSIFIED INTELLIGENCE: We brought snacks and a camcorder.\""
+    },
+    {
+      "schemaVersion": 2,
+      "id": "CRY-TS-038",
+      "faction": "truth",
+      "name": "Invisible Aircraft Photos",
+      "type": "MEDIA",
+      "rarity": "legendary",
+      "effects": {
+        "truthDelta": 4
+      },
+      "tags": [
+        "cryptid",
+        "media",
+        "truth"
+      ],
+      "cost": 6,
+      "flavor": "\"CLASSIFIED INTELLIGENCE: We brought snacks and a camcorder.\""
+    },
+    {
+      "schemaVersion": 2,
+      "id": "CRY-TS-039",
+      "faction": "truth",
+      "name": "Missing Time Survivor Network",
+      "type": "MEDIA",
+      "rarity": "rare",
+      "effects": {
+        "truthDelta": 3
+      },
+      "tags": [
+        "cryptid",
+        "media",
+        "truth"
+      ],
+      "cost": 5,
+      "flavor": "\"CLASSIFIED INTELLIGENCE: Experts disagree; the crowd screams yes.\""
+    },
+    {
+      "schemaVersion": 2,
+      "id": "CRY-TS-040",
+      "faction": "truth",
+      "name": "Grey Alien Eyewitness Testimony",
+      "type": "MEDIA",
+      "rarity": "rare",
+      "effects": {
+        "truthDelta": 3
+      },
+      "tags": [
+        "alien",
+        "cryptid",
+        "media",
+        "truth"
+      ],
+      "cost": 5,
+      "flavor": "\"CLASSIFIED INTELLIGENCE: Pixels enhanced: chills confirmed.\""
+    },
+    {
+      "schemaVersion": 2,
+      "id": "CRY-TS-041",
+      "faction": "truth",
+      "name": "Reality Breach Detector",
+      "type": "MEDIA",
+      "rarity": "legendary",
+      "effects": {
+        "truthDelta": 4
+      },
+      "tags": [
+        "cryptid",
+        "media",
+        "truth"
+      ],
+      "cost": 6,
+      "flavor": "\"CLASSIFIED INTELLIGENCE: We brought snacks and a camcorder.\""
+    },
+    {
+      "schemaVersion": 2,
+      "id": "CRY-TS-042",
+      "faction": "truth",
+      "name": "Paranormal Investigation Society",
+      "type": "MEDIA",
+      "rarity": "uncommon",
+      "effects": {
+        "truthDelta": 2
+      },
+      "tags": [
+        "cryptid",
+        "media",
+        "truth"
+      ],
+      "cost": 4,
+      "flavor": "\"CLASSIFIED INTELLIGENCE: Tabloid headline writes itself.\""
+    },
+    {
+      "schemaVersion": 2,
+      "id": "CRY-TS-043",
+      "faction": "truth",
+      "name": "Alien Implant Removal Clinic",
+      "type": "ZONE",
+      "rarity": "rare",
+      "effects": {
+        "pressureDelta": 3
+      },
+      "tags": [
+        "alien",
+        "cryptid",
+        "truth",
+        "zone"
+      ],
+      "cost": 6,
+      "flavor": "\"CLASSIFIED INTELLIGENCE: Experts disagree; the crowd screams yes.\""
+    },
+    {
+      "schemaVersion": 2,
+      "id": "CRY-TS-044",
+      "faction": "truth",
+      "name": "Consciousness Expansion Workshop",
+      "type": "MEDIA",
+      "rarity": "rare",
+      "effects": {
+        "truthDelta": 3
+      },
+      "tags": [
+        "cryptid",
+        "media",
+        "truth"
+      ],
+      "cost": 5,
+      "flavor": "\"CLASSIFIED INTELLIGENCE: Tabloid headline writes itself.\""
+    },
+    {
+      "schemaVersion": 2,
+      "id": "CRY-TS-045",
+      "faction": "truth",
+      "name": "Multidimensional Gateway",
+      "type": "MEDIA",
+      "rarity": "legendary",
+      "effects": {
+        "truthDelta": 4
+      },
+      "tags": [
+        "cryptid",
+        "media",
+        "truth"
+      ],
+      "cost": 6,
+      "flavor": "\"CLASSIFIED INTELLIGENCE: Tabloid headline writes itself.\""
+    },
+    {
+      "schemaVersion": 2,
+      "id": "CRY-TS-046",
+      "faction": "truth",
+      "name": "Moon Landing Hoax Evidence",
+      "type": "MEDIA",
+      "rarity": "uncommon",
+      "effects": {
+        "truthDelta": 2
+      },
+      "tags": [
+        "cryptid",
+        "media",
+        "truth"
+      ],
+      "cost": 4,
+      "flavor": "\"CLASSIFIED INTELLIGENCE: Experts disagree; the crowd screams yes.\""
+    },
+    {
+      "schemaVersion": 2,
+      "id": "CRY-TS-047",
+      "faction": "truth",
+      "name": "Memory Recovery Session",
+      "type": "MEDIA",
+      "rarity": "rare",
+      "effects": {
+        "truthDelta": 3
+      },
+      "tags": [
+        "cryptid",
+        "media",
+        "truth"
+      ],
+      "cost": 5,
+      "flavor": "\"CLASSIFIED INTELLIGENCE: Tabloid headline writes itself.\""
+    },
+    {
+      "schemaVersion": 2,
+      "id": "CRY-TS-048",
+      "faction": "truth",
+      "name": "Shadow Government Infiltration",
+      "type": "ATTACK",
+      "rarity": "legendary",
+      "effects": {
+        "ipDelta": {
+          "opponent": 4
+        },
+        "discardOpponent": 2
+      },
+      "tags": [
+        "attack",
+        "cryptid",
+        "truth"
+      ],
+      "cost": 5,
+      "flavor": "\"CLASSIFIED INTELLIGENCE: Pixels enhanced: chills confirmed.\""
+    },
+    {
+      "schemaVersion": 2,
+      "id": "CRY-TS-049",
+      "faction": "truth",
+      "name": "Operation Paperclip Files",
+      "type": "MEDIA",
+      "rarity": "rare",
+      "effects": {
+        "truthDelta": 3
+      },
+      "tags": [
+        "bureaucracy",
+        "coverup",
+        "cryptid",
+        "media",
+        "truth"
+      ],
+      "cost": 5,
+      "flavor": "\"CLASSIFIED INTELLIGENCE: Pixels enhanced: chills confirmed.\""
+    },
+    {
+      "schemaVersion": 2,
+      "id": "CRY-TS-050",
+      "faction": "truth",
+      "name": "Holographic Universe Theory",
+      "type": "MEDIA",
+      "rarity": "uncommon",
+      "effects": {
+        "truthDelta": 2
+      },
+      "tags": [
+        "cryptid",
+        "media",
+        "truth"
+      ],
+      "cost": 4,
+      "flavor": "\"CLASSIFIED INTELLIGENCE: Tabloid headline writes itself.\""
+    },
+    {
+      "schemaVersion": 2,
+      "id": "CRY-TS-051",
+      "faction": "truth",
+      "name": "Cryptid DNA Evidence Database",
+      "type": "MEDIA",
+      "rarity": "rare",
+      "effects": {
+        "truthDelta": 3
+      },
+      "tags": [
+        "cryptid",
+        "media",
+        "truth"
+      ],
+      "cost": 5,
+      "flavor": "\"CLASSIFIED INTELLIGENCE: Experts disagree; the crowd screams yes.\""
+    },
+    {
+      "schemaVersion": 2,
+      "id": "CRY-TS-052",
+      "faction": "truth",
+      "name": "Phantom Satellite Tracking",
+      "type": "MEDIA",
+      "rarity": "rare",
+      "effects": {
+        "truthDelta": 3
+      },
+      "tags": [
+        "cryptid",
+        "media",
+        "truth"
+      ],
+      "cost": 5,
+      "flavor": "\"CLASSIFIED INTELLIGENCE: We brought snacks and a camcorder.\""
+    },
+    {
+      "schemaVersion": 2,
+      "id": "CRY-TS-053",
+      "faction": "truth",
+      "name": "Consciousness Upload Technology",
+      "type": "MEDIA",
+      "rarity": "uncommon",
+      "effects": {
+        "truthDelta": 2
+      },
+      "tags": [
+        "cryptid",
+        "media",
+        "truth"
+      ],
+      "cost": 4,
+      "flavor": "\"CLASSIFIED INTELLIGENCE: We brought snacks and a camcorder.\""
+    },
+    {
+      "schemaVersion": 2,
+      "id": "CRY-TS-054",
+      "faction": "truth",
+      "name": "Multidimensional Broadcast Network",
+      "type": "ZONE",
+      "rarity": "legendary",
+      "effects": {
+        "pressureDelta": 4
+      },
+      "tags": [
+        "cryptid",
+        "media",
+        "truth",
+        "zone"
+      ],
+      "cost": 7,
+      "flavor": "\"CLASSIFIED INTELLIGENCE: We brought snacks and a camcorder.\""
+    },
+    {
+      "schemaVersion": 2,
+      "id": "CRY-TS-055",
+      "faction": "truth",
+      "name": "Crystal Wi-Fi Chakra Network",
+      "type": "MEDIA",
+      "rarity": "uncommon",
+      "effects": {
+        "truthDelta": 2
+      },
+      "tags": [
+        "cryptid",
+        "media",
+        "truth"
+      ],
+      "cost": 4,
+      "flavor": "\"CLASSIFIED INTELLIGENCE: Tabloid headline writes itself.\""
+    },
+    {
+      "schemaVersion": 2,
+      "id": "CRY-TS-056",
+      "faction": "truth",
+      "name": "Late Night AM Radio",
+      "type": "MEDIA",
+      "rarity": "uncommon",
+      "effects": {
+        "truthDelta": 2
+      },
+      "tags": [
+        "cryptid",
+        "media",
+        "truth"
+      ],
+      "cost": 4,
+      "flavor": "\"CLASSIFIED INTELLIGENCE: Experts disagree; the crowd screams yes.\""
+    },
+    {
+      "schemaVersion": 2,
+      "id": "CRY-TS-057",
+      "faction": "truth",
+      "name": "Viral Thread Storm",
+      "type": "MEDIA",
+      "rarity": "rare",
+      "effects": {
+        "truthDelta": 3
+      },
+      "tags": [
+        "cryptid",
+        "media",
+        "truth"
+      ],
+      "cost": 5,
+      "flavor": "\"CLASSIFIED INTELLIGENCE: Pixels enhanced: chills confirmed.\""
+    },
+    {
+      "schemaVersion": 2,
+      "id": "CRY-TS-058",
+      "faction": "truth",
+      "name": "Bigfoot Field Operations",
+      "type": "ZONE",
+      "rarity": "rare",
+      "effects": {
+        "pressureDelta": 3
+      },
+      "tags": [
+        "bigfoot",
+        "cryptid",
+        "truth",
+        "zone"
+      ],
+      "cost": 6,
+      "flavor": "\"CLASSIFIED INTELLIGENCE: Bigfoot looked straight into the lens.\""
+    },
+    {
+      "schemaVersion": 2,
+      "id": "CRY-TS-059",
+      "faction": "truth",
+      "name": "Mothman Omen Network",
+      "type": "ATTACK",
+      "rarity": "uncommon",
+      "effects": {
+        "ipDelta": {
+          "opponent": 2
+        }
+      },
+      "tags": [
+        "attack",
+        "cryptid",
+        "mothman",
+        "truth"
+      ],
+      "cost": 3,
+      "flavor": "\"CLASSIFIED INTELLIGENCE: Experts disagree; the crowd screams yes.\""
+    },
+    {
+      "schemaVersion": 2,
+      "id": "CRY-TS-060",
+      "faction": "truth",
+      "name": "Essential Oils Mind Shield",
+      "type": "MEDIA",
+      "rarity": "uncommon",
+      "effects": {
+        "truthDelta": 2
+      },
+      "tags": [
+        "cryptid",
+        "media",
+        "truth"
+      ],
+      "cost": 4,
+      "flavor": "\"CLASSIFIED INTELLIGENCE: Pixels enhanced: chills confirmed.\""
+    },
+    {
+      "schemaVersion": 2,
+      "id": "CRY-TS-061",
+      "faction": "truth",
+      "name": "Healing Crystal Array",
+      "type": "MEDIA",
+      "rarity": "uncommon",
+      "effects": {
+        "truthDelta": 2
+      },
+      "tags": [
+        "cryptid",
+        "media",
+        "truth"
+      ],
+      "cost": 4,
+      "flavor": "\"CLASSIFIED INTELLIGENCE: Healing looked straight into the lens.\""
+    },
+    {
+      "schemaVersion": 2,
+      "id": "CRY-TS-062",
+      "faction": "truth",
+      "name": "Really Long YouTube Videos",
+      "type": "MEDIA",
+      "rarity": "uncommon",
+      "effects": {
+        "truthDelta": 2
+      },
+      "tags": [
+        "cryptid",
+        "media",
+        "truth"
+      ],
+      "cost": 4,
+      "flavor": "\"CLASSIFIED INTELLIGENCE: Pixels enhanced: chills confirmed.\""
+    },
+    {
+      "schemaVersion": 2,
+      "id": "CRY-TS-063",
+      "faction": "truth",
+      "name": "Whistleblower Protection Network",
+      "type": "MEDIA",
+      "rarity": "rare",
+      "effects": {
+        "truthDelta": 3
+      },
+      "tags": [
+        "cryptid",
+        "media",
+        "truth"
+      ],
+      "cost": 5,
+      "flavor": "\"CLASSIFIED INTELLIGENCE: Pixels enhanced: chills confirmed.\""
+    },
+    {
+      "schemaVersion": 2,
+      "id": "CRY-TS-064",
+      "faction": "truth",
+      "name": "Anonymous Leak Platform",
+      "type": "MEDIA",
+      "rarity": "rare",
+      "effects": {
+        "truthDelta": 3
+      },
+      "tags": [
+        "cryptid",
+        "media",
+        "truth"
+      ],
+      "cost": 5,
+      "flavor": "\"CLASSIFIED INTELLIGENCE: Tabloid headline writes itself.\""
+    },
+    {
+      "schemaVersion": 2,
+      "id": "CRY-TS-065",
+      "faction": "truth",
+      "name": "Flat Earth Conference",
+      "type": "MEDIA",
+      "rarity": "uncommon",
+      "effects": {
+        "truthDelta": 2
+      },
+      "tags": [
+        "cryptid",
+        "media",
+        "truth"
+      ],
+      "cost": 4,
+      "flavor": "\"CLASSIFIED INTELLIGENCE: Flat looked straight into the lens.\""
+    },
+    {
+      "schemaVersion": 2,
+      "id": "CRY-TS-066",
+      "faction": "truth",
+      "name": "Chemtrail Detection Kit",
+      "type": "ZONE",
+      "rarity": "uncommon",
+      "effects": {
+        "pressureDelta": 2
+      },
+      "tags": [
+        "chemtrail",
+        "cryptid",
+        "truth",
+        "zone"
+      ],
+      "cost": 5,
+      "flavor": "\"CLASSIFIED INTELLIGENCE: We brought snacks and a camcorder.\""
+    },
+    {
+      "schemaVersion": 2,
+      "id": "CRY-TS-067",
+      "faction": "truth",
+      "name": "Vaccine Truth Bomb Campaign",
+      "type": "ZONE",
+      "rarity": "rare",
+      "effects": {
+        "pressureDelta": 3
+      },
+      "tags": [
+        "cryptid",
+        "truth",
+        "zone"
+      ],
+      "cost": 6,
+      "flavor": "\"CLASSIFIED INTELLIGENCE: Tabloid headline writes itself.\""
+    },
+    {
+      "schemaVersion": 2,
+      "id": "CRY-TS-068",
+      "faction": "truth",
+      "name": "Alabama Cryptid Mass Sighting",
+      "type": "ATTACK",
+      "rarity": "common",
+      "effects": {
+        "ipDelta": {
+          "opponent": 1
+        }
+      },
+      "tags": [
+        "alabama",
+        "alabama-cryptid",
+        "attack",
+        "cryptid",
+        "truth"
+      ],
+      "cost": 2,
+      "flavor": "\"CLASSIFIED INTELLIGENCE: The locals swear alabama cryptid waved back.\""
+    },
+    {
+      "schemaVersion": 2,
+      "id": "CRY-TS-069",
+      "faction": "truth",
+      "name": "Tizheruk Mass Sighting",
+      "type": "ZONE",
+      "rarity": "common",
+      "effects": {
+        "pressureDelta": 1
+      },
+      "tags": [
+        "alaska",
+        "cryptid",
+        "tizheruk",
+        "truth",
+        "zone"
+      ],
+      "cost": 4,
+      "flavor": "\"CLASSIFIED INTELLIGENCE: The locals swear tizheruk waved back.\""
+    },
+    {
+      "schemaVersion": 2,
+      "id": "CRY-TS-070",
+      "faction": "truth",
+      "name": "Thunderbird Mass Sighting",
+      "type": "ATTACK",
+      "rarity": "common",
+      "effects": {
+        "ipDelta": {
+          "opponent": 1
+        }
+      },
+      "tags": [
+        "arizona",
+        "attack",
+        "cryptid",
+        "thunderbird",
+        "truth"
+      ],
+      "cost": 2,
+      "flavor": "\"CLASSIFIED INTELLIGENCE: The locals swear thunderbird waved back.\""
+    },
+    {
+      "schemaVersion": 2,
+      "id": "CRY-TS-071",
+      "faction": "truth",
+      "name": "Fouke Monster Mass Sighting",
+      "type": "ATTACK",
+      "rarity": "common",
+      "effects": {
+        "ipDelta": {
+          "opponent": 1
+        }
+      },
+      "tags": [
+        "arkansas",
+        "attack",
+        "cryptid",
+        "fouke-monster",
+        "truth"
+      ],
+      "cost": 2,
+      "flavor": "\"CLASSIFIED INTELLIGENCE: The locals swear fouke monster waved back.\""
+    },
+    {
+      "schemaVersion": 2,
+      "id": "CRY-TS-072",
+      "faction": "truth",
+      "name": "Bigfoot Mass Sighting",
+      "type": "ZONE",
+      "rarity": "common",
+      "effects": {
+        "pressureDelta": 1
+      },
+      "tags": [
+        "bigfoot",
+        "california",
+        "cryptid",
+        "truth",
+        "zone"
+      ],
+      "cost": 4,
+      "flavor": "\"CLASSIFIED INTELLIGENCE: The locals swear bigfoot waved back.\""
+    },
+    {
+      "schemaVersion": 2,
+      "id": "CRY-TS-073",
+      "faction": "truth",
+      "name": "Colorado Cryptid Mass Sighting",
+      "type": "ATTACK",
+      "rarity": "common",
+      "effects": {
+        "ipDelta": {
+          "opponent": 1
+        }
+      },
+      "tags": [
+        "attack",
+        "colorado",
+        "colorado-cryptid",
+        "cryptid",
+        "truth"
+      ],
+      "cost": 2,
+      "flavor": "\"CLASSIFIED INTELLIGENCE: The locals swear colorado cryptid waved back.\""
+    },
+    {
+      "schemaVersion": 2,
+      "id": "CRY-TS-074",
+      "faction": "truth",
+      "name": "Connecticut Cryptid Mass Sighting",
+      "type": "ATTACK",
+      "rarity": "common",
+      "effects": {
+        "ipDelta": {
+          "opponent": 1
+        }
+      },
+      "tags": [
+        "attack",
+        "connecticut",
+        "connecticut-cryptid",
+        "cryptid",
+        "truth"
+      ],
+      "cost": 2,
+      "flavor": "\"CLASSIFIED INTELLIGENCE: The locals swear connecticut cryptid waved back.\""
+    },
+    {
+      "schemaVersion": 2,
+      "id": "CRY-TS-075",
+      "faction": "truth",
+      "name": "Delaware Cryptid Mass Sighting",
+      "type": "ZONE",
+      "rarity": "common",
+      "effects": {
+        "pressureDelta": 1
+      },
+      "tags": [
+        "cryptid",
+        "delaware",
+        "delaware-cryptid",
+        "truth",
+        "zone"
+      ],
+      "cost": 4,
+      "flavor": "\"CLASSIFIED INTELLIGENCE: The locals swear delaware cryptid waved back.\""
+    },
+    {
+      "schemaVersion": 2,
+      "id": "CRY-TS-076",
+      "faction": "truth",
+      "name": "Skunk Ape Mass Sighting",
+      "type": "ZONE",
+      "rarity": "common",
+      "effects": {
+        "pressureDelta": 1
+      },
+      "tags": [
+        "cryptid",
+        "florida",
+        "skunk-ape",
+        "truth",
+        "zone"
+      ],
+      "cost": 4,
+      "flavor": "\"CLASSIFIED INTELLIGENCE: The locals swear skunk ape waved back.\""
+    },
+    {
+      "schemaVersion": 2,
+      "id": "CRY-TS-077",
+      "faction": "truth",
+      "name": "Georgia Cryptid Mass Sighting",
+      "type": "ZONE",
+      "rarity": "common",
+      "effects": {
+        "pressureDelta": 1
+      },
+      "tags": [
+        "cryptid",
+        "georgia",
+        "georgia-cryptid",
+        "truth",
+        "zone"
+      ],
+      "cost": 4,
+      "flavor": "\"CLASSIFIED INTELLIGENCE: The locals swear georgia cryptid waved back.\""
+    },
+    {
+      "schemaVersion": 2,
+      "id": "CRY-TS-078",
+      "faction": "truth",
+      "name": "Hawaii Cryptid Mass Sighting",
+      "type": "ZONE",
+      "rarity": "common",
+      "effects": {
+        "pressureDelta": 1
+      },
+      "tags": [
+        "cryptid",
+        "hawaii",
+        "hawaii-cryptid",
+        "truth",
+        "zone"
+      ],
+      "cost": 4,
+      "flavor": "\"CLASSIFIED INTELLIGENCE: The locals swear hawaii cryptid waved back.\""
+    },
+    {
+      "schemaVersion": 2,
+      "id": "CRY-TS-079",
+      "faction": "truth",
+      "name": "Idaho Cryptid Mass Sighting",
+      "type": "ZONE",
+      "rarity": "common",
+      "effects": {
+        "pressureDelta": 1
+      },
+      "tags": [
+        "cryptid",
+        "idaho",
+        "idaho-cryptid",
+        "truth",
+        "zone"
+      ],
+      "cost": 4,
+      "flavor": "\"CLASSIFIED INTELLIGENCE: The locals swear idaho cryptid waved back.\""
+    },
+    {
+      "schemaVersion": 2,
+      "id": "CRY-TS-080",
+      "faction": "truth",
+      "name": "Enfield Horror Mass Sighting",
+      "type": "ZONE",
+      "rarity": "common",
+      "effects": {
+        "pressureDelta": 1
+      },
+      "tags": [
+        "cryptid",
+        "enfield-horror",
+        "illinois",
+        "truth",
+        "zone"
+      ],
+      "cost": 4,
+      "flavor": "\"CLASSIFIED INTELLIGENCE: The locals swear enfield horror waved back.\""
+    },
+    {
+      "schemaVersion": 2,
+      "id": "CRY-TS-081",
+      "faction": "truth",
+      "name": "Indiana Cryptid Mass Sighting",
+      "type": "ZONE",
+      "rarity": "common",
+      "effects": {
+        "pressureDelta": 1
+      },
+      "tags": [
+        "cryptid",
+        "indiana",
+        "indiana-cryptid",
+        "truth",
+        "zone"
+      ],
+      "cost": 4,
+      "flavor": "\"CLASSIFIED INTELLIGENCE: The locals swear indiana cryptid waved back.\""
+    },
+    {
+      "schemaVersion": 2,
+      "id": "CRY-TS-082",
+      "faction": "truth",
+      "name": "Iowa Cryptid Mass Sighting",
+      "type": "ZONE",
+      "rarity": "common",
+      "effects": {
+        "pressureDelta": 1
+      },
+      "tags": [
+        "cryptid",
+        "iowa",
+        "iowa-cryptid",
+        "truth",
+        "zone"
+      ],
+      "cost": 4,
+      "flavor": "\"CLASSIFIED INTELLIGENCE: The locals swear iowa cryptid waved back.\""
+    },
+    {
+      "schemaVersion": 2,
+      "id": "CRY-TS-083",
+      "faction": "truth",
+      "name": "Kansas Cryptid Mass Sighting",
+      "type": "ZONE",
+      "rarity": "common",
+      "effects": {
+        "pressureDelta": 1
+      },
+      "tags": [
+        "cryptid",
+        "kansas",
+        "kansas-cryptid",
+        "truth",
+        "zone"
+      ],
+      "cost": 4,
+      "flavor": "\"CLASSIFIED INTELLIGENCE: The locals swear kansas cryptid waved back.\""
+    },
+    {
+      "schemaVersion": 2,
+      "id": "CRY-TS-084",
+      "faction": "truth",
+      "name": "Kelly–Hopkinsville Goblins Mass Sighting",
+      "type": "ZONE",
+      "rarity": "common",
+      "effects": {
+        "pressureDelta": 1
+      },
+      "tags": [
+        "cryptid",
+        "kelly-hopkinsville-goblins",
+        "kentucky",
+        "truth",
+        "zone"
+      ],
+      "cost": 4,
+      "flavor": "\"CLASSIFIED INTELLIGENCE: The locals swear kelly–hopkinsville goblins waved back.\""
+    },
+    {
+      "schemaVersion": 2,
+      "id": "CRY-TS-085",
+      "faction": "truth",
+      "name": "Rougarou Mass Sighting",
+      "type": "ZONE",
+      "rarity": "common",
+      "effects": {
+        "pressureDelta": 1
+      },
+      "tags": [
+        "cryptid",
+        "louisiana",
+        "rougarou",
+        "truth",
+        "zone"
+      ],
+      "cost": 4,
+      "flavor": "\"CLASSIFIED INTELLIGENCE: The locals swear rougarou waved back.\""
+    },
+    {
+      "schemaVersion": 2,
+      "id": "CRY-TS-086",
+      "faction": "truth",
+      "name": "Maine Cryptid Mass Sighting",
+      "type": "ZONE",
+      "rarity": "common",
+      "effects": {
+        "pressureDelta": 1
+      },
+      "tags": [
+        "cryptid",
+        "maine",
+        "maine-cryptid",
+        "truth",
+        "zone"
+      ],
+      "cost": 4,
+      "flavor": "\"CLASSIFIED INTELLIGENCE: The locals swear maine cryptid waved back.\""
+    },
+    {
+      "schemaVersion": 2,
+      "id": "CRY-TS-087",
+      "faction": "truth",
+      "name": "Snallygaster Mass Sighting",
+      "type": "ZONE",
+      "rarity": "common",
+      "effects": {
+        "pressureDelta": 1
+      },
+      "tags": [
+        "cryptid",
+        "maryland",
+        "snallygaster",
+        "truth",
+        "zone"
+      ],
+      "cost": 4,
+      "flavor": "\"CLASSIFIED INTELLIGENCE: The locals swear snallygaster waved back.\""
+    },
+    {
+      "schemaVersion": 2,
+      "id": "CRY-TS-088",
+      "faction": "truth",
+      "name": "Dover Demon Mass Sighting",
+      "type": "ZONE",
+      "rarity": "common",
+      "effects": {
+        "pressureDelta": 1
+      },
+      "tags": [
+        "cryptid",
+        "dover-demon",
+        "massachusetts",
+        "truth",
+        "zone"
+      ],
+      "cost": 4,
+      "flavor": "\"CLASSIFIED INTELLIGENCE: The locals swear dover demon waved back.\""
+    },
+    {
+      "schemaVersion": 2,
+      "id": "CRY-TS-089",
+      "faction": "truth",
+      "name": "Dogman Mass Sighting",
+      "type": "ZONE",
+      "rarity": "common",
+      "effects": {
+        "pressureDelta": 1
+      },
+      "tags": [
+        "cryptid",
+        "dogman",
+        "michigan",
+        "truth",
+        "zone"
+      ],
+      "cost": 4,
+      "flavor": "\"CLASSIFIED INTELLIGENCE: The locals swear dogman waved back.\""
+    },
+    {
+      "schemaVersion": 2,
+      "id": "CRY-TS-090",
+      "faction": "truth",
+      "name": "Wendigo Mass Sighting",
+      "type": "ATTACK",
+      "rarity": "common",
+      "effects": {
+        "ipDelta": {
+          "opponent": 1
+        }
+      },
+      "tags": [
+        "attack",
+        "cryptid",
+        "minnesota",
+        "truth",
+        "wendigo"
+      ],
+      "cost": 2,
+      "flavor": "\"CLASSIFIED INTELLIGENCE: The locals swear wendigo waved back.\""
+    },
+    {
+      "schemaVersion": 2,
+      "id": "CRY-TS-091",
+      "faction": "truth",
+      "name": "Mississippi Cryptid Mass Sighting",
+      "type": "ZONE",
+      "rarity": "common",
+      "effects": {
+        "pressureDelta": 1
+      },
+      "tags": [
+        "cryptid",
+        "mississippi",
+        "mississippi-cryptid",
+        "truth",
+        "zone"
+      ],
+      "cost": 4,
+      "flavor": "\"CLASSIFIED INTELLIGENCE: The locals swear mississippi cryptid waved back.\""
+    },
+    {
+      "schemaVersion": 2,
+      "id": "CRY-TS-092",
+      "faction": "truth",
+      "name": "Missouri Cryptid Mass Sighting",
+      "type": "ZONE",
+      "rarity": "common",
+      "effects": {
+        "pressureDelta": 1
+      },
+      "tags": [
+        "cryptid",
+        "missouri",
+        "missouri-cryptid",
+        "truth",
+        "zone"
+      ],
+      "cost": 4,
+      "flavor": "\"CLASSIFIED INTELLIGENCE: The locals swear missouri cryptid waved back.\""
+    },
+    {
+      "schemaVersion": 2,
+      "id": "CRY-TS-093",
+      "faction": "truth",
+      "name": "Shunka Warakin Mass Sighting",
+      "type": "ZONE",
+      "rarity": "common",
+      "effects": {
+        "pressureDelta": 1
+      },
+      "tags": [
+        "cryptid",
+        "montana",
+        "shunka-warakin",
+        "truth",
+        "zone"
+      ],
+      "cost": 4,
+      "flavor": "\"CLASSIFIED INTELLIGENCE: The locals swear shunka warakin waved back.\""
+    },
+    {
+      "schemaVersion": 2,
+      "id": "CRY-TS-094",
+      "faction": "truth",
+      "name": "Nebraska Cryptid Mass Sighting",
+      "type": "ZONE",
+      "rarity": "common",
+      "effects": {
+        "pressureDelta": 1
+      },
+      "tags": [
+        "cryptid",
+        "nebraska",
+        "nebraska-cryptid",
+        "truth",
+        "zone"
+      ],
+      "cost": 4,
+      "flavor": "\"CLASSIFIED INTELLIGENCE: The locals swear nebraska cryptid waved back.\""
+    },
+    {
+      "schemaVersion": 2,
+      "id": "CRY-TS-095",
+      "faction": "truth",
+      "name": "Tahoe Tessie Mass Sighting",
+      "type": "ZONE",
+      "rarity": "common",
+      "effects": {
+        "pressureDelta": 1
+      },
+      "tags": [
+        "cryptid",
+        "nevada",
+        "tahoe-tessie",
+        "truth",
+        "zone"
+      ],
+      "cost": 4,
+      "flavor": "\"CLASSIFIED INTELLIGENCE: The locals swear tahoe tessie waved back.\""
+    },
+    {
+      "schemaVersion": 2,
+      "id": "CRY-TS-096",
+      "faction": "truth",
+      "name": "Wood Devils Mass Sighting",
+      "type": "ZONE",
+      "rarity": "common",
+      "effects": {
+        "pressureDelta": 1
+      },
+      "tags": [
+        "cryptid",
+        "new-hampshire",
+        "truth",
+        "wood-devils",
+        "zone"
+      ],
+      "cost": 4,
+      "flavor": "\"CLASSIFIED INTELLIGENCE: The locals swear wood devils waved back.\""
+    },
+    {
+      "schemaVersion": 2,
+      "id": "CRY-TS-097",
+      "faction": "truth",
+      "name": "Jersey Devil Mass Sighting",
+      "type": "ATTACK",
+      "rarity": "common",
+      "effects": {
+        "ipDelta": {
+          "opponent": 1
+        }
+      },
+      "tags": [
+        "attack",
+        "cryptid",
+        "jersey-devil",
+        "new-jersey",
+        "truth"
+      ],
+      "cost": 2,
+      "flavor": "\"CLASSIFIED INTELLIGENCE: The locals swear jersey devil waved back.\""
+    },
+    {
+      "schemaVersion": 2,
+      "id": "CRY-TS-098",
+      "faction": "truth",
+      "name": "Skinwalkers Mass Sighting",
+      "type": "ATTACK",
+      "rarity": "common",
+      "effects": {
+        "ipDelta": {
+          "opponent": 1
+        }
+      },
+      "tags": [
+        "attack",
+        "cryptid",
+        "new-mexico",
+        "skinwalkers",
+        "truth"
+      ],
+      "cost": 2,
+      "flavor": "\"CLASSIFIED INTELLIGENCE: The locals swear skinwalkers waved back.\""
+    },
+    {
+      "schemaVersion": 2,
+      "id": "CRY-TS-099",
+      "faction": "truth",
+      "name": "Montauk Monster Mass Sighting",
+      "type": "ZONE",
+      "rarity": "common",
+      "effects": {
+        "pressureDelta": 1
+      },
+      "tags": [
+        "cryptid",
+        "montauk-monster",
+        "new-york",
+        "truth",
+        "zone"
+      ],
+      "cost": 4,
+      "flavor": "\"CLASSIFIED INTELLIGENCE: The locals swear montauk monster waved back.\""
+    },
+    {
+      "schemaVersion": 2,
+      "id": "CRY-TS-100",
+      "faction": "truth",
+      "name": "North Carolina Cryptid Mass Sighting",
+      "type": "ZONE",
+      "rarity": "common",
+      "effects": {
+        "pressureDelta": 1
+      },
+      "tags": [
+        "cryptid",
+        "north-carolina",
+        "north-carolina-cryptid",
+        "truth",
+        "zone"
+      ],
+      "cost": 4,
+      "flavor": "\"CLASSIFIED INTELLIGENCE: The locals swear north carolina cryptid waved back.\""
+    },
+    {
+      "schemaVersion": 2,
+      "id": "CRY-TS-101",
+      "faction": "truth",
+      "name": "North Dakota Cryptid Mass Sighting",
+      "type": "ZONE",
+      "rarity": "common",
+      "effects": {
+        "pressureDelta": 1
+      },
+      "tags": [
+        "cryptid",
+        "north-dakota",
+        "north-dakota-cryptid",
+        "truth",
+        "zone"
+      ],
+      "cost": 4,
+      "flavor": "\"CLASSIFIED INTELLIGENCE: The locals swear north dakota cryptid waved back.\""
+    },
+    {
+      "schemaVersion": 2,
+      "id": "CRY-TS-102",
+      "faction": "truth",
+      "name": "Loveland Frogman Mass Sighting",
+      "type": "ZONE",
+      "rarity": "common",
+      "effects": {
+        "pressureDelta": 1
+      },
+      "tags": [
+        "cryptid",
+        "loveland-frogman",
+        "ohio",
+        "truth",
+        "zone"
+      ],
+      "cost": 4,
+      "flavor": "\"CLASSIFIED INTELLIGENCE: The locals swear loveland frogman waved back.\""
+    },
+    {
+      "schemaVersion": 2,
+      "id": "CRY-TS-103",
+      "faction": "truth",
+      "name": "Oklahoma Cryptid Mass Sighting",
+      "type": "ZONE",
+      "rarity": "common",
+      "effects": {
+        "pressureDelta": 1
+      },
+      "tags": [
+        "cryptid",
+        "oklahoma",
+        "oklahoma-cryptid",
+        "truth",
+        "zone"
+      ],
+      "cost": 4,
+      "flavor": "\"CLASSIFIED INTELLIGENCE: The locals swear oklahoma cryptid waved back.\""
+    },
+    {
+      "schemaVersion": 2,
+      "id": "CRY-TS-104",
+      "faction": "truth",
+      "name": "Bigfoot Mass Sighting",
+      "type": "ZONE",
+      "rarity": "common",
+      "effects": {
+        "pressureDelta": 1
+      },
+      "tags": [
+        "bigfoot",
+        "cryptid",
+        "oregon",
+        "truth",
+        "zone"
+      ],
+      "cost": 4,
+      "flavor": "\"CLASSIFIED INTELLIGENCE: The locals swear bigfoot waved back.\""
+    },
+    {
+      "schemaVersion": 2,
+      "id": "CRY-TS-105",
+      "faction": "truth",
+      "name": "Pennsylvania Cryptid Mass Sighting",
+      "type": "ZONE",
+      "rarity": "common",
+      "effects": {
+        "pressureDelta": 1
+      },
+      "tags": [
+        "cryptid",
+        "pennsylvania",
+        "pennsylvania-cryptid",
+        "truth",
+        "zone"
+      ],
+      "cost": 4,
+      "flavor": "\"CLASSIFIED INTELLIGENCE: The locals swear pennsylvania cryptid waved back.\""
+    },
+    {
+      "schemaVersion": 2,
+      "id": "CRY-TS-106",
+      "faction": "truth",
+      "name": "Rhode Island Cryptid Mass Sighting",
+      "type": "ZONE",
+      "rarity": "common",
+      "effects": {
+        "pressureDelta": 1
+      },
+      "tags": [
+        "cryptid",
+        "rhode-island",
+        "rhode-island-cryptid",
+        "truth",
+        "zone"
+      ],
+      "cost": 4,
+      "flavor": "\"CLASSIFIED INTELLIGENCE: The locals swear rhode island cryptid waved back.\""
+    },
+    {
+      "schemaVersion": 2,
+      "id": "CRY-TS-107",
+      "faction": "truth",
+      "name": "South Carolina Cryptid Mass Sighting",
+      "type": "ZONE",
+      "rarity": "common",
+      "effects": {
+        "pressureDelta": 1
+      },
+      "tags": [
+        "cryptid",
+        "south-carolina",
+        "south-carolina-cryptid",
+        "truth",
+        "zone"
+      ],
+      "cost": 4,
+      "flavor": "\"CLASSIFIED INTELLIGENCE: The locals swear south carolina cryptid waved back.\""
+    },
+    {
+      "schemaVersion": 2,
+      "id": "CRY-TS-108",
+      "faction": "truth",
+      "name": "South Dakota Cryptid Mass Sighting",
+      "type": "ZONE",
+      "rarity": "common",
+      "effects": {
+        "pressureDelta": 1
+      },
+      "tags": [
+        "cryptid",
+        "south-dakota",
+        "south-dakota-cryptid",
+        "truth",
+        "zone"
+      ],
+      "cost": 4,
+      "flavor": "\"CLASSIFIED INTELLIGENCE: The locals swear south dakota cryptid waved back.\""
+    },
+    {
+      "schemaVersion": 2,
+      "id": "CRY-TS-109",
+      "faction": "truth",
+      "name": "Tennessee Cryptid Mass Sighting",
+      "type": "ZONE",
+      "rarity": "common",
+      "effects": {
+        "pressureDelta": 1
+      },
+      "tags": [
+        "cryptid",
+        "tennessee",
+        "tennessee-cryptid",
+        "truth",
+        "zone"
+      ],
+      "cost": 4,
+      "flavor": "\"CLASSIFIED INTELLIGENCE: The locals swear tennessee cryptid waved back.\""
+    },
+    {
+      "schemaVersion": 2,
+      "id": "CRY-TS-110",
+      "faction": "truth",
+      "name": "Chupacabra Mass Sighting",
+      "type": "ATTACK",
+      "rarity": "common",
+      "effects": {
+        "ipDelta": {
+          "opponent": 1
+        }
+      },
+      "tags": [
+        "attack",
+        "chupacabra",
+        "cryptid",
+        "texas",
+        "truth"
+      ],
+      "cost": 2,
+      "flavor": "\"CLASSIFIED INTELLIGENCE: The locals swear chupacabra waved back.\""
+    },
+    {
+      "schemaVersion": 2,
+      "id": "CRY-TS-111",
+      "faction": "truth",
+      "name": "Utah Cryptid Mass Sighting",
+      "type": "ZONE",
+      "rarity": "common",
+      "effects": {
+        "pressureDelta": 1
+      },
+      "tags": [
+        "cryptid",
+        "truth",
+        "utah",
+        "utah-cryptid",
+        "zone"
+      ],
+      "cost": 4,
+      "flavor": "\"CLASSIFIED INTELLIGENCE: The locals swear utah cryptid waved back.\""
+    },
+    {
+      "schemaVersion": 2,
+      "id": "CRY-TS-112",
+      "faction": "truth",
+      "name": "Champ Mass Sighting",
+      "type": "ZONE",
+      "rarity": "common",
+      "effects": {
+        "pressureDelta": 1
+      },
+      "tags": [
+        "champ",
+        "cryptid",
+        "truth",
+        "vermont",
+        "zone"
+      ],
+      "cost": 4,
+      "flavor": "\"CLASSIFIED INTELLIGENCE: The locals swear champ waved back.\""
+    },
+    {
+      "schemaVersion": 2,
+      "id": "CRY-TS-113",
+      "faction": "truth",
+      "name": "Virginia Cryptid Mass Sighting",
+      "type": "ZONE",
+      "rarity": "common",
+      "effects": {
+        "pressureDelta": 1
+      },
+      "tags": [
+        "cryptid",
+        "truth",
+        "virginia",
+        "virginia-cryptid",
+        "zone"
+      ],
+      "cost": 4,
+      "flavor": "\"CLASSIFIED INTELLIGENCE: The locals swear virginia cryptid waved back.\""
+    },
+    {
+      "schemaVersion": 2,
+      "id": "CRY-TS-114",
+      "faction": "truth",
+      "name": "Bigfoot Mass Sighting",
+      "type": "ZONE",
+      "rarity": "common",
+      "effects": {
+        "pressureDelta": 1
+      },
+      "tags": [
+        "bigfoot",
+        "cryptid",
+        "truth",
+        "washington",
+        "zone"
+      ],
+      "cost": 4,
+      "flavor": "\"CLASSIFIED INTELLIGENCE: The locals swear bigfoot waved back.\""
+    },
+    {
+      "schemaVersion": 2,
+      "id": "CRY-TS-115",
+      "faction": "truth",
+      "name": "Mothman Mass Sighting",
+      "type": "ATTACK",
+      "rarity": "common",
+      "effects": {
+        "ipDelta": {
+          "opponent": 1
+        }
+      },
+      "tags": [
+        "attack",
+        "cryptid",
+        "mothman",
+        "truth",
+        "west-virginia"
+      ],
+      "cost": 2,
+      "flavor": "\"CLASSIFIED INTELLIGENCE: The locals swear mothman waved back.\""
+    },
+    {
+      "schemaVersion": 2,
+      "id": "CRY-TS-116",
+      "faction": "truth",
+      "name": "Beast of Bray Road Mass Sighting",
+      "type": "ATTACK",
+      "rarity": "common",
+      "effects": {
+        "ipDelta": {
+          "opponent": 1
+        }
+      },
+      "tags": [
+        "attack",
+        "beast-of-bray-road",
+        "cryptid",
+        "truth",
+        "wisconsin"
+      ],
+      "cost": 2,
+      "flavor": "\"CLASSIFIED INTELLIGENCE: The locals swear beast of bray road waved back.\""
+    },
+    {
+      "schemaVersion": 2,
+      "id": "CRY-TS-117",
+      "faction": "truth",
+      "name": "Wyoming Cryptid Mass Sighting",
+      "type": "ZONE",
+      "rarity": "common",
+      "effects": {
+        "pressureDelta": 1
+      },
+      "tags": [
+        "cryptid",
+        "truth",
+        "wyoming",
+        "wyoming-cryptid",
+        "zone"
+      ],
+      "cost": 4,
+      "flavor": "\"CLASSIFIED INTELLIGENCE: The locals swear wyoming cryptid waved back.\""
+    },
+    {
+      "schemaVersion": 2,
+      "id": "CRY-TS-118",
+      "faction": "truth",
+      "name": "Chupacabra Panic Wave",
+      "type": "ATTACK",
+      "rarity": "common",
+      "effects": {
+        "ipDelta": {
+          "opponent": 1
+        }
+      },
+      "tags": [
+        "attack",
+        "chupacabra",
+        "cryptid",
+        "truth"
+      ],
+      "cost": 2,
+      "flavor": "\"CLASSIFIED INTELLIGENCE: Eyewitnesses report chills and grainy footage.\""
+    },
+    {
+      "schemaVersion": 2,
+      "id": "CRY-TS-119",
+      "faction": "truth",
+      "name": "Tizheruk Panic Wave",
+      "type": "ATTACK",
+      "rarity": "common",
+      "effects": {
+        "ipDelta": {
+          "opponent": 1
+        }
+      },
+      "tags": [
+        "attack",
+        "cryptid",
+        "tizheruk",
+        "truth"
+      ],
+      "cost": 2,
+      "flavor": "\"CLASSIFIED INTELLIGENCE: Eyewitnesses report chills and grainy footage.\""
+    },
+    {
+      "schemaVersion": 2,
+      "id": "CRY-TS-120",
+      "faction": "truth",
+      "name": "Wendigo Watch Patrols",
+      "type": "ATTACK",
+      "rarity": "common",
+      "effects": {
+        "ipDelta": {
+          "opponent": 1
+        }
+      },
+      "tags": [
+        "attack",
+        "cryptid",
+        "truth",
+        "wendigo"
+      ],
+      "cost": 2,
+      "flavor": "\"CLASSIFIED INTELLIGENCE: Eyewitnesses report chills and grainy footage.\""
+    },
+    {
+      "schemaVersion": 2,
+      "id": "CRY-TS-121",
+      "faction": "truth",
+      "name": "Loveland Frogman Watch Patrols",
+      "type": "MEDIA",
+      "rarity": "common",
+      "effects": {
+        "truthDelta": 1
+      },
+      "tags": [
+        "cryptid",
+        "loveland-frogman",
+        "media",
+        "truth"
+      ],
+      "cost": 3,
+      "flavor": "\"CLASSIFIED INTELLIGENCE: Eyewitnesses report chills and grainy footage.\""
+    },
+    {
+      "schemaVersion": 2,
+      "id": "CRY-TS-122",
+      "faction": "truth",
+      "name": "Bigfoot Panic Wave",
+      "type": "ATTACK",
+      "rarity": "common",
+      "effects": {
+        "ipDelta": {
+          "opponent": 1
+        }
+      },
+      "tags": [
+        "attack",
+        "bigfoot",
+        "cryptid",
+        "truth"
+      ],
+      "cost": 2,
+      "flavor": "\"CLASSIFIED INTELLIGENCE: Eyewitnesses report chills and grainy footage.\""
+    },
+    {
+      "schemaVersion": 2,
+      "id": "CRY-TS-123",
+      "faction": "truth",
+      "name": "Dogman Panic Wave",
+      "type": "ATTACK",
+      "rarity": "common",
+      "effects": {
+        "ipDelta": {
+          "opponent": 1
+        }
+      },
+      "tags": [
+        "attack",
+        "cryptid",
+        "dogman",
+        "truth"
+      ],
+      "cost": 2,
+      "flavor": "\"CLASSIFIED INTELLIGENCE: Eyewitnesses report chills and grainy footage.\""
+    },
+    {
+      "schemaVersion": 2,
+      "id": "CRY-TS-124",
+      "faction": "truth",
+      "name": "Rougarou Watch Patrols",
+      "type": "MEDIA",
+      "rarity": "common",
+      "effects": {
+        "truthDelta": 1
+      },
+      "tags": [
+        "cryptid",
+        "media",
+        "rougarou",
+        "truth"
+      ],
+      "cost": 3,
+      "flavor": "\"CLASSIFIED INTELLIGENCE: Eyewitnesses report chills and grainy footage.\""
+    },
+    {
+      "schemaVersion": 2,
+      "id": "CRY-TS-125",
+      "faction": "truth",
+      "name": "Tahoe Tessie Panic Wave",
+      "type": "ATTACK",
+      "rarity": "common",
+      "effects": {
+        "ipDelta": {
+          "opponent": 1
+        }
+      },
+      "tags": [
+        "attack",
+        "cryptid",
+        "tahoe-tessie",
+        "truth"
+      ],
+      "cost": 2,
+      "flavor": "\"CLASSIFIED INTELLIGENCE: Eyewitnesses report chills and grainy footage.\""
+    },
+    {
+      "schemaVersion": 2,
+      "id": "CRY-TS-126",
+      "faction": "truth",
+      "name": "Beast of Bray Road Watch Patrols",
+      "type": "ATTACK",
+      "rarity": "common",
+      "effects": {
+        "ipDelta": {
+          "opponent": 1
+        }
+      },
+      "tags": [
+        "attack",
+        "beast-of-bray-road",
+        "cryptid",
+        "truth"
+      ],
+      "cost": 2,
+      "flavor": "\"CLASSIFIED INTELLIGENCE: Eyewitnesses report chills and grainy footage.\""
+    },
+    {
+      "schemaVersion": 2,
+      "id": "CRY-TS-127",
+      "faction": "truth",
+      "name": "Wendigo Watch Patrols",
+      "type": "ATTACK",
+      "rarity": "common",
+      "effects": {
+        "ipDelta": {
+          "opponent": 1
+        }
+      },
+      "tags": [
+        "attack",
+        "cryptid",
+        "truth",
+        "wendigo"
+      ],
+      "cost": 2,
+      "flavor": "\"CLASSIFIED INTELLIGENCE: Eyewitnesses report chills and grainy footage.\""
+    },
+    {
+      "schemaVersion": 2,
+      "id": "CRY-TS-128",
+      "faction": "truth",
+      "name": "Dover Demon Panic Wave",
+      "type": "ATTACK",
+      "rarity": "common",
+      "effects": {
+        "ipDelta": {
+          "opponent": 1
+        }
+      },
+      "tags": [
+        "attack",
+        "cryptid",
+        "dover-demon",
+        "truth"
+      ],
+      "cost": 2,
+      "flavor": "\"CLASSIFIED INTELLIGENCE: Eyewitnesses report chills and grainy footage.\""
+    },
+    {
+      "schemaVersion": 2,
+      "id": "CRY-TS-129",
+      "faction": "truth",
+      "name": "Tizheruk Watch Patrols",
+      "type": "MEDIA",
+      "rarity": "common",
+      "effects": {
+        "truthDelta": 1
+      },
+      "tags": [
+        "cryptid",
+        "media",
+        "tizheruk",
+        "truth"
+      ],
+      "cost": 3,
+      "flavor": "\"CLASSIFIED INTELLIGENCE: Eyewitnesses report chills and grainy footage.\""
+    },
+    {
+      "schemaVersion": 2,
+      "id": "CRY-TS-130",
+      "faction": "truth",
+      "name": "Fouke Monster Watch Patrols",
+      "type": "MEDIA",
+      "rarity": "common",
+      "effects": {
+        "truthDelta": 1
+      },
+      "tags": [
+        "cryptid",
+        "fouke-monster",
+        "media",
+        "truth"
+      ],
+      "cost": 3,
+      "flavor": "\"CLASSIFIED INTELLIGENCE: Eyewitnesses report chills and grainy footage.\""
+    },
+    {
+      "schemaVersion": 2,
+      "id": "CRY-TS-131",
+      "faction": "truth",
+      "name": "Jersey Devil Panic Wave",
+      "type": "ATTACK",
+      "rarity": "common",
+      "effects": {
+        "ipDelta": {
+          "opponent": 1
+        }
+      },
+      "tags": [
+        "attack",
+        "cryptid",
+        "jersey-devil",
+        "truth"
+      ],
+      "cost": 2,
+      "flavor": "\"CLASSIFIED INTELLIGENCE: Eyewitnesses report chills and grainy footage.\""
+    },
+    {
+      "schemaVersion": 2,
+      "id": "CRY-TS-132",
+      "faction": "truth",
+      "name": "Tizheruk Panic Wave",
+      "type": "ATTACK",
+      "rarity": "common",
+      "effects": {
+        "ipDelta": {
+          "opponent": 1
+        }
+      },
+      "tags": [
+        "attack",
+        "cryptid",
+        "tizheruk",
+        "truth"
+      ],
+      "cost": 2,
+      "flavor": "\"CLASSIFIED INTELLIGENCE: Eyewitnesses report chills and grainy footage.\""
+    },
+    {
+      "schemaVersion": 2,
+      "id": "CRY-TS-133",
+      "faction": "truth",
+      "name": "Tahoe Tessie Panic Wave",
+      "type": "ATTACK",
+      "rarity": "common",
+      "effects": {
+        "ipDelta": {
+          "opponent": 1
+        }
+      },
+      "tags": [
+        "attack",
+        "cryptid",
+        "tahoe-tessie",
+        "truth"
+      ],
+      "cost": 2,
+      "flavor": "\"CLASSIFIED INTELLIGENCE: Eyewitnesses report chills and grainy footage.\""
+    },
+    {
+      "schemaVersion": 2,
+      "id": "CRY-TS-134",
+      "faction": "truth",
+      "name": "Fouke Monster Panic Wave",
+      "type": "ATTACK",
+      "rarity": "common",
+      "effects": {
+        "ipDelta": {
+          "opponent": 1
+        }
+      },
+      "tags": [
+        "attack",
+        "cryptid",
+        "fouke-monster",
+        "truth"
+      ],
+      "cost": 2,
+      "flavor": "\"CLASSIFIED INTELLIGENCE: Eyewitnesses report chills and grainy footage.\""
+    },
+    {
+      "schemaVersion": 2,
+      "id": "CRY-TS-135",
+      "faction": "truth",
+      "name": "Snallygaster Watch Patrols",
+      "type": "MEDIA",
+      "rarity": "common",
+      "effects": {
+        "truthDelta": 1
+      },
+      "tags": [
+        "cryptid",
+        "media",
+        "snallygaster",
+        "truth"
+      ],
+      "cost": 3,
+      "flavor": "\"CLASSIFIED INTELLIGENCE: Eyewitnesses report chills and grainy footage.\""
+    },
+    {
+      "schemaVersion": 2,
+      "id": "CRY-TS-136",
+      "faction": "truth",
+      "name": "Chupacabra Panic Wave",
+      "type": "ATTACK",
+      "rarity": "common",
+      "effects": {
+        "ipDelta": {
+          "opponent": 1
+        }
+      },
+      "tags": [
+        "attack",
+        "chupacabra",
+        "cryptid",
+        "truth"
+      ],
+      "cost": 2,
+      "flavor": "\"CLASSIFIED INTELLIGENCE: Eyewitnesses report chills and grainy footage.\""
+    },
+    {
+      "schemaVersion": 2,
+      "id": "CRY-TS-137",
+      "faction": "truth",
+      "name": "Shunka Warakin Panic Wave",
+      "type": "ATTACK",
+      "rarity": "common",
+      "effects": {
+        "ipDelta": {
+          "opponent": 1
+        }
+      },
+      "tags": [
+        "attack",
+        "cryptid",
+        "shunka-warakin",
+        "truth"
+      ],
+      "cost": 2,
+      "flavor": "\"CLASSIFIED INTELLIGENCE: Eyewitnesses report chills and grainy footage.\""
+    },
+    {
+      "schemaVersion": 2,
+      "id": "CRY-TS-138",
+      "faction": "truth",
+      "name": "Tizheruk Panic Wave",
+      "type": "ATTACK",
+      "rarity": "common",
+      "effects": {
+        "ipDelta": {
+          "opponent": 1
+        }
+      },
+      "tags": [
+        "attack",
+        "cryptid",
+        "tizheruk",
+        "truth"
+      ],
+      "cost": 2,
+      "flavor": "\"CLASSIFIED INTELLIGENCE: Eyewitnesses report chills and grainy footage.\""
+    },
+    {
+      "schemaVersion": 2,
+      "id": "CRY-TS-139",
+      "faction": "truth",
+      "name": "Fouke Monster Panic Wave",
+      "type": "ATTACK",
+      "rarity": "common",
+      "effects": {
+        "ipDelta": {
+          "opponent": 1
+        }
+      },
+      "tags": [
+        "attack",
+        "cryptid",
+        "fouke-monster",
+        "truth"
+      ],
+      "cost": 2,
+      "flavor": "\"CLASSIFIED INTELLIGENCE: Eyewitnesses report chills and grainy footage.\""
+    },
+    {
+      "schemaVersion": 2,
+      "id": "CRY-TS-140",
+      "faction": "truth",
+      "name": "Dover Demon Panic Wave",
+      "type": "ATTACK",
+      "rarity": "common",
+      "effects": {
+        "ipDelta": {
+          "opponent": 1
+        }
+      },
+      "tags": [
+        "attack",
+        "cryptid",
+        "dover-demon",
+        "truth"
+      ],
+      "cost": 2,
+      "flavor": "\"CLASSIFIED INTELLIGENCE: Eyewitnesses report chills and grainy footage.\""
+    },
+    {
+      "schemaVersion": 2,
+      "id": "CRY-TS-141",
+      "faction": "truth",
+      "name": "Shunka Warakin Panic Wave",
+      "type": "ATTACK",
+      "rarity": "common",
+      "effects": {
+        "ipDelta": {
+          "opponent": 1
+        }
+      },
+      "tags": [
+        "attack",
+        "cryptid",
+        "shunka-warakin",
+        "truth"
+      ],
+      "cost": 2,
+      "flavor": "\"CLASSIFIED INTELLIGENCE: Eyewitnesses report chills and grainy footage.\""
+    },
+    {
+      "schemaVersion": 2,
+      "id": "CRY-TS-142",
+      "faction": "truth",
+      "name": "Champ Watch Patrols",
+      "type": "MEDIA",
+      "rarity": "common",
+      "effects": {
+        "truthDelta": 1
+      },
+      "tags": [
+        "champ",
+        "cryptid",
+        "media",
+        "truth"
+      ],
+      "cost": 3,
+      "flavor": "\"CLASSIFIED INTELLIGENCE: Eyewitnesses report chills and grainy footage.\""
+    },
+    {
+      "schemaVersion": 2,
+      "id": "CRY-TS-143",
+      "faction": "truth",
+      "name": "Loveland Frogman Watch Patrols",
+      "type": "MEDIA",
+      "rarity": "common",
+      "effects": {
+        "truthDelta": 1
+      },
+      "tags": [
+        "cryptid",
+        "loveland-frogman",
+        "media",
+        "truth"
+      ],
+      "cost": 3,
+      "flavor": "\"CLASSIFIED INTELLIGENCE: Eyewitnesses report chills and grainy footage.\""
+    },
+    {
+      "schemaVersion": 2,
+      "id": "CRY-TS-144",
+      "faction": "truth",
+      "name": "Montauk Monster Panic Wave",
+      "type": "ATTACK",
+      "rarity": "common",
+      "effects": {
+        "ipDelta": {
+          "opponent": 1
+        }
+      },
+      "tags": [
+        "attack",
+        "cryptid",
+        "montauk-monster",
+        "truth"
+      ],
+      "cost": 2,
+      "flavor": "\"CLASSIFIED INTELLIGENCE: Eyewitnesses report chills and grainy footage.\""
+    },
+    {
+      "schemaVersion": 2,
+      "id": "CRY-TS-145",
+      "faction": "truth",
+      "name": "Dogman Panic Wave",
+      "type": "ATTACK",
+      "rarity": "common",
+      "effects": {
+        "ipDelta": {
+          "opponent": 1
+        }
+      },
+      "tags": [
+        "attack",
+        "cryptid",
+        "dogman",
+        "truth"
+      ],
+      "cost": 2,
+      "flavor": "\"CLASSIFIED INTELLIGENCE: Eyewitnesses report chills and grainy footage.\""
+    },
+    {
+      "schemaVersion": 2,
+      "id": "CRY-TS-146",
+      "faction": "truth",
+      "name": "Tizheruk Panic Wave",
+      "type": "ATTACK",
+      "rarity": "common",
+      "effects": {
+        "ipDelta": {
+          "opponent": 1
+        }
+      },
+      "tags": [
+        "attack",
+        "cryptid",
+        "tizheruk",
+        "truth"
+      ],
+      "cost": 2,
+      "flavor": "\"CLASSIFIED INTELLIGENCE: Eyewitnesses report chills and grainy footage.\""
+    },
+    {
+      "schemaVersion": 2,
+      "id": "CRY-TS-147",
+      "faction": "truth",
+      "name": "Dover Demon Panic Wave",
+      "type": "ATTACK",
+      "rarity": "common",
+      "effects": {
+        "ipDelta": {
+          "opponent": 1
+        }
+      },
+      "tags": [
+        "attack",
+        "cryptid",
+        "dover-demon",
+        "truth"
+      ],
+      "cost": 2,
+      "flavor": "\"CLASSIFIED INTELLIGENCE: Eyewitnesses report chills and grainy footage.\""
+    },
+    {
+      "schemaVersion": 2,
+      "id": "CRY-TS-148",
+      "faction": "truth",
+      "name": "Snallygaster Watch Patrols",
+      "type": "MEDIA",
+      "rarity": "common",
+      "effects": {
+        "truthDelta": 1
+      },
+      "tags": [
+        "cryptid",
+        "media",
+        "snallygaster",
+        "truth"
+      ],
+      "cost": 3,
+      "flavor": "\"CLASSIFIED INTELLIGENCE: Eyewitnesses report chills and grainy footage.\""
+    },
+    {
+      "schemaVersion": 2,
+      "id": "CRY-TS-149",
+      "faction": "truth",
+      "name": "Rougarou Panic Wave",
+      "type": "ATTACK",
+      "rarity": "common",
+      "effects": {
+        "ipDelta": {
+          "opponent": 1
+        }
+      },
+      "tags": [
+        "attack",
+        "cryptid",
+        "rougarou",
+        "truth"
+      ],
+      "cost": 2,
+      "flavor": "\"CLASSIFIED INTELLIGENCE: Eyewitnesses report chills and grainy footage.\""
+    },
+    {
+      "schemaVersion": 2,
+      "id": "CRY-TS-150",
+      "faction": "truth",
+      "name": "Montauk Monster Panic Wave",
+      "type": "ATTACK",
+      "rarity": "common",
+      "effects": {
+        "ipDelta": {
+          "opponent": 1
+        }
+      },
+      "tags": [
+        "attack",
+        "cryptid",
+        "montauk-monster",
+        "truth"
+      ],
+      "cost": 2,
+      "flavor": "\"CLASSIFIED INTELLIGENCE: Eyewitnesses report chills and grainy footage.\""
+    },
+    {
+      "schemaVersion": 2,
+      "id": "CRY-GV-001",
+      "faction": "government",
+      "name": "Men in Black Sweep",
+      "type": "ATTACK",
+      "rarity": "rare",
+      "effects": {
+        "ipDelta": {
+          "opponent": 3
+        },
+        "discardOpponent": 1
+      },
+      "tags": [
+        "attack",
+        "cryptid",
+        "government",
+        "mib"
+      ],
+      "cost": 4,
+      "flavor": "\"CLASSIFIED INTELLIGENCE: Situation normal—memo drafted and archived.\""
+    },
+    {
+      "schemaVersion": 2,
+      "id": "CRY-GV-002",
+      "faction": "government",
+      "name": "Weather Machine Alpha",
+      "type": "ZONE",
+      "rarity": "uncommon",
+      "effects": {
+        "pressureDelta": 2
+      },
+      "tags": [
+        "cryptid",
+        "government",
+        "zone"
+      ],
+      "cost": 5,
+      "flavor": "\"CLASSIFIED INTELLIGENCE: Situation normal—memo drafted and archived.\""
+    },
+    {
+      "schemaVersion": 2,
+      "id": "CRY-GV-003",
+      "faction": "government",
+      "name": "Project Grand Mandela",
+      "type": "MEDIA",
+      "rarity": "rare",
+      "effects": {
+        "truthDelta": -3
+      },
+      "tags": [
+        "bureaucracy",
+        "coverup",
+        "cryptid",
+        "government",
+        "media"
+      ],
+      "cost": 5,
+      "flavor": "\"CLASSIFIED INTELLIGENCE: Awaiting lab results; likely weather and shadows.\""
+    },
+    {
+      "schemaVersion": 2,
+      "id": "CRY-GV-004",
+      "faction": "government",
+      "name": "Chemtrail Deployment",
+      "type": "ZONE",
+      "rarity": "uncommon",
+      "effects": {
+        "pressureDelta": 2
+      },
+      "tags": [
+        "chemtrail",
+        "cryptid",
+        "government",
+        "zone"
+      ],
+      "cost": 5,
+      "flavor": "\"CLASSIFIED INTELLIGENCE: Public guidance issued; no chemtrail detected.\""
+    },
+    {
+      "schemaVersion": 2,
+      "id": "CRY-GV-005",
+      "faction": "government",
+      "name": "Area 51 Security",
+      "type": "ZONE",
+      "rarity": "common",
+      "effects": {
+        "pressureDelta": 1
+      },
+      "tags": [
+        "area51",
+        "cryptid",
+        "government",
+        "zone"
+      ],
+      "cost": 4,
+      "flavor": "\"CLASSIFIED INTELLIGENCE: Filed under routine wildlife misidentification.\""
+    },
+    {
+      "schemaVersion": 2,
+      "id": "CRY-GV-006",
+      "faction": "government",
+      "name": "Fake Alien Invasion",
+      "type": "ZONE",
+      "rarity": "legendary",
+      "effects": {
+        "pressureDelta": 4
+      },
+      "tags": [
+        "alien",
+        "cryptid",
+        "government",
+        "zone"
+      ],
+      "cost": 7,
+      "flavor": "\"CLASSIFIED INTELLIGENCE: Field note logged; further action unnecessary.\""
+    },
+    {
+      "schemaVersion": 2,
+      "id": "CRY-GV-007",
+      "faction": "government",
+      "name": "Roswell Cover Story",
+      "type": "MEDIA",
+      "rarity": "uncommon",
+      "effects": {
+        "truthDelta": -2
+      },
+      "tags": [
+        "cryptid",
+        "government",
+        "media",
+        "roswell"
+      ],
+      "cost": 4,
+      "flavor": "\"CLASSIFIED INTELLIGENCE: Public guidance issued; no roswell detected.\""
+    },
+    {
+      "schemaVersion": 2,
+      "id": "CRY-GV-008",
+      "faction": "government",
+      "name": "Disinformation Bureau",
+      "type": "MEDIA",
+      "rarity": "rare",
+      "effects": {
+        "truthDelta": -3
+      },
+      "tags": [
+        "bureaucracy",
+        "coverup",
+        "cryptid",
+        "government",
+        "media"
+      ],
+      "cost": 5,
+      "flavor": "\"CLASSIFIED INTELLIGENCE: Awaiting lab results; likely weather and shadows.\""
+    },
+    {
+      "schemaVersion": 2,
+      "id": "CRY-GV-009",
+      "faction": "government",
+      "name": "Bigfoot Suit Factory",
+      "type": "ZONE",
+      "rarity": "uncommon",
+      "effects": {
+        "pressureDelta": 2
+      },
+      "tags": [
+        "bigfoot",
+        "cryptid",
+        "government",
+        "zone"
+      ],
+      "cost": 5,
+      "flavor": "\"CLASSIFIED INTELLIGENCE: Field note logged; further action unnecessary.\""
+    },
+    {
+      "schemaVersion": 2,
+      "id": "CRY-GV-010",
+      "faction": "government",
+      "name": "Project Blue Beam",
+      "type": "ATTACK",
+      "rarity": "legendary",
+      "effects": {
+        "ipDelta": {
+          "opponent": 4
+        },
+        "discardOpponent": 2
+      },
+      "tags": [
+        "attack",
+        "blue-beam",
+        "bureaucracy",
+        "coverup",
+        "cryptid",
+        "government"
+      ],
+      "cost": 5,
+      "flavor": "\"CLASSIFIED INTELLIGENCE: Filed under routine wildlife misidentification.\""
+    },
+    {
+      "schemaVersion": 2,
+      "id": "CRY-GV-011",
+      "faction": "government",
+      "name": "Mothman Relocation Program",
+      "type": "ATTACK",
+      "rarity": "rare",
+      "effects": {
+        "ipDelta": {
+          "opponent": 3
+        },
+        "discardOpponent": 1
+      },
+      "tags": [
+        "attack",
+        "cryptid",
+        "government",
+        "mothman"
+      ],
+      "cost": 4,
+      "flavor": "\"CLASSIFIED INTELLIGENCE: Awaiting lab results; likely weather and shadows.\""
+    },
+    {
+      "schemaVersion": 2,
+      "id": "CRY-GV-012",
+      "faction": "government",
+      "name": "Chupacabra Protocol",
+      "type": "ATTACK",
+      "rarity": "uncommon",
+      "effects": {
+        "ipDelta": {
+          "opponent": 2
+        }
+      },
+      "tags": [
+        "attack",
+        "cryptid",
+        "government"
+      ],
+      "cost": 3,
+      "flavor": "\"CLASSIFIED INTELLIGENCE: Filed under routine wildlife misidentification.\""
+    },
+    {
+      "schemaVersion": 2,
+      "id": "CRY-GV-013",
+      "faction": "government",
+      "name": "Cryptid Containment Unit",
+      "type": "MEDIA",
+      "rarity": "common",
+      "effects": {
+        "truthDelta": -1
+      },
+      "tags": [
+        "cryptid",
+        "government",
+        "media"
+      ],
+      "cost": 3,
+      "flavor": "\"CLASSIFIED INTELLIGENCE: Awaiting lab results; likely weather and shadows.\""
+    },
+    {
+      "schemaVersion": 2,
+      "id": "CRY-GV-014",
+      "faction": "government",
+      "name": "Jersey Devil Task Force",
+      "type": "ATTACK",
+      "rarity": "common",
+      "effects": {
+        "ipDelta": {
+          "opponent": 1
+        }
+      },
+      "tags": [
+        "attack",
+        "cryptid",
+        "government"
+      ],
+      "cost": 2,
+      "flavor": "\"CLASSIFIED INTELLIGENCE: Public guidance issued; no jersey devil detected.\""
+    },
+    {
+      "schemaVersion": 2,
+      "id": "CRY-GV-015",
+      "faction": "government",
+      "name": "Lake Monster Drainage",
+      "type": "ATTACK",
+      "rarity": "uncommon",
+      "effects": {
+        "ipDelta": {
+          "opponent": 2
+        }
+      },
+      "tags": [
+        "attack",
+        "cryptid",
+        "government"
+      ],
+      "cost": 3,
+      "flavor": "\"CLASSIFIED INTELLIGENCE: Public guidance issued; no lake detected.\""
+    },
+    {
+      "schemaVersion": 2,
+      "id": "CRY-GV-016",
+      "faction": "government",
+      "name": "Men in Beige",
+      "type": "ATTACK",
+      "rarity": "common",
+      "effects": {
+        "ipDelta": {
+          "opponent": 1
+        }
+      },
+      "tags": [
+        "attack",
+        "cryptid",
+        "government"
+      ],
+      "cost": 2,
+      "flavor": "\"CLASSIFIED INTELLIGENCE: Filed under routine wildlife misidentification.\""
+    },
+    {
+      "schemaVersion": 2,
+      "id": "CRY-GV-017",
+      "faction": "government",
+      "name": "Swamp Gas Generator",
+      "type": "ZONE",
+      "rarity": "uncommon",
+      "effects": {
+        "pressureDelta": 2
+      },
+      "tags": [
+        "cryptid",
+        "government",
+        "location",
+        "zone"
+      ],
+      "cost": 5,
+      "flavor": "\"CLASSIFIED INTELLIGENCE: Situation normal—memo drafted and archived.\""
+    },
+    {
+      "schemaVersion": 2,
+      "id": "CRY-GV-018",
+      "faction": "government",
+      "name": "Deniability Protocols",
+      "type": "ZONE",
+      "rarity": "uncommon",
+      "effects": {
+        "pressureDelta": 2
+      },
+      "tags": [
+        "cryptid",
+        "government",
+        "zone"
+      ],
+      "cost": 5,
+      "flavor": "\"CLASSIFIED INTELLIGENCE: Field note logged; further action unnecessary.\""
+    },
+    {
+      "schemaVersion": 2,
+      "id": "CRY-GV-019",
+      "faction": "government",
+      "name": "Black Helicopters",
+      "type": "ATTACK",
+      "rarity": "rare",
+      "effects": {
+        "ipDelta": {
+          "opponent": 3
+        },
+        "discardOpponent": 1
+      },
+      "tags": [
+        "attack",
+        "cryptid",
+        "government"
+      ],
+      "cost": 4,
+      "flavor": "\"CLASSIFIED INTELLIGENCE: Public guidance issued; no black detected.\""
+    },
+    {
+      "schemaVersion": 2,
+      "id": "CRY-GV-020",
+      "faction": "government",
+      "name": "Cryptozoology Department",
+      "type": "ZONE",
+      "rarity": "uncommon",
+      "effects": {
+        "pressureDelta": 2
+      },
+      "tags": [
+        "bureaucracy",
+        "coverup",
+        "cryptid",
+        "government",
+        "zone"
+      ],
+      "cost": 5,
+      "flavor": "\"CLASSIFIED INTELLIGENCE: Field note logged; further action unnecessary.\""
+    },
+    {
+      "schemaVersion": 2,
+      "id": "CRY-GV-021",
+      "faction": "government",
+      "name": "Flatwoods Incident",
+      "type": "ZONE",
+      "rarity": "uncommon",
+      "effects": {
+        "pressureDelta": 2
+      },
+      "tags": [
+        "cryptid",
+        "government",
+        "zone"
+      ],
+      "cost": 5,
+      "flavor": "\"CLASSIFIED INTELLIGENCE: Awaiting lab results; likely weather and shadows.\""
+    },
+    {
+      "schemaVersion": 2,
+      "id": "CRY-GV-022",
+      "faction": "government",
+      "name": "Skunk Ape Safari",
+      "type": "ZONE",
+      "rarity": "common",
+      "effects": {
+        "pressureDelta": 1
+      },
+      "tags": [
+        "cryptid",
+        "government",
+        "zone"
+      ],
+      "cost": 4,
+      "flavor": "\"CLASSIFIED INTELLIGENCE: Field note logged; further action unnecessary.\""
+    },
+    {
+      "schemaVersion": 2,
+      "id": "CRY-GV-023",
+      "faction": "government",
+      "name": "Thunderbird Tracking",
+      "type": "ATTACK",
+      "rarity": "uncommon",
+      "effects": {
+        "ipDelta": {
+          "opponent": 2
+        }
+      },
+      "tags": [
+        "attack",
+        "cryptid",
+        "government"
+      ],
+      "cost": 3,
+      "flavor": "\"CLASSIFIED INTELLIGENCE: Public guidance issued; no thunderbird detected.\""
+    },
+    {
+      "schemaVersion": 2,
+      "id": "CRY-GV-024",
+      "faction": "government",
+      "name": "Shadow People Census",
+      "type": "ATTACK",
+      "rarity": "uncommon",
+      "effects": {
+        "ipDelta": {
+          "opponent": 2
+        }
+      },
+      "tags": [
+        "attack",
+        "cryptid",
+        "government"
+      ],
+      "cost": 3,
+      "flavor": "\"CLASSIFIED INTELLIGENCE: Public guidance issued; no shadow detected.\""
+    },
+    {
+      "schemaVersion": 2,
+      "id": "CRY-GV-025",
+      "faction": "government",
+      "name": "Hopkinsville Goblins",
+      "type": "ZONE",
+      "rarity": "rare",
+      "effects": {
+        "pressureDelta": 3
+      },
+      "tags": [
+        "cryptid",
+        "government",
+        "zone"
+      ],
+      "cost": 6,
+      "flavor": "\"CLASSIFIED INTELLIGENCE: Situation normal—memo drafted and archived.\""
+    },
+    {
+      "schemaVersion": 2,
+      "id": "CRY-GV-026",
+      "faction": "government",
+      "name": "Lizard Person Council",
+      "type": "MEDIA",
+      "rarity": "legendary",
+      "effects": {
+        "truthDelta": -4
+      },
+      "tags": [
+        "cryptid",
+        "government",
+        "media"
+      ],
+      "cost": 6,
+      "flavor": "\"CLASSIFIED INTELLIGENCE: Situation normal—memo drafted and archived.\""
+    },
+    {
+      "schemaVersion": 2,
+      "id": "CRY-GV-027",
+      "faction": "government",
+      "name": "Hollow Earth Drilling",
+      "type": "ZONE",
+      "rarity": "rare",
+      "effects": {
+        "pressureDelta": 3
+      },
+      "tags": [
+        "cryptid",
+        "government",
+        "zone"
+      ],
+      "cost": 6,
+      "flavor": "\"CLASSIFIED INTELLIGENCE: Situation normal—memo drafted and archived.\""
+    },
+    {
+      "schemaVersion": 2,
+      "id": "CRY-GV-028",
+      "faction": "government",
+      "name": "Time Travel Bureau",
+      "type": "MEDIA",
+      "rarity": "uncommon",
+      "effects": {
+        "truthDelta": -2
+      },
+      "tags": [
+        "bureaucracy",
+        "coverup",
+        "cryptid",
+        "government",
+        "media"
+      ],
+      "cost": 4,
+      "flavor": "\"CLASSIFIED INTELLIGENCE: Public guidance issued; no time detected.\""
+    },
+    {
+      "schemaVersion": 2,
+      "id": "CRY-GV-029",
+      "faction": "government",
+      "name": "Flying Saucer Hangar",
+      "type": "ZONE",
+      "rarity": "rare",
+      "effects": {
+        "pressureDelta": 3
+      },
+      "tags": [
+        "cryptid",
+        "government",
+        "location",
+        "zone"
+      ],
+      "cost": 6,
+      "flavor": "\"CLASSIFIED INTELLIGENCE: Filed under routine wildlife misidentification.\""
+    },
+    {
+      "schemaVersion": 2,
+      "id": "CRY-GV-030",
+      "faction": "government",
+      "name": "Interdimensional Gate",
+      "type": "ZONE",
+      "rarity": "rare",
+      "effects": {
+        "pressureDelta": 3
+      },
+      "tags": [
+        "cryptid",
+        "government",
+        "zone"
+      ],
+      "cost": 6,
+      "flavor": "\"CLASSIFIED INTELLIGENCE: Filed under routine wildlife misidentification.\""
+    },
+    {
+      "schemaVersion": 2,
+      "id": "CRY-GV-031",
+      "faction": "government",
+      "name": "Yeti Expedition Hoax",
+      "type": "ZONE",
+      "rarity": "uncommon",
+      "effects": {
+        "pressureDelta": 2
+      },
+      "tags": [
+        "cryptid",
+        "government",
+        "zone"
+      ],
+      "cost": 5,
+      "flavor": "\"CLASSIFIED INTELLIGENCE: Field note logged; further action unnecessary.\""
+    },
+    {
+      "schemaVersion": 2,
+      "id": "CRY-GV-032",
+      "faction": "government",
+      "name": "Skinwalker Ranch Buyout",
+      "type": "ATTACK",
+      "rarity": "uncommon",
+      "effects": {
+        "ipDelta": {
+          "opponent": 2
+        }
+      },
+      "tags": [
+        "attack",
+        "cryptid",
+        "government"
+      ],
+      "cost": 3,
+      "flavor": "\"CLASSIFIED INTELLIGENCE: Field note logged; further action unnecessary.\""
+    },
+    {
+      "schemaVersion": 2,
+      "id": "CRY-GV-033",
+      "faction": "government",
+      "name": "Dover Demon Debunking",
+      "type": "ZONE",
+      "rarity": "uncommon",
+      "effects": {
+        "pressureDelta": 2
+      },
+      "tags": [
+        "cryptid",
+        "government",
+        "zone"
+      ],
+      "cost": 5,
+      "flavor": "\"CLASSIFIED INTELLIGENCE: Filed under routine wildlife misidentification.\""
+    },
+    {
+      "schemaVersion": 2,
+      "id": "CRY-GV-034",
+      "faction": "government",
+      "name": "Alien Autopsy Studio",
+      "type": "ZONE",
+      "rarity": "rare",
+      "effects": {
+        "pressureDelta": 3
+      },
+      "tags": [
+        "alien",
+        "cryptid",
+        "government",
+        "zone"
+      ],
+      "cost": 6,
+      "flavor": "\"CLASSIFIED INTELLIGENCE: Filed under routine wildlife misidentification.\""
+    },
+    {
+      "schemaVersion": 2,
+      "id": "CRY-GV-035",
+      "faction": "government",
+      "name": "Cattle Mutilation Labs",
+      "type": "ZONE",
+      "rarity": "uncommon",
+      "effects": {
+        "pressureDelta": 2
+      },
+      "tags": [
+        "cryptid",
+        "government",
+        "zone"
+      ],
+      "cost": 5,
+      "flavor": "\"CLASSIFIED INTELLIGENCE: Filed under routine wildlife misidentification.\""
+    },
+    {
+      "schemaVersion": 2,
+      "id": "CRY-GV-036",
+      "faction": "government",
+      "name": "Crop Circle Artists Guild",
+      "type": "ZONE",
+      "rarity": "uncommon",
+      "effects": {
+        "pressureDelta": 2
+      },
+      "tags": [
+        "cryptid",
+        "government",
+        "zone"
+      ],
+      "cost": 5,
+      "flavor": "\"CLASSIFIED INTELLIGENCE: Awaiting lab results; likely weather and shadows.\""
+    },
+    {
+      "schemaVersion": 2,
+      "id": "CRY-GV-037",
+      "faction": "government",
+      "name": "Phantom Airships",
+      "type": "ZONE",
+      "rarity": "common",
+      "effects": {
+        "pressureDelta": 1
+      },
+      "tags": [
+        "cryptid",
+        "government",
+        "zone"
+      ],
+      "cost": 4,
+      "flavor": "\"CLASSIFIED INTELLIGENCE: Field note logged; further action unnecessary.\""
+    },
+    {
+      "schemaVersion": 2,
+      "id": "CRY-GV-038",
+      "faction": "government",
+      "name": "Washington Sea Serpent",
+      "type": "ZONE",
+      "rarity": "uncommon",
+      "effects": {
+        "pressureDelta": 2
+      },
+      "tags": [
+        "cryptid",
+        "government",
+        "zone"
+      ],
+      "cost": 5,
+      "flavor": "\"CLASSIFIED INTELLIGENCE: Awaiting lab results; likely weather and shadows.\""
+    },
+    {
+      "schemaVersion": 2,
+      "id": "CRY-GV-039",
+      "faction": "government",
+      "name": "Moon-Eyed People Census",
+      "type": "ZONE",
+      "rarity": "uncommon",
+      "effects": {
+        "pressureDelta": 2
+      },
+      "tags": [
+        "cryptid",
+        "government",
+        "zone"
+      ],
+      "cost": 5,
+      "flavor": "\"CLASSIFIED INTELLIGENCE: Public guidance issued; no moon-eyed detected.\""
+    },
+    {
+      "schemaVersion": 2,
+      "id": "CRY-GV-040",
+      "faction": "government",
+      "name": "Giant Octopus Cover-up",
+      "type": "MEDIA",
+      "rarity": "rare",
+      "effects": {
+        "truthDelta": -3
+      },
+      "tags": [
+        "cryptid",
+        "government",
+        "media"
+      ],
+      "cost": 5,
+      "flavor": "\"CLASSIFIED INTELLIGENCE: Public guidance issued; no giant detected.\""
+    },
+    {
+      "schemaVersion": 2,
+      "id": "CRY-GV-041",
+      "faction": "government",
+      "name": "Psychic Spying Program",
+      "type": "ZONE",
+      "rarity": "uncommon",
+      "effects": {
+        "pressureDelta": 2
+      },
+      "tags": [
+        "cryptid",
+        "government",
+        "zone"
+      ],
+      "cost": 5,
+      "flavor": "\"CLASSIFIED INTELLIGENCE: Field note logged; further action unnecessary.\""
+    },
+    {
+      "schemaVersion": 2,
+      "id": "CRY-GV-042",
+      "faction": "government",
+      "name": "Invisible Aircraft Project",
+      "type": "MEDIA",
+      "rarity": "legendary",
+      "effects": {
+        "truthDelta": -4
+      },
+      "tags": [
+        "bureaucracy",
+        "coverup",
+        "cryptid",
+        "government",
+        "media"
+      ],
+      "cost": 6,
+      "flavor": "\"CLASSIFIED INTELLIGENCE: Public guidance issued; no invisible detected.\""
+    },
+    {
+      "schemaVersion": 2,
+      "id": "CRY-GV-043",
+      "faction": "government",
+      "name": "Missing Time Protocol",
+      "type": "ATTACK",
+      "rarity": "uncommon",
+      "effects": {
+        "ipDelta": {
+          "opponent": 2
+        }
+      },
+      "tags": [
+        "attack",
+        "cryptid",
+        "government"
+      ],
+      "cost": 3,
+      "flavor": "\"CLASSIFIED INTELLIGENCE: Situation normal—memo drafted and archived.\""
+    },
+    {
+      "schemaVersion": 2,
+      "id": "CRY-GV-044",
+      "faction": "government",
+      "name": "Greys Employment Program",
+      "type": "ZONE",
+      "rarity": "uncommon",
+      "effects": {
+        "pressureDelta": 2
+      },
+      "tags": [
+        "cryptid",
+        "government",
+        "zone"
+      ],
+      "cost": 5,
+      "flavor": "\"CLASSIFIED INTELLIGENCE: Filed under routine wildlife misidentification.\""
+    },
+    {
+      "schemaVersion": 2,
+      "id": "CRY-GV-045",
+      "faction": "government",
+      "name": "Reality Anchor Array",
+      "type": "MEDIA",
+      "rarity": "rare",
+      "effects": {
+        "truthDelta": -3
+      },
+      "tags": [
+        "cryptid",
+        "government",
+        "media"
+      ],
+      "cost": 5,
+      "flavor": "\"CLASSIFIED INTELLIGENCE: Situation normal—memo drafted and archived.\""
+    },
+    {
+      "schemaVersion": 2,
+      "id": "CRY-GV-046",
+      "faction": "government",
+      "name": "Dimension X Portal",
+      "type": "ZONE",
+      "rarity": "uncommon",
+      "effects": {
+        "pressureDelta": 2
+      },
+      "tags": [
+        "cryptid",
+        "government",
+        "zone"
+      ],
+      "cost": 5,
+      "flavor": "\"CLASSIFIED INTELLIGENCE: Situation normal—memo drafted and archived.\""
+    },
+    {
+      "schemaVersion": 2,
+      "id": "CRY-GV-047",
+      "faction": "government",
+      "name": "Cryptid Rehabilitation Center",
+      "type": "ZONE",
+      "rarity": "common",
+      "effects": {
+        "pressureDelta": 1
+      },
+      "tags": [
+        "cryptid",
+        "government",
+        "zone"
+      ],
+      "cost": 4,
+      "flavor": "\"CLASSIFIED INTELLIGENCE: Situation normal—memo drafted and archived.\""
+    },
+    {
+      "schemaVersion": 2,
+      "id": "CRY-GV-048",
+      "faction": "government",
+      "name": "Mind Probe Study",
+      "type": "ATTACK",
+      "rarity": "uncommon",
+      "effects": {
+        "ipDelta": {
+          "opponent": 2
+        }
+      },
+      "tags": [
+        "attack",
+        "cryptid",
+        "government"
+      ],
+      "cost": 3,
+      "flavor": "\"CLASSIFIED INTELLIGENCE: Filed under routine wildlife misidentification.\""
+    },
+    {
+      "schemaVersion": 2,
+      "id": "CRY-GV-049",
+      "faction": "government",
+      "name": "Subliminal Broadcast Network",
+      "type": "ZONE",
+      "rarity": "rare",
+      "effects": {
+        "pressureDelta": 3
+      },
+      "tags": [
+        "cryptid",
+        "government",
+        "media",
+        "zone"
+      ],
+      "cost": 6,
+      "flavor": "\"CLASSIFIED INTELLIGENCE: Situation normal—memo drafted and archived.\""
+    },
+    {
+      "schemaVersion": 2,
+      "id": "CRY-GV-050",
+      "faction": "government",
+      "name": "Fake Moon Landing Set",
+      "type": "ZONE",
+      "rarity": "uncommon",
+      "effects": {
+        "pressureDelta": 2
+      },
+      "tags": [
+        "cryptid",
+        "government",
+        "zone"
+      ],
+      "cost": 5,
+      "flavor": "\"CLASSIFIED INTELLIGENCE: Filed under routine wildlife misidentification.\""
+    },
+    {
+      "schemaVersion": 2,
+      "id": "CRY-GV-051",
+      "faction": "government",
+      "name": "Neuralyzer Deployment",
+      "type": "MEDIA",
+      "rarity": "uncommon",
+      "effects": {
+        "truthDelta": -2
+      },
+      "tags": [
+        "cryptid",
+        "government",
+        "media"
+      ],
+      "cost": 4,
+      "flavor": "\"CLASSIFIED INTELLIGENCE: Public guidance issued; no neuralyzer detected.\""
+    },
+    {
+      "schemaVersion": 2,
+      "id": "CRY-GV-052",
+      "faction": "government",
+      "name": "Shadow Government HQ",
+      "type": "ATTACK",
+      "rarity": "legendary",
+      "effects": {
+        "ipDelta": {
+          "opponent": 4
+        },
+        "discardOpponent": 2
+      },
+      "tags": [
+        "attack",
+        "cryptid",
+        "government"
+      ],
+      "cost": 5,
+      "flavor": "\"CLASSIFIED INTELLIGENCE: Field note logged; further action unnecessary.\""
+    },
+    {
+      "schemaVersion": 2,
+      "id": "CRY-GV-053",
+      "faction": "government",
+      "name": "Operation Paperclip II",
+      "type": "MEDIA",
+      "rarity": "uncommon",
+      "effects": {
+        "truthDelta": -2
+      },
+      "tags": [
+        "bureaucracy",
+        "coverup",
+        "cryptid",
+        "government",
+        "media"
+      ],
+      "cost": 4,
+      "flavor": "\"CLASSIFIED INTELLIGENCE: Public guidance issued; no operation detected.\""
+    },
+    {
+      "schemaVersion": 2,
+      "id": "CRY-GV-054",
+      "faction": "government",
+      "name": "Holographic UFO Display",
+      "type": "MEDIA",
+      "rarity": "uncommon",
+      "effects": {
+        "truthDelta": -2
+      },
+      "tags": [
+        "cryptid",
+        "government",
+        "media",
+        "ufo"
+      ],
+      "cost": 4,
+      "flavor": "\"CLASSIFIED INTELLIGENCE: Public guidance issued; no holographic detected.\""
+    },
+    {
+      "schemaVersion": 2,
+      "id": "CRY-GV-055",
+      "faction": "government",
+      "name": "Cryptid Breeding Program",
+      "type": "MEDIA",
+      "rarity": "rare",
+      "effects": {
+        "truthDelta": -3
+      },
+      "tags": [
+        "cryptid",
+        "government",
+        "media"
+      ],
+      "cost": 5,
+      "flavor": "\"CLASSIFIED INTELLIGENCE: Situation normal—memo drafted and archived.\""
+    },
+    {
+      "schemaVersion": 2,
+      "id": "CRY-GV-056",
+      "faction": "government",
+      "name": "False Flag Cryptid Attack",
+      "type": "ATTACK",
+      "rarity": "legendary",
+      "effects": {
+        "ipDelta": {
+          "opponent": 4
+        },
+        "discardOpponent": 2
+      },
+      "tags": [
+        "attack",
+        "cryptid",
+        "government"
+      ],
+      "cost": 5,
+      "flavor": "\"CLASSIFIED INTELLIGENCE: Filed under routine wildlife misidentification.\""
+    },
+    {
+      "schemaVersion": 2,
+      "id": "CRY-GV-057",
+      "faction": "government",
+      "name": "Extraterrestrial Non-Disclosure Treaty",
+      "type": "ZONE",
+      "rarity": "uncommon",
+      "effects": {
+        "pressureDelta": 2
+      },
+      "tags": [
+        "cryptid",
+        "government",
+        "zone"
+      ],
+      "cost": 5,
+      "flavor": "\"CLASSIFIED INTELLIGENCE: Field note logged; further action unnecessary.\""
+    },
+    {
+      "schemaVersion": 2,
+      "id": "CRY-GV-058",
+      "faction": "government",
+      "name": "Quantum Bigfoot Experiment",
+      "type": "ZONE",
+      "rarity": "rare",
+      "effects": {
+        "pressureDelta": 3
+      },
+      "tags": [
+        "bigfoot",
+        "cryptid",
+        "government",
+        "zone"
+      ],
+      "cost": 6,
+      "flavor": "\"CLASSIFIED INTELLIGENCE: Filed under routine wildlife misidentification.\""
+    },
+    {
+      "schemaVersion": 2,
+      "id": "CRY-GV-059",
+      "faction": "government",
+      "name": "Interdimensional Customs",
+      "type": "ZONE",
+      "rarity": "uncommon",
+      "effects": {
+        "pressureDelta": 2
+      },
+      "tags": [
+        "cryptid",
+        "government",
+        "zone"
+      ],
+      "cost": 5,
+      "flavor": "\"CLASSIFIED INTELLIGENCE: Filed under routine wildlife misidentification.\""
+    },
+    {
+      "schemaVersion": 2,
+      "id": "CRY-GV-060",
+      "faction": "government",
+      "name": "Cosmic Horror Containment",
+      "type": "MEDIA",
+      "rarity": "rare",
+      "effects": {
+        "truthDelta": -3
+      },
+      "tags": [
+        "cryptid",
+        "government",
+        "media"
+      ],
+      "cost": 5,
+      "flavor": "\"CLASSIFIED INTELLIGENCE: Public guidance issued; no cosmic detected.\""
+    },
+    {
+      "schemaVersion": 2,
+      "id": "CRY-GV-061",
+      "faction": "government",
+      "name": "Reptilian Shapeshifter Agent",
+      "type": "ATTACK",
+      "rarity": "uncommon",
+      "effects": {
+        "ipDelta": {
+          "opponent": 2
+        }
+      },
+      "tags": [
+        "attack",
+        "cryptid",
+        "government"
+      ],
+      "cost": 3,
+      "flavor": "\"CLASSIFIED INTELLIGENCE: Situation normal—memo drafted and archived.\""
+    },
+    {
+      "schemaVersion": 2,
+      "id": "CRY-GV-062",
+      "faction": "government",
+      "name": "Memory Modification Clinic",
+      "type": "ATTACK",
+      "rarity": "rare",
+      "effects": {
+        "ipDelta": {
+          "opponent": 3
+        },
+        "discardOpponent": 1
+      },
+      "tags": [
+        "attack",
+        "cryptid",
+        "government"
+      ],
+      "cost": 4,
+      "flavor": "\"CLASSIFIED INTELLIGENCE: Situation normal—memo drafted and archived.\""
+    },
+    {
+      "schemaVersion": 2,
+      "id": "CRY-GV-063",
+      "faction": "government",
+      "name": "Psy-Ops Division",
+      "type": "MEDIA",
+      "rarity": "uncommon",
+      "effects": {
+        "truthDelta": -2
+      },
+      "tags": [
+        "cryptid",
+        "government",
+        "media"
+      ],
+      "cost": 4,
+      "flavor": "\"CLASSIFIED INTELLIGENCE: Situation normal—memo drafted and archived.\""
+    },
+    {
+      "schemaVersion": 2,
+      "id": "CRY-GV-064",
+      "faction": "government",
+      "name": "Cryptid Witness Protection",
+      "type": "MEDIA",
+      "rarity": "uncommon",
+      "effects": {
+        "truthDelta": -2
+      },
+      "tags": [
+        "cryptid",
+        "government",
+        "media"
+      ],
+      "cost": 4,
+      "flavor": "\"CLASSIFIED INTELLIGENCE: Public guidance issued; no cryptid detected.\""
+    },
+    {
+      "schemaVersion": 2,
+      "id": "CRY-GV-065",
+      "faction": "government",
+      "name": "Underground Bunker Network",
+      "type": "ZONE",
+      "rarity": "uncommon",
+      "effects": {
+        "pressureDelta": 2
+      },
+      "tags": [
+        "cryptid",
+        "government",
+        "zone"
+      ],
+      "cost": 5,
+      "flavor": "\"CLASSIFIED INTELLIGENCE: Filed under routine wildlife misidentification.\""
+    },
+    {
+      "schemaVersion": 2,
+      "id": "CRY-GV-066",
+      "faction": "government",
+      "name": "Orbital Mind Control Platform",
+      "type": "ZONE",
+      "rarity": "uncommon",
+      "effects": {
+        "pressureDelta": 2
+      },
+      "tags": [
+        "cryptid",
+        "government",
+        "zone"
+      ],
+      "cost": 5,
+      "flavor": "\"CLASSIFIED INTELLIGENCE: Awaiting lab results; likely weather and shadows.\""
+    },
+    {
+      "schemaVersion": 2,
+      "id": "CRY-GV-067",
+      "faction": "government",
+      "name": "Temporal Loop Device",
+      "type": "MEDIA",
+      "rarity": "rare",
+      "effects": {
+        "truthDelta": -3
+      },
+      "tags": [
+        "cryptid",
+        "government",
+        "media"
+      ],
+      "cost": 5,
+      "flavor": "\"CLASSIFIED INTELLIGENCE: Awaiting lab results; likely weather and shadows.\""
+    },
+    {
+      "schemaVersion": 2,
+      "id": "CRY-GV-068",
+      "faction": "government",
+      "name": "Anomalous Materials Division",
+      "type": "ZONE",
+      "rarity": "uncommon",
+      "effects": {
+        "pressureDelta": 2
+      },
+      "tags": [
+        "cryptid",
+        "government",
+        "zone"
+      ],
+      "cost": 5,
+      "flavor": "\"CLASSIFIED INTELLIGENCE: Field note logged; further action unnecessary.\""
+    },
+    {
+      "schemaVersion": 2,
+      "id": "CRY-GV-069",
+      "faction": "government",
+      "name": "Phantom Helicopter Squadron",
+      "type": "ZONE",
+      "rarity": "common",
+      "effects": {
+        "pressureDelta": 1
+      },
+      "tags": [
+        "cryptid",
+        "government",
+        "zone"
+      ],
+      "cost": 4,
+      "flavor": "\"CLASSIFIED INTELLIGENCE: Public guidance issued; no phantom detected.\""
+    },
+    {
+      "schemaVersion": 2,
+      "id": "CRY-GV-070",
+      "faction": "government",
+      "name": "Reality Distortion Field",
+      "type": "ZONE",
+      "rarity": "uncommon",
+      "effects": {
+        "pressureDelta": 2
+      },
+      "tags": [
+        "cryptid",
+        "government",
+        "zone"
+      ],
+      "cost": 5,
+      "flavor": "\"CLASSIFIED INTELLIGENCE: Awaiting lab results; likely weather and shadows.\""
+    },
+    {
+      "schemaVersion": 2,
+      "id": "CRY-GV-071",
+      "faction": "government",
+      "name": "Cryptid DNA Database",
+      "type": "ZONE",
+      "rarity": "rare",
+      "effects": {
+        "pressureDelta": 3
+      },
+      "tags": [
+        "cryptid",
+        "government",
+        "zone"
+      ],
+      "cost": 6,
+      "flavor": "\"CLASSIFIED INTELLIGENCE: Filed under routine wildlife misidentification.\""
+    },
+    {
+      "schemaVersion": 2,
+      "id": "CRY-GV-072",
+      "faction": "government",
+      "name": "Phantom Satellite Grid",
+      "type": "ZONE",
+      "rarity": "rare",
+      "effects": {
+        "pressureDelta": 3
+      },
+      "tags": [
+        "cryptid",
+        "government",
+        "zone"
+      ],
+      "cost": 6,
+      "flavor": "\"CLASSIFIED INTELLIGENCE: Field note logged; further action unnecessary.\""
+    },
+    {
+      "schemaVersion": 2,
+      "id": "CRY-GV-073",
+      "faction": "government",
+      "name": "Consciousness Transfer Lab",
+      "type": "ATTACK",
+      "rarity": "uncommon",
+      "effects": {
+        "ipDelta": {
+          "opponent": 2
+        }
+      },
+      "tags": [
+        "attack",
+        "cryptid",
+        "government"
+      ],
+      "cost": 3,
+      "flavor": "\"CLASSIFIED INTELLIGENCE: Awaiting lab results; likely weather and shadows.\""
+    },
+    {
+      "schemaVersion": 2,
+      "id": "CRY-GV-074",
+      "faction": "government",
+      "name": "Multidimensional Embassy",
+      "type": "ZONE",
+      "rarity": "uncommon",
+      "effects": {
+        "pressureDelta": 2
+      },
+      "tags": [
+        "cryptid",
+        "government",
+        "zone"
+      ],
+      "cost": 5,
+      "flavor": "\"CLASSIFIED INTELLIGENCE: Filed under routine wildlife misidentification.\""
+    },
+    {
+      "schemaVersion": 2,
+      "id": "CRY-GV-075",
+      "faction": "government",
+      "name": "Alabama Wildlife Advisory",
+      "type": "MEDIA",
+      "rarity": "common",
+      "effects": {
+        "truthDelta": -1
+      },
+      "tags": [
+        "advisory",
+        "alabama",
+        "cryptid",
+        "government",
+        "media"
+      ],
+      "cost": 3,
+      "flavor": "\"CLASSIFIED INTELLIGENCE: Public bulletin: Do not feed the alabama cryptid.\""
+    },
+    {
+      "schemaVersion": 2,
+      "id": "CRY-GV-076",
+      "faction": "government",
+      "name": "Alaska Wildlife Advisory",
+      "type": "MEDIA",
+      "rarity": "common",
+      "effects": {
+        "truthDelta": -1
+      },
+      "tags": [
+        "advisory",
+        "alaska",
+        "cryptid",
+        "government",
+        "media"
+      ],
+      "cost": 3,
+      "flavor": "\"CLASSIFIED INTELLIGENCE: Public bulletin: Do not feed the tizheruk.\""
+    },
+    {
+      "schemaVersion": 2,
+      "id": "CRY-GV-077",
+      "faction": "government",
+      "name": "Arizona Wildlife Advisory",
+      "type": "ATTACK",
+      "rarity": "common",
+      "effects": {
+        "ipDelta": {
+          "opponent": 1
+        }
+      },
+      "tags": [
+        "advisory",
+        "arizona",
+        "attack",
+        "cryptid",
+        "government"
+      ],
+      "cost": 2,
+      "flavor": "\"CLASSIFIED INTELLIGENCE: Public bulletin: Do not feed the thunderbird.\""
+    },
+    {
+      "schemaVersion": 2,
+      "id": "CRY-GV-078",
+      "faction": "government",
+      "name": "Arkansas Wildlife Advisory",
+      "type": "MEDIA",
+      "rarity": "common",
+      "effects": {
+        "truthDelta": -1
+      },
+      "tags": [
+        "advisory",
+        "arkansas",
+        "cryptid",
+        "government",
+        "media"
+      ],
+      "cost": 3,
+      "flavor": "\"CLASSIFIED INTELLIGENCE: Public bulletin: Do not feed the fouke monster.\""
+    },
+    {
+      "schemaVersion": 2,
+      "id": "CRY-GV-079",
+      "faction": "government",
+      "name": "California Wildlife Advisory",
+      "type": "ZONE",
+      "rarity": "common",
+      "effects": {
+        "pressureDelta": 1
+      },
+      "tags": [
+        "advisory",
+        "california",
+        "cryptid",
+        "government",
+        "zone"
+      ],
+      "cost": 4,
+      "flavor": "\"CLASSIFIED INTELLIGENCE: Public bulletin: Do not feed the bigfoot.\""
+    },
+    {
+      "schemaVersion": 2,
+      "id": "CRY-GV-080",
+      "faction": "government",
+      "name": "Colorado Wildlife Advisory",
+      "type": "ZONE",
+      "rarity": "common",
+      "effects": {
+        "pressureDelta": 1
+      },
+      "tags": [
+        "advisory",
+        "colorado",
+        "cryptid",
+        "government",
+        "zone"
+      ],
+      "cost": 4,
+      "flavor": "\"CLASSIFIED INTELLIGENCE: Public bulletin: Do not feed the colorado cryptid.\""
+    },
+    {
+      "schemaVersion": 2,
+      "id": "CRY-GV-081",
+      "faction": "government",
+      "name": "Connecticut Wildlife Advisory",
+      "type": "MEDIA",
+      "rarity": "common",
+      "effects": {
+        "truthDelta": -1
+      },
+      "tags": [
+        "advisory",
+        "connecticut",
+        "cryptid",
+        "government",
+        "media"
+      ],
+      "cost": 3,
+      "flavor": "\"CLASSIFIED INTELLIGENCE: Public bulletin: Do not feed the connecticut cryptid.\""
+    },
+    {
+      "schemaVersion": 2,
+      "id": "CRY-GV-082",
+      "faction": "government",
+      "name": "Delaware Wildlife Advisory",
+      "type": "MEDIA",
+      "rarity": "common",
+      "effects": {
+        "truthDelta": -1
+      },
+      "tags": [
+        "advisory",
+        "cryptid",
+        "delaware",
+        "government",
+        "media"
+      ],
+      "cost": 3,
+      "flavor": "\"CLASSIFIED INTELLIGENCE: Public bulletin: Do not feed the delaware cryptid.\""
+    },
+    {
+      "schemaVersion": 2,
+      "id": "CRY-GV-083",
+      "faction": "government",
+      "name": "Florida Wildlife Advisory",
+      "type": "MEDIA",
+      "rarity": "common",
+      "effects": {
+        "truthDelta": -1
+      },
+      "tags": [
+        "advisory",
+        "cryptid",
+        "florida",
+        "florida-man",
+        "government",
+        "media"
+      ],
+      "cost": 3,
+      "flavor": "\"CLASSIFIED INTELLIGENCE: Public bulletin: Do not feed the skunk ape.\""
+    },
+    {
+      "schemaVersion": 2,
+      "id": "CRY-GV-084",
+      "faction": "government",
+      "name": "Georgia Wildlife Advisory",
+      "type": "MEDIA",
+      "rarity": "common",
+      "effects": {
+        "truthDelta": -1
+      },
+      "tags": [
+        "advisory",
+        "cryptid",
+        "georgia",
+        "government",
+        "media"
+      ],
+      "cost": 3,
+      "flavor": "\"CLASSIFIED INTELLIGENCE: Public bulletin: Do not feed the georgia cryptid.\""
+    },
+    {
+      "schemaVersion": 2,
+      "id": "CRY-GV-085",
+      "faction": "government",
+      "name": "Hawaii Wildlife Advisory",
+      "type": "MEDIA",
+      "rarity": "common",
+      "effects": {
+        "truthDelta": -1
+      },
+      "tags": [
+        "advisory",
+        "cryptid",
+        "government",
+        "hawaii",
+        "media"
+      ],
+      "cost": 3,
+      "flavor": "\"CLASSIFIED INTELLIGENCE: Public bulletin: Do not feed the hawaii cryptid.\""
+    },
+    {
+      "schemaVersion": 2,
+      "id": "CRY-GV-086",
+      "faction": "government",
+      "name": "Idaho Wildlife Advisory",
+      "type": "MEDIA",
+      "rarity": "common",
+      "effects": {
+        "truthDelta": -1
+      },
+      "tags": [
+        "advisory",
+        "cryptid",
+        "government",
+        "idaho",
+        "media"
+      ],
+      "cost": 3,
+      "flavor": "\"CLASSIFIED INTELLIGENCE: Public bulletin: Do not feed the idaho cryptid.\""
+    },
+    {
+      "schemaVersion": 2,
+      "id": "CRY-GV-087",
+      "faction": "government",
+      "name": "Illinois Wildlife Advisory",
+      "type": "ZONE",
+      "rarity": "common",
+      "effects": {
+        "pressureDelta": 1
+      },
+      "tags": [
+        "advisory",
+        "cryptid",
+        "government",
+        "illinois",
+        "zone"
+      ],
+      "cost": 4,
+      "flavor": "\"CLASSIFIED INTELLIGENCE: Public bulletin: Do not feed the enfield horror.\""
+    },
+    {
+      "schemaVersion": 2,
+      "id": "CRY-GV-088",
+      "faction": "government",
+      "name": "Indiana Wildlife Advisory",
+      "type": "MEDIA",
+      "rarity": "common",
+      "effects": {
+        "truthDelta": -1
+      },
+      "tags": [
+        "advisory",
+        "cryptid",
+        "government",
+        "indiana",
+        "media"
+      ],
+      "cost": 3,
+      "flavor": "\"CLASSIFIED INTELLIGENCE: Public bulletin: Do not feed the indiana cryptid.\""
+    },
+    {
+      "schemaVersion": 2,
+      "id": "CRY-GV-089",
+      "faction": "government",
+      "name": "Iowa Wildlife Advisory",
+      "type": "MEDIA",
+      "rarity": "common",
+      "effects": {
+        "truthDelta": -1
+      },
+      "tags": [
+        "advisory",
+        "cryptid",
+        "government",
+        "iowa",
+        "media"
+      ],
+      "cost": 3,
+      "flavor": "\"CLASSIFIED INTELLIGENCE: Public bulletin: Do not feed the iowa cryptid.\""
+    },
+    {
+      "schemaVersion": 2,
+      "id": "CRY-GV-090",
+      "faction": "government",
+      "name": "Kansas Wildlife Advisory",
+      "type": "MEDIA",
+      "rarity": "common",
+      "effects": {
+        "truthDelta": -1
+      },
+      "tags": [
+        "advisory",
+        "cryptid",
+        "government",
+        "kansas",
+        "media"
+      ],
+      "cost": 3,
+      "flavor": "\"CLASSIFIED INTELLIGENCE: Public bulletin: Do not feed the kansas cryptid.\""
+    },
+    {
+      "schemaVersion": 2,
+      "id": "CRY-GV-091",
+      "faction": "government",
+      "name": "Kentucky Wildlife Advisory",
+      "type": "MEDIA",
+      "rarity": "common",
+      "effects": {
+        "truthDelta": -1
+      },
+      "tags": [
+        "advisory",
+        "cryptid",
+        "government",
+        "kentucky",
+        "media"
+      ],
+      "cost": 3,
+      "flavor": "\"CLASSIFIED INTELLIGENCE: Public bulletin: Do not feed the kelly–hopkinsville goblins.\""
+    },
+    {
+      "schemaVersion": 2,
+      "id": "CRY-GV-092",
+      "faction": "government",
+      "name": "Louisiana Wildlife Advisory",
+      "type": "MEDIA",
+      "rarity": "common",
+      "effects": {
+        "truthDelta": -1
+      },
+      "tags": [
+        "advisory",
+        "cryptid",
+        "government",
+        "louisiana",
+        "media"
+      ],
+      "cost": 3,
+      "flavor": "\"CLASSIFIED INTELLIGENCE: Public bulletin: Do not feed the rougarou.\""
+    },
+    {
+      "schemaVersion": 2,
+      "id": "CRY-GV-093",
+      "faction": "government",
+      "name": "Maine Wildlife Advisory",
+      "type": "MEDIA",
+      "rarity": "common",
+      "effects": {
+        "truthDelta": -1
+      },
+      "tags": [
+        "advisory",
+        "cryptid",
+        "government",
+        "maine",
+        "media"
+      ],
+      "cost": 3,
+      "flavor": "\"CLASSIFIED INTELLIGENCE: Public bulletin: Do not feed the maine cryptid.\""
+    },
+    {
+      "schemaVersion": 2,
+      "id": "CRY-GV-094",
+      "faction": "government",
+      "name": "Maryland Wildlife Advisory",
+      "type": "MEDIA",
+      "rarity": "common",
+      "effects": {
+        "truthDelta": -1
+      },
+      "tags": [
+        "advisory",
+        "cryptid",
+        "government",
+        "maryland",
+        "media"
+      ],
+      "cost": 3,
+      "flavor": "\"CLASSIFIED INTELLIGENCE: Public bulletin: Do not feed the snallygaster.\""
+    },
+    {
+      "schemaVersion": 2,
+      "id": "CRY-GV-095",
+      "faction": "government",
+      "name": "Massachusetts Wildlife Advisory",
+      "type": "MEDIA",
+      "rarity": "common",
+      "effects": {
+        "truthDelta": -1
+      },
+      "tags": [
+        "advisory",
+        "cryptid",
+        "government",
+        "massachusetts",
+        "media"
+      ],
+      "cost": 3,
+      "flavor": "\"CLASSIFIED INTELLIGENCE: Public bulletin: Do not feed the dover demon.\""
+    },
+    {
+      "schemaVersion": 2,
+      "id": "CRY-GV-096",
+      "faction": "government",
+      "name": "Michigan Wildlife Advisory",
+      "type": "MEDIA",
+      "rarity": "common",
+      "effects": {
+        "truthDelta": -1
+      },
+      "tags": [
+        "advisory",
+        "cryptid",
+        "government",
+        "media",
+        "michigan"
+      ],
+      "cost": 3,
+      "flavor": "\"CLASSIFIED INTELLIGENCE: Public bulletin: Do not feed the dogman.\""
+    },
+    {
+      "schemaVersion": 2,
+      "id": "CRY-GV-097",
+      "faction": "government",
+      "name": "Minnesota Wildlife Advisory",
+      "type": "ATTACK",
+      "rarity": "common",
+      "effects": {
+        "ipDelta": {
+          "opponent": 1
+        }
+      },
+      "tags": [
+        "advisory",
+        "attack",
+        "cryptid",
+        "government",
+        "minnesota"
+      ],
+      "cost": 2,
+      "flavor": "\"CLASSIFIED INTELLIGENCE: Public bulletin: Do not feed the wendigo.\""
+    },
+    {
+      "schemaVersion": 2,
+      "id": "CRY-GV-098",
+      "faction": "government",
+      "name": "Mississippi Wildlife Advisory",
+      "type": "MEDIA",
+      "rarity": "common",
+      "effects": {
+        "truthDelta": -1
+      },
+      "tags": [
+        "advisory",
+        "cryptid",
+        "government",
+        "media",
+        "mississippi"
+      ],
+      "cost": 3,
+      "flavor": "\"CLASSIFIED INTELLIGENCE: Public bulletin: Do not feed the mississippi cryptid.\""
+    },
+    {
+      "schemaVersion": 2,
+      "id": "CRY-GV-099",
+      "faction": "government",
+      "name": "Missouri Wildlife Advisory",
+      "type": "MEDIA",
+      "rarity": "common",
+      "effects": {
+        "truthDelta": -1
+      },
+      "tags": [
+        "advisory",
+        "cryptid",
+        "government",
+        "media",
+        "missouri"
+      ],
+      "cost": 3,
+      "flavor": "\"CLASSIFIED INTELLIGENCE: Public bulletin: Do not feed the missouri cryptid.\""
+    },
+    {
+      "schemaVersion": 2,
+      "id": "CRY-GV-100",
+      "faction": "government",
+      "name": "Montana Wildlife Advisory",
+      "type": "MEDIA",
+      "rarity": "common",
+      "effects": {
+        "truthDelta": -1
+      },
+      "tags": [
+        "advisory",
+        "cryptid",
+        "government",
+        "media",
+        "montana"
+      ],
+      "cost": 3,
+      "flavor": "\"CLASSIFIED INTELLIGENCE: Public bulletin: Do not feed the shunka warakin.\""
+    },
+    {
+      "schemaVersion": 2,
+      "id": "CRY-GV-101",
+      "faction": "government",
+      "name": "Nebraska Wildlife Advisory",
+      "type": "MEDIA",
+      "rarity": "common",
+      "effects": {
+        "truthDelta": -1
+      },
+      "tags": [
+        "advisory",
+        "cryptid",
+        "government",
+        "media",
+        "nebraska"
+      ],
+      "cost": 3,
+      "flavor": "\"CLASSIFIED INTELLIGENCE: Public bulletin: Do not feed the nebraska cryptid.\""
+    },
+    {
+      "schemaVersion": 2,
+      "id": "CRY-GV-102",
+      "faction": "government",
+      "name": "Nevada Wildlife Advisory",
+      "type": "MEDIA",
+      "rarity": "common",
+      "effects": {
+        "truthDelta": -1
+      },
+      "tags": [
+        "advisory",
+        "cryptid",
+        "government",
+        "media",
+        "nevada"
+      ],
+      "cost": 3,
+      "flavor": "\"CLASSIFIED INTELLIGENCE: Public bulletin: Do not feed the tahoe tessie.\""
+    },
+    {
+      "schemaVersion": 2,
+      "id": "CRY-GV-103",
+      "faction": "government",
+      "name": "New Hampshire Wildlife Advisory",
+      "type": "MEDIA",
+      "rarity": "common",
+      "effects": {
+        "truthDelta": -1
+      },
+      "tags": [
+        "advisory",
+        "cryptid",
+        "government",
+        "media",
+        "new-hampshire"
+      ],
+      "cost": 3,
+      "flavor": "\"CLASSIFIED INTELLIGENCE: Public bulletin: Do not feed the wood devils.\""
+    },
+    {
+      "schemaVersion": 2,
+      "id": "CRY-GV-104",
+      "faction": "government",
+      "name": "New Jersey Wildlife Advisory",
+      "type": "ATTACK",
+      "rarity": "common",
+      "effects": {
+        "ipDelta": {
+          "opponent": 1
+        }
+      },
+      "tags": [
+        "advisory",
+        "attack",
+        "cryptid",
+        "government",
+        "new-jersey"
+      ],
+      "cost": 2,
+      "flavor": "\"CLASSIFIED INTELLIGENCE: Public bulletin: Do not feed the jersey devil.\""
+    },
+    {
+      "schemaVersion": 2,
+      "id": "CRY-GV-105",
+      "faction": "government",
+      "name": "New Mexico Wildlife Advisory",
+      "type": "ATTACK",
+      "rarity": "common",
+      "effects": {
+        "ipDelta": {
+          "opponent": 1
+        }
+      },
+      "tags": [
+        "advisory",
+        "attack",
+        "cryptid",
+        "government",
+        "new-mexico"
+      ],
+      "cost": 2,
+      "flavor": "\"CLASSIFIED INTELLIGENCE: Public bulletin: Do not feed the skinwalkers.\""
+    },
+    {
+      "schemaVersion": 2,
+      "id": "CRY-GV-106",
+      "faction": "government",
+      "name": "New York Wildlife Advisory",
+      "type": "MEDIA",
+      "rarity": "common",
+      "effects": {
+        "truthDelta": -1
+      },
+      "tags": [
+        "advisory",
+        "cryptid",
+        "government",
+        "media",
+        "new-york"
+      ],
+      "cost": 3,
+      "flavor": "\"CLASSIFIED INTELLIGENCE: Public bulletin: Do not feed the montauk monster.\""
+    },
+    {
+      "schemaVersion": 2,
+      "id": "CRY-GV-107",
+      "faction": "government",
+      "name": "North Carolina Wildlife Advisory",
+      "type": "MEDIA",
+      "rarity": "common",
+      "effects": {
+        "truthDelta": -1
+      },
+      "tags": [
+        "advisory",
+        "cryptid",
+        "government",
+        "media",
+        "north-carolina"
+      ],
+      "cost": 3,
+      "flavor": "\"CLASSIFIED INTELLIGENCE: Public bulletin: Do not feed the north carolina cryptid.\""
+    },
+    {
+      "schemaVersion": 2,
+      "id": "CRY-GV-108",
+      "faction": "government",
+      "name": "North Dakota Wildlife Advisory",
+      "type": "MEDIA",
+      "rarity": "common",
+      "effects": {
+        "truthDelta": -1
+      },
+      "tags": [
+        "advisory",
+        "cryptid",
+        "government",
+        "media",
+        "north-dakota"
+      ],
+      "cost": 3,
+      "flavor": "\"CLASSIFIED INTELLIGENCE: Public bulletin: Do not feed the north dakota cryptid.\""
+    },
+    {
+      "schemaVersion": 2,
+      "id": "CRY-GV-109",
+      "faction": "government",
+      "name": "Ohio Wildlife Advisory",
+      "type": "MEDIA",
+      "rarity": "common",
+      "effects": {
+        "truthDelta": -1
+      },
+      "tags": [
+        "advisory",
+        "cryptid",
+        "government",
+        "media",
+        "ohio"
+      ],
+      "cost": 3,
+      "flavor": "\"CLASSIFIED INTELLIGENCE: Public bulletin: Do not feed the loveland frogman.\""
+    },
+    {
+      "schemaVersion": 2,
+      "id": "CRY-GV-110",
+      "faction": "government",
+      "name": "Oklahoma Wildlife Advisory",
+      "type": "MEDIA",
+      "rarity": "common",
+      "effects": {
+        "truthDelta": -1
+      },
+      "tags": [
+        "advisory",
+        "cryptid",
+        "government",
+        "media",
+        "oklahoma"
+      ],
+      "cost": 3,
+      "flavor": "\"CLASSIFIED INTELLIGENCE: Public bulletin: Do not feed the oklahoma cryptid.\""
+    },
+    {
+      "schemaVersion": 2,
+      "id": "CRY-GV-111",
+      "faction": "government",
+      "name": "Oregon Wildlife Advisory",
+      "type": "MEDIA",
+      "rarity": "common",
+      "effects": {
+        "truthDelta": -1
+      },
+      "tags": [
+        "advisory",
+        "cryptid",
+        "government",
+        "media",
+        "oregon"
+      ],
+      "cost": 3,
+      "flavor": "\"CLASSIFIED INTELLIGENCE: Public bulletin: Do not feed the bigfoot.\""
+    },
+    {
+      "schemaVersion": 2,
+      "id": "CRY-GV-112",
+      "faction": "government",
+      "name": "Pennsylvania Wildlife Advisory",
+      "type": "MEDIA",
+      "rarity": "common",
+      "effects": {
+        "truthDelta": -1
+      },
+      "tags": [
+        "advisory",
+        "cryptid",
+        "government",
+        "media",
+        "pennsylvania"
+      ],
+      "cost": 3,
+      "flavor": "\"CLASSIFIED INTELLIGENCE: Public bulletin: Do not feed the pennsylvania cryptid.\""
+    },
+    {
+      "schemaVersion": 2,
+      "id": "CRY-GV-113",
+      "faction": "government",
+      "name": "Rhode Island Wildlife Advisory",
+      "type": "MEDIA",
+      "rarity": "common",
+      "effects": {
+        "truthDelta": -1
+      },
+      "tags": [
+        "advisory",
+        "cryptid",
+        "government",
+        "media",
+        "rhode-island"
+      ],
+      "cost": 3,
+      "flavor": "\"CLASSIFIED INTELLIGENCE: Public bulletin: Do not feed the rhode island cryptid.\""
+    },
+    {
+      "schemaVersion": 2,
+      "id": "CRY-GV-114",
+      "faction": "government",
+      "name": "South Carolina Wildlife Advisory",
+      "type": "MEDIA",
+      "rarity": "common",
+      "effects": {
+        "truthDelta": -1
+      },
+      "tags": [
+        "advisory",
+        "cryptid",
+        "government",
+        "media",
+        "south-carolina"
+      ],
+      "cost": 3,
+      "flavor": "\"CLASSIFIED INTELLIGENCE: Public bulletin: Do not feed the south carolina cryptid.\""
+    },
+    {
+      "schemaVersion": 2,
+      "id": "CRY-GV-115",
+      "faction": "government",
+      "name": "South Dakota Wildlife Advisory",
+      "type": "MEDIA",
+      "rarity": "common",
+      "effects": {
+        "truthDelta": -1
+      },
+      "tags": [
+        "advisory",
+        "cryptid",
+        "government",
+        "media",
+        "south-dakota"
+      ],
+      "cost": 3,
+      "flavor": "\"CLASSIFIED INTELLIGENCE: Public bulletin: Do not feed the south dakota cryptid.\""
+    },
+    {
+      "schemaVersion": 2,
+      "id": "CRY-GV-116",
+      "faction": "government",
+      "name": "Tennessee Wildlife Advisory",
+      "type": "MEDIA",
+      "rarity": "common",
+      "effects": {
+        "truthDelta": -1
+      },
+      "tags": [
+        "advisory",
+        "cryptid",
+        "government",
+        "media",
+        "tennessee"
+      ],
+      "cost": 3,
+      "flavor": "\"CLASSIFIED INTELLIGENCE: Public bulletin: Do not feed the tennessee cryptid.\""
+    },
+    {
+      "schemaVersion": 2,
+      "id": "CRY-GV-117",
+      "faction": "government",
+      "name": "Texas Wildlife Advisory",
+      "type": "ATTACK",
+      "rarity": "common",
+      "effects": {
+        "ipDelta": {
+          "opponent": 1
+        }
+      },
+      "tags": [
+        "advisory",
+        "attack",
+        "cryptid",
+        "government",
+        "texas"
+      ],
+      "cost": 2,
+      "flavor": "\"CLASSIFIED INTELLIGENCE: Public bulletin: Do not feed the chupacabra.\""
+    },
+    {
+      "schemaVersion": 2,
+      "id": "CRY-GV-118",
+      "faction": "government",
+      "name": "Utah Wildlife Advisory",
+      "type": "MEDIA",
+      "rarity": "common",
+      "effects": {
+        "truthDelta": -1
+      },
+      "tags": [
+        "advisory",
+        "cryptid",
+        "government",
+        "media",
+        "utah"
+      ],
+      "cost": 3,
+      "flavor": "\"CLASSIFIED INTELLIGENCE: Public bulletin: Do not feed the utah cryptid.\""
+    },
+    {
+      "schemaVersion": 2,
+      "id": "CRY-GV-119",
+      "faction": "government",
+      "name": "Vermont Wildlife Advisory",
+      "type": "MEDIA",
+      "rarity": "common",
+      "effects": {
+        "truthDelta": -1
+      },
+      "tags": [
+        "advisory",
+        "cryptid",
+        "government",
+        "media",
+        "vermont"
+      ],
+      "cost": 3,
+      "flavor": "\"CLASSIFIED INTELLIGENCE: Public bulletin: Do not feed the champ.\""
+    },
+    {
+      "schemaVersion": 2,
+      "id": "CRY-GV-120",
+      "faction": "government",
+      "name": "Virginia Wildlife Advisory",
+      "type": "MEDIA",
+      "rarity": "common",
+      "effects": {
+        "truthDelta": -1
+      },
+      "tags": [
+        "advisory",
+        "cryptid",
+        "government",
+        "media",
+        "virginia"
+      ],
+      "cost": 3,
+      "flavor": "\"CLASSIFIED INTELLIGENCE: Public bulletin: Do not feed the virginia cryptid.\""
+    },
+    {
+      "schemaVersion": 2,
+      "id": "CRY-GV-121",
+      "faction": "government",
+      "name": "Washington Wildlife Advisory",
+      "type": "MEDIA",
+      "rarity": "common",
+      "effects": {
+        "truthDelta": -1
+      },
+      "tags": [
+        "advisory",
+        "cryptid",
+        "government",
+        "media",
+        "washington"
+      ],
+      "cost": 3,
+      "flavor": "\"CLASSIFIED INTELLIGENCE: Public bulletin: Do not feed the bigfoot.\""
+    },
+    {
+      "schemaVersion": 2,
+      "id": "CRY-GV-122",
+      "faction": "government",
+      "name": "West Virginia Wildlife Advisory",
+      "type": "ATTACK",
+      "rarity": "common",
+      "effects": {
+        "ipDelta": {
+          "opponent": 1
+        }
+      },
+      "tags": [
+        "advisory",
+        "attack",
+        "cryptid",
+        "government",
+        "west-virginia"
+      ],
+      "cost": 2,
+      "flavor": "\"CLASSIFIED INTELLIGENCE: Public bulletin: Do not feed the mothman.\""
+    },
+    {
+      "schemaVersion": 2,
+      "id": "CRY-GV-123",
+      "faction": "government",
+      "name": "Wisconsin Wildlife Advisory",
+      "type": "ATTACK",
+      "rarity": "common",
+      "effects": {
+        "ipDelta": {
+          "opponent": 1
+        }
+      },
+      "tags": [
+        "advisory",
+        "attack",
+        "cryptid",
+        "government",
+        "wisconsin"
+      ],
+      "cost": 2,
+      "flavor": "\"CLASSIFIED INTELLIGENCE: Public bulletin: Do not feed the beast of bray road.\""
+    },
+    {
+      "schemaVersion": 2,
+      "id": "CRY-GV-124",
+      "faction": "government",
+      "name": "Wyoming Wildlife Advisory",
+      "type": "MEDIA",
+      "rarity": "common",
+      "effects": {
+        "truthDelta": -1
+      },
+      "tags": [
+        "advisory",
+        "cryptid",
+        "government",
+        "media",
+        "wyoming"
+      ],
+      "cost": 3,
+      "flavor": "\"CLASSIFIED INTELLIGENCE: Public bulletin: Do not feed the wyoming cryptid.\""
+    },
+    {
+      "schemaVersion": 2,
+      "id": "CRY-GV-125",
+      "faction": "government",
+      "name": "Chupacabra Area Closure",
+      "type": "ATTACK",
+      "rarity": "common",
+      "effects": {
+        "ipDelta": {
+          "opponent": 1
+        }
+      },
+      "tags": [
+        "attack",
+        "chupacabra",
+        "cryptid",
+        "government"
+      ],
+      "cost": 2,
+      "flavor": "\"CLASSIFIED INTELLIGENCE: Standard operating procedure, nothing to see.\""
+    },
+    {
+      "schemaVersion": 2,
+      "id": "CRY-GV-126",
+      "faction": "government",
+      "name": "Skunk Ape Area Closure",
+      "type": "ZONE",
+      "rarity": "common",
+      "effects": {
+        "pressureDelta": 1
+      },
+      "tags": [
+        "cryptid",
+        "government",
+        "skunk-ape",
+        "zone"
+      ],
+      "cost": 4,
+      "flavor": "\"CLASSIFIED INTELLIGENCE: Standard operating procedure, nothing to see.\""
+    },
+    {
+      "schemaVersion": 2,
+      "id": "CRY-GV-127",
+      "faction": "government",
+      "name": "Snallygaster Perimeter Lockdown",
+      "type": "MEDIA",
+      "rarity": "common",
+      "effects": {
+        "truthDelta": -1
+      },
+      "tags": [
+        "cryptid",
+        "government",
+        "media",
+        "snallygaster"
+      ],
+      "cost": 3,
+      "flavor": "\"CLASSIFIED INTELLIGENCE: Standard operating procedure, nothing to see.\""
+    },
+    {
+      "schemaVersion": 2,
+      "id": "CRY-GV-128",
+      "faction": "government",
+      "name": "Snallygaster Budget Audit",
+      "type": "ATTACK",
+      "rarity": "common",
+      "effects": {
+        "ipDelta": {
+          "opponent": 1
+        }
+      },
+      "tags": [
+        "attack",
+        "cryptid",
+        "government",
+        "snallygaster"
+      ],
+      "cost": 2,
+      "flavor": "\"CLASSIFIED INTELLIGENCE: Standard operating procedure, nothing to see.\""
+    },
+    {
+      "schemaVersion": 2,
+      "id": "CRY-GV-129",
+      "faction": "government",
+      "name": "Bigfoot Area Closure",
+      "type": "ZONE",
+      "rarity": "common",
+      "effects": {
+        "pressureDelta": 1
+      },
+      "tags": [
+        "bigfoot",
+        "cryptid",
+        "government",
+        "zone"
+      ],
+      "cost": 4,
+      "flavor": "\"CLASSIFIED INTELLIGENCE: Standard operating procedure, nothing to see.\""
+    },
+    {
+      "schemaVersion": 2,
+      "id": "CRY-GV-130",
+      "faction": "government",
+      "name": "Thunderbird Area Closure",
+      "type": "ATTACK",
+      "rarity": "common",
+      "effects": {
+        "ipDelta": {
+          "opponent": 1
+        }
+      },
+      "tags": [
+        "attack",
+        "cryptid",
+        "government",
+        "thunderbird"
+      ],
+      "cost": 2,
+      "flavor": "\"CLASSIFIED INTELLIGENCE: Standard operating procedure, nothing to see.\""
+    },
+    {
+      "schemaVersion": 2,
+      "id": "CRY-GV-131",
+      "faction": "government",
+      "name": "Montauk Monster Area Closure",
+      "type": "ZONE",
+      "rarity": "common",
+      "effects": {
+        "pressureDelta": 1
+      },
+      "tags": [
+        "cryptid",
+        "government",
+        "montauk-monster",
+        "zone"
+      ],
+      "cost": 4,
+      "flavor": "\"CLASSIFIED INTELLIGENCE: Standard operating procedure, nothing to see.\""
+    },
+    {
+      "schemaVersion": 2,
+      "id": "CRY-GV-132",
+      "faction": "government",
+      "name": "Dogman Area Closure",
+      "type": "ZONE",
+      "rarity": "common",
+      "effects": {
+        "pressureDelta": 1
+      },
+      "tags": [
+        "cryptid",
+        "dogman",
+        "government",
+        "zone"
+      ],
+      "cost": 4,
+      "flavor": "\"CLASSIFIED INTELLIGENCE: Standard operating procedure, nothing to see.\""
+    },
+    {
+      "schemaVersion": 2,
+      "id": "CRY-GV-133",
+      "faction": "government",
+      "name": "Champ Budget Audit",
+      "type": "ATTACK",
+      "rarity": "common",
+      "effects": {
+        "ipDelta": {
+          "opponent": 1
+        }
+      },
+      "tags": [
+        "attack",
+        "champ",
+        "cryptid",
+        "government"
+      ],
+      "cost": 2,
+      "flavor": "\"CLASSIFIED INTELLIGENCE: Standard operating procedure, nothing to see.\""
+    },
+    {
+      "schemaVersion": 2,
+      "id": "CRY-GV-134",
+      "faction": "government",
+      "name": "Montauk Monster Area Closure",
+      "type": "ZONE",
+      "rarity": "common",
+      "effects": {
+        "pressureDelta": 1
+      },
+      "tags": [
+        "cryptid",
+        "government",
+        "montauk-monster",
+        "zone"
+      ],
+      "cost": 4,
+      "flavor": "\"CLASSIFIED INTELLIGENCE: Standard operating procedure, nothing to see.\""
+    },
+    {
+      "schemaVersion": 2,
+      "id": "CRY-GV-135",
+      "faction": "government",
+      "name": "Dover Demon Area Closure",
+      "type": "ZONE",
+      "rarity": "common",
+      "effects": {
+        "pressureDelta": 1
+      },
+      "tags": [
+        "cryptid",
+        "dover-demon",
+        "government",
+        "zone"
+      ],
+      "cost": 4,
+      "flavor": "\"CLASSIFIED INTELLIGENCE: Standard operating procedure, nothing to see.\""
+    },
+    {
+      "schemaVersion": 2,
+      "id": "CRY-GV-136",
+      "faction": "government",
+      "name": "Tahoe Tessie Area Closure",
+      "type": "ZONE",
+      "rarity": "common",
+      "effects": {
+        "pressureDelta": 1
+      },
+      "tags": [
+        "cryptid",
+        "government",
+        "tahoe-tessie",
+        "zone"
+      ],
+      "cost": 4,
+      "flavor": "\"CLASSIFIED INTELLIGENCE: Standard operating procedure, nothing to see.\""
+    },
+    {
+      "schemaVersion": 2,
+      "id": "CRY-GV-137",
+      "faction": "government",
+      "name": "Beast of Bray Road Budget Audit",
+      "type": "ATTACK",
+      "rarity": "common",
+      "effects": {
+        "ipDelta": {
+          "opponent": 1
+        }
+      },
+      "tags": [
+        "attack",
+        "beast-of-bray-road",
+        "cryptid",
+        "government"
+      ],
+      "cost": 2,
+      "flavor": "\"CLASSIFIED INTELLIGENCE: Standard operating procedure, nothing to see.\""
+    },
+    {
+      "schemaVersion": 2,
+      "id": "CRY-GV-138",
+      "faction": "government",
+      "name": "Thunderbird Perimeter Lockdown",
+      "type": "ATTACK",
+      "rarity": "common",
+      "effects": {
+        "ipDelta": {
+          "opponent": 1
+        }
+      },
+      "tags": [
+        "attack",
+        "cryptid",
+        "government",
+        "thunderbird"
+      ],
+      "cost": 2,
+      "flavor": "\"CLASSIFIED INTELLIGENCE: Standard operating procedure, nothing to see.\""
+    },
+    {
+      "schemaVersion": 2,
+      "id": "CRY-GV-139",
+      "faction": "government",
+      "name": "Rougarou Perimeter Lockdown",
+      "type": "MEDIA",
+      "rarity": "common",
+      "effects": {
+        "truthDelta": -1
+      },
+      "tags": [
+        "cryptid",
+        "government",
+        "media",
+        "rougarou"
+      ],
+      "cost": 3,
+      "flavor": "\"CLASSIFIED INTELLIGENCE: Standard operating procedure, nothing to see.\""
+    },
+    {
+      "schemaVersion": 2,
+      "id": "CRY-GV-140",
+      "faction": "government",
+      "name": "Jersey Devil Area Closure",
+      "type": "ATTACK",
+      "rarity": "common",
+      "effects": {
+        "ipDelta": {
+          "opponent": 1
+        }
+      },
+      "tags": [
+        "attack",
+        "cryptid",
+        "government",
+        "jersey-devil"
+      ],
+      "cost": 2,
+      "flavor": "\"CLASSIFIED INTELLIGENCE: Standard operating procedure, nothing to see.\""
+    },
+    {
+      "schemaVersion": 2,
+      "id": "CRY-GV-141",
+      "faction": "government",
+      "name": "Dogman Area Closure",
+      "type": "ZONE",
+      "rarity": "common",
+      "effects": {
+        "pressureDelta": 1
+      },
+      "tags": [
+        "cryptid",
+        "dogman",
+        "government",
+        "zone"
+      ],
+      "cost": 4,
+      "flavor": "\"CLASSIFIED INTELLIGENCE: Standard operating procedure, nothing to see.\""
+    },
+    {
+      "schemaVersion": 2,
+      "id": "CRY-GV-142",
+      "faction": "government",
+      "name": "Wendigo Perimeter Lockdown",
+      "type": "ATTACK",
+      "rarity": "common",
+      "effects": {
+        "ipDelta": {
+          "opponent": 1
+        }
+      },
+      "tags": [
+        "attack",
+        "cryptid",
+        "government",
+        "wendigo"
+      ],
+      "cost": 2,
+      "flavor": "\"CLASSIFIED INTELLIGENCE: Standard operating procedure, nothing to see.\""
+    },
+    {
+      "schemaVersion": 2,
+      "id": "CRY-GV-143",
+      "faction": "government",
+      "name": "Shunka Warakin Area Closure",
+      "type": "ZONE",
+      "rarity": "common",
+      "effects": {
+        "pressureDelta": 1
+      },
+      "tags": [
+        "cryptid",
+        "government",
+        "shunka-warakin",
+        "zone"
+      ],
+      "cost": 4,
+      "flavor": "\"CLASSIFIED INTELLIGENCE: Standard operating procedure, nothing to see.\""
+    },
+    {
+      "schemaVersion": 2,
+      "id": "CRY-GV-144",
+      "faction": "government",
+      "name": "Dover Demon Budget Audit",
+      "type": "ATTACK",
+      "rarity": "common",
+      "effects": {
+        "ipDelta": {
+          "opponent": 1
+        }
+      },
+      "tags": [
+        "attack",
+        "cryptid",
+        "dover-demon",
+        "government"
+      ],
+      "cost": 2,
+      "flavor": "\"CLASSIFIED INTELLIGENCE: Standard operating procedure, nothing to see.\""
+    },
+    {
+      "schemaVersion": 2,
+      "id": "CRY-GV-145",
+      "faction": "government",
+      "name": "Thunderbird Perimeter Lockdown",
+      "type": "ATTACK",
+      "rarity": "common",
+      "effects": {
+        "ipDelta": {
+          "opponent": 1
+        }
+      },
+      "tags": [
+        "attack",
+        "cryptid",
+        "government",
+        "thunderbird"
+      ],
+      "cost": 2,
+      "flavor": "\"CLASSIFIED INTELLIGENCE: Standard operating procedure, nothing to see.\""
+    },
+    {
+      "schemaVersion": 2,
+      "id": "CRY-GV-146",
+      "faction": "government",
+      "name": "Skunk Ape Area Closure",
+      "type": "ZONE",
+      "rarity": "common",
+      "effects": {
+        "pressureDelta": 1
+      },
+      "tags": [
+        "cryptid",
+        "government",
+        "skunk-ape",
+        "zone"
+      ],
+      "cost": 4,
+      "flavor": "\"CLASSIFIED INTELLIGENCE: Standard operating procedure, nothing to see.\""
+    },
+    {
+      "schemaVersion": 2,
+      "id": "CRY-GV-147",
+      "faction": "government",
+      "name": "Rougarou Budget Audit",
+      "type": "ATTACK",
+      "rarity": "common",
+      "effects": {
+        "ipDelta": {
+          "opponent": 1
+        }
+      },
+      "tags": [
+        "attack",
+        "cryptid",
+        "government",
+        "rougarou"
+      ],
+      "cost": 2,
+      "flavor": "\"CLASSIFIED INTELLIGENCE: Standard operating procedure, nothing to see.\""
+    },
+    {
+      "schemaVersion": 2,
+      "id": "CRY-GV-148",
+      "faction": "government",
+      "name": "Chupacabra Budget Audit",
+      "type": "ATTACK",
+      "rarity": "common",
+      "effects": {
+        "ipDelta": {
+          "opponent": 1
+        }
+      },
+      "tags": [
+        "attack",
+        "chupacabra",
+        "cryptid",
+        "government"
+      ],
+      "cost": 2,
+      "flavor": "\"CLASSIFIED INTELLIGENCE: Standard operating procedure, nothing to see.\""
+    },
+    {
+      "schemaVersion": 2,
+      "id": "CRY-GV-149",
+      "faction": "government",
+      "name": "Dover Demon Budget Audit",
+      "type": "ATTACK",
+      "rarity": "common",
+      "effects": {
+        "ipDelta": {
+          "opponent": 1
+        }
+      },
+      "tags": [
+        "attack",
+        "cryptid",
+        "dover-demon",
+        "government"
+      ],
+      "cost": 2,
+      "flavor": "\"CLASSIFIED INTELLIGENCE: Standard operating procedure, nothing to see.\""
+    },
+    {
+      "schemaVersion": 2,
+      "id": "CRY-GV-150",
+      "faction": "government",
+      "name": "Jersey Devil Perimeter Lockdown",
+      "type": "ATTACK",
+      "rarity": "common",
+      "effects": {
+        "ipDelta": {
+          "opponent": 1
+        }
+      },
+      "tags": [
+        "attack",
+        "cryptid",
+        "government",
+        "jersey-devil"
+      ],
+      "cost": 2,
+      "flavor": "\"CLASSIFIED INTELLIGENCE: Standard operating procedure, nothing to see.\""
+    }
+  ]
 }

--- a/public/extensions/halloween_spooktacular_with_temp_image.json
+++ b/public/extensions/halloween_spooktacular_with_temp_image.json
@@ -23,7 +23,12 @@
       },
       "text": "Opponent −1 IP.",
       "flavor": "Someone left the portal open again.",
-      "artId": "halloween_spooktacular-Temp-Image"
+      "artId": "halloween_spooktacular-Temp-Image",
+      "tags": [
+        "attack",
+        "government",
+        "halloween"
+      ]
     },
     {
       "id": "hallo-gov-spider-scare-incident-002",
@@ -39,7 +44,12 @@
       },
       "text": "Opponent −1 IP.",
       "flavor": "Bring a flashlight and plausible deniability.",
-      "artId": "halloween_spooktacular-Temp-Image"
+      "artId": "halloween_spooktacular-Temp-Image",
+      "tags": [
+        "attack",
+        "government",
+        "halloween"
+      ]
     },
     {
       "id": "hallo-gov-cauldron-whispers-incident-003",
@@ -55,7 +65,12 @@
       },
       "text": "Opponent −1 IP.",
       "flavor": "All treats, suspicious tricks.",
-      "artId": "halloween_spooktacular-Temp-Image"
+      "artId": "halloween_spooktacular-Temp-Image",
+      "tags": [
+        "attack",
+        "government",
+        "halloween"
+      ]
     },
     {
       "id": "hallo-gov-ouija-shuffle-incident-004",
@@ -69,7 +84,12 @@
       },
       "text": "−1% Truth.",
       "flavor": "Approved by the Council of Shadows.",
-      "artId": "halloween_spooktacular-Temp-Image"
+      "artId": "halloween_spooktacular-Temp-Image",
+      "tags": [
+        "government",
+        "halloween",
+        "media"
+      ]
     },
     {
       "id": "hallo-gov-report-of-the-fog-machine-005",
@@ -85,7 +105,15 @@
       },
       "text": "Opponent −1 IP.",
       "flavor": "Someone left the portal open again.",
-      "artId": "halloween_spooktacular-Temp-Image"
+      "artId": "halloween_spooktacular-Temp-Image",
+      "tags": [
+        "attack",
+        "bureaucracy",
+        "coverup",
+        "government",
+        "halloween",
+        "media"
+      ]
     },
     {
       "id": "hallo-gov-dracula-shuffle-protocol-006",
@@ -99,7 +127,12 @@
       },
       "text": "−1% Truth.",
       "flavor": "Do not taunt the poltergeist.",
-      "artId": "halloween_spooktacular-Temp-Image"
+      "artId": "halloween_spooktacular-Temp-Image",
+      "tags": [
+        "government",
+        "halloween",
+        "media"
+      ]
     },
     {
       "id": "hallo-gov-wolfman-shenanigans-007",
@@ -113,7 +146,12 @@
       },
       "text": "−1% Truth.",
       "flavor": "Rated PG‑Paranoid.",
-      "artId": "halloween_spooktacular-Temp-Image"
+      "artId": "halloween_spooktacular-Temp-Image",
+      "tags": [
+        "government",
+        "halloween",
+        "media"
+      ]
     },
     {
       "id": "hallo-gov-press-release-of-the-full-moon-008",
@@ -127,7 +165,12 @@
       },
       "text": "−1% Truth.",
       "flavor": "Whispers from the cornfield.",
-      "artId": "halloween_spooktacular-Temp-Image"
+      "artId": "halloween_spooktacular-Temp-Image",
+      "tags": [
+        "government",
+        "halloween",
+        "media"
+      ]
     },
     {
       "id": "hallo-gov-scare-of-the-midnight-009",
@@ -143,7 +186,12 @@
       },
       "text": "Opponent −1 IP.",
       "flavor": "Batteries not included.",
-      "artId": "halloween_spooktacular-Temp-Image"
+      "artId": "halloween_spooktacular-Temp-Image",
+      "tags": [
+        "attack",
+        "government",
+        "halloween"
+      ]
     },
     {
       "id": "hallo-gov-bat-boy-shuffle-protocol-010",
@@ -158,7 +206,14 @@
       "text": "+1 Pressure in a chosen state.",
       "requiresTarget": true,
       "flavor": "Red eyes in the rear-view mirror.",
-      "artId": "halloween_spooktacular-Temp-Image"
+      "artId": "halloween_spooktacular-Temp-Image",
+      "tags": [
+        "bat-boy",
+        "cryptid",
+        "government",
+        "halloween",
+        "zone"
+      ]
     },
     {
       "id": "hallo-gov-skeleton-press-release-files-011",
@@ -174,7 +229,15 @@
       },
       "text": "Opponent −1 IP.",
       "flavor": "Approved by the Council of Shadows.",
-      "artId": "halloween_spooktacular-Temp-Image"
+      "artId": "halloween_spooktacular-Temp-Image",
+      "tags": [
+        "attack",
+        "bureaucracy",
+        "coverup",
+        "government",
+        "halloween",
+        "media"
+      ]
     },
     {
       "id": "hallo-gov-trick-or-treat-pamphlet-files-012",
@@ -188,7 +251,14 @@
       },
       "text": "−1% Truth.",
       "flavor": "Whispers from the cornfield.",
-      "artId": "halloween_spooktacular-Temp-Image"
+      "artId": "halloween_spooktacular-Temp-Image",
+      "tags": [
+        "bureaucracy",
+        "coverup",
+        "government",
+        "halloween",
+        "media"
+      ]
     },
     {
       "id": "hallo-gov-haunted-rally-protocol-013",
@@ -204,7 +274,15 @@
       },
       "text": "Opponent −1 IP.",
       "flavor": "Bring a flashlight and plausible deniability.",
-      "artId": "halloween_spooktacular-Temp-Image"
+      "artId": "halloween_spooktacular-Temp-Image",
+      "tags": [
+        "attack",
+        "ghost",
+        "government",
+        "halloween",
+        "haunted",
+        "protest"
+      ]
     },
     {
       "id": "hallo-gov-raven-flyer-protocol-014",
@@ -218,7 +296,12 @@
       },
       "text": "−1% Truth.",
       "flavor": "They came for the candy, stayed for the cover‑up.",
-      "artId": "halloween_spooktacular-Temp-Image"
+      "artId": "halloween_spooktacular-Temp-Image",
+      "tags": [
+        "government",
+        "halloween",
+        "media"
+      ]
     },
     {
       "id": "hallo-gov-poltergeist-alert-protocol-015",
@@ -234,7 +317,12 @@
       },
       "text": "Opponent −1 IP.",
       "flavor": "Mind the ectoplasm.",
-      "artId": "halloween_spooktacular-Temp-Image"
+      "artId": "halloween_spooktacular-Temp-Image",
+      "tags": [
+        "attack",
+        "government",
+        "halloween"
+      ]
     },
     {
       "id": "hallo-gov-scarecrow-shenanigans-incident-016",
@@ -248,7 +336,12 @@
       },
       "text": "−1% Truth.",
       "flavor": "‘It was just the wind,’ said the intern.",
-      "artId": "halloween_spooktacular-Temp-Image"
+      "artId": "halloween_spooktacular-Temp-Image",
+      "tags": [
+        "government",
+        "halloween",
+        "media"
+      ]
     },
     {
       "id": "hallo-gov-scare-of-the-ghost-017",
@@ -262,7 +355,14 @@
       },
       "text": "−1% Truth.",
       "flavor": "Smells like fog machine and fear.",
-      "artId": "halloween_spooktacular-Temp-Image"
+      "artId": "halloween_spooktacular-Temp-Image",
+      "tags": [
+        "ghost",
+        "government",
+        "halloween",
+        "haunted",
+        "media"
+      ]
     },
     {
       "id": "hallo-gov-banshee-shenanigans-incident-018",
@@ -278,7 +378,12 @@
       },
       "text": "Opponent −1 IP.",
       "flavor": "The veil is thin tonight.",
-      "artId": "halloween_spooktacular-Temp-Image"
+      "artId": "halloween_spooktacular-Temp-Image",
+      "tags": [
+        "attack",
+        "government",
+        "halloween"
+      ]
     },
     {
       "id": "hallo-gov-wolfman-pamphlet-incident-019",
@@ -294,7 +399,12 @@
       },
       "text": "Opponent −1 IP.",
       "flavor": "Someone left the portal open again.",
-      "artId": "halloween_spooktacular-Temp-Image"
+      "artId": "halloween_spooktacular-Temp-Image",
+      "tags": [
+        "attack",
+        "government",
+        "halloween"
+      ]
     },
     {
       "id": "hallo-gov-bat-boy-shuffle-020",
@@ -310,7 +420,14 @@
       },
       "text": "Opponent −1 IP.",
       "flavor": "‘It was just the wind,’ said the intern.",
-      "artId": "halloween_spooktacular-Temp-Image"
+      "artId": "halloween_spooktacular-Temp-Image",
+      "tags": [
+        "attack",
+        "bat-boy",
+        "cryptid",
+        "government",
+        "halloween"
+      ]
     },
     {
       "id": "hallo-gov-moonlight-scare-files-021",
@@ -325,7 +442,15 @@
       "text": "+1 Pressure in a chosen state.",
       "requiresTarget": true,
       "flavor": "‘It was just the wind,’ said the intern.",
-      "artId": "halloween_spooktacular-Temp-Image"
+      "artId": "halloween_spooktacular-Temp-Image",
+      "tags": [
+        "bureaucracy",
+        "coverup",
+        "government",
+        "halloween",
+        "media",
+        "zone"
+      ]
     },
     {
       "id": "hallo-gov-shuffle-of-the-mummy-022",
@@ -341,7 +466,12 @@
       },
       "text": "Opponent −1 IP.",
       "flavor": "The veil is thin tonight.",
-      "artId": "halloween_spooktacular-Temp-Image"
+      "artId": "halloween_spooktacular-Temp-Image",
+      "tags": [
+        "attack",
+        "government",
+        "halloween"
+      ]
     },
     {
       "id": "hallo-gov-haunted-mansion-whispers-023",
@@ -357,7 +487,14 @@
       },
       "text": "Opponent −1 IP.",
       "flavor": "We can neither confirm nor deny the howling.",
-      "artId": "halloween_spooktacular-Temp-Image"
+      "artId": "halloween_spooktacular-Temp-Image",
+      "tags": [
+        "attack",
+        "ghost",
+        "government",
+        "halloween",
+        "haunted"
+      ]
     },
     {
       "id": "hallo-gov-raven-scare-024",
@@ -371,7 +508,12 @@
       },
       "text": "−1% Truth.",
       "flavor": "Mind the ectoplasm.",
-      "artId": "halloween_spooktacular-Temp-Image"
+      "artId": "halloween_spooktacular-Temp-Image",
+      "tags": [
+        "government",
+        "halloween",
+        "media"
+      ]
     },
     {
       "id": "hallo-gov-frankenstein-pamphlet-initiative-025",
@@ -386,7 +528,12 @@
       "text": "+1 Pressure in a chosen state.",
       "requiresTarget": true,
       "flavor": "Red eyes in the rear-view mirror.",
-      "artId": "halloween_spooktacular-Temp-Image"
+      "artId": "halloween_spooktacular-Temp-Image",
+      "tags": [
+        "government",
+        "halloween",
+        "zone"
+      ]
     },
     {
       "id": "hallo-gov-shenanigans-of-the-cauldron-026",
@@ -400,7 +547,12 @@
       },
       "text": "−1% Truth.",
       "flavor": "Bring a flashlight and plausible deniability.",
-      "artId": "halloween_spooktacular-Temp-Image"
+      "artId": "halloween_spooktacular-Temp-Image",
+      "tags": [
+        "government",
+        "halloween",
+        "media"
+      ]
     },
     {
       "id": "hallo-gov-headless-horseman-pamphlet-files-027",
@@ -416,7 +568,15 @@
       },
       "text": "Opponent −1 IP.",
       "flavor": "Licensed spooktacular.",
-      "artId": "halloween_spooktacular-Temp-Image"
+      "artId": "halloween_spooktacular-Temp-Image",
+      "tags": [
+        "attack",
+        "bureaucracy",
+        "coverup",
+        "government",
+        "halloween",
+        "media"
+      ]
     },
     {
       "id": "hallo-gov-ouija-scare-protocol-028",
@@ -430,7 +590,12 @@
       },
       "text": "−1% Truth.",
       "flavor": "Try not to scream on camera.",
-      "artId": "halloween_spooktacular-Temp-Image"
+      "artId": "halloween_spooktacular-Temp-Image",
+      "tags": [
+        "government",
+        "halloween",
+        "media"
+      ]
     },
     {
       "id": "hallo-gov-skeleton-flyer-files-029",
@@ -446,7 +611,15 @@
       },
       "text": "Opponent −1 IP.",
       "flavor": "Whispers from the cornfield.",
-      "artId": "halloween_spooktacular-Temp-Image"
+      "artId": "halloween_spooktacular-Temp-Image",
+      "tags": [
+        "attack",
+        "bureaucracy",
+        "coverup",
+        "government",
+        "halloween",
+        "media"
+      ]
     },
     {
       "id": "hallo-gov-brief-of-the-skeleton-030",
@@ -460,7 +633,14 @@
       },
       "text": "−1% Truth.",
       "flavor": "They came for the candy, stayed for the cover‑up.",
-      "artId": "halloween_spooktacular-Temp-Image"
+      "artId": "halloween_spooktacular-Temp-Image",
+      "tags": [
+        "bureaucracy",
+        "coverup",
+        "government",
+        "halloween",
+        "media"
+      ]
     },
     {
       "id": "hallo-gov-frankenstein-flyer-incident-031",
@@ -474,7 +654,12 @@
       },
       "text": "−1% Truth.",
       "flavor": "They came for the candy, stayed for the cover‑up.",
-      "artId": "halloween_spooktacular-Temp-Image"
+      "artId": "halloween_spooktacular-Temp-Image",
+      "tags": [
+        "government",
+        "halloween",
+        "media"
+      ]
     },
     {
       "id": "hallo-gov-coven-scare-032",
@@ -489,7 +674,12 @@
       "text": "+1 Pressure in a chosen state.",
       "requiresTarget": true,
       "flavor": "The crypt Wi‑Fi is excellent.",
-      "artId": "halloween_spooktacular-Temp-Image"
+      "artId": "halloween_spooktacular-Temp-Image",
+      "tags": [
+        "government",
+        "halloween",
+        "zone"
+      ]
     },
     {
       "id": "hallo-gov-poltergeist-flyer-033",
@@ -505,7 +695,12 @@
       },
       "text": "Opponent −1 IP.",
       "flavor": "Someone left the portal open again.",
-      "artId": "halloween_spooktacular-Temp-Image"
+      "artId": "halloween_spooktacular-Temp-Image",
+      "tags": [
+        "attack",
+        "government",
+        "halloween"
+      ]
     },
     {
       "id": "hallo-gov-fog-machine-rally-034",
@@ -519,7 +714,13 @@
       },
       "text": "−1% Truth.",
       "flavor": "Mind the ectoplasm.",
-      "artId": "halloween_spooktacular-Temp-Image"
+      "artId": "halloween_spooktacular-Temp-Image",
+      "tags": [
+        "government",
+        "halloween",
+        "media",
+        "protest"
+      ]
     },
     {
       "id": "hallo-gov-ghoul-alert-protocol-035",
@@ -533,7 +734,12 @@
       },
       "text": "−1% Truth.",
       "flavor": "Licensed spooktacular.",
-      "artId": "halloween_spooktacular-Temp-Image"
+      "artId": "halloween_spooktacular-Temp-Image",
+      "tags": [
+        "government",
+        "halloween",
+        "media"
+      ]
     },
     {
       "id": "hallo-gov-cobweb-scare-036",
@@ -548,7 +754,12 @@
       "text": "+1 Pressure in a chosen state.",
       "requiresTarget": true,
       "flavor": "The veil is thin tonight.",
-      "artId": "halloween_spooktacular-Temp-Image"
+      "artId": "halloween_spooktacular-Temp-Image",
+      "tags": [
+        "government",
+        "halloween",
+        "zone"
+      ]
     },
     {
       "id": "hallo-gov-seance-alert-initiative-037",
@@ -563,7 +774,12 @@
       "text": "+1 Pressure in a chosen state.",
       "requiresTarget": true,
       "flavor": "Bring a flashlight and plausible deniability.",
-      "artId": "halloween_spooktacular-Temp-Image"
+      "artId": "halloween_spooktacular-Temp-Image",
+      "tags": [
+        "government",
+        "halloween",
+        "zone"
+      ]
     },
     {
       "id": "hallo-gov-ghost-alert-initiative-038",
@@ -577,7 +793,14 @@
       },
       "text": "−1% Truth.",
       "flavor": "Red eyes in the rear-view mirror.",
-      "artId": "halloween_spooktacular-Temp-Image"
+      "artId": "halloween_spooktacular-Temp-Image",
+      "tags": [
+        "ghost",
+        "government",
+        "halloween",
+        "haunted",
+        "media"
+      ]
     },
     {
       "id": "hallo-gov-poltergeist-report-initiative-039",
@@ -591,7 +814,14 @@
       },
       "text": "−1% Truth.",
       "flavor": "Mind the ectoplasm.",
-      "artId": "halloween_spooktacular-Temp-Image"
+      "artId": "halloween_spooktacular-Temp-Image",
+      "tags": [
+        "bureaucracy",
+        "coverup",
+        "government",
+        "halloween",
+        "media"
+      ]
     },
     {
       "id": "hallo-gov-alert-of-the-haunted-mansion-040",
@@ -607,7 +837,14 @@
       },
       "text": "Opponent −1 IP.",
       "flavor": "Try not to scream on camera.",
-      "artId": "halloween_spooktacular-Temp-Image"
+      "artId": "halloween_spooktacular-Temp-Image",
+      "tags": [
+        "attack",
+        "ghost",
+        "government",
+        "halloween",
+        "haunted"
+      ]
     },
     {
       "id": "hallo-gov-ghost-flyer-protocol-041",
@@ -622,7 +859,14 @@
       "text": "+1 Pressure in a chosen state.",
       "requiresTarget": true,
       "flavor": "Try not to scream on camera.",
-      "artId": "halloween_spooktacular-Temp-Image"
+      "artId": "halloween_spooktacular-Temp-Image",
+      "tags": [
+        "ghost",
+        "government",
+        "halloween",
+        "haunted",
+        "zone"
+      ]
     },
     {
       "id": "hallo-gov-jack-o-lantern-alert-042",
@@ -636,7 +880,12 @@
       },
       "text": "−1% Truth.",
       "flavor": "Keep garlic handy.",
-      "artId": "halloween_spooktacular-Temp-Image"
+      "artId": "halloween_spooktacular-Temp-Image",
+      "tags": [
+        "government",
+        "halloween",
+        "media"
+      ]
     },
     {
       "id": "hallo-gov-seance-shenanigans-043",
@@ -652,7 +901,12 @@
       },
       "text": "Opponent −1 IP.",
       "flavor": "Whispers from the cornfield.",
-      "artId": "halloween_spooktacular-Temp-Image"
+      "artId": "halloween_spooktacular-Temp-Image",
+      "tags": [
+        "attack",
+        "government",
+        "halloween"
+      ]
     },
     {
       "id": "hallo-gov-zombie-pamphlet-incident-044",
@@ -668,7 +922,12 @@
       },
       "text": "Opponent −1 IP.",
       "flavor": "Bring a flashlight and plausible deniability.",
-      "artId": "halloween_spooktacular-Temp-Image"
+      "artId": "halloween_spooktacular-Temp-Image",
+      "tags": [
+        "attack",
+        "government",
+        "halloween"
+      ]
     },
     {
       "id": "hallo-gov-crypt-rumor-protocol-045",
@@ -684,7 +943,12 @@
       },
       "text": "Opponent −1 IP.",
       "flavor": "Sticky with sugar and secrets.",
-      "artId": "halloween_spooktacular-Temp-Image"
+      "artId": "halloween_spooktacular-Temp-Image",
+      "tags": [
+        "attack",
+        "government",
+        "halloween"
+      ]
     },
     {
       "id": "hallo-gov-skeleton-whispers-initiative-046",
@@ -698,7 +962,12 @@
       },
       "text": "−1% Truth.",
       "flavor": "Keep garlic handy.",
-      "artId": "halloween_spooktacular-Temp-Image"
+      "artId": "halloween_spooktacular-Temp-Image",
+      "tags": [
+        "government",
+        "halloween",
+        "media"
+      ]
     },
     {
       "id": "hallo-gov-report-of-the-moonlight-047",
@@ -712,7 +981,14 @@
       },
       "text": "−1% Truth.",
       "flavor": "The crypt Wi‑Fi is excellent.",
-      "artId": "halloween_spooktacular-Temp-Image"
+      "artId": "halloween_spooktacular-Temp-Image",
+      "tags": [
+        "bureaucracy",
+        "coverup",
+        "government",
+        "halloween",
+        "media"
+      ]
     },
     {
       "id": "hallo-gov-ectoplasm-brief-files-048",
@@ -728,7 +1004,15 @@
       },
       "text": "Opponent −1 IP.",
       "flavor": "‘It was just the wind,’ said the intern.",
-      "artId": "halloween_spooktacular-Temp-Image"
+      "artId": "halloween_spooktacular-Temp-Image",
+      "tags": [
+        "attack",
+        "bureaucracy",
+        "coverup",
+        "government",
+        "halloween",
+        "media"
+      ]
     },
     {
       "id": "hallo-gov-cobweb-report-files-049",
@@ -742,7 +1026,14 @@
       },
       "text": "−1% Truth.",
       "flavor": "Someone left the portal open again.",
-      "artId": "halloween_spooktacular-Temp-Image"
+      "artId": "halloween_spooktacular-Temp-Image",
+      "tags": [
+        "bureaucracy",
+        "coverup",
+        "government",
+        "halloween",
+        "media"
+      ]
     },
     {
       "id": "hallo-gov-cobweb-alert-protocol-050",
@@ -756,7 +1047,12 @@
       },
       "text": "−1% Truth.",
       "flavor": "Bring a flashlight and plausible deniability.",
-      "artId": "halloween_spooktacular-Temp-Image"
+      "artId": "halloween_spooktacular-Temp-Image",
+      "tags": [
+        "government",
+        "halloween",
+        "media"
+      ]
     },
     {
       "id": "hallo-gov-omen-pamphlet-files-051",
@@ -771,7 +1067,15 @@
       "text": "+1 Pressure in a chosen state.",
       "requiresTarget": true,
       "flavor": "They came for the candy, stayed for the cover‑up.",
-      "artId": "halloween_spooktacular-Temp-Image"
+      "artId": "halloween_spooktacular-Temp-Image",
+      "tags": [
+        "bureaucracy",
+        "coverup",
+        "government",
+        "halloween",
+        "media",
+        "zone"
+      ]
     },
     {
       "id": "hallo-gov-ghost-scare-files-052",
@@ -787,7 +1091,17 @@
       },
       "text": "Opponent −1 IP.",
       "flavor": "The veil is thin tonight.",
-      "artId": "halloween_spooktacular-Temp-Image"
+      "artId": "halloween_spooktacular-Temp-Image",
+      "tags": [
+        "attack",
+        "bureaucracy",
+        "coverup",
+        "ghost",
+        "government",
+        "halloween",
+        "haunted",
+        "media"
+      ]
     },
     {
       "id": "hallo-gov-frankenstein-pamphlet-protocol-053",
@@ -803,7 +1117,12 @@
       },
       "text": "Opponent −1 IP.",
       "flavor": "Mind the ectoplasm.",
-      "artId": "halloween_spooktacular-Temp-Image"
+      "artId": "halloween_spooktacular-Temp-Image",
+      "tags": [
+        "attack",
+        "government",
+        "halloween"
+      ]
     },
     {
       "id": "hallo-gov-cobweb-whispers-054",
@@ -819,7 +1138,12 @@
       },
       "text": "Opponent −1 IP.",
       "flavor": "Do not feed after midnight.",
-      "artId": "halloween_spooktacular-Temp-Image"
+      "artId": "halloween_spooktacular-Temp-Image",
+      "tags": [
+        "attack",
+        "government",
+        "halloween"
+      ]
     },
     {
       "id": "hallo-gov-full-moon-press-release-incident-055",
@@ -833,7 +1157,12 @@
       },
       "text": "−1% Truth.",
       "flavor": "Sticky with sugar and secrets.",
-      "artId": "halloween_spooktacular-Temp-Image"
+      "artId": "halloween_spooktacular-Temp-Image",
+      "tags": [
+        "government",
+        "halloween",
+        "media"
+      ]
     },
     {
       "id": "hallo-gov-shuffle-of-the-haunted-056",
@@ -849,7 +1178,14 @@
       },
       "text": "Opponent −1 IP.",
       "flavor": "Someone left the portal open again.",
-      "artId": "halloween_spooktacular-Temp-Image"
+      "artId": "halloween_spooktacular-Temp-Image",
+      "tags": [
+        "attack",
+        "ghost",
+        "government",
+        "halloween",
+        "haunted"
+      ]
     },
     {
       "id": "hallo-gov-cobweb-shenanigans-incident-057",
@@ -865,7 +1201,12 @@
       },
       "text": "Opponent −1 IP.",
       "flavor": "Approved by the Council of Shadows.",
-      "artId": "halloween_spooktacular-Temp-Image"
+      "artId": "halloween_spooktacular-Temp-Image",
+      "tags": [
+        "attack",
+        "government",
+        "halloween"
+      ]
     },
     {
       "id": "hallo-gov-witch-shenanigans-058",
@@ -880,7 +1221,12 @@
       "text": "+1 Pressure in a chosen state.",
       "requiresTarget": true,
       "flavor": "This is fine. Probably.",
-      "artId": "halloween_spooktacular-Temp-Image"
+      "artId": "halloween_spooktacular-Temp-Image",
+      "tags": [
+        "government",
+        "halloween",
+        "zone"
+      ]
     },
     {
       "id": "hallo-gov-zombie-rally-files-059",
@@ -895,7 +1241,16 @@
       "text": "+1 Pressure in a chosen state.",
       "requiresTarget": true,
       "flavor": "Red eyes in the rear-view mirror.",
-      "artId": "halloween_spooktacular-Temp-Image"
+      "artId": "halloween_spooktacular-Temp-Image",
+      "tags": [
+        "bureaucracy",
+        "coverup",
+        "government",
+        "halloween",
+        "media",
+        "protest",
+        "zone"
+      ]
     },
     {
       "id": "hallo-gov-dracula-shenanigans-060",
@@ -909,7 +1264,12 @@
       },
       "text": "−1% Truth.",
       "flavor": "Licensed spooktacular.",
-      "artId": "halloween_spooktacular-Temp-Image"
+      "artId": "halloween_spooktacular-Temp-Image",
+      "tags": [
+        "government",
+        "halloween",
+        "media"
+      ]
     },
     {
       "id": "hallo-gov-ouija-rumor-061",
@@ -925,7 +1285,12 @@
       },
       "text": "Opponent −1 IP.",
       "flavor": "This is fine. Probably.",
-      "artId": "halloween_spooktacular-Temp-Image"
+      "artId": "halloween_spooktacular-Temp-Image",
+      "tags": [
+        "attack",
+        "government",
+        "halloween"
+      ]
     },
     {
       "id": "hallo-gov-skeleton-rally-protocol-062",
@@ -941,7 +1306,13 @@
       },
       "text": "Opponent −1 IP.",
       "flavor": "Haunting sponsored by a totally normal NGO.",
-      "artId": "halloween_spooktacular-Temp-Image"
+      "artId": "halloween_spooktacular-Temp-Image",
+      "tags": [
+        "attack",
+        "government",
+        "halloween",
+        "protest"
+      ]
     },
     {
       "id": "hallo-gov-spider-shuffle-063",
@@ -957,7 +1328,12 @@
       },
       "text": "Opponent −1 IP.",
       "flavor": "Approved by the Council of Shadows.",
-      "artId": "halloween_spooktacular-Temp-Image"
+      "artId": "halloween_spooktacular-Temp-Image",
+      "tags": [
+        "attack",
+        "government",
+        "halloween"
+      ]
     },
     {
       "id": "hallo-gov-candy-corn-whispers-064",
@@ -973,7 +1349,12 @@
       },
       "text": "Opponent −1 IP.",
       "flavor": "This is fine. Probably.",
-      "artId": "halloween_spooktacular-Temp-Image"
+      "artId": "halloween_spooktacular-Temp-Image",
+      "tags": [
+        "attack",
+        "government",
+        "halloween"
+      ]
     },
     {
       "id": "hallo-gov-moonlight-scare-initiative-065",
@@ -987,7 +1368,12 @@
       },
       "text": "−1% Truth.",
       "flavor": "All treats, suspicious tricks.",
-      "artId": "halloween_spooktacular-Temp-Image"
+      "artId": "halloween_spooktacular-Temp-Image",
+      "tags": [
+        "government",
+        "halloween",
+        "media"
+      ]
     },
     {
       "id": "hallo-gov-jack-o-lantern-rally-incident-066",
@@ -1001,7 +1387,13 @@
       },
       "text": "−1% Truth.",
       "flavor": "Do not taunt the poltergeist.",
-      "artId": "halloween_spooktacular-Temp-Image"
+      "artId": "halloween_spooktacular-Temp-Image",
+      "tags": [
+        "government",
+        "halloween",
+        "media",
+        "protest"
+      ]
     },
     {
       "id": "hallo-gov-full-moon-shenanigans-067",
@@ -1017,7 +1409,12 @@
       },
       "text": "Opponent −1 IP.",
       "flavor": "This is fine. Probably.",
-      "artId": "halloween_spooktacular-Temp-Image"
+      "artId": "halloween_spooktacular-Temp-Image",
+      "tags": [
+        "attack",
+        "government",
+        "halloween"
+      ]
     },
     {
       "id": "hallo-gov-wolfman-flyer-protocol-068",
@@ -1033,7 +1430,12 @@
       },
       "text": "Opponent −1 IP.",
       "flavor": "This is fine. Probably.",
-      "artId": "halloween_spooktacular-Temp-Image"
+      "artId": "halloween_spooktacular-Temp-Image",
+      "tags": [
+        "attack",
+        "government",
+        "halloween"
+      ]
     },
     {
       "id": "hallo-gov-brief-of-the-midnight-069",
@@ -1049,7 +1451,14 @@
       },
       "text": "Opponent −1 IP.",
       "flavor": "Haunting sponsored by a totally normal NGO.",
-      "artId": "halloween_spooktacular-Temp-Image"
+      "artId": "halloween_spooktacular-Temp-Image",
+      "tags": [
+        "attack",
+        "bureaucracy",
+        "coverup",
+        "government",
+        "halloween"
+      ]
     },
     {
       "id": "hallo-gov-witch-press-release-incident-070",
@@ -1065,7 +1474,13 @@
       },
       "text": "Opponent −1 IP.",
       "flavor": "Sticky with sugar and secrets.",
-      "artId": "halloween_spooktacular-Temp-Image"
+      "artId": "halloween_spooktacular-Temp-Image",
+      "tags": [
+        "attack",
+        "government",
+        "halloween",
+        "media"
+      ]
     },
     {
       "id": "hallo-gov-ghoul-sweep-initiative-001",
@@ -1081,7 +1496,12 @@
       },
       "text": "Opponent −2 IP.",
       "flavor": "Bring a flashlight and plausible deniability.",
-      "artId": "halloween_spooktacular-Temp-Image"
+      "artId": "halloween_spooktacular-Temp-Image",
+      "tags": [
+        "attack",
+        "government",
+        "halloween"
+      ]
     },
     {
       "id": "hallo-gov-bat-boy-operation-protocol-002",
@@ -1095,7 +1515,16 @@
       },
       "text": "−2% Truth.",
       "flavor": "This is fine. Probably.",
-      "artId": "halloween_spooktacular-Temp-Image"
+      "artId": "halloween_spooktacular-Temp-Image",
+      "tags": [
+        "bat-boy",
+        "bureaucracy",
+        "coverup",
+        "cryptid",
+        "government",
+        "halloween",
+        "media"
+      ]
     },
     {
       "id": "hallo-gov-broadcast-of-the-seance-003",
@@ -1109,7 +1538,12 @@
       },
       "text": "−2% Truth.",
       "flavor": "Whispers from the cornfield.",
-      "artId": "halloween_spooktacular-Temp-Image"
+      "artId": "halloween_spooktacular-Temp-Image",
+      "tags": [
+        "government",
+        "halloween",
+        "media"
+      ]
     },
     {
       "id": "hallo-gov-spooky-hayride-operation-initiative-004",
@@ -1125,7 +1559,14 @@
       },
       "text": "Opponent −2 IP.",
       "flavor": "All treats, suspicious tricks.",
-      "artId": "halloween_spooktacular-Temp-Image"
+      "artId": "halloween_spooktacular-Temp-Image",
+      "tags": [
+        "attack",
+        "bureaucracy",
+        "coverup",
+        "government",
+        "halloween"
+      ]
     },
     {
       "id": "hallo-gov-ploy-of-the-headless-horseman-005",
@@ -1141,7 +1582,12 @@
       },
       "text": "Opponent −2 IP.",
       "flavor": "Smells like fog machine and fear.",
-      "artId": "halloween_spooktacular-Temp-Image"
+      "artId": "halloween_spooktacular-Temp-Image",
+      "tags": [
+        "attack",
+        "government",
+        "halloween"
+      ]
     },
     {
       "id": "hallo-gov-jack-o-lantern-stakeout-006",
@@ -1157,7 +1603,12 @@
       },
       "text": "Opponent −2 IP.",
       "flavor": "Licensed spooktacular.",
-      "artId": "halloween_spooktacular-Temp-Image"
+      "artId": "halloween_spooktacular-Temp-Image",
+      "tags": [
+        "attack",
+        "government",
+        "halloween"
+      ]
     },
     {
       "id": "hallo-gov-poltergeist-murmur-network-incident-007",
@@ -1171,7 +1622,12 @@
       },
       "text": "−2% Truth.",
       "flavor": "Rated PG‑Paranoid.",
-      "artId": "halloween_spooktacular-Temp-Image"
+      "artId": "halloween_spooktacular-Temp-Image",
+      "tags": [
+        "government",
+        "halloween",
+        "media"
+      ]
     },
     {
       "id": "hallo-gov-moonlight-expedition-incident-008",
@@ -1185,7 +1641,12 @@
       },
       "text": "−2% Truth.",
       "flavor": "They came for the candy, stayed for the cover‑up.",
-      "artId": "halloween_spooktacular-Temp-Image"
+      "artId": "halloween_spooktacular-Temp-Image",
+      "tags": [
+        "government",
+        "halloween",
+        "media"
+      ]
     },
     {
       "id": "hallo-gov-seance-broadcast-incident-009",
@@ -1199,7 +1660,12 @@
       },
       "text": "−2% Truth.",
       "flavor": "Licensed spooktacular.",
-      "artId": "halloween_spooktacular-Temp-Image"
+      "artId": "halloween_spooktacular-Temp-Image",
+      "tags": [
+        "government",
+        "halloween",
+        "media"
+      ]
     },
     {
       "id": "hallo-gov-midnight-ploy-protocol-010",
@@ -1213,7 +1679,12 @@
       },
       "text": "−2% Truth.",
       "flavor": "Do not feed after midnight.",
-      "artId": "halloween_spooktacular-Temp-Image"
+      "artId": "halloween_spooktacular-Temp-Image",
+      "tags": [
+        "government",
+        "halloween",
+        "media"
+      ]
     },
     {
       "id": "hallo-gov-banshee-investigation-files-011",
@@ -1227,7 +1698,14 @@
       },
       "text": "−2% Truth.",
       "flavor": "Smells like fog machine and fear.",
-      "artId": "halloween_spooktacular-Temp-Image"
+      "artId": "halloween_spooktacular-Temp-Image",
+      "tags": [
+        "bureaucracy",
+        "coverup",
+        "government",
+        "halloween",
+        "media"
+      ]
     },
     {
       "id": "hallo-gov-poltergeist-expedition-012",
@@ -1243,7 +1721,12 @@
       },
       "text": "Opponent −2 IP.",
       "flavor": "Try not to scream on camera.",
-      "artId": "halloween_spooktacular-Temp-Image"
+      "artId": "halloween_spooktacular-Temp-Image",
+      "tags": [
+        "attack",
+        "government",
+        "halloween"
+      ]
     },
     {
       "id": "hallo-gov-graveyard-expedition-initiative-013",
@@ -1258,7 +1741,12 @@
       "text": "+2 Pressure in a chosen state.",
       "requiresTarget": true,
       "flavor": "Sticky with sugar and secrets.",
-      "artId": "halloween_spooktacular-Temp-Image"
+      "artId": "halloween_spooktacular-Temp-Image",
+      "tags": [
+        "government",
+        "halloween",
+        "zone"
+      ]
     },
     {
       "id": "hallo-gov-zombie-murmur-network-files-014",
@@ -1273,7 +1761,15 @@
       "text": "+2 Pressure in a chosen state.",
       "requiresTarget": true,
       "flavor": "Rated PG‑Paranoid.",
-      "artId": "halloween_spooktacular-Temp-Image"
+      "artId": "halloween_spooktacular-Temp-Image",
+      "tags": [
+        "bureaucracy",
+        "coverup",
+        "government",
+        "halloween",
+        "media",
+        "zone"
+      ]
     },
     {
       "id": "hallo-gov-haunted-mansion-ploy-protocol-015",
@@ -1287,7 +1783,14 @@
       },
       "text": "−2% Truth.",
       "flavor": "This is fine. Probably.",
-      "artId": "halloween_spooktacular-Temp-Image"
+      "artId": "halloween_spooktacular-Temp-Image",
+      "tags": [
+        "ghost",
+        "government",
+        "halloween",
+        "haunted",
+        "media"
+      ]
     },
     {
       "id": "hallo-gov-headless-horseman-investigation-initiative-016",
@@ -1302,7 +1805,12 @@
       "text": "+2 Pressure in a chosen state.",
       "requiresTarget": true,
       "flavor": "Mind the ectoplasm.",
-      "artId": "halloween_spooktacular-Temp-Image"
+      "artId": "halloween_spooktacular-Temp-Image",
+      "tags": [
+        "government",
+        "halloween",
+        "zone"
+      ]
     },
     {
       "id": "hallo-gov-headless-horseman-gambit-017",
@@ -1316,7 +1824,12 @@
       },
       "text": "−2% Truth.",
       "flavor": "Licensed spooktacular.",
-      "artId": "halloween_spooktacular-Temp-Image"
+      "artId": "halloween_spooktacular-Temp-Image",
+      "tags": [
+        "government",
+        "halloween",
+        "media"
+      ]
     },
     {
       "id": "hallo-gov-candy-corn-expedition-protocol-018",
@@ -1330,7 +1843,12 @@
       },
       "text": "−2% Truth.",
       "flavor": "This is fine. Probably.",
-      "artId": "halloween_spooktacular-Temp-Image"
+      "artId": "halloween_spooktacular-Temp-Image",
+      "tags": [
+        "government",
+        "halloween",
+        "media"
+      ]
     },
     {
       "id": "hallo-gov-banshee-broadcast-initiative-019",
@@ -1345,7 +1863,13 @@
       "text": "+2 Pressure in a chosen state.",
       "requiresTarget": true,
       "flavor": "They came for the candy, stayed for the cover‑up.",
-      "artId": "halloween_spooktacular-Temp-Image"
+      "artId": "halloween_spooktacular-Temp-Image",
+      "tags": [
+        "government",
+        "halloween",
+        "media",
+        "zone"
+      ]
     },
     {
       "id": "hallo-gov-spider-gambit-protocol-020",
@@ -1359,7 +1883,12 @@
       },
       "text": "−2% Truth.",
       "flavor": "Batteries not included.",
-      "artId": "halloween_spooktacular-Temp-Image"
+      "artId": "halloween_spooktacular-Temp-Image",
+      "tags": [
+        "government",
+        "halloween",
+        "media"
+      ]
     },
     {
       "id": "hallo-gov-revelation-of-the-graveyard-001",
@@ -1373,7 +1902,12 @@
       },
       "text": "−3% Truth.",
       "flavor": "They came for the candy, stayed for the cover‑up.",
-      "artId": "halloween_spooktacular-Temp-Image"
+      "artId": "halloween_spooktacular-Temp-Image",
+      "tags": [
+        "government",
+        "halloween",
+        "media"
+      ]
     },
     {
       "id": "hallo-gov-raven-revelation-initiative-002",
@@ -1387,7 +1921,12 @@
       },
       "text": "−3% Truth.",
       "flavor": "The crypt Wi‑Fi is excellent.",
-      "artId": "halloween_spooktacular-Temp-Image"
+      "artId": "halloween_spooktacular-Temp-Image",
+      "tags": [
+        "government",
+        "halloween",
+        "media"
+      ]
     },
     {
       "id": "hallo-gov-containment-of-the-cauldron-003",
@@ -1404,7 +1943,12 @@
       },
       "text": "Opponent −3 IP, discard 1.",
       "flavor": "Try not to scream on camera.",
-      "artId": "halloween_spooktacular-Temp-Image"
+      "artId": "halloween_spooktacular-Temp-Image",
+      "tags": [
+        "attack",
+        "government",
+        "halloween"
+      ]
     },
     {
       "id": "hallo-gov-banshee-prime-directive-files-004",
@@ -1418,7 +1962,14 @@
       },
       "text": "−3% Truth.",
       "flavor": "Try not to scream on camera.",
-      "artId": "halloween_spooktacular-Temp-Image"
+      "artId": "halloween_spooktacular-Temp-Image",
+      "tags": [
+        "bureaucracy",
+        "coverup",
+        "government",
+        "halloween",
+        "media"
+      ]
     },
     {
       "id": "hallo-gov-seance-containment-files-005",
@@ -1432,7 +1983,14 @@
       },
       "text": "−3% Truth.",
       "flavor": "Rated PG‑Paranoid.",
-      "artId": "halloween_spooktacular-Temp-Image"
+      "artId": "halloween_spooktacular-Temp-Image",
+      "tags": [
+        "bureaucracy",
+        "coverup",
+        "government",
+        "halloween",
+        "media"
+      ]
     },
     {
       "id": "hallo-gov-raven-project-protocol-006",
@@ -1446,7 +2004,14 @@
       },
       "text": "−3% Truth.",
       "flavor": "Filed under ‘Seasonal Anomalies’.",
-      "artId": "halloween_spooktacular-Temp-Image"
+      "artId": "halloween_spooktacular-Temp-Image",
+      "tags": [
+        "bureaucracy",
+        "coverup",
+        "government",
+        "halloween",
+        "media"
+      ]
     },
     {
       "id": "hallo-gov-moonlight-deep-cover-007",
@@ -1460,7 +2025,12 @@
       },
       "text": "−3% Truth.",
       "flavor": "Someone left the portal open again.",
-      "artId": "halloween_spooktacular-Temp-Image"
+      "artId": "halloween_spooktacular-Temp-Image",
+      "tags": [
+        "government",
+        "halloween",
+        "media"
+      ]
     },
     {
       "id": "hallo-truth-full-moon-pamphlet-initiative-001",
@@ -1474,7 +2044,12 @@
       },
       "text": "+1% Truth.",
       "flavor": "Do not taunt the poltergeist.",
-      "artId": "halloween_spooktacular-Temp-Image"
+      "artId": "halloween_spooktacular-Temp-Image",
+      "tags": [
+        "halloween",
+        "media",
+        "truth"
+      ]
     },
     {
       "id": "hallo-truth-trick-or-treat-press-release-incident-002",
@@ -1488,7 +2063,12 @@
       },
       "text": "+1% Truth.",
       "flavor": "Try not to scream on camera.",
-      "artId": "halloween_spooktacular-Temp-Image"
+      "artId": "halloween_spooktacular-Temp-Image",
+      "tags": [
+        "halloween",
+        "media",
+        "truth"
+      ]
     },
     {
       "id": "hallo-truth-seance-scare-protocol-003",
@@ -1504,7 +2084,12 @@
       },
       "text": "Opponent −1 IP.",
       "flavor": "Try not to scream on camera.",
-      "artId": "halloween_spooktacular-Temp-Image"
+      "artId": "halloween_spooktacular-Temp-Image",
+      "tags": [
+        "attack",
+        "halloween",
+        "truth"
+      ]
     },
     {
       "id": "hallo-truth-banshee-shuffle-004",
@@ -1520,7 +2105,12 @@
       },
       "text": "Opponent −1 IP.",
       "flavor": "They came for the candy, stayed for the cover‑up.",
-      "artId": "halloween_spooktacular-Temp-Image"
+      "artId": "halloween_spooktacular-Temp-Image",
+      "tags": [
+        "attack",
+        "halloween",
+        "truth"
+      ]
     },
     {
       "id": "hallo-truth-candy-corn-shuffle-protocol-005",
@@ -1534,7 +2124,12 @@
       },
       "text": "+1% Truth.",
       "flavor": "Mind the ectoplasm.",
-      "artId": "halloween_spooktacular-Temp-Image"
+      "artId": "halloween_spooktacular-Temp-Image",
+      "tags": [
+        "halloween",
+        "media",
+        "truth"
+      ]
     },
     {
       "id": "hallo-truth-scare-of-the-coven-006",
@@ -1548,7 +2143,12 @@
       },
       "text": "+1% Truth.",
       "flavor": "Mind the ectoplasm.",
-      "artId": "halloween_spooktacular-Temp-Image"
+      "artId": "halloween_spooktacular-Temp-Image",
+      "tags": [
+        "halloween",
+        "media",
+        "truth"
+      ]
     },
     {
       "id": "hallo-truth-spooky-hayride-pamphlet-files-007",
@@ -1563,7 +2163,15 @@
       "text": "+1 Pressure in a chosen state.",
       "requiresTarget": true,
       "flavor": "The veil is thin tonight.",
-      "artId": "halloween_spooktacular-Temp-Image"
+      "artId": "halloween_spooktacular-Temp-Image",
+      "tags": [
+        "bureaucracy",
+        "coverup",
+        "halloween",
+        "media",
+        "truth",
+        "zone"
+      ]
     },
     {
       "id": "hallo-truth-ouija-shenanigans-files-008",
@@ -1577,7 +2185,14 @@
       },
       "text": "+1% Truth.",
       "flavor": "They came for the candy, stayed for the cover‑up.",
-      "artId": "halloween_spooktacular-Temp-Image"
+      "artId": "halloween_spooktacular-Temp-Image",
+      "tags": [
+        "bureaucracy",
+        "coverup",
+        "halloween",
+        "media",
+        "truth"
+      ]
     },
     {
       "id": "hallo-truth-black-cat-shenanigans-files-009",
@@ -1591,7 +2206,14 @@
       },
       "text": "+1% Truth.",
       "flavor": "Licensed spooktacular.",
-      "artId": "halloween_spooktacular-Temp-Image"
+      "artId": "halloween_spooktacular-Temp-Image",
+      "tags": [
+        "bureaucracy",
+        "coverup",
+        "halloween",
+        "media",
+        "truth"
+      ]
     },
     {
       "id": "hallo-truth-candy-corn-rumor-010",
@@ -1607,7 +2229,12 @@
       },
       "text": "Opponent −1 IP.",
       "flavor": "Someone left the portal open again.",
-      "artId": "halloween_spooktacular-Temp-Image"
+      "artId": "halloween_spooktacular-Temp-Image",
+      "tags": [
+        "attack",
+        "halloween",
+        "truth"
+      ]
     },
     {
       "id": "hallo-truth-rumor-of-the-witch-011",
@@ -1622,7 +2249,12 @@
       "text": "+1 Pressure in a chosen state.",
       "requiresTarget": true,
       "flavor": "Red eyes in the rear-view mirror.",
-      "artId": "halloween_spooktacular-Temp-Image"
+      "artId": "halloween_spooktacular-Temp-Image",
+      "tags": [
+        "halloween",
+        "truth",
+        "zone"
+      ]
     },
     {
       "id": "hallo-truth-jack-o-lantern-press-release-protocol-012",
@@ -1637,7 +2269,13 @@
       "text": "+1 Pressure in a chosen state.",
       "requiresTarget": true,
       "flavor": "Sticky with sugar and secrets.",
-      "artId": "halloween_spooktacular-Temp-Image"
+      "artId": "halloween_spooktacular-Temp-Image",
+      "tags": [
+        "halloween",
+        "media",
+        "truth",
+        "zone"
+      ]
     },
     {
       "id": "hallo-truth-witch-report-013",
@@ -1653,7 +2291,15 @@
       },
       "text": "Opponent −1 IP.",
       "flavor": "Red eyes in the rear-view mirror.",
-      "artId": "halloween_spooktacular-Temp-Image"
+      "artId": "halloween_spooktacular-Temp-Image",
+      "tags": [
+        "attack",
+        "bureaucracy",
+        "coverup",
+        "halloween",
+        "media",
+        "truth"
+      ]
     },
     {
       "id": "hallo-truth-ghost-brief-protocol-014",
@@ -1667,7 +2313,16 @@
       },
       "text": "+1% Truth.",
       "flavor": "Someone left the portal open again.",
-      "artId": "halloween_spooktacular-Temp-Image"
+      "artId": "halloween_spooktacular-Temp-Image",
+      "tags": [
+        "bureaucracy",
+        "coverup",
+        "ghost",
+        "halloween",
+        "haunted",
+        "media",
+        "truth"
+      ]
     },
     {
       "id": "hallo-truth-raven-report-initiative-015",
@@ -1681,7 +2336,14 @@
       },
       "text": "+1% Truth.",
       "flavor": "This is fine. Probably.",
-      "artId": "halloween_spooktacular-Temp-Image"
+      "artId": "halloween_spooktacular-Temp-Image",
+      "tags": [
+        "bureaucracy",
+        "coverup",
+        "halloween",
+        "media",
+        "truth"
+      ]
     },
     {
       "id": "hallo-truth-ghost-report-initiative-016",
@@ -1695,7 +2357,16 @@
       },
       "text": "+1% Truth.",
       "flavor": "They came for the candy, stayed for the cover‑up.",
-      "artId": "halloween_spooktacular-Temp-Image"
+      "artId": "halloween_spooktacular-Temp-Image",
+      "tags": [
+        "bureaucracy",
+        "coverup",
+        "ghost",
+        "halloween",
+        "haunted",
+        "media",
+        "truth"
+      ]
     },
     {
       "id": "hallo-truth-alert-of-the-ghost-017",
@@ -1709,7 +2380,14 @@
       },
       "text": "+1% Truth.",
       "flavor": "We can neither confirm nor deny the howling.",
-      "artId": "halloween_spooktacular-Temp-Image"
+      "artId": "halloween_spooktacular-Temp-Image",
+      "tags": [
+        "ghost",
+        "halloween",
+        "haunted",
+        "media",
+        "truth"
+      ]
     },
     {
       "id": "hallo-truth-zombie-press-release-incident-018",
@@ -1723,7 +2401,12 @@
       },
       "text": "+1% Truth.",
       "flavor": "Licensed spooktacular.",
-      "artId": "halloween_spooktacular-Temp-Image"
+      "artId": "halloween_spooktacular-Temp-Image",
+      "tags": [
+        "halloween",
+        "media",
+        "truth"
+      ]
     },
     {
       "id": "hallo-truth-cemetery-press-release-initiative-019",
@@ -1737,7 +2420,12 @@
       },
       "text": "+1% Truth.",
       "flavor": "Rated PG‑Paranoid.",
-      "artId": "halloween_spooktacular-Temp-Image"
+      "artId": "halloween_spooktacular-Temp-Image",
+      "tags": [
+        "halloween",
+        "media",
+        "truth"
+      ]
     },
     {
       "id": "hallo-truth-rally-of-the-dracula-020",
@@ -1751,7 +2439,13 @@
       },
       "text": "+1% Truth.",
       "flavor": "Filed under ‘Seasonal Anomalies’.",
-      "artId": "halloween_spooktacular-Temp-Image"
+      "artId": "halloween_spooktacular-Temp-Image",
+      "tags": [
+        "halloween",
+        "media",
+        "protest",
+        "truth"
+      ]
     },
     {
       "id": "hallo-truth-seance-alert-incident-021",
@@ -1765,7 +2459,12 @@
       },
       "text": "+1% Truth.",
       "flavor": "Smells like fog machine and fear.",
-      "artId": "halloween_spooktacular-Temp-Image"
+      "artId": "halloween_spooktacular-Temp-Image",
+      "tags": [
+        "halloween",
+        "media",
+        "truth"
+      ]
     },
     {
       "id": "hallo-truth-cauldron-shuffle-protocol-022",
@@ -1779,7 +2478,12 @@
       },
       "text": "+1% Truth.",
       "flavor": "Sticky with sugar and secrets.",
-      "artId": "halloween_spooktacular-Temp-Image"
+      "artId": "halloween_spooktacular-Temp-Image",
+      "tags": [
+        "halloween",
+        "media",
+        "truth"
+      ]
     },
     {
       "id": "hallo-truth-poltergeist-scare-files-023",
@@ -1795,7 +2499,15 @@
       },
       "text": "Opponent −1 IP.",
       "flavor": "Try not to scream on camera.",
-      "artId": "halloween_spooktacular-Temp-Image"
+      "artId": "halloween_spooktacular-Temp-Image",
+      "tags": [
+        "attack",
+        "bureaucracy",
+        "coverup",
+        "halloween",
+        "media",
+        "truth"
+      ]
     },
     {
       "id": "hallo-truth-coven-shenanigans-024",
@@ -1811,7 +2523,12 @@
       },
       "text": "Opponent −1 IP.",
       "flavor": "Red eyes in the rear-view mirror.",
-      "artId": "halloween_spooktacular-Temp-Image"
+      "artId": "halloween_spooktacular-Temp-Image",
+      "tags": [
+        "attack",
+        "halloween",
+        "truth"
+      ]
     },
     {
       "id": "hallo-truth-whispers-of-the-skeleton-025",
@@ -1826,7 +2543,12 @@
       "text": "+1 Pressure in a chosen state.",
       "requiresTarget": true,
       "flavor": "Do not taunt the poltergeist.",
-      "artId": "halloween_spooktacular-Temp-Image"
+      "artId": "halloween_spooktacular-Temp-Image",
+      "tags": [
+        "halloween",
+        "truth",
+        "zone"
+      ]
     },
     {
       "id": "hallo-truth-midnight-shuffle-026",
@@ -1841,7 +2563,12 @@
       "text": "+1 Pressure in a chosen state.",
       "requiresTarget": true,
       "flavor": "Sticky with sugar and secrets.",
-      "artId": "halloween_spooktacular-Temp-Image"
+      "artId": "halloween_spooktacular-Temp-Image",
+      "tags": [
+        "halloween",
+        "truth",
+        "zone"
+      ]
     },
     {
       "id": "hallo-truth-trick-or-treat-brief-incident-027",
@@ -1857,7 +2584,14 @@
       },
       "text": "Opponent −1 IP.",
       "flavor": "Whispers from the cornfield.",
-      "artId": "halloween_spooktacular-Temp-Image"
+      "artId": "halloween_spooktacular-Temp-Image",
+      "tags": [
+        "attack",
+        "bureaucracy",
+        "coverup",
+        "halloween",
+        "truth"
+      ]
     },
     {
       "id": "hallo-truth-crypt-press-release-protocol-028",
@@ -1871,7 +2605,12 @@
       },
       "text": "+1% Truth.",
       "flavor": "We can neither confirm nor deny the howling.",
-      "artId": "halloween_spooktacular-Temp-Image"
+      "artId": "halloween_spooktacular-Temp-Image",
+      "tags": [
+        "halloween",
+        "media",
+        "truth"
+      ]
     },
     {
       "id": "hallo-truth-raven-press-release-029",
@@ -1886,7 +2625,13 @@
       "text": "+1 Pressure in a chosen state.",
       "requiresTarget": true,
       "flavor": "Try not to scream on camera.",
-      "artId": "halloween_spooktacular-Temp-Image"
+      "artId": "halloween_spooktacular-Temp-Image",
+      "tags": [
+        "halloween",
+        "media",
+        "truth",
+        "zone"
+      ]
     },
     {
       "id": "hallo-truth-witch-shuffle-incident-030",
@@ -1900,7 +2645,12 @@
       },
       "text": "+1% Truth.",
       "flavor": "Approved by the Council of Shadows.",
-      "artId": "halloween_spooktacular-Temp-Image"
+      "artId": "halloween_spooktacular-Temp-Image",
+      "tags": [
+        "halloween",
+        "media",
+        "truth"
+      ]
     },
     {
       "id": "hallo-truth-ghoul-pamphlet-initiative-031",
@@ -1915,7 +2665,12 @@
       "text": "+1 Pressure in a chosen state.",
       "requiresTarget": true,
       "flavor": "The crypt Wi‑Fi is excellent.",
-      "artId": "halloween_spooktacular-Temp-Image"
+      "artId": "halloween_spooktacular-Temp-Image",
+      "tags": [
+        "halloween",
+        "truth",
+        "zone"
+      ]
     },
     {
       "id": "hallo-truth-crypt-pamphlet-032",
@@ -1931,7 +2686,12 @@
       },
       "text": "Opponent −1 IP.",
       "flavor": "All treats, suspicious tricks.",
-      "artId": "halloween_spooktacular-Temp-Image"
+      "artId": "halloween_spooktacular-Temp-Image",
+      "tags": [
+        "attack",
+        "halloween",
+        "truth"
+      ]
     },
     {
       "id": "hallo-truth-headless-horseman-rally-incident-033",
@@ -1945,7 +2705,13 @@
       },
       "text": "+1% Truth.",
       "flavor": "Red eyes in the rear-view mirror.",
-      "artId": "halloween_spooktacular-Temp-Image"
+      "artId": "halloween_spooktacular-Temp-Image",
+      "tags": [
+        "halloween",
+        "media",
+        "protest",
+        "truth"
+      ]
     },
     {
       "id": "hallo-truth-headless-horseman-brief-034",
@@ -1961,7 +2727,14 @@
       },
       "text": "Opponent −1 IP.",
       "flavor": "Smells like fog machine and fear.",
-      "artId": "halloween_spooktacular-Temp-Image"
+      "artId": "halloween_spooktacular-Temp-Image",
+      "tags": [
+        "attack",
+        "bureaucracy",
+        "coverup",
+        "halloween",
+        "truth"
+      ]
     },
     {
       "id": "hallo-truth-jack-o-lantern-shuffle-incident-035",
@@ -1975,7 +2748,12 @@
       },
       "text": "+1% Truth.",
       "flavor": "Whispers from the cornfield.",
-      "artId": "halloween_spooktacular-Temp-Image"
+      "artId": "halloween_spooktacular-Temp-Image",
+      "tags": [
+        "halloween",
+        "media",
+        "truth"
+      ]
     },
     {
       "id": "hallo-truth-cobweb-alert-protocol-036",
@@ -1989,7 +2767,12 @@
       },
       "text": "+1% Truth.",
       "flavor": "Someone left the portal open again.",
-      "artId": "halloween_spooktacular-Temp-Image"
+      "artId": "halloween_spooktacular-Temp-Image",
+      "tags": [
+        "halloween",
+        "media",
+        "truth"
+      ]
     },
     {
       "id": "hallo-truth-rally-of-the-cauldron-037",
@@ -2003,7 +2786,13 @@
       },
       "text": "+1% Truth.",
       "flavor": "Mind the ectoplasm.",
-      "artId": "halloween_spooktacular-Temp-Image"
+      "artId": "halloween_spooktacular-Temp-Image",
+      "tags": [
+        "halloween",
+        "media",
+        "protest",
+        "truth"
+      ]
     },
     {
       "id": "hallo-truth-scare-of-the-zombie-038",
@@ -2017,7 +2806,12 @@
       },
       "text": "+1% Truth.",
       "flavor": "Batteries not included.",
-      "artId": "halloween_spooktacular-Temp-Image"
+      "artId": "halloween_spooktacular-Temp-Image",
+      "tags": [
+        "halloween",
+        "media",
+        "truth"
+      ]
     },
     {
       "id": "hallo-truth-haunted-mansion-flyer-protocol-039",
@@ -2032,7 +2826,14 @@
       "text": "+1 Pressure in a chosen state.",
       "requiresTarget": true,
       "flavor": "Red eyes in the rear-view mirror.",
-      "artId": "halloween_spooktacular-Temp-Image"
+      "artId": "halloween_spooktacular-Temp-Image",
+      "tags": [
+        "ghost",
+        "halloween",
+        "haunted",
+        "truth",
+        "zone"
+      ]
     },
     {
       "id": "hallo-truth-shuffle-of-the-spooky-hayride-040",
@@ -2048,7 +2849,12 @@
       },
       "text": "Opponent −1 IP.",
       "flavor": "Haunting sponsored by a totally normal NGO.",
-      "artId": "halloween_spooktacular-Temp-Image"
+      "artId": "halloween_spooktacular-Temp-Image",
+      "tags": [
+        "attack",
+        "halloween",
+        "truth"
+      ]
     },
     {
       "id": "hallo-truth-cauldron-brief-files-041",
@@ -2062,7 +2868,14 @@
       },
       "text": "+1% Truth.",
       "flavor": "Smells like fog machine and fear.",
-      "artId": "halloween_spooktacular-Temp-Image"
+      "artId": "halloween_spooktacular-Temp-Image",
+      "tags": [
+        "bureaucracy",
+        "coverup",
+        "halloween",
+        "media",
+        "truth"
+      ]
     },
     {
       "id": "hallo-truth-moonlight-report-042",
@@ -2078,7 +2891,15 @@
       },
       "text": "Opponent −1 IP.",
       "flavor": "Try not to scream on camera.",
-      "artId": "halloween_spooktacular-Temp-Image"
+      "artId": "halloween_spooktacular-Temp-Image",
+      "tags": [
+        "attack",
+        "bureaucracy",
+        "coverup",
+        "halloween",
+        "media",
+        "truth"
+      ]
     },
     {
       "id": "hallo-truth-haunted-mansion-alert-initiative-043",
@@ -2094,7 +2915,14 @@
       },
       "text": "Opponent −1 IP.",
       "flavor": "Mind the ectoplasm.",
-      "artId": "halloween_spooktacular-Temp-Image"
+      "artId": "halloween_spooktacular-Temp-Image",
+      "tags": [
+        "attack",
+        "ghost",
+        "halloween",
+        "haunted",
+        "truth"
+      ]
     },
     {
       "id": "hallo-truth-banshee-shuffle-protocol-044",
@@ -2109,7 +2937,12 @@
       "text": "+1 Pressure in a chosen state.",
       "requiresTarget": true,
       "flavor": "We can neither confirm nor deny the howling.",
-      "artId": "halloween_spooktacular-Temp-Image"
+      "artId": "halloween_spooktacular-Temp-Image",
+      "tags": [
+        "halloween",
+        "truth",
+        "zone"
+      ]
     },
     {
       "id": "hallo-truth-ouija-rally-initiative-045",
@@ -2125,7 +2958,13 @@
       },
       "text": "Opponent −1 IP.",
       "flavor": "All treats, suspicious tricks.",
-      "artId": "halloween_spooktacular-Temp-Image"
+      "artId": "halloween_spooktacular-Temp-Image",
+      "tags": [
+        "attack",
+        "halloween",
+        "protest",
+        "truth"
+      ]
     },
     {
       "id": "hallo-truth-banshee-shenanigans-files-046",
@@ -2139,7 +2978,14 @@
       },
       "text": "+1% Truth.",
       "flavor": "They came for the candy, stayed for the cover‑up.",
-      "artId": "halloween_spooktacular-Temp-Image"
+      "artId": "halloween_spooktacular-Temp-Image",
+      "tags": [
+        "bureaucracy",
+        "coverup",
+        "halloween",
+        "media",
+        "truth"
+      ]
     },
     {
       "id": "hallo-truth-frankenstein-brief-incident-047",
@@ -2154,7 +3000,14 @@
       "text": "+1 Pressure in a chosen state.",
       "requiresTarget": true,
       "flavor": "Licensed spooktacular.",
-      "artId": "halloween_spooktacular-Temp-Image"
+      "artId": "halloween_spooktacular-Temp-Image",
+      "tags": [
+        "bureaucracy",
+        "coverup",
+        "halloween",
+        "truth",
+        "zone"
+      ]
     },
     {
       "id": "hallo-truth-poltergeist-whispers-files-048",
@@ -2168,7 +3021,14 @@
       },
       "text": "+1% Truth.",
       "flavor": "Keep garlic handy.",
-      "artId": "halloween_spooktacular-Temp-Image"
+      "artId": "halloween_spooktacular-Temp-Image",
+      "tags": [
+        "bureaucracy",
+        "coverup",
+        "halloween",
+        "media",
+        "truth"
+      ]
     },
     {
       "id": "hallo-truth-candy-corn-shuffle-incident-049",
@@ -2182,7 +3042,12 @@
       },
       "text": "+1% Truth.",
       "flavor": "This is fine. Probably.",
-      "artId": "halloween_spooktacular-Temp-Image"
+      "artId": "halloween_spooktacular-Temp-Image",
+      "tags": [
+        "halloween",
+        "media",
+        "truth"
+      ]
     },
     {
       "id": "hallo-truth-spider-shenanigans-protocol-050",
@@ -2197,7 +3062,12 @@
       "text": "+1 Pressure in a chosen state.",
       "requiresTarget": true,
       "flavor": "They came for the candy, stayed for the cover‑up.",
-      "artId": "halloween_spooktacular-Temp-Image"
+      "artId": "halloween_spooktacular-Temp-Image",
+      "tags": [
+        "halloween",
+        "truth",
+        "zone"
+      ]
     },
     {
       "id": "hallo-truth-haunted-press-release-051",
@@ -2211,7 +3081,14 @@
       },
       "text": "+1% Truth.",
       "flavor": "Filed under ‘Seasonal Anomalies’.",
-      "artId": "halloween_spooktacular-Temp-Image"
+      "artId": "halloween_spooktacular-Temp-Image",
+      "tags": [
+        "ghost",
+        "halloween",
+        "haunted",
+        "media",
+        "truth"
+      ]
     },
     {
       "id": "hallo-truth-ouija-flyer-052",
@@ -2225,7 +3102,12 @@
       },
       "text": "+1% Truth.",
       "flavor": "Batteries not included.",
-      "artId": "halloween_spooktacular-Temp-Image"
+      "artId": "halloween_spooktacular-Temp-Image",
+      "tags": [
+        "halloween",
+        "media",
+        "truth"
+      ]
     },
     {
       "id": "hallo-truth-shuffle-of-the-dracula-053",
@@ -2241,7 +3123,12 @@
       },
       "text": "Opponent −1 IP.",
       "flavor": "Whispers from the cornfield.",
-      "artId": "halloween_spooktacular-Temp-Image"
+      "artId": "halloween_spooktacular-Temp-Image",
+      "tags": [
+        "attack",
+        "halloween",
+        "truth"
+      ]
     },
     {
       "id": "hallo-truth-ghost-report-protocol-054",
@@ -2257,7 +3144,17 @@
       },
       "text": "Opponent −1 IP.",
       "flavor": "We can neither confirm nor deny the howling.",
-      "artId": "halloween_spooktacular-Temp-Image"
+      "artId": "halloween_spooktacular-Temp-Image",
+      "tags": [
+        "attack",
+        "bureaucracy",
+        "coverup",
+        "ghost",
+        "halloween",
+        "haunted",
+        "media",
+        "truth"
+      ]
     },
     {
       "id": "hallo-truth-pamphlet-of-the-raven-055",
@@ -2271,7 +3168,12 @@
       },
       "text": "+1% Truth.",
       "flavor": "Haunting sponsored by a totally normal NGO.",
-      "artId": "halloween_spooktacular-Temp-Image"
+      "artId": "halloween_spooktacular-Temp-Image",
+      "tags": [
+        "halloween",
+        "media",
+        "truth"
+      ]
     },
     {
       "id": "hallo-truth-seance-shuffle-incident-056",
@@ -2287,7 +3189,12 @@
       },
       "text": "Opponent −1 IP.",
       "flavor": "Red eyes in the rear-view mirror.",
-      "artId": "halloween_spooktacular-Temp-Image"
+      "artId": "halloween_spooktacular-Temp-Image",
+      "tags": [
+        "attack",
+        "halloween",
+        "truth"
+      ]
     },
     {
       "id": "hallo-truth-pumpkin-rally-initiative-057",
@@ -2301,7 +3208,13 @@
       },
       "text": "+1% Truth.",
       "flavor": "Keep garlic handy.",
-      "artId": "halloween_spooktacular-Temp-Image"
+      "artId": "halloween_spooktacular-Temp-Image",
+      "tags": [
+        "halloween",
+        "media",
+        "protest",
+        "truth"
+      ]
     },
     {
       "id": "hallo-truth-black-cat-press-release-protocol-058",
@@ -2315,7 +3228,12 @@
       },
       "text": "+1% Truth.",
       "flavor": "Red eyes in the rear-view mirror.",
-      "artId": "halloween_spooktacular-Temp-Image"
+      "artId": "halloween_spooktacular-Temp-Image",
+      "tags": [
+        "halloween",
+        "media",
+        "truth"
+      ]
     },
     {
       "id": "hallo-truth-cemetery-rumor-initiative-059",
@@ -2329,7 +3247,12 @@
       },
       "text": "+1% Truth.",
       "flavor": "Try not to scream on camera.",
-      "artId": "halloween_spooktacular-Temp-Image"
+      "artId": "halloween_spooktacular-Temp-Image",
+      "tags": [
+        "halloween",
+        "media",
+        "truth"
+      ]
     },
     {
       "id": "hallo-truth-midnight-flyer-protocol-060",
@@ -2345,7 +3268,12 @@
       },
       "text": "Opponent −1 IP.",
       "flavor": "Red eyes in the rear-view mirror.",
-      "artId": "halloween_spooktacular-Temp-Image"
+      "artId": "halloween_spooktacular-Temp-Image",
+      "tags": [
+        "attack",
+        "halloween",
+        "truth"
+      ]
     },
     {
       "id": "hallo-truth-ghost-press-release-files-061",
@@ -2359,7 +3287,16 @@
       },
       "text": "+1% Truth.",
       "flavor": "Rated PG‑Paranoid.",
-      "artId": "halloween_spooktacular-Temp-Image"
+      "artId": "halloween_spooktacular-Temp-Image",
+      "tags": [
+        "bureaucracy",
+        "coverup",
+        "ghost",
+        "halloween",
+        "haunted",
+        "media",
+        "truth"
+      ]
     },
     {
       "id": "hallo-truth-pamphlet-of-the-ouija-062",
@@ -2374,7 +3311,12 @@
       "text": "+1 Pressure in a chosen state.",
       "requiresTarget": true,
       "flavor": "Filed under ‘Seasonal Anomalies’.",
-      "artId": "halloween_spooktacular-Temp-Image"
+      "artId": "halloween_spooktacular-Temp-Image",
+      "tags": [
+        "halloween",
+        "truth",
+        "zone"
+      ]
     },
     {
       "id": "hallo-truth-frankenstein-pamphlet-063",
@@ -2389,7 +3331,12 @@
       "text": "+1 Pressure in a chosen state.",
       "requiresTarget": true,
       "flavor": "Whispers from the cornfield.",
-      "artId": "halloween_spooktacular-Temp-Image"
+      "artId": "halloween_spooktacular-Temp-Image",
+      "tags": [
+        "halloween",
+        "truth",
+        "zone"
+      ]
     },
     {
       "id": "hallo-truth-ectoplasm-whispers-incident-064",
@@ -2405,7 +3352,12 @@
       },
       "text": "Opponent −1 IP.",
       "flavor": "Keep garlic handy.",
-      "artId": "halloween_spooktacular-Temp-Image"
+      "artId": "halloween_spooktacular-Temp-Image",
+      "tags": [
+        "attack",
+        "halloween",
+        "truth"
+      ]
     },
     {
       "id": "hallo-truth-crypt-flyer-initiative-065",
@@ -2419,7 +3371,12 @@
       },
       "text": "+1% Truth.",
       "flavor": "Do not feed after midnight.",
-      "artId": "halloween_spooktacular-Temp-Image"
+      "artId": "halloween_spooktacular-Temp-Image",
+      "tags": [
+        "halloween",
+        "media",
+        "truth"
+      ]
     },
     {
       "id": "hallo-truth-full-moon-brief-incident-066",
@@ -2434,7 +3391,14 @@
       "text": "+1 Pressure in a chosen state.",
       "requiresTarget": true,
       "flavor": "Red eyes in the rear-view mirror.",
-      "artId": "halloween_spooktacular-Temp-Image"
+      "artId": "halloween_spooktacular-Temp-Image",
+      "tags": [
+        "bureaucracy",
+        "coverup",
+        "halloween",
+        "truth",
+        "zone"
+      ]
     },
     {
       "id": "hallo-truth-spooky-hayride-rally-protocol-067",
@@ -2448,7 +3412,13 @@
       },
       "text": "+1% Truth.",
       "flavor": "Someone left the portal open again.",
-      "artId": "halloween_spooktacular-Temp-Image"
+      "artId": "halloween_spooktacular-Temp-Image",
+      "tags": [
+        "halloween",
+        "media",
+        "protest",
+        "truth"
+      ]
     },
     {
       "id": "hallo-truth-alert-of-the-skeleton-068",
@@ -2462,7 +3432,12 @@
       },
       "text": "+1% Truth.",
       "flavor": "Mind the ectoplasm.",
-      "artId": "halloween_spooktacular-Temp-Image"
+      "artId": "halloween_spooktacular-Temp-Image",
+      "tags": [
+        "halloween",
+        "media",
+        "truth"
+      ]
     },
     {
       "id": "hallo-truth-headless-horseman-whispers-protocol-069",
@@ -2478,7 +3453,12 @@
       },
       "text": "Opponent −1 IP.",
       "flavor": "The crypt Wi‑Fi is excellent.",
-      "artId": "halloween_spooktacular-Temp-Image"
+      "artId": "halloween_spooktacular-Temp-Image",
+      "tags": [
+        "attack",
+        "halloween",
+        "truth"
+      ]
     },
     {
       "id": "hallo-truth-candy-corn-press-release-initiative-070",
@@ -2494,7 +3474,13 @@
       },
       "text": "Opponent −1 IP.",
       "flavor": "Filed under ‘Seasonal Anomalies’.",
-      "artId": "halloween_spooktacular-Temp-Image"
+      "artId": "halloween_spooktacular-Temp-Image",
+      "tags": [
+        "attack",
+        "halloween",
+        "media",
+        "truth"
+      ]
     },
     {
       "id": "hallo-truth-graveyard-murmur-network-protocol-001",
@@ -2510,7 +3496,12 @@
       },
       "text": "Opponent −2 IP.",
       "flavor": "Keep garlic handy.",
-      "artId": "halloween_spooktacular-Temp-Image"
+      "artId": "halloween_spooktacular-Temp-Image",
+      "tags": [
+        "attack",
+        "halloween",
+        "truth"
+      ]
     },
     {
       "id": "hallo-truth-poltergeist-broadcast-files-002",
@@ -2526,7 +3517,15 @@
       },
       "text": "Opponent −2 IP.",
       "flavor": "Whispers from the cornfield.",
-      "artId": "halloween_spooktacular-Temp-Image"
+      "artId": "halloween_spooktacular-Temp-Image",
+      "tags": [
+        "attack",
+        "bureaucracy",
+        "coverup",
+        "halloween",
+        "media",
+        "truth"
+      ]
     },
     {
       "id": "hallo-truth-haunted-mansion-operation-003",
@@ -2542,7 +3541,16 @@
       },
       "text": "Opponent −2 IP.",
       "flavor": "Licensed spooktacular.",
-      "artId": "halloween_spooktacular-Temp-Image"
+      "artId": "halloween_spooktacular-Temp-Image",
+      "tags": [
+        "attack",
+        "bureaucracy",
+        "coverup",
+        "ghost",
+        "halloween",
+        "haunted",
+        "truth"
+      ]
     },
     {
       "id": "hallo-truth-spider-expedition-incident-004",
@@ -2558,7 +3566,12 @@
       },
       "text": "Opponent −2 IP.",
       "flavor": "Batteries not included.",
-      "artId": "halloween_spooktacular-Temp-Image"
+      "artId": "halloween_spooktacular-Temp-Image",
+      "tags": [
+        "attack",
+        "halloween",
+        "truth"
+      ]
     },
     {
       "id": "hallo-truth-haunted-mansion-expedition-protocol-005",
@@ -2572,7 +3585,14 @@
       },
       "text": "+2% Truth.",
       "flavor": "Bring a flashlight and plausible deniability.",
-      "artId": "halloween_spooktacular-Temp-Image"
+      "artId": "halloween_spooktacular-Temp-Image",
+      "tags": [
+        "ghost",
+        "halloween",
+        "haunted",
+        "media",
+        "truth"
+      ]
     },
     {
       "id": "hallo-truth-seance-sweep-006",
@@ -2586,7 +3606,12 @@
       },
       "text": "+2% Truth.",
       "flavor": "The crypt Wi‑Fi is excellent.",
-      "artId": "halloween_spooktacular-Temp-Image"
+      "artId": "halloween_spooktacular-Temp-Image",
+      "tags": [
+        "halloween",
+        "media",
+        "truth"
+      ]
     },
     {
       "id": "hallo-truth-trick-or-treat-ploy-007",
@@ -2600,7 +3625,12 @@
       },
       "text": "+2% Truth.",
       "flavor": "Batteries not included.",
-      "artId": "halloween_spooktacular-Temp-Image"
+      "artId": "halloween_spooktacular-Temp-Image",
+      "tags": [
+        "halloween",
+        "media",
+        "truth"
+      ]
     },
     {
       "id": "hallo-truth-graveyard-gambit-protocol-008",
@@ -2616,7 +3646,12 @@
       },
       "text": "Opponent −2 IP.",
       "flavor": "Bring a flashlight and plausible deniability.",
-      "artId": "halloween_spooktacular-Temp-Image"
+      "artId": "halloween_spooktacular-Temp-Image",
+      "tags": [
+        "attack",
+        "halloween",
+        "truth"
+      ]
     },
     {
       "id": "hallo-truth-cobweb-ploy-incident-009",
@@ -2630,7 +3665,12 @@
       },
       "text": "+2% Truth.",
       "flavor": "Do not feed after midnight.",
-      "artId": "halloween_spooktacular-Temp-Image"
+      "artId": "halloween_spooktacular-Temp-Image",
+      "tags": [
+        "halloween",
+        "media",
+        "truth"
+      ]
     },
     {
       "id": "hallo-truth-cauldron-gambit-protocol-010",
@@ -2645,7 +3685,12 @@
       "text": "+2 Pressure in a chosen state.",
       "requiresTarget": true,
       "flavor": "Mind the ectoplasm.",
-      "artId": "halloween_spooktacular-Temp-Image"
+      "artId": "halloween_spooktacular-Temp-Image",
+      "tags": [
+        "halloween",
+        "truth",
+        "zone"
+      ]
     },
     {
       "id": "hallo-truth-witch-operation-files-011",
@@ -2661,7 +3706,15 @@
       },
       "text": "Opponent −2 IP.",
       "flavor": "The crypt Wi‑Fi is excellent.",
-      "artId": "halloween_spooktacular-Temp-Image"
+      "artId": "halloween_spooktacular-Temp-Image",
+      "tags": [
+        "attack",
+        "bureaucracy",
+        "coverup",
+        "halloween",
+        "media",
+        "truth"
+      ]
     },
     {
       "id": "hallo-truth-seance-sweep-012",
@@ -2676,7 +3729,12 @@
       "text": "+2 Pressure in a chosen state.",
       "requiresTarget": true,
       "flavor": "Whispers from the cornfield.",
-      "artId": "halloween_spooktacular-Temp-Image"
+      "artId": "halloween_spooktacular-Temp-Image",
+      "tags": [
+        "halloween",
+        "truth",
+        "zone"
+      ]
     },
     {
       "id": "hallo-truth-zombie-murmur-network-013",
@@ -2690,7 +3748,12 @@
       },
       "text": "+2% Truth.",
       "flavor": "Licensed spooktacular.",
-      "artId": "halloween_spooktacular-Temp-Image"
+      "artId": "halloween_spooktacular-Temp-Image",
+      "tags": [
+        "halloween",
+        "media",
+        "truth"
+      ]
     },
     {
       "id": "hallo-truth-moonlight-operation-initiative-014",
@@ -2705,7 +3768,14 @@
       "text": "+2 Pressure in a chosen state.",
       "requiresTarget": true,
       "flavor": "Rated PG‑Paranoid.",
-      "artId": "halloween_spooktacular-Temp-Image"
+      "artId": "halloween_spooktacular-Temp-Image",
+      "tags": [
+        "bureaucracy",
+        "coverup",
+        "halloween",
+        "truth",
+        "zone"
+      ]
     },
     {
       "id": "hallo-truth-jack-o-lantern-broadcast-initiative-015",
@@ -2719,7 +3789,12 @@
       },
       "text": "+2% Truth.",
       "flavor": "They came for the candy, stayed for the cover‑up.",
-      "artId": "halloween_spooktacular-Temp-Image"
+      "artId": "halloween_spooktacular-Temp-Image",
+      "tags": [
+        "halloween",
+        "media",
+        "truth"
+      ]
     },
     {
       "id": "hallo-truth-ghoul-operation-initiative-016",
@@ -2733,7 +3808,14 @@
       },
       "text": "+2% Truth.",
       "flavor": "Keep garlic handy.",
-      "artId": "halloween_spooktacular-Temp-Image"
+      "artId": "halloween_spooktacular-Temp-Image",
+      "tags": [
+        "bureaucracy",
+        "coverup",
+        "halloween",
+        "media",
+        "truth"
+      ]
     },
     {
       "id": "hallo-truth-operation-of-the-mummy-017",
@@ -2749,7 +3831,14 @@
       },
       "text": "Opponent −2 IP.",
       "flavor": "Rated PG‑Paranoid.",
-      "artId": "halloween_spooktacular-Temp-Image"
+      "artId": "halloween_spooktacular-Temp-Image",
+      "tags": [
+        "attack",
+        "bureaucracy",
+        "coverup",
+        "halloween",
+        "truth"
+      ]
     },
     {
       "id": "hallo-truth-poltergeist-murmur-network-incident-018",
@@ -2763,7 +3852,12 @@
       },
       "text": "+2% Truth.",
       "flavor": "Someone left the portal open again.",
-      "artId": "halloween_spooktacular-Temp-Image"
+      "artId": "halloween_spooktacular-Temp-Image",
+      "tags": [
+        "halloween",
+        "media",
+        "truth"
+      ]
     },
     {
       "id": "hallo-truth-cobweb-ploy-initiative-019",
@@ -2777,7 +3871,12 @@
       },
       "text": "+2% Truth.",
       "flavor": "This is fine. Probably.",
-      "artId": "halloween_spooktacular-Temp-Image"
+      "artId": "halloween_spooktacular-Temp-Image",
+      "tags": [
+        "halloween",
+        "media",
+        "truth"
+      ]
     },
     {
       "id": "hallo-truth-headless-horseman-expedition-files-020",
@@ -2791,7 +3890,14 @@
       },
       "text": "+2% Truth.",
       "flavor": "Filed under ‘Seasonal Anomalies’.",
-      "artId": "halloween_spooktacular-Temp-Image"
+      "artId": "halloween_spooktacular-Temp-Image",
+      "tags": [
+        "bureaucracy",
+        "coverup",
+        "halloween",
+        "media",
+        "truth"
+      ]
     },
     {
       "id": "hallo-truth-mummy-sanction-001",
@@ -2808,7 +3914,12 @@
       },
       "text": "Opponent −3 IP, discard 1.",
       "flavor": "Do not taunt the poltergeist.",
-      "artId": "halloween_spooktacular-Temp-Image"
+      "artId": "halloween_spooktacular-Temp-Image",
+      "tags": [
+        "attack",
+        "halloween",
+        "truth"
+      ]
     },
     {
       "id": "hallo-truth-frankenstein-project-incident-002",
@@ -2822,7 +3933,14 @@
       },
       "text": "+3% Truth.",
       "flavor": "This is fine. Probably.",
-      "artId": "halloween_spooktacular-Temp-Image"
+      "artId": "halloween_spooktacular-Temp-Image",
+      "tags": [
+        "bureaucracy",
+        "coverup",
+        "halloween",
+        "media",
+        "truth"
+      ]
     },
     {
       "id": "hallo-truth-zombie-deep-cover-files-003",
@@ -2836,7 +3954,14 @@
       },
       "text": "+3% Truth.",
       "flavor": "Whispers from the cornfield.",
-      "artId": "halloween_spooktacular-Temp-Image"
+      "artId": "halloween_spooktacular-Temp-Image",
+      "tags": [
+        "bureaucracy",
+        "coverup",
+        "halloween",
+        "media",
+        "truth"
+      ]
     },
     {
       "id": "hallo-truth-cauldron-grand-ritual-protocol-004",
@@ -2851,7 +3976,12 @@
       "text": "+3 Pressure in a chosen state.",
       "requiresTarget": true,
       "flavor": "‘It was just the wind,’ said the intern.",
-      "artId": "halloween_spooktacular-Temp-Image"
+      "artId": "halloween_spooktacular-Temp-Image",
+      "tags": [
+        "halloween",
+        "truth",
+        "zone"
+      ]
     },
     {
       "id": "hallo-truth-spooky-hayride-revelation-005",
@@ -2868,7 +3998,12 @@
       },
       "text": "Opponent −3 IP, discard 1.",
       "flavor": "Try not to scream on camera.",
-      "artId": "halloween_spooktacular-Temp-Image"
+      "artId": "halloween_spooktacular-Temp-Image",
+      "tags": [
+        "attack",
+        "halloween",
+        "truth"
+      ]
     },
     {
       "id": "hallo-truth-ghoul-project-incident-006",
@@ -2885,7 +4020,14 @@
       },
       "text": "Opponent −3 IP, discard 1.",
       "flavor": "Red eyes in the rear-view mirror.",
-      "artId": "halloween_spooktacular-Temp-Image"
+      "artId": "halloween_spooktacular-Temp-Image",
+      "tags": [
+        "attack",
+        "bureaucracy",
+        "coverup",
+        "halloween",
+        "truth"
+      ]
     },
     {
       "id": "hallo-truth-cemetery-deep-cover-protocol-007",
@@ -2899,7 +4041,12 @@
       },
       "text": "+3% Truth.",
       "flavor": "Do not feed after midnight.",
-      "artId": "halloween_spooktacular-Temp-Image"
+      "artId": "halloween_spooktacular-Temp-Image",
+      "tags": [
+        "halloween",
+        "media",
+        "truth"
+      ]
     },
     {
       "id": "hallo-gov-operation-pumpkin-spice-legendary",
@@ -2913,7 +4060,14 @@
       },
       "text": "−4% Truth.",
       "flavor": "Approved by the Starbucks Council of Shadows.",
-      "artId": "halloween_spooktacular-Temp-Image"
+      "artId": "halloween_spooktacular-Temp-Image",
+      "tags": [
+        "bureaucracy",
+        "coverup",
+        "government",
+        "halloween",
+        "media"
+      ]
     },
     {
       "id": "hallo-gov-containment-protocol-dracula-legendary",
@@ -2927,7 +4081,12 @@
       },
       "text": "−3% Truth.",
       "flavor": "Stake, garlic, plausible deniability.",
-      "artId": "halloween_spooktacular-Temp-Image"
+      "artId": "halloween_spooktacular-Temp-Image",
+      "tags": [
+        "government",
+        "halloween",
+        "media"
+      ]
     },
     {
       "id": "hallo-gov-the-skeleton-army-rises-legendary",
@@ -2942,7 +4101,12 @@
       "text": "+3 Pressure in a chosen state.",
       "requiresTarget": true,
       "flavor": "From the boneyard to the ballot box.",
-      "artId": "halloween_spooktacular-Temp-Image"
+      "artId": "halloween_spooktacular-Temp-Image",
+      "tags": [
+        "government",
+        "halloween",
+        "zone"
+      ]
     },
     {
       "id": "hallo-truth-elvira-mistress-of-the-leaks-legendary",
@@ -2956,7 +4120,12 @@
       },
       "text": "+4% Truth.",
       "flavor": "Late-night camp, early-morning chaos.",
-      "artId": "halloween_spooktacular-Temp-Image"
+      "artId": "halloween_spooktacular-Temp-Image",
+      "tags": [
+        "halloween",
+        "media",
+        "truth"
+      ]
     },
     {
       "id": "hallo-truth-bat-boy-s-rebellion-legendary",
@@ -2973,7 +4142,14 @@
       },
       "text": "Opponent −4 IP, discard 2.",
       "flavor": "Finally escaped the tabloids — and he’s pissed.",
-      "artId": "halloween_spooktacular-Temp-Image"
+      "artId": "halloween_spooktacular-Temp-Image",
+      "tags": [
+        "attack",
+        "bat-boy",
+        "cryptid",
+        "halloween",
+        "truth"
+      ]
     },
     {
       "id": "hallo-truth-candy-apocalypse-legendary",
@@ -2990,7 +4166,12 @@
       },
       "text": "Opponent −3 IP, discard 1.",
       "flavor": "Too much sugar unleashes the truth.",
-      "artId": "halloween_spooktacular-Temp-Image"
+      "artId": "halloween_spooktacular-Temp-Image",
+      "tags": [
+        "attack",
+        "halloween",
+        "truth"
+      ]
     }
   ]
 }

--- a/scripts/tagCards.ts
+++ b/scripts/tagCards.ts
@@ -1,0 +1,140 @@
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+import {
+  applyNameHeuristics,
+  Card,
+  COVERUP_BUREAUCRACY_PATTERN,
+  DeckFile,
+  inferFactionTag,
+  inferTypeTag,
+  resolveExpansionTags,
+  TARGET_FILES,
+  uniqSort,
+} from './tagMaps';
+
+type ProcessResult = {
+  file: string;
+  changed: boolean;
+  count: number;
+};
+
+const mergeTags = (base: string[], extras: string[]) => uniqSort([...base, ...extras]);
+
+const ensureMinimums = (tags: string[], factionTag: string, typeTag: string, expansionTags: string[]) =>
+  uniqSort([...tags, factionTag, typeTag, ...expansionTags]);
+
+export const processCard = (file: string, card: Card): Card => {
+  const name = card.name || '';
+  const existing = Array.isArray(card.tags) ? card.tags : [];
+  const factionTag = inferFactionTag(file, card);
+  const typeTag = inferTypeTag(card);
+  const expansionTags = resolveExpansionTags(file);
+
+  let tags = mergeTags(existing, applyNameHeuristics(name));
+
+  const conflictingTag = factionTag === 'truth' ? 'government' : 'truth';
+  tags = tags.filter((tag) => tag !== conflictingTag);
+
+  if (COVERUP_BUREAUCRACY_PATTERN.test(name)) {
+    tags = mergeTags(tags, ['bureaucracy', 'coverup']);
+  }
+
+  tags = ensureMinimums(tags, factionTag, typeTag, expansionTags);
+
+  return { ...card, tags };
+};
+
+const loadJson = (p: string): unknown => JSON.parse(fs.readFileSync(p, 'utf-8'));
+
+const saveJson = (p: string, data: unknown) => fs.writeFileSync(p, JSON.stringify(data, null, 2) + '\n');
+
+const isCard = (value: unknown): value is Card => typeof value === 'object' && value !== null;
+
+const isCardArray = (value: unknown): value is Card[] => Array.isArray(value) && value.every(isCard);
+
+const isRecord = (value: unknown): value is Record<string, unknown> => typeof value === 'object' && value !== null;
+
+const processDeckFile = (file: DeckFile, checkOnly = false): ProcessResult => {
+  const full = path.resolve(process.cwd(), file);
+  if (!fs.existsSync(full)) {
+    console.warn(`[skip] Not found: ${file}`);
+    return { file, changed: false, count: 0 };
+  }
+
+  const data = loadJson(full);
+  let changed = false;
+  let count = 0;
+
+  const mutateCard = (c: Card) => processCard(file, c);
+
+  const before = JSON.stringify(data);
+
+  if (isCardArray(data)) {
+    for (let i = 0; i < data.length; i += 1) {
+      data[i] = mutateCard(data[i]);
+      count += 1;
+    }
+  } else if (isRecord(data)) {
+    const record = data;
+    const keys = ['cards', 'deck', 'data', 'list', 'items'];
+    let touched = false;
+    for (const key of keys) {
+      const value = record[key];
+      if (isCardArray(value)) {
+        record[key] = value.map(mutateCard);
+        count += value.length;
+        touched = true;
+      }
+    }
+    if (!touched) {
+      for (const [key, value] of Object.entries(record)) {
+        if (isCardArray(value)) {
+          record[key] = value.map(mutateCard);
+          count += value.length;
+        }
+      }
+    }
+  }
+
+  const after = JSON.stringify(data);
+  changed = before !== after;
+
+  if (!checkOnly && changed) {
+    saveJson(full, data);
+  }
+
+  return { file, changed, count };
+};
+
+export const runTagging = (checkOnly = false) => {
+  const results = TARGET_FILES.map((f) => processDeckFile(f, checkOnly));
+  const total = results.reduce((acc, result) => acc + result.count, 0);
+  const changed = results.filter((r) => r.changed).map((r) => r.file);
+
+  console.log(`Processed cards: ${total}`);
+  if (checkOnly) {
+    if (changed.length) {
+      console.error(`Tagging differences detected in: ${changed.join(', ')}`);
+      process.exitCode = 2;
+    } else {
+      console.log('All files already properly tagged.');
+    }
+  } else {
+    console.log(changed.length ? `Updated: ${changed.join(', ')}` : 'No changes needed.');
+  }
+
+  return { results, changed };
+};
+
+const main = () => {
+  const checkOnly = process.argv.includes('--check');
+  runTagging(checkOnly);
+};
+
+if (process.argv[1]?.endsWith('tagCards.ts')) {
+  main();
+}
+
+export { ensureMinimums, mergeTags, processDeckFile };
+

--- a/scripts/tagMaps.ts
+++ b/scripts/tagMaps.ts
@@ -1,0 +1,96 @@
+import * as path from 'node:path';
+
+export type Card = {
+  id?: string;
+  name?: string;
+  type?: 'ATTACK' | 'MEDIA' | 'ZONE' | string;
+  faction?: 'TRUTH' | 'GOV' | string;
+  tags?: string[];
+  [k: string]: unknown;
+};
+
+export type DeckFile = string;
+
+export type TagRule = {
+  pattern: RegExp;
+  tags: string[];
+};
+
+export const TARGET_FILES: DeckFile[] = [
+  'src/data/core/core_truth_MVP_balanced.json',
+  'src/data/core/core_government_MVP_balanced.json',
+  'public/extensions/cryptids.json',
+  'public/extensions/halloween_spooktacular_with_temp_image.json',
+];
+
+export const EXPANSION_HINT: Record<string, string[]> = {
+  'cryptids.json': ['cryptid'],
+  'halloween_spooktacular_with_temp_image.json': ['halloween'],
+};
+
+export const NAME_TAG_RULES: TagRule[] = [
+  { pattern: /\bbigfoot\b|\bsasquatch\b/i, tags: ['cryptid', 'bigfoot'] },
+  { pattern: /\bmothman\b/i, tags: ['cryptid', 'mothman'] },
+  { pattern: /\bbat[\s-]?boy\b/i, tags: ['bat-boy', 'cryptid'] },
+  { pattern: /\belvis\b/i, tags: ['elvis'] },
+  { pattern: /\bufo\b/i, tags: ['ufo'] },
+  { pattern: /\balien(s)?\b/i, tags: ['alien'] },
+  { pattern: /\broswell\b/i, tags: ['roswell'] },
+  { pattern: /\barea[\s-]?51\b/i, tags: ['area51'] },
+  { pattern: /\bghost\b|\bhaunted\b|\bspirit\b/i, tags: ['ghost', 'haunted'] },
+  { pattern: /\bflorida\b/i, tags: ['florida-man'] },
+  { pattern: /\bblue[\s-]?beam\b/i, tags: ['blue-beam'] },
+  { pattern: /\bmockingbird\b/i, tags: ['mockingbird'] },
+  { pattern: /\bchemtrail(s)?\b/i, tags: ['chemtrail'] },
+  { pattern: /\bmen in (black|charcoal)\b/i, tags: ['mib'] },
+  {
+    pattern: /\b(plaza|mall|swamp|woods|forest|lighthouse|stadium|cornfield|walmart|hangar|highway|park|tower)\b/i,
+    tags: ['location'],
+  },
+  {
+    pattern: /\b(press|report|files|memo|camera|leak|radio|tv|podcast|livestream|broadcast|tabloid)\b/i,
+    tags: ['media'],
+  },
+  { pattern: /\b(protest|rally|march)\b/i, tags: ['protest'] },
+];
+
+export const COVERUP_BUREAUCRACY_PATTERN = /\b(report|files|memo|brief|bureau|ministry|department|project|operation)\b/i;
+
+export const toKebab = (s: string) => s.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, '');
+
+export const uniqSort = (arr: string[]) => Array.from(new Set(arr.map(toKebab))).sort();
+
+export const applyNameHeuristics = (name: string): string[] => {
+  const tags: string[] = [];
+  for (const rule of NAME_TAG_RULES) {
+    if (rule.pattern.test(name)) {
+      tags.push(...rule.tags);
+    }
+  }
+  return tags;
+};
+
+export const inferFactionTag = (file: string, card: Card): string => {
+  const faction = (card.faction || '').toUpperCase();
+  if (faction === 'TRUTH' || /truth/i.test(file)) {
+    return 'truth';
+  }
+  if (faction === 'GOV' || faction === 'GOVERNMENT' || /govern/i.test(file)) {
+    return 'government';
+  }
+  return /ministry|department|bureau|protocol|official|brief/i.test(card.name || '') ? 'government' : 'truth';
+};
+
+export const inferTypeTag = (card: Card): string => {
+  const t = (card.type || '').toUpperCase();
+  if (t === 'ATTACK' || t === 'MEDIA' || t === 'ZONE') {
+    return t.toLowerCase();
+  }
+  return 'zone';
+};
+
+export const resolveExpansionTags = (file: string): string[] => {
+  const base = path.basename(file);
+  return EXPANSION_HINT[base] ?? [];
+};
+

--- a/src/data/core/core_government_MVP_balanced.json
+++ b/src/data/core/core_government_MVP_balanced.json
@@ -8,7 +8,11 @@
     "cost": 3,
     "effects": {
       "truthDelta": -1
-    }
+    },
+    "tags": [
+      "government",
+      "media"
+    ]
   },
   {
     "id": "GOV-002",
@@ -20,7 +24,11 @@
     "effects": {
       "truthDelta": -2
     },
-    "flavor": "The fewer words, the safer the world."
+    "flavor": "The fewer words, the safer the world.",
+    "tags": [
+      "government",
+      "media"
+    ]
   },
   {
     "id": "GOV-003",
@@ -34,7 +42,11 @@
         "opponent": 2
       }
     },
-    "flavor": "Democracy is great. Backups are greater."
+    "flavor": "Democracy is great. Backups are greater.",
+    "tags": [
+      "attack",
+      "government"
+    ]
   },
   {
     "id": "GOV-004",
@@ -46,7 +58,11 @@
     "effects": {
       "truthDelta": -1
     },
-    "flavor": "No windows, two clocks, three alarms."
+    "flavor": "No windows, two clocks, three alarms.",
+    "tags": [
+      "government",
+      "media"
+    ]
   },
   {
     "id": "GOV-005",
@@ -58,7 +74,11 @@
     "effects": {
       "truthDelta": -1
     },
-    "flavor": "Your transparency request is very important to us."
+    "flavor": "Your transparency request is very important to us.",
+    "tags": [
+      "government",
+      "media"
+    ]
   },
   {
     "id": "GOV-006",
@@ -70,7 +90,14 @@
     "effects": {
       "truthDelta": -3
     },
-    "flavor": "Tonight's top story was approved at noon."
+    "flavor": "Tonight's top story was approved at noon.",
+    "tags": [
+      "bureaucracy",
+      "coverup",
+      "government",
+      "media",
+      "mockingbird"
+    ]
   },
   {
     "id": "GOV-007",
@@ -82,7 +109,11 @@
     "effects": {
       "pressureDelta": 2
     },
-    "flavor": "In the interest of national serenity."
+    "flavor": "In the interest of national serenity.",
+    "tags": [
+      "government",
+      "zone"
+    ]
   },
   {
     "id": "GOV-008",
@@ -96,7 +127,11 @@
         "opponent": 1
       }
     },
-    "flavor": "Line items are a state of mind."
+    "flavor": "Line items are a state of mind.",
+    "tags": [
+      "attack",
+      "government"
+    ]
   },
   {
     "id": "GOV-009",
@@ -110,7 +145,12 @@
         "opponent": 2
       }
     },
-    "flavor": "They don't need badges when they have clipboards."
+    "flavor": "They don't need badges when they have clipboards.",
+    "tags": [
+      "attack",
+      "government",
+      "mib"
+    ]
   },
   {
     "id": "GOV-010",
@@ -122,7 +162,11 @@
     "effects": {
       "pressureDelta": 2
     },
-    "flavor": "The left hand files the right hand."
+    "flavor": "The left hand files the right hand.",
+    "tags": [
+      "government",
+      "zone"
+    ]
   },
   {
     "id": "GOV-011",
@@ -136,7 +180,11 @@
         "opponent": 1
       }
     },
-    "flavor": "Static is the sound of safety."
+    "flavor": "Static is the sound of safety.",
+    "tags": [
+      "attack",
+      "government"
+    ]
   },
   {
     "id": "GOV-012",
@@ -148,7 +196,11 @@
     "effects": {
       "truthDelta": -1
     },
-    "flavor": "Please cry on lines two and three."
+    "flavor": "Please cry on lines two and three.",
+    "tags": [
+      "government",
+      "media"
+    ]
   },
   {
     "id": "GOV-013",
@@ -160,7 +212,13 @@
     "effects": {
       "pressureDelta": 2
     },
-    "flavor": "Crates labeled 'Weather Balloon' (wink)."
+    "flavor": "Crates labeled 'Weather Balloon' (wink).",
+    "tags": [
+      "government",
+      "location",
+      "roswell",
+      "zone"
+    ]
   },
   {
     "id": "GOV-014",
@@ -172,7 +230,11 @@
     "effects": {
       "truthDelta": -3
     },
-    "flavor": "Your regularly scheduled reality will return shortly."
+    "flavor": "Your regularly scheduled reality will return shortly.",
+    "tags": [
+      "government",
+      "media"
+    ]
   },
   {
     "id": "GOV-015",
@@ -186,7 +248,11 @@
         "opponent": 1
       }
     },
-    "flavor": "If it beeped, we kept it."
+    "flavor": "If it beeped, we kept it.",
+    "tags": [
+      "attack",
+      "government"
+    ]
   },
   {
     "id": "GOV-016",
@@ -200,7 +266,11 @@
         "opponent": 1
       }
     },
-    "flavor": "We can neither confirm nor deny that we denied."
+    "flavor": "We can neither confirm nor deny that we denied.",
+    "tags": [
+      "attack",
+      "government"
+    ]
   },
   {
     "id": "GOV-017",
@@ -212,7 +282,11 @@
     "effects": {
       "truthDelta": -1
     },
-    "flavor": "Seats 12, alarms 13."
+    "flavor": "Seats 12, alarms 13.",
+    "tags": [
+      "government",
+      "media"
+    ]
   },
   {
     "id": "GOV-018",
@@ -224,7 +298,11 @@
     "effects": {
       "pressureDelta": 2
     },
-    "flavor": "Money laundering? Please, we dry-clean it."
+    "flavor": "Money laundering? Please, we dry-clean it.",
+    "tags": [
+      "government",
+      "zone"
+    ]
   },
   {
     "id": "GOV-019",
@@ -236,7 +314,11 @@
     "effects": {
       "truthDelta": -1
     },
-    "flavor": "Clip art is a weapon system."
+    "flavor": "Clip art is a weapon system.",
+    "tags": [
+      "government",
+      "media"
+    ]
   },
   {
     "id": "GOV-020",
@@ -250,7 +332,11 @@
         "opponent": 2
       }
     },
-    "flavor": "Sign here. Smile there."
+    "flavor": "Sign here. Smile there.",
+    "tags": [
+      "attack",
+      "government"
+    ]
   },
   {
     "id": "GOV-021",
@@ -262,7 +348,11 @@
     "effects": {
       "truthDelta": -2
     },
-    "flavor": "Gag orders pair well with coffee."
+    "flavor": "Gag orders pair well with coffee.",
+    "tags": [
+      "government",
+      "media"
+    ]
   },
   {
     "id": "GOV-022",
@@ -277,7 +367,13 @@
         "opponentPercent": 0.1
       }
     },
-    "flavor": "Zeroes are patriotic."
+    "flavor": "Zeroes are patriotic.",
+    "tags": [
+      "attack",
+      "ghost",
+      "government",
+      "haunted"
+    ]
   },
   {
     "id": "GOV-023",
@@ -289,7 +385,11 @@
     "effects": {
       "truthDelta": -1
     },
-    "flavor": "Shoes off. Beliefs off."
+    "flavor": "Shoes off. Beliefs off.",
+    "tags": [
+      "government",
+      "media"
+    ]
   },
   {
     "id": "GOV-024",
@@ -303,7 +403,11 @@
         "opponent": 1
       }
     },
-    "flavor": "Trust the trench coat."
+    "flavor": "Trust the trench coat.",
+    "tags": [
+      "attack",
+      "government"
+    ]
   },
   {
     "id": "GOV-025",
@@ -315,7 +419,11 @@
     "effects": {
       "truthDelta": -3
     },
-    "flavor": "The smoke alarm is for show."
+    "flavor": "The smoke alarm is for show.",
+    "tags": [
+      "government",
+      "media"
+    ]
   },
   {
     "id": "GOV-026",
@@ -327,7 +435,13 @@
     "effects": {
       "truthDelta": -1
     },
-    "flavor": "Filed under 'Sometime'."
+    "flavor": "Filed under 'Sometime'.",
+    "tags": [
+      "bureaucracy",
+      "coverup",
+      "government",
+      "media"
+    ]
   },
   {
     "id": "GOV-027",
@@ -339,7 +453,11 @@
     "effects": {
       "pressureDelta": 3
     },
-    "flavor": "Art, tunnels, and a lot of keycards."
+    "flavor": "Art, tunnels, and a lot of keycards.",
+    "tags": [
+      "government",
+      "zone"
+    ]
   },
   {
     "id": "GOV-028",
@@ -353,7 +471,11 @@
         "opponent": 1
       }
     },
-    "flavor": "You can hear them when it's too late."
+    "flavor": "You can hear them when it's too late.",
+    "tags": [
+      "attack",
+      "government"
+    ]
   },
   {
     "id": "GOV-029",
@@ -365,7 +487,11 @@
     "effects": {
       "truthDelta": -1
     },
-    "flavor": "History will vindicate page 47."
+    "flavor": "History will vindicate page 47.",
+    "tags": [
+      "government",
+      "media"
+    ]
   },
   {
     "id": "GOV-030",
@@ -377,7 +503,11 @@
     "effects": {
       "pressureDelta": 2
     },
-    "flavor": "Interoperability is its own language."
+    "flavor": "Interoperability is its own language.",
+    "tags": [
+      "government",
+      "zone"
+    ]
   },
   {
     "id": "GOV-031",
@@ -391,7 +521,11 @@
         "opponent": 2
       }
     },
-    "flavor": "Allegedly mandatory."
+    "flavor": "Allegedly mandatory.",
+    "tags": [
+      "attack",
+      "government"
+    ]
   },
   {
     "id": "GOV-032",
@@ -403,7 +537,11 @@
     "effects": {
       "truthDelta": -1
     },
-    "flavor": "Terms of service, revised."
+    "flavor": "Terms of service, revised.",
+    "tags": [
+      "government",
+      "media"
+    ]
   },
   {
     "id": "GOV-033",
@@ -415,7 +553,11 @@
     "effects": {
       "pressureDelta": 1
     },
-    "flavor": "Everything important is in row 51."
+    "flavor": "Everything important is in row 51.",
+    "tags": [
+      "government",
+      "zone"
+    ]
   },
   {
     "id": "GOV-034",
@@ -427,7 +569,11 @@
     "effects": {
       "truthDelta": -2
     },
-    "flavor": "Four Pinocchios wearing sunglasses."
+    "flavor": "Four Pinocchios wearing sunglasses.",
+    "tags": [
+      "government",
+      "media"
+    ]
   },
   {
     "id": "GOV-035",
@@ -441,7 +587,11 @@
         "opponent": 1
       }
     },
-    "flavor": "It's full of paper and power."
+    "flavor": "It's full of paper and power.",
+    "tags": [
+      "attack",
+      "government"
+    ]
   },
   {
     "id": "GOV-036",
@@ -453,7 +603,11 @@
     "effects": {
       "pressureDelta": 2
     },
-    "flavor": "Owls aren't what they seem. Neither are antennas."
+    "flavor": "Owls aren't what they seem. Neither are antennas.",
+    "tags": [
+      "government",
+      "zone"
+    ]
   },
   {
     "id": "GOV-037",
@@ -469,7 +623,11 @@
       },
       "discardOpponent": 1
     },
-    "flavor": "A handshake you don't wash off."
+    "flavor": "A handshake you don't wash off.",
+    "tags": [
+      "attack",
+      "government"
+    ]
   },
   {
     "id": "GOV-038",
@@ -483,7 +641,11 @@
         "opponent": 2
       }
     },
-    "flavor": "Forms first, outrage later."
+    "flavor": "Forms first, outrage later.",
+    "tags": [
+      "attack",
+      "government"
+    ]
   },
   {
     "id": "GOV-039",
@@ -495,7 +657,11 @@
     "effects": {
       "truthDelta": -1
     },
-    "flavor": "Coverage is a privilege."
+    "flavor": "Coverage is a privilege.",
+    "tags": [
+      "government",
+      "media"
+    ]
   },
   {
     "id": "GOV-040",
@@ -507,7 +673,11 @@
     "effects": {
       "truthDelta": -2
     },
-    "flavor": "Now with 30% more beeping."
+    "flavor": "Now with 30% more beeping.",
+    "tags": [
+      "government",
+      "media"
+    ]
   },
   {
     "id": "GOV-041",
@@ -519,7 +689,11 @@
     "effects": {
       "truthDelta": -3
     },
-    "flavor": "Justice is blindfolded and ear-plugged."
+    "flavor": "Justice is blindfolded and ear-plugged.",
+    "tags": [
+      "government",
+      "media"
+    ]
   },
   {
     "id": "GOV-042",
@@ -531,7 +705,11 @@
     "effects": {
       "pressureDelta": 1
     },
-    "flavor": "Manifest says 'miscellaneous'."
+    "flavor": "Manifest says 'miscellaneous'.",
+    "tags": [
+      "government",
+      "zone"
+    ]
   },
   {
     "id": "GOV-043",
@@ -543,7 +721,11 @@
     "effects": {
       "truthDelta": -2
     },
-    "flavor": "We A/B test reality."
+    "flavor": "We A/B test reality.",
+    "tags": [
+      "government",
+      "media"
+    ]
   },
   {
     "id": "GOV-044",
@@ -555,7 +737,11 @@
     "effects": {
       "pressureDelta": 2
     },
-    "flavor": "Keyholders unknown."
+    "flavor": "Keyholders unknown.",
+    "tags": [
+      "government",
+      "zone"
+    ]
   },
   {
     "id": "GOV-045",
@@ -567,7 +753,11 @@
     "effects": {
       "truthDelta": -1
     },
-    "flavor": "The salad blinks first."
+    "flavor": "The salad blinks first.",
+    "tags": [
+      "government",
+      "media"
+    ]
   },
   {
     "id": "GOV-046",
@@ -581,7 +771,11 @@
         "opponent": 3
       }
     },
-    "flavor": "Innovation you'll never hear about."
+    "flavor": "Innovation you'll never hear about.",
+    "tags": [
+      "attack",
+      "government"
+    ]
   },
   {
     "id": "GOV-047",
@@ -593,7 +787,11 @@
     "effects": {
       "pressureDelta": 3
     },
-    "flavor": "When the lights go out, these go on."
+    "flavor": "When the lights go out, these go on.",
+    "tags": [
+      "government",
+      "zone"
+    ]
   },
   {
     "id": "GOV-048",
@@ -607,7 +805,11 @@
         "opponent": 2
       }
     },
-    "flavor": "New name, same story—now quieter."
+    "flavor": "New name, same story—now quieter.",
+    "tags": [
+      "attack",
+      "government"
+    ]
   },
   {
     "id": "GOV-049",
@@ -619,7 +821,11 @@
     "effects": {
       "truthDelta": -4
     },
-    "flavor": "Minutes not taken. Decisions irreversible."
+    "flavor": "Minutes not taken. Decisions irreversible.",
+    "tags": [
+      "government",
+      "media"
+    ]
   },
   {
     "id": "GOV-050",
@@ -631,7 +837,11 @@
     "effects": {
       "truthDelta": -3
     },
-    "flavor": "It's not a cover-up if it's a comforter."
+    "flavor": "It's not a cover-up if it's a comforter.",
+    "tags": [
+      "government",
+      "media"
+    ]
   },
   {
     "id": "GOV-051",
@@ -645,7 +855,12 @@
         "opponent": 2
       }
     },
-    "flavor": "Nobody remembers the encounter… and that's the point."
+    "flavor": "Nobody remembers the encounter… and that's the point.",
+    "tags": [
+      "attack",
+      "government",
+      "mib"
+    ]
   },
   {
     "id": "GOV-052",
@@ -657,7 +872,11 @@
     "effects": {
       "pressureDelta": 2
     },
-    "flavor": "Forecast: 100% chance of plausible deniability."
+    "flavor": "Forecast: 100% chance of plausible deniability.",
+    "tags": [
+      "government",
+      "zone"
+    ]
   },
   {
     "id": "GOV-053",
@@ -669,7 +888,11 @@
     "effects": {
       "truthDelta": -3
     },
-    "flavor": "His smoke breaks last decades."
+    "flavor": "His smoke breaks last decades.",
+    "tags": [
+      "government",
+      "media"
+    ]
   },
   {
     "id": "GOV-054",
@@ -681,7 +904,14 @@
     "effects": {
       "truthDelta": -2
     },
-    "flavor": "Sponsored by your friendly neighborhood broadcast network."
+    "flavor": "Sponsored by your friendly neighborhood broadcast network.",
+    "tags": [
+      "bureaucracy",
+      "coverup",
+      "government",
+      "media",
+      "mockingbird"
+    ]
   },
   {
     "id": "GOV-055",
@@ -695,7 +925,11 @@
         "opponent": 1
       }
     },
-    "flavor": "Forms must be filed in triplicate, notarized, and burned."
+    "flavor": "Forms must be filed in triplicate, notarized, and burned.",
+    "tags": [
+      "attack",
+      "government"
+    ]
   },
   {
     "id": "GOV-056",
@@ -709,7 +943,11 @@
         "opponent": 1
       }
     },
-    "flavor": "Somewhere, in an Excel sheet nobody is allowed to open."
+    "flavor": "Somewhere, in an Excel sheet nobody is allowed to open.",
+    "tags": [
+      "attack",
+      "government"
+    ]
   },
   {
     "id": "GOV-057",
@@ -723,7 +961,12 @@
         "opponent": 3
       }
     },
-    "flavor": "Grainy VHS footage? Totally fake. Trust us."
+    "flavor": "Grainy VHS footage? Totally fake. Trust us.",
+    "tags": [
+      "alien",
+      "attack",
+      "government"
+    ]
   },
   {
     "id": "GOV-058",
@@ -735,7 +978,11 @@
     "effects": {
       "pressureDelta": 2
     },
-    "flavor": "You'll never find it on Google Maps."
+    "flavor": "You'll never find it on Google Maps.",
+    "tags": [
+      "government",
+      "zone"
+    ]
   },
   {
     "id": "GOV-059",
@@ -747,7 +994,11 @@
     "effects": {
       "truthDelta": -2
     },
-    "flavor": "For your safety. Definitely not ours."
+    "flavor": "For your safety. Definitely not ours.",
+    "tags": [
+      "government",
+      "media"
+    ]
   },
   {
     "id": "GOV-060",
@@ -759,7 +1010,11 @@
     "effects": {
       "truthDelta": -1
     },
-    "flavor": "It's in the water. Drink up."
+    "flavor": "It's in the water. Drink up.",
+    "tags": [
+      "government",
+      "media"
+    ]
   },
   {
     "id": "GOV-061",
@@ -772,7 +1027,13 @@
       "ipDelta": {
         "opponent": 1
       }
-    }
+    },
+    "tags": [
+      "attack",
+      "bureaucracy",
+      "coverup",
+      "government"
+    ]
   },
   {
     "id": "GOV-062",
@@ -786,7 +1047,11 @@
         "opponent": 3
       }
     },
-    "flavor": "He works for everyone. And no one."
+    "flavor": "He works for everyone. And no one.",
+    "tags": [
+      "attack",
+      "government"
+    ]
   },
   {
     "id": "GOV-063",
@@ -800,7 +1065,11 @@
         "opponent": 1
       }
     },
-    "flavor": "Please hold. Your conspiracy is important to us."
+    "flavor": "Please hold. Your conspiracy is important to us.",
+    "tags": [
+      "attack",
+      "government"
+    ]
   },
   {
     "id": "GOV-064",
@@ -812,7 +1081,11 @@
     "effects": {
       "pressureDelta": 1
     },
-    "flavor": "Your camera is on."
+    "flavor": "Your camera is on.",
+    "tags": [
+      "government",
+      "zone"
+    ]
   },
   {
     "id": "GOV-065",
@@ -826,7 +1099,11 @@
         "opponent": 2
       }
     },
-    "flavor": "Always in the background, always adjusting his tie."
+    "flavor": "Always in the background, always adjusting his tie.",
+    "tags": [
+      "attack",
+      "government"
+    ]
   },
   {
     "id": "GOV-066",
@@ -838,7 +1115,11 @@
     "effects": {
       "pressureDelta": 1
     },
-    "flavor": "Microfilm never dies."
+    "flavor": "Microfilm never dies.",
+    "tags": [
+      "government",
+      "zone"
+    ]
   },
   {
     "id": "GOV-067",
@@ -850,7 +1131,11 @@
     "effects": {
       "truthDelta": -2
     },
-    "flavor": "The narrative never rests."
+    "flavor": "The narrative never rests.",
+    "tags": [
+      "government",
+      "media"
+    ]
   },
   {
     "id": "GOV-068",
@@ -862,7 +1147,11 @@
     "effects": {
       "pressureDelta": 2
     },
-    "flavor": "Shiny wreckage becomes classified instantly."
+    "flavor": "Shiny wreckage becomes classified instantly.",
+    "tags": [
+      "government",
+      "zone"
+    ]
   },
   {
     "id": "GOV-069",
@@ -874,7 +1163,11 @@
     "effects": {
       "truthDelta": -1
     },
-    "flavor": "All cameras off, all lies on."
+    "flavor": "All cameras off, all lies on.",
+    "tags": [
+      "government",
+      "media"
+    ]
   },
   {
     "id": "GOV-070",
@@ -886,7 +1179,11 @@
     "effects": {
       "pressureDelta": 2
     },
-    "flavor": "Testing slogans on rats and voters alike."
+    "flavor": "Testing slogans on rats and voters alike.",
+    "tags": [
+      "government",
+      "zone"
+    ]
   },
   {
     "id": "GOV-071",
@@ -900,7 +1197,11 @@
         "opponent": 3
       }
     },
-    "flavor": "One ring controls all."
+    "flavor": "One ring controls all.",
+    "tags": [
+      "attack",
+      "government"
+    ]
   },
   {
     "id": "GOV-072",
@@ -912,7 +1213,11 @@
     "effects": {
       "pressureDelta": 1
     },
-    "flavor": "Cones, tape, and classified tape."
+    "flavor": "Cones, tape, and classified tape.",
+    "tags": [
+      "government",
+      "zone"
+    ]
   },
   {
     "id": "GOV-073",
@@ -926,7 +1231,13 @@
         "opponent": 1
       }
     },
-    "flavor": "The truth hurts, but pays well."
+    "flavor": "The truth hurts, but pays well.",
+    "tags": [
+      "attack",
+      "bureaucracy",
+      "coverup",
+      "government"
+    ]
   },
   {
     "id": "GOV-074",
@@ -938,7 +1249,11 @@
     "effects": {
       "pressureDelta": 1
     },
-    "flavor": "The shredder is always hungry."
+    "flavor": "The shredder is always hungry.",
+    "tags": [
+      "government",
+      "zone"
+    ]
   },
   {
     "id": "GOV-075",
@@ -952,7 +1267,11 @@
         "opponent": 1
       }
     },
-    "flavor": "Nothing to see, nothing to seize."
+    "flavor": "Nothing to see, nothing to seize.",
+    "tags": [
+      "attack",
+      "government"
+    ]
   },
   {
     "id": "GOV-076",
@@ -964,7 +1283,11 @@
     "effects": {
       "pressureDelta": 3
     },
-    "flavor": "█████████ everywhere."
+    "flavor": "█████████ everywhere.",
+    "tags": [
+      "government",
+      "zone"
+    ]
   },
   {
     "id": "GOV-077",
@@ -976,7 +1299,11 @@
     "effects": {
       "pressureDelta": 2
     },
-    "flavor": "Every ping is patriotism."
+    "flavor": "Every ping is patriotism.",
+    "tags": [
+      "government",
+      "zone"
+    ]
   },
   {
     "id": "GOV-078",
@@ -990,7 +1317,11 @@
         "opponent": 2
       }
     },
-    "flavor": "Bribes are the sincerest form of flattery."
+    "flavor": "Bribes are the sincerest form of flattery.",
+    "tags": [
+      "attack",
+      "government"
+    ]
   },
   {
     "id": "GOV-079",
@@ -1002,7 +1333,11 @@
     "effects": {
       "pressureDelta": 1
     },
-    "flavor": "Every crisis needs a committee."
+    "flavor": "Every crisis needs a committee.",
+    "tags": [
+      "government",
+      "zone"
+    ]
   },
   {
     "id": "GOV-080",
@@ -1014,7 +1349,11 @@
     "effects": {
       "pressureDelta": 3
     },
-    "flavor": "Built for a rainy doomsday."
+    "flavor": "Built for a rainy doomsday.",
+    "tags": [
+      "government",
+      "zone"
+    ]
   },
   {
     "id": "GOV-081",
@@ -1026,7 +1365,11 @@
     "effects": {
       "truthDelta": -3
     },
-    "flavor": "Prescription: more headlines."
+    "flavor": "Prescription: more headlines.",
+    "tags": [
+      "government",
+      "media"
+    ]
   },
   {
     "id": "GOV-082",
@@ -1038,7 +1381,11 @@
     "effects": {
       "pressureDelta": 3
     },
-    "flavor": "Their nightmares are our research notes."
+    "flavor": "Their nightmares are our research notes.",
+    "tags": [
+      "government",
+      "zone"
+    ]
   },
   {
     "id": "GOV-083",
@@ -1050,7 +1397,11 @@
     "effects": {
       "pressureDelta": 2
     },
-    "flavor": "We filed time under Pending."
+    "flavor": "We filed time under Pending.",
+    "tags": [
+      "government",
+      "zone"
+    ]
   },
   {
     "id": "GOV-084",
@@ -1065,7 +1416,11 @@
       }
     },
     "flavor": "Minutes vanish, so do freedoms.",
-    "orig_type": "MEDIA"
+    "orig_type": "MEDIA",
+    "tags": [
+      "attack",
+      "government"
+    ]
   },
   {
     "id": "GOV-085",
@@ -1077,7 +1432,11 @@
     "effects": {
       "pressureDelta": 1
     },
-    "flavor": "Looks legit, smells classified."
+    "flavor": "Looks legit, smells classified.",
+    "tags": [
+      "government",
+      "zone"
+    ]
   },
   {
     "id": "GOV-086",
@@ -1089,7 +1448,11 @@
     "effects": {
       "truthDelta": -1
     },
-    "flavor": "Your news, their loss."
+    "flavor": "Your news, their loss.",
+    "tags": [
+      "government",
+      "media"
+    ]
   },
   {
     "id": "GOV-087",
@@ -1101,7 +1464,11 @@
     "effects": {
       "truthDelta": -1
     },
-    "flavor": "We repeat until it becomes history."
+    "flavor": "We repeat until it becomes history.",
+    "tags": [
+      "government",
+      "media"
+    ]
   },
   {
     "id": "GOV-088",
@@ -1115,7 +1482,11 @@
         "opponent": 2
       }
     },
-    "flavor": "Intimidation is a safety feature."
+    "flavor": "Intimidation is a safety feature.",
+    "tags": [
+      "attack",
+      "government"
+    ]
   },
   {
     "id": "GOV-089",
@@ -1127,7 +1498,11 @@
     "effects": {
       "pressureDelta": 2
     },
-    "flavor": "Backups for backups."
+    "flavor": "Backups for backups.",
+    "tags": [
+      "government",
+      "zone"
+    ]
   },
   {
     "id": "GOV-090",
@@ -1139,7 +1514,11 @@
     "effects": {
       "pressureDelta": 1
     },
-    "flavor": "Roped-off narratives."
+    "flavor": "Roped-off narratives.",
+    "tags": [
+      "government",
+      "zone"
+    ]
   },
   {
     "id": "GOV-091",
@@ -1153,7 +1532,11 @@
         "opponent": 2
       }
     },
-    "flavor": "Forms first, outrage later."
+    "flavor": "Forms first, outrage later.",
+    "tags": [
+      "attack",
+      "government"
+    ]
   },
   {
     "id": "GOV-092",
@@ -1165,7 +1548,11 @@
     "effects": {
       "truthDelta": -2
     },
-    "flavor": "This is only a drill. Or is it?"
+    "flavor": "This is only a drill. Or is it?",
+    "tags": [
+      "government",
+      "media"
+    ]
   },
   {
     "id": "GOV-093",
@@ -1177,7 +1564,11 @@
     "effects": {
       "pressureDelta": 1
     },
-    "flavor": "The red light means 'welcome'."
+    "flavor": "The red light means 'welcome'.",
+    "tags": [
+      "government",
+      "zone"
+    ]
   },
   {
     "id": "GOV-094",
@@ -1191,7 +1582,11 @@
         "opponent": 1
       }
     },
-    "flavor": "Promotion to 'Elsewhere'."
+    "flavor": "Promotion to 'Elsewhere'.",
+    "tags": [
+      "attack",
+      "government"
+    ]
   },
   {
     "id": "GOV-095",
@@ -1203,7 +1598,11 @@
     "effects": {
       "pressureDelta": 2
     },
-    "flavor": "Interoperability is when everyone watches you together."
+    "flavor": "Interoperability is when everyone watches you together.",
+    "tags": [
+      "government",
+      "zone"
+    ]
   },
   {
     "id": "GOV-096",
@@ -1215,7 +1614,11 @@
     "effects": {
       "truthDelta": -1
     },
-    "flavor": "Peer review by peers we hired."
+    "flavor": "Peer review by peers we hired.",
+    "tags": [
+      "government",
+      "media"
+    ]
   },
   {
     "id": "GOV-097",
@@ -1227,7 +1630,11 @@
     "effects": {
       "pressureDelta": 2
     },
-    "flavor": "Owls aren't what they seem. Neither are antennas."
+    "flavor": "Owls aren't what they seem. Neither are antennas.",
+    "tags": [
+      "government",
+      "zone"
+    ]
   },
   {
     "id": "GOV-098",
@@ -1241,7 +1648,11 @@
         "opponent": 2
       }
     },
-    "flavor": "Gag orders pair well with coffee."
+    "flavor": "Gag orders pair well with coffee.",
+    "tags": [
+      "attack",
+      "government"
+    ]
   },
   {
     "id": "GOV-099",
@@ -1253,7 +1664,11 @@
     "effects": {
       "pressureDelta": 1
     },
-    "flavor": "We dry-clean money and reputations."
+    "flavor": "We dry-clean money and reputations.",
+    "tags": [
+      "government",
+      "zone"
+    ]
   },
   {
     "id": "GOV-100",
@@ -1265,7 +1680,11 @@
     "effects": {
       "pressureDelta": 1
     },
-    "flavor": "Manifest says 'miscellaneous'."
+    "flavor": "Manifest says 'miscellaneous'.",
+    "tags": [
+      "government",
+      "zone"
+    ]
   },
   {
     "id": "GOV-101",
@@ -1277,7 +1696,11 @@
     "effects": {
       "truthDelta": -3
     },
-    "flavor": "He lights the story before it's written."
+    "flavor": "He lights the story before it's written.",
+    "tags": [
+      "government",
+      "media"
+    ]
   },
   {
     "id": "GOV-102",
@@ -1292,7 +1715,11 @@
       },
       "discardOpponent": 1
     },
-    "flavor": "He shakes with one hand and pockets with the other."
+    "flavor": "He shakes with one hand and pockets with the other.",
+    "tags": [
+      "attack",
+      "government"
+    ]
   },
   {
     "id": "GOV-103",
@@ -1304,7 +1731,11 @@
     "effects": {
       "truthDelta": -2
     },
-    "flavor": "The agenda item is secrecy."
+    "flavor": "The agenda item is secrecy.",
+    "tags": [
+      "government",
+      "media"
+    ]
   },
   {
     "id": "GOV-104",
@@ -1316,7 +1747,11 @@
     "effects": {
       "pressureDelta": 1
     },
-    "flavor": "Unmarked, unlimited, unavailable."
+    "flavor": "Unmarked, unlimited, unavailable.",
+    "tags": [
+      "government",
+      "zone"
+    ]
   },
   {
     "id": "GOV-105",
@@ -1330,7 +1765,11 @@
         "opponent": 1
       }
     },
-    "flavor": "Everyone knows no one."
+    "flavor": "Everyone knows no one.",
+    "tags": [
+      "attack",
+      "government"
+    ]
   },
   {
     "id": "GOV-106",
@@ -1342,7 +1781,11 @@
     "effects": {
       "truthDelta": -1
     },
-    "flavor": "Routine. Repeated. Reassuring."
+    "flavor": "Routine. Repeated. Reassuring.",
+    "tags": [
+      "government",
+      "media"
+    ]
   },
   {
     "id": "GOV-107",
@@ -1354,7 +1797,11 @@
     "effects": {
       "pressureDelta": 2
     },
-    "flavor": "Bleach for inconvenient ink."
+    "flavor": "Bleach for inconvenient ink.",
+    "tags": [
+      "government",
+      "zone"
+    ]
   },
   {
     "id": "GOV-108",
@@ -1366,7 +1813,11 @@
     "effects": {
       "truthDelta": -2
     },
-    "flavor": "Perception is nine-tenths of reality."
+    "flavor": "Perception is nine-tenths of reality.",
+    "tags": [
+      "government",
+      "media"
+    ]
   },
   {
     "id": "GOV-109",
@@ -1378,7 +1829,11 @@
     "effects": {
       "pressureDelta": 1
     },
-    "flavor": "Subjects moved. Storyline removed."
+    "flavor": "Subjects moved. Storyline removed.",
+    "tags": [
+      "government",
+      "zone"
+    ]
   },
   {
     "id": "GOV-110",
@@ -1390,7 +1845,11 @@
     "effects": {
       "pressureDelta": 2
     },
-    "flavor": "The wind carries more than sand."
+    "flavor": "The wind carries more than sand.",
+    "tags": [
+      "government",
+      "zone"
+    ]
   },
   {
     "id": "GOV-111",
@@ -1404,7 +1863,11 @@
         "opponent": 2
       }
     },
-    "flavor": "The system defends itself."
+    "flavor": "The system defends itself.",
+    "tags": [
+      "attack",
+      "government"
+    ]
   },
   {
     "id": "GOV-112",
@@ -1418,7 +1881,11 @@
         "opponent": 3
       }
     },
-    "flavor": "Local control, centrally approved."
+    "flavor": "Local control, centrally approved.",
+    "tags": [
+      "attack",
+      "government"
+    ]
   },
   {
     "id": "GOV-113",
@@ -1430,7 +1897,11 @@
     "effects": {
       "pressureDelta": 1
     },
-    "flavor": "Fast track to nowhere you know."
+    "flavor": "Fast track to nowhere you know.",
+    "tags": [
+      "government",
+      "zone"
+    ]
   },
   {
     "id": "GOV-114",
@@ -1442,7 +1913,11 @@
     "effects": {
       "truthDelta": -2
     },
-    "flavor": "Blue checks for black ops."
+    "flavor": "Blue checks for black ops.",
+    "tags": [
+      "government",
+      "media"
+    ]
   },
   {
     "id": "GOV-115",
@@ -1454,7 +1929,11 @@
     "effects": {
       "truthDelta": -1
     },
-    "flavor": "A budget is a moral narrative."
+    "flavor": "A budget is a moral narrative.",
+    "tags": [
+      "government",
+      "media"
+    ]
   },
   {
     "id": "GOV-116",
@@ -1466,7 +1945,12 @@
     "effects": {
       "pressureDelta": 1
     },
-    "flavor": "Closed for renovations since forever."
+    "flavor": "Closed for renovations since forever.",
+    "tags": [
+      "government",
+      "location",
+      "zone"
+    ]
   },
   {
     "id": "GOV-117",
@@ -1481,7 +1965,12 @@
       }
     },
     "flavor": "Practice makes perfect headlines.",
-    "orig_type": "MEDIA"
+    "orig_type": "MEDIA",
+    "tags": [
+      "attack",
+      "government",
+      "media"
+    ]
   },
   {
     "id": "GOV-118",
@@ -1495,7 +1984,11 @@
         "opponent": 3
       }
     },
-    "flavor": "Numbers that never audit."
+    "flavor": "Numbers that never audit.",
+    "tags": [
+      "attack",
+      "government"
+    ]
   },
   {
     "id": "GOV-119",
@@ -1507,7 +2000,11 @@
     "effects": {
       "pressureDelta": 2
     },
-    "flavor": "Hold the cargo. Hold the narrative."
+    "flavor": "Hold the cargo. Hold the narrative.",
+    "tags": [
+      "government",
+      "zone"
+    ]
   },
   {
     "id": "GOV-120",
@@ -1521,7 +2018,11 @@
         "opponent": 2
       }
     },
-    "flavor": "Trust withdrawn at the speed of pen."
+    "flavor": "Trust withdrawn at the speed of pen.",
+    "tags": [
+      "attack",
+      "government"
+    ]
   },
   {
     "id": "GOV-121",
@@ -1535,7 +2036,11 @@
         "opponent": 3
       }
     },
-    "flavor": "Everything not nailed down becomes evidence."
+    "flavor": "Everything not nailed down becomes evidence.",
+    "tags": [
+      "attack",
+      "government"
+    ]
   },
   {
     "id": "GOV-122",
@@ -1547,7 +2052,11 @@
     "effects": {
       "pressureDelta": 1
     },
-    "flavor": "The filing cabinets hum ominously."
+    "flavor": "The filing cabinets hum ominously.",
+    "tags": [
+      "government",
+      "zone"
+    ]
   },
   {
     "id": "GOV-123",
@@ -1559,7 +2068,11 @@
     "effects": {
       "truthDelta": -2
     },
-    "flavor": "Access is a privilege with paperwork."
+    "flavor": "Access is a privilege with paperwork.",
+    "tags": [
+      "government",
+      "media"
+    ]
   },
   {
     "id": "GOV-124",
@@ -1571,7 +2084,11 @@
     "effects": {
       "truthDelta": -2
     },
-    "flavor": "Bring all voices into one key."
+    "flavor": "Bring all voices into one key.",
+    "tags": [
+      "government",
+      "media"
+    ]
   },
   {
     "id": "GOV-125",
@@ -1583,7 +2100,11 @@
     "effects": {
       "pressureDelta": 1
     },
-    "flavor": "Muted. Camera off. Case closed."
+    "flavor": "Muted. Camera off. Case closed.",
+    "tags": [
+      "government",
+      "zone"
+    ]
   },
   {
     "id": "GOV-126",
@@ -1597,7 +2118,11 @@
         "opponent": 1
       }
     },
-    "flavor": "Answer the question you weren't asked."
+    "flavor": "Answer the question you weren't asked.",
+    "tags": [
+      "attack",
+      "government"
+    ]
   },
   {
     "id": "GOV-127",
@@ -1609,7 +2134,11 @@
     "effects": {
       "truthDelta": -1
     },
-    "flavor": "Repetition is retention."
+    "flavor": "Repetition is retention.",
+    "tags": [
+      "government",
+      "media"
+    ]
   },
   {
     "id": "GOV-128",
@@ -1621,7 +2150,11 @@
     "effects": {
       "pressureDelta": 2
     },
-    "flavor": "The waters whisper; we record."
+    "flavor": "The waters whisper; we record.",
+    "tags": [
+      "government",
+      "zone"
+    ]
   },
   {
     "id": "GOV-129",
@@ -1635,7 +2168,11 @@
         "opponent": 1
       }
     },
-    "flavor": "We categorically decline reality."
+    "flavor": "We categorically decline reality.",
+    "tags": [
+      "attack",
+      "government"
+    ]
   },
   {
     "id": "GOV-130",
@@ -1649,7 +2186,11 @@
         "opponent": 1
       }
     },
-    "flavor": "Security patches for public perception."
+    "flavor": "Security patches for public perception.",
+    "tags": [
+      "attack",
+      "government"
+    ]
   },
   {
     "id": "GOV-131",
@@ -1661,7 +2202,11 @@
     "effects": {
       "pressureDelta": 3
     },
-    "flavor": "The best view is from behind glass."
+    "flavor": "The best view is from behind glass.",
+    "tags": [
+      "government",
+      "zone"
+    ]
   },
   {
     "id": "GOV-132",
@@ -1675,7 +2220,11 @@
         "opponent": 2
       }
     },
-    "flavor": "Cell B2 says you're compromised."
+    "flavor": "Cell B2 says you're compromised.",
+    "tags": [
+      "attack",
+      "government"
+    ]
   },
   {
     "id": "GOV-133",
@@ -1689,7 +2238,11 @@
         "opponent": 2
       }
     },
-    "flavor": "Stop motion truth."
+    "flavor": "Stop motion truth.",
+    "tags": [
+      "attack",
+      "government"
+    ]
   },
   {
     "id": "GOV-134",
@@ -1701,7 +2254,11 @@
     "effects": {
       "pressureDelta": 1
     },
-    "flavor": "All shipments marked 'later'."
+    "flavor": "All shipments marked 'later'.",
+    "tags": [
+      "government",
+      "zone"
+    ]
   },
   {
     "id": "GOV-135",
@@ -1713,7 +2270,11 @@
     "effects": {
       "truthDelta": -2
     },
-    "flavor": "Handshake, headline, hush."
+    "flavor": "Handshake, headline, hush.",
+    "tags": [
+      "government",
+      "media"
+    ]
   },
   {
     "id": "GOV-136",
@@ -1727,7 +2288,11 @@
         "opponent": 1
       }
     },
-    "flavor": "We read what matters. You read what remains."
+    "flavor": "We read what matters. You read what remains.",
+    "tags": [
+      "attack",
+      "government"
+    ]
   },
   {
     "id": "GOV-137",
@@ -1739,7 +2304,11 @@
     "effects": {
       "pressureDelta": 2
     },
-    "flavor": "Put the facts on ice."
+    "flavor": "Put the facts on ice.",
+    "tags": [
+      "government",
+      "zone"
+    ]
   },
   {
     "id": "GOV-138",
@@ -1754,7 +2323,11 @@
       },
       "discardOpponent": 1
     },
-    "flavor": "A warrant, a forklift, a silence."
+    "flavor": "A warrant, a forklift, a silence.",
+    "tags": [
+      "attack",
+      "government"
+    ]
   },
   {
     "id": "GOV-139",
@@ -1766,7 +2339,11 @@
     "effects": {
       "truthDelta": -1
     },
-    "flavor": "Precision-crafted statements of nothing."
+    "flavor": "Precision-crafted statements of nothing.",
+    "tags": [
+      "government",
+      "media"
+    ]
   },
   {
     "id": "GOV-140",
@@ -1781,7 +2358,11 @@
       }
     },
     "flavor": "Darken the lights, dim the doubts.",
-    "orig_type": "MEDIA"
+    "orig_type": "MEDIA",
+    "tags": [
+      "attack",
+      "government"
+    ]
   },
   {
     "id": "GOV-141",
@@ -1793,7 +2374,11 @@
     "effects": {
       "pressureDelta": 1
     },
-    "flavor": "Every track leads off-map."
+    "flavor": "Every track leads off-map.",
+    "tags": [
+      "government",
+      "zone"
+    ]
   },
   {
     "id": "GOV-142",
@@ -1805,7 +2390,11 @@
     "effects": {
       "pressureDelta": 2
     },
-    "flavor": "Partnerships need no sunlight."
+    "flavor": "Partnerships need no sunlight.",
+    "tags": [
+      "government",
+      "zone"
+    ]
   },
   {
     "id": "GOV-143",
@@ -1817,7 +2406,11 @@
     "effects": {
       "truthDelta": -2
     },
-    "flavor": "Missing context, found budget."
+    "flavor": "Missing context, found budget.",
+    "tags": [
+      "government",
+      "media"
+    ]
   },
   {
     "id": "GOV-144",
@@ -1829,7 +2422,11 @@
     "effects": {
       "pressureDelta": 2
     },
-    "flavor": "By the time you arrive, you're out of bounds."
+    "flavor": "By the time you arrive, you're out of bounds.",
+    "tags": [
+      "government",
+      "zone"
+    ]
   },
   {
     "id": "GOV-145",
@@ -1841,7 +2438,11 @@
     "effects": {
       "truthDelta": -3
     },
-    "flavor": "Your regularly scheduled reality has been rescheduled."
+    "flavor": "Your regularly scheduled reality has been rescheduled.",
+    "tags": [
+      "government",
+      "media"
+    ]
   },
   {
     "id": "GOV-146",
@@ -1853,7 +2454,11 @@
     "effects": {
       "truthDelta": -2
     },
-    "flavor": "Money talks. In code names."
+    "flavor": "Money talks. In code names.",
+    "tags": [
+      "government",
+      "media"
+    ]
   },
   {
     "id": "GOV-147",
@@ -1865,7 +2470,11 @@
     "effects": {
       "truthDelta": -4
     },
-    "flavor": "Decisions made above clearance."
+    "flavor": "Decisions made above clearance.",
+    "tags": [
+      "government",
+      "media"
+    ]
   },
   {
     "id": "GOV-148",
@@ -1879,7 +2488,11 @@
         "opponent": 1
       }
     },
-    "flavor": "Reality must adhere to policy."
+    "flavor": "Reality must adhere to policy.",
+    "tags": [
+      "attack",
+      "government"
+    ]
   },
   {
     "id": "GOV-149",
@@ -1893,7 +2506,11 @@
         "opponent": 2
       }
     },
-    "flavor": "A persistent storage problem."
+    "flavor": "A persistent storage problem.",
+    "tags": [
+      "attack",
+      "government"
+    ]
   },
   {
     "id": "GOV-150",
@@ -1905,7 +2522,11 @@
     "effects": {
       "truthDelta": -4
     },
-    "flavor": "When the room clears, the map has changed."
+    "flavor": "When the room clears, the map has changed.",
+    "tags": [
+      "government",
+      "media"
+    ]
   },
   {
     "id": "GOV-151",
@@ -1917,7 +2538,11 @@
     "effects": {
       "truthDelta": -2
     },
-    "flavor": "The fewer details, the greater the reassurance."
+    "flavor": "The fewer details, the greater the reassurance.",
+    "tags": [
+      "government",
+      "media"
+    ]
   },
   {
     "id": "GOV-152",
@@ -1929,7 +2554,13 @@
     "effects": {
       "truthDelta": -2
     },
-    "flavor": "Every talking point has a billing code."
+    "flavor": "Every talking point has a billing code.",
+    "tags": [
+      "bureaucracy",
+      "coverup",
+      "government",
+      "media"
+    ]
   },
   {
     "id": "GOV-153",
@@ -1941,7 +2572,11 @@
     "effects": {
       "truthDelta": -1
     },
-    "flavor": "Transparency occurs when no one's looking."
+    "flavor": "Transparency occurs when no one's looking.",
+    "tags": [
+      "government",
+      "media"
+    ]
   },
   {
     "id": "GOV-154",
@@ -1953,7 +2588,11 @@
     "effects": {
       "pressureDelta": 1
     },
-    "flavor": "Inbound: pallets of acronyms."
+    "flavor": "Inbound: pallets of acronyms.",
+    "tags": [
+      "government",
+      "zone"
+    ]
   },
   {
     "id": "GOV-155",
@@ -1965,7 +2604,11 @@
     "effects": {
       "truthDelta": -2
     },
-    "flavor": "Public oversight—privately conducted."
+    "flavor": "Public oversight—privately conducted.",
+    "tags": [
+      "government",
+      "media"
+    ]
   },
   {
     "id": "GOV-156",
@@ -1979,7 +2622,11 @@
         "opponent": 1
       }
     },
-    "flavor": "The signature is a wink."
+    "flavor": "The signature is a wink.",
+    "tags": [
+      "attack",
+      "government"
+    ]
   },
   {
     "id": "GOV-157",
@@ -1991,7 +2638,11 @@
     "effects": {
       "pressureDelta": 2
     },
-    "flavor": "Weather data, rumor data—air is air."
+    "flavor": "Weather data, rumor data—air is air.",
+    "tags": [
+      "government",
+      "zone"
+    ]
   },
   {
     "id": "GOV-158",
@@ -2006,7 +2657,14 @@
       }
     },
     "flavor": "If it leaks on time, it isn't an accident.",
-    "orig_type": "MEDIA"
+    "orig_type": "MEDIA",
+    "tags": [
+      "attack",
+      "bureaucracy",
+      "coverup",
+      "government",
+      "media"
+    ]
   },
   {
     "id": "GOV-159",
@@ -2020,7 +2678,11 @@
         "opponent": 3
       }
     },
-    "flavor": "A river of funds with no banks."
+    "flavor": "A river of funds with no banks.",
+    "tags": [
+      "attack",
+      "government"
+    ]
   },
   {
     "id": "GOV-160",
@@ -2032,7 +2694,11 @@
     "effects": {
       "pressureDelta": 1
     },
-    "flavor": "License, registration, and intentions."
+    "flavor": "License, registration, and intentions.",
+    "tags": [
+      "government",
+      "zone"
+    ]
   },
   {
     "id": "GOV-161",
@@ -2047,7 +2713,11 @@
       }
     },
     "flavor": "The story will be told later. Maybe.",
-    "orig_type": "MEDIA"
+    "orig_type": "MEDIA",
+    "tags": [
+      "attack",
+      "government"
+    ]
   },
   {
     "id": "GOV-162",
@@ -2059,7 +2729,11 @@
     "effects": {
       "pressureDelta": 2
     },
-    "flavor": "A file folder with doors."
+    "flavor": "A file folder with doors.",
+    "tags": [
+      "government",
+      "zone"
+    ]
   },
   {
     "id": "GOV-163",
@@ -2071,7 +2745,11 @@
     "effects": {
       "truthDelta": -1
     },
-    "flavor": "Questions pre-approved, answers pre-written."
+    "flavor": "Questions pre-approved, answers pre-written.",
+    "tags": [
+      "government",
+      "media"
+    ]
   },
   {
     "id": "GOV-164",
@@ -2083,7 +2761,11 @@
     "effects": {
       "pressureDelta": 1
     },
-    "flavor": "From somewhere to nowhere in one stop."
+    "flavor": "From somewhere to nowhere in one stop.",
+    "tags": [
+      "government",
+      "zone"
+    ]
   },
   {
     "id": "GOV-165",
@@ -2097,7 +2779,13 @@
         "opponent": 2
       }
     },
-    "flavor": "A quiet call at a loud hour."
+    "flavor": "A quiet call at a loud hour.",
+    "tags": [
+      "attack",
+      "bureaucracy",
+      "coverup",
+      "government"
+    ]
   },
   {
     "id": "GOV-166",
@@ -2111,7 +2799,11 @@
         "opponent": 1
       }
     },
-    "flavor": "Paperwork moves at the speed of ice."
+    "flavor": "Paperwork moves at the speed of ice.",
+    "tags": [
+      "attack",
+      "government"
+    ]
   },
   {
     "id": "GOV-167",
@@ -2123,7 +2815,11 @@
     "effects": {
       "pressureDelta": 2
     },
-    "flavor": "Passes available in theory."
+    "flavor": "Passes available in theory.",
+    "tags": [
+      "government",
+      "zone"
+    ]
   },
   {
     "id": "GOV-168",
@@ -2135,7 +2831,11 @@
     "effects": {
       "truthDelta": -2
     },
-    "flavor": "We pick what people remember."
+    "flavor": "We pick what people remember.",
+    "tags": [
+      "government",
+      "media"
+    ]
   },
   {
     "id": "GOV-169",
@@ -2147,7 +2847,11 @@
     "effects": {
       "pressureDelta": 1
     },
-    "flavor": "Jet fuel evaporates, rumors too."
+    "flavor": "Jet fuel evaporates, rumors too.",
+    "tags": [
+      "government",
+      "zone"
+    ]
   },
   {
     "id": "GOV-170",
@@ -2162,7 +2866,12 @@
       }
     },
     "flavor": "The abstract tells a comforting story.",
-    "orig_type": "MEDIA"
+    "orig_type": "MEDIA",
+    "tags": [
+      "attack",
+      "government",
+      "media"
+    ]
   },
   {
     "id": "GOV-171",
@@ -2174,7 +2883,11 @@
     "effects": {
       "truthDelta": -2
     },
-    "flavor": "Practice makes pressure."
+    "flavor": "Practice makes pressure.",
+    "tags": [
+      "government",
+      "media"
+    ]
   },
   {
     "id": "GOV-172",
@@ -2186,7 +2899,11 @@
     "effects": {
       "pressureDelta": 3
     },
-    "flavor": "The lock has a clearance."
+    "flavor": "The lock has a clearance.",
+    "tags": [
+      "government",
+      "zone"
+    ]
   },
   {
     "id": "GOV-173",
@@ -2200,7 +2917,11 @@
         "opponent": 1
       }
     },
-    "flavor": "The edit history is patriotic."
+    "flavor": "The edit history is patriotic.",
+    "tags": [
+      "attack",
+      "government"
+    ]
   },
   {
     "id": "GOV-174",
@@ -2212,7 +2933,11 @@
     "effects": {
       "pressureDelta": 2
     },
-    "flavor": "The tide waits on paperwork."
+    "flavor": "The tide waits on paperwork.",
+    "tags": [
+      "government",
+      "zone"
+    ]
   },
   {
     "id": "GOV-175",
@@ -2224,7 +2949,11 @@
     "effects": {
       "truthDelta": -4
     },
-    "flavor": "Every signal is a confession."
+    "flavor": "Every signal is a confession.",
+    "tags": [
+      "government",
+      "media"
+    ]
   },
   {
     "id": "GOV-176",
@@ -2238,7 +2967,12 @@
         "opponent": 2
       }
     },
-    "flavor": "Access revoked for service rendered."
+    "flavor": "Access revoked for service rendered.",
+    "tags": [
+      "attack",
+      "government",
+      "media"
+    ]
   },
   {
     "id": "GOV-177",
@@ -2250,7 +2984,11 @@
     "effects": {
       "pressureDelta": 1
     },
-    "flavor": "The map is the minefield."
+    "flavor": "The map is the minefield.",
+    "tags": [
+      "government",
+      "zone"
+    ]
   },
   {
     "id": "GOV-178",
@@ -2262,7 +3000,11 @@
     "effects": {
       "truthDelta": -3
     },
-    "flavor": "We keep talking so you don't have to think."
+    "flavor": "We keep talking so you don't have to think.",
+    "tags": [
+      "government",
+      "media"
+    ]
   },
   {
     "id": "GOV-179",
@@ -2276,7 +3018,11 @@
         "opponent": 1
       }
     },
-    "flavor": "A daisy chain of deniability."
+    "flavor": "A daisy chain of deniability.",
+    "tags": [
+      "attack",
+      "government"
+    ]
   },
   {
     "id": "GOV-180",
@@ -2288,7 +3034,11 @@
     "effects": {
       "pressureDelta": 1
     },
-    "flavor": "Miles of wings, gallons of dust."
+    "flavor": "Miles of wings, gallons of dust.",
+    "tags": [
+      "government",
+      "zone"
+    ]
   },
   {
     "id": "GOV-181",
@@ -2302,7 +3052,11 @@
         "opponent": 2
       }
     },
-    "flavor": "A paper wall is still a wall."
+    "flavor": "A paper wall is still a wall.",
+    "tags": [
+      "attack",
+      "government"
+    ]
   },
   {
     "id": "GOV-182",
@@ -2316,7 +3070,11 @@
         "opponent": 1
       }
     },
-    "flavor": "Budgets travel faster than rumors."
+    "flavor": "Budgets travel faster than rumors.",
+    "tags": [
+      "attack",
+      "government"
+    ]
   },
   {
     "id": "GOV-183",
@@ -2328,7 +3086,11 @@
     "effects": {
       "pressureDelta": 2
     },
-    "flavor": "The airwaves learn to lie."
+    "flavor": "The airwaves learn to lie.",
+    "tags": [
+      "government",
+      "zone"
+    ]
   },
   {
     "id": "GOV-184",
@@ -2340,7 +3102,11 @@
     "effects": {
       "truthDelta": -2
     },
-    "flavor": "A still surface hides any depth."
+    "flavor": "A still surface hides any depth.",
+    "tags": [
+      "government",
+      "media"
+    ]
   },
   {
     "id": "GOV-185",
@@ -2352,7 +3118,11 @@
     "effects": {
       "truthDelta": -2
     },
-    "flavor": "We overspent on silence."
+    "flavor": "We overspent on silence.",
+    "tags": [
+      "government",
+      "media"
+    ]
   },
   {
     "id": "GOV-186",
@@ -2364,7 +3134,11 @@
     "effects": {
       "pressureDelta": 3
     },
-    "flavor": "It only goes down."
+    "flavor": "It only goes down.",
+    "tags": [
+      "government",
+      "zone"
+    ]
   },
   {
     "id": "GOV-187",
@@ -2378,7 +3152,11 @@
         "opponent": 2
       }
     },
-    "flavor": "Answer yourself, on the record."
+    "flavor": "Answer yourself, on the record.",
+    "tags": [
+      "attack",
+      "government"
+    ]
   },
   {
     "id": "GOV-188",
@@ -2390,7 +3168,11 @@
     "effects": {
       "truthDelta": -4
     },
-    "flavor": "When the lights go out, the map stops moving."
+    "flavor": "When the lights go out, the map stops moving.",
+    "tags": [
+      "government",
+      "media"
+    ]
   },
   {
     "id": "GOV-189",
@@ -2402,7 +3184,12 @@
     "effects": {
       "pressureDelta": 2
     },
-    "flavor": "Authorized personnel invent authorization."
+    "flavor": "Authorized personnel invent authorization.",
+    "tags": [
+      "government",
+      "location",
+      "zone"
+    ]
   },
   {
     "id": "GOV-190",
@@ -2414,7 +3201,11 @@
     "effects": {
       "truthDelta": -2
     },
-    "flavor": "The best offense is a press release."
+    "flavor": "The best offense is a press release.",
+    "tags": [
+      "government",
+      "media"
+    ]
   },
   {
     "id": "GOV-191",
@@ -2426,7 +3217,11 @@
     "effects": {
       "truthDelta": -2
     },
-    "flavor": "The blinking lights mean it's working."
+    "flavor": "The blinking lights mean it's working.",
+    "tags": [
+      "government",
+      "media"
+    ]
   },
   {
     "id": "GOV-192",
@@ -2441,7 +3236,11 @@
       }
     },
     "flavor": "Every line ends in our pocket.",
-    "orig_type": "ZONE"
+    "orig_type": "ZONE",
+    "tags": [
+      "attack",
+      "government"
+    ]
   },
   {
     "id": "GOV-193",
@@ -2453,7 +3252,11 @@
     "effects": {
       "pressureDelta": 1
     },
-    "flavor": "Echoes of nothing important."
+    "flavor": "Echoes of nothing important.",
+    "tags": [
+      "government",
+      "zone"
+    ]
   },
   {
     "id": "GOV-194",
@@ -2465,7 +3268,11 @@
     "effects": {
       "truthDelta": -3
     },
-    "flavor": "A waterfall of 'no comment'."
+    "flavor": "A waterfall of 'no comment'.",
+    "tags": [
+      "government",
+      "media"
+    ]
   },
   {
     "id": "GOV-195",
@@ -2480,7 +3287,11 @@
       }
     },
     "flavor": "The stagehands run the show.",
-    "orig_type": "MEDIA"
+    "orig_type": "MEDIA",
+    "tags": [
+      "attack",
+      "government"
+    ]
   },
   {
     "id": "GOV-196",
@@ -2492,7 +3303,11 @@
     "effects": {
       "pressureDelta": 2
     },
-    "flavor": "Requests go in. Winters come out."
+    "flavor": "Requests go in. Winters come out.",
+    "tags": [
+      "government",
+      "zone"
+    ]
   },
   {
     "id": "GOV-197",
@@ -2504,7 +3319,11 @@
     "effects": {
       "pressureDelta": 1
     },
-    "flavor": "Evidence of control."
+    "flavor": "Evidence of control.",
+    "tags": [
+      "government",
+      "zone"
+    ]
   },
   {
     "id": "GOV-198",
@@ -2516,7 +3335,11 @@
     "effects": {
       "truthDelta": -1
     },
-    "flavor": "Lights out means mics off."
+    "flavor": "Lights out means mics off.",
+    "tags": [
+      "government",
+      "media"
+    ]
   },
   {
     "id": "GOV-199",
@@ -2528,7 +3351,11 @@
     "effects": {
       "truthDelta": -2
     },
-    "flavor": "Sources say sources exist."
+    "flavor": "Sources say sources exist.",
+    "tags": [
+      "government",
+      "media"
+    ]
   },
   {
     "id": "GOV-200",
@@ -2543,6 +3370,10 @@
       }
     },
     "flavor": "Even the shadow has a shadow.",
-    "orig_type": "MEDIA"
+    "orig_type": "MEDIA",
+    "tags": [
+      "attack",
+      "government"
+    ]
   }
 ]

--- a/src/data/core/core_truth_MVP_balanced.json
+++ b/src/data/core/core_truth_MVP_balanced.json
@@ -9,7 +9,13 @@
     "effects": {
       "truthDelta": 1
     },
-    "flavor": "Experts confirm: pixels don't lie."
+    "flavor": "Experts confirm: pixels don't lie.",
+    "tags": [
+      "bigfoot",
+      "cryptid",
+      "media",
+      "truth"
+    ]
   },
   {
     "id": "TRUTH-002",
@@ -21,7 +27,12 @@
     "effects": {
       "pressureDelta": 2
     },
-    "flavor": "The King recommends the midnight pancakes."
+    "flavor": "The King recommends the midnight pancakes.",
+    "tags": [
+      "elvis",
+      "truth",
+      "zone"
+    ]
   },
   {
     "id": "TRUTH-003",
@@ -33,7 +44,11 @@
     "effects": {
       "truthDelta": 3
     },
-    "flavor": "Sponsored by Doomsday Beans™."
+    "flavor": "Sponsored by Doomsday Beans™.",
+    "tags": [
+      "media",
+      "truth"
+    ]
   },
   {
     "id": "TRUTH-004",
@@ -45,7 +60,13 @@
     "effects": {
       "truthDelta": 2
     },
-    "flavor": "His platform: windows with no curtains."
+    "flavor": "His platform: windows with no curtains.",
+    "tags": [
+      "bat-boy",
+      "cryptid",
+      "media",
+      "truth"
+    ]
   },
   {
     "id": "TRUTH-005",
@@ -59,7 +80,12 @@
         "opponent": 1
       }
     },
-    "flavor": "Rice thrown… immediately abducted."
+    "flavor": "Rice thrown… immediately abducted.",
+    "tags": [
+      "alien",
+      "attack",
+      "truth"
+    ]
   },
   {
     "id": "TRUTH-006",
@@ -71,7 +97,11 @@
     "effects": {
       "truthDelta": 1
     },
-    "flavor": "They politely asked for tea."
+    "flavor": "They politely asked for tea.",
+    "tags": [
+      "media",
+      "truth"
+    ]
   },
   {
     "id": "TRUTH-007",
@@ -83,7 +113,12 @@
     "effects": {
       "pressureDelta": 2
     },
-    "flavor": "Halftime show beamed in from Andromeda."
+    "flavor": "Halftime show beamed in from Andromeda.",
+    "tags": [
+      "truth",
+      "ufo",
+      "zone"
+    ]
   },
   {
     "id": "TRUTH-008",
@@ -95,7 +130,11 @@
     "effects": {
       "truthDelta": 1
     },
-    "flavor": "#NoFilter #DefinitelyReal"
+    "flavor": "#NoFilter #DefinitelyReal",
+    "tags": [
+      "media",
+      "truth"
+    ]
   },
   {
     "id": "TRUTH-009",
@@ -109,7 +148,12 @@
         "opponent": 2
       }
     },
-    "flavor": "He composts the tabloids."
+    "flavor": "He composts the tabloids.",
+    "tags": [
+      "attack",
+      "elvis",
+      "truth"
+    ]
   },
   {
     "id": "TRUTH-010",
@@ -121,7 +165,11 @@
     "effects": {
       "truthDelta": 3
     },
-    "flavor": "Ink smudges reveal more than black bars."
+    "flavor": "Ink smudges reveal more than black bars.",
+    "tags": [
+      "media",
+      "truth"
+    ]
   },
   {
     "id": "TRUTH-011",
@@ -133,7 +181,11 @@
     "effects": {
       "truthDelta": 3
     },
-    "flavor": "Chat: 'first!'"
+    "flavor": "Chat: 'first!'",
+    "tags": [
+      "media",
+      "truth"
+    ]
   },
   {
     "id": "TRUTH-012",
@@ -145,7 +197,12 @@
     "effects": {
       "truthDelta": 1
     },
-    "flavor": "He brought snacks. Questionable snacks."
+    "flavor": "He brought snacks. Questionable snacks.",
+    "tags": [
+      "florida-man",
+      "media",
+      "truth"
+    ]
   },
   {
     "id": "TRUTH-013",
@@ -157,7 +214,13 @@
     "effects": {
       "pressureDelta": 2
     },
-    "flavor": "Tip jar shaped like a saucer."
+    "flavor": "Tip jar shaped like a saucer.",
+    "tags": [
+      "area51",
+      "elvis",
+      "truth",
+      "zone"
+    ]
   },
   {
     "id": "TRUTH-014",
@@ -171,7 +234,11 @@
         "opponent": 1
       }
     },
-    "flavor": "Phones are better than binoculars."
+    "flavor": "Phones are better than binoculars.",
+    "tags": [
+      "attack",
+      "truth"
+    ]
   },
   {
     "id": "TRUTH-015",
@@ -185,7 +252,11 @@
         "opponent": 2
       }
     },
-    "flavor": "BYO tractor."
+    "flavor": "BYO tractor.",
+    "tags": [
+      "attack",
+      "truth"
+    ]
   },
   {
     "id": "TRUTH-016",
@@ -200,7 +271,12 @@
         "opponentPercent": 0.08
       }
     },
-    "flavor": "The squeak heard round the world."
+    "flavor": "The squeak heard round the world.",
+    "tags": [
+      "attack",
+      "media",
+      "truth"
+    ]
   },
   {
     "id": "TRUTH-017",
@@ -212,7 +288,14 @@
     "effects": {
       "truthDelta": 3
     },
-    "flavor": "Historic handshake, very furry."
+    "flavor": "Historic handshake, very furry.",
+    "tags": [
+      "bat-boy",
+      "bigfoot",
+      "cryptid",
+      "media",
+      "truth"
+    ]
   },
   {
     "id": "TRUTH-018",
@@ -224,7 +307,13 @@
     "effects": {
       "truthDelta": 3
     },
-    "flavor": "Thank you, interstellar much."
+    "flavor": "Thank you, interstellar much.",
+    "tags": [
+      "elvis",
+      "media",
+      "truth",
+      "ufo"
+    ]
   },
   {
     "id": "TRUTH-019",
@@ -236,7 +325,14 @@
     "effects": {
       "pressureDelta": 2
     },
-    "flavor": "Rollback prices on cursed dolls."
+    "flavor": "Rollback prices on cursed dolls.",
+    "tags": [
+      "ghost",
+      "haunted",
+      "location",
+      "truth",
+      "zone"
+    ]
   },
   {
     "id": "TRUTH-020",
@@ -248,7 +344,12 @@
     "effects": {
       "pressureDelta": 3
     },
-    "flavor": "Free tractor rides included."
+    "flavor": "Free tractor rides included.",
+    "tags": [
+      "location",
+      "truth",
+      "zone"
+    ]
   },
   {
     "id": "TRUTH-021",
@@ -260,7 +361,13 @@
     "effects": {
       "pressureDelta": 3
     },
-    "flavor": "Please don't feed the senator."
+    "flavor": "Please don't feed the senator.",
+    "tags": [
+      "bigfoot",
+      "cryptid",
+      "truth",
+      "zone"
+    ]
   },
   {
     "id": "TRUTH-022",
@@ -272,7 +379,12 @@
     "effects": {
       "pressureDelta": 2
     },
-    "flavor": "Burning love, steady income."
+    "flavor": "Burning love, steady income.",
+    "tags": [
+      "elvis",
+      "truth",
+      "zone"
+    ]
   },
   {
     "id": "TRUTH-023",
@@ -284,7 +396,13 @@
     "effects": {
       "pressureDelta": 2
     },
-    "flavor": "Knitting needles levitate on Tuesdays."
+    "flavor": "Knitting needles levitate on Tuesdays.",
+    "tags": [
+      "ghost",
+      "haunted",
+      "truth",
+      "zone"
+    ]
   },
   {
     "id": "TRUTH-024",
@@ -296,7 +414,12 @@
     "effects": {
       "pressureDelta": 2
     },
-    "flavor": "Ink stains reveal hidden messages."
+    "flavor": "Ink stains reveal hidden messages.",
+    "tags": [
+      "media",
+      "truth",
+      "zone"
+    ]
   },
   {
     "id": "TRUTH-025",
@@ -308,7 +431,13 @@
     "effects": {
       "pressureDelta": 2
     },
-    "flavor": "Room service knocks itself."
+    "flavor": "Room service knocks itself.",
+    "tags": [
+      "ghost",
+      "haunted",
+      "truth",
+      "zone"
+    ]
   },
   {
     "id": "TRUTH-026",
@@ -320,7 +449,13 @@
     "effects": {
       "pressureDelta": 2
     },
-    "flavor": "Static carries secrets."
+    "flavor": "Static carries secrets.",
+    "tags": [
+      "location",
+      "media",
+      "truth",
+      "zone"
+    ]
   },
   {
     "id": "TRUTH-027",
@@ -332,7 +467,11 @@
     "effects": {
       "pressureDelta": 3
     },
-    "flavor": "Stamped 'definitely not a front'."
+    "flavor": "Stamped 'definitely not a front'.",
+    "tags": [
+      "truth",
+      "zone"
+    ]
   },
   {
     "id": "TRUTH-028",
@@ -344,7 +483,11 @@
     "effects": {
       "pressureDelta": 2
     },
-    "flavor": "No refunds on splash damage."
+    "flavor": "No refunds on splash damage.",
+    "tags": [
+      "truth",
+      "zone"
+    ]
   },
   {
     "id": "TRUTH-029",
@@ -356,7 +499,12 @@
     "effects": {
       "pressureDelta": 2
     },
-    "flavor": "Wax figures hum suspiciously on Thursdays."
+    "flavor": "Wax figures hum suspiciously on Thursdays.",
+    "tags": [
+      "elvis",
+      "truth",
+      "zone"
+    ]
   },
   {
     "id": "TRUTH-030",
@@ -368,7 +516,11 @@
     "effects": {
       "pressureDelta": 3
     },
-    "flavor": "Tilt-a-Whirl screams back."
+    "flavor": "Tilt-a-Whirl screams back.",
+    "tags": [
+      "truth",
+      "zone"
+    ]
   },
   {
     "id": "TRUTH-031",
@@ -382,7 +534,11 @@
         "opponent": 1
       }
     },
-    "flavor": "Family-pack protection."
+    "flavor": "Family-pack protection.",
+    "tags": [
+      "attack",
+      "truth"
+    ]
   },
   {
     "id": "TRUTH-032",
@@ -396,7 +552,12 @@
         "opponent": 2
       }
     },
-    "flavor": "AM band, PM truths."
+    "flavor": "AM band, PM truths.",
+    "tags": [
+      "attack",
+      "media",
+      "truth"
+    ]
   },
   {
     "id": "TRUTH-033",
@@ -410,7 +571,12 @@
         "opponent": 2
       }
     },
-    "flavor": "Front page beats front line."
+    "flavor": "Front page beats front line.",
+    "tags": [
+      "attack",
+      "media",
+      "truth"
+    ]
   },
   {
     "id": "TRUTH-034",
@@ -424,7 +590,13 @@
         "opponent": 2
       }
     },
-    "flavor": "They ain't afraid of your hand size."
+    "flavor": "They ain't afraid of your hand size.",
+    "tags": [
+      "attack",
+      "ghost",
+      "haunted",
+      "truth"
+    ]
   },
   {
     "id": "TRUTH-035",
@@ -439,7 +611,11 @@
         "opponentPercent": 0.08
       }
     },
-    "flavor": "Keynote featuring laser pointer to Orion."
+    "flavor": "Keynote featuring laser pointer to Orion.",
+    "tags": [
+      "attack",
+      "truth"
+    ]
   },
   {
     "id": "TRUTH-036",
@@ -453,7 +629,11 @@
         "opponent": 1
       }
     },
-    "flavor": "Hold, your call is very important to justice."
+    "flavor": "Hold, your call is very important to justice.",
+    "tags": [
+      "attack",
+      "truth"
+    ]
   },
   {
     "id": "TRUTH-037",
@@ -468,7 +648,11 @@
         "opponentPercent": 0.1
       }
     },
-    "flavor": "Uploaded by user 'ghost_admin'."
+    "flavor": "Uploaded by user 'ghost_admin'.",
+    "tags": [
+      "attack",
+      "truth"
+    ]
   },
   {
     "id": "TRUTH-038",
@@ -482,7 +666,11 @@
         "opponent": 2
       }
     },
-    "flavor": "Everybody saw something."
+    "flavor": "Everybody saw something.",
+    "tags": [
+      "attack",
+      "truth"
+    ]
   },
   {
     "id": "TRUTH-039",
@@ -498,7 +686,11 @@
       },
       "discardOpponent": 1
     },
-    "flavor": "Heavily unredacted, lightly folded."
+    "flavor": "Heavily unredacted, lightly folded.",
+    "tags": [
+      "attack",
+      "truth"
+    ]
   },
   {
     "id": "TRUTH-040",
@@ -512,7 +704,13 @@
         "opponent": 2
       }
     },
-    "flavor": "Those wings weren't for show."
+    "flavor": "Those wings weren't for show.",
+    "tags": [
+      "attack",
+      "cryptid",
+      "mothman",
+      "truth"
+    ]
   },
   {
     "id": "TRUTH-041",
@@ -524,7 +722,12 @@
     "effects": {
       "truthDelta": 1
     },
-    "flavor": "Cranial shine, divine design."
+    "flavor": "Cranial shine, divine design.",
+    "tags": [
+      "alien",
+      "media",
+      "truth"
+    ]
   },
   {
     "id": "TRUTH-042",
@@ -536,7 +739,11 @@
     "effects": {
       "truthDelta": 2
     },
-    "flavor": "Neighborhood eyes beat satellite spies."
+    "flavor": "Neighborhood eyes beat satellite spies.",
+    "tags": [
+      "media",
+      "truth"
+    ]
   },
   {
     "id": "TRUTH-043",
@@ -548,7 +755,12 @@
     "effects": {
       "pressureDelta": 2
     },
-    "flavor": "Chant louder, doubt quieter."
+    "flavor": "Chant louder, doubt quieter.",
+    "tags": [
+      "protest",
+      "truth",
+      "zone"
+    ]
   },
   {
     "id": "TRUTH-044",
@@ -560,7 +772,11 @@
     "effects": {
       "truthDelta": 3
     },
-    "flavor": "Invisible hands hold your hand."
+    "flavor": "Invisible hands hold your hand.",
+    "tags": [
+      "media",
+      "truth"
+    ]
   },
   {
     "id": "TRUTH-045",
@@ -572,7 +788,11 @@
     "effects": {
       "truthDelta": 2
     },
-    "flavor": "Broadcast jammed by cosmic drizzle."
+    "flavor": "Broadcast jammed by cosmic drizzle.",
+    "tags": [
+      "media",
+      "truth"
+    ]
   },
   {
     "id": "TRUTH-046",
@@ -584,7 +804,11 @@
     "effects": {
       "truthDelta": 3
     },
-    "flavor": "Many eyes, fewer lies."
+    "flavor": "Many eyes, fewer lies.",
+    "tags": [
+      "media",
+      "truth"
+    ]
   },
   {
     "id": "TRUTH-047",
@@ -596,7 +820,11 @@
     "effects": {
       "truthDelta": 2
     },
-    "flavor": "Coupons clipped from reality."
+    "flavor": "Coupons clipped from reality.",
+    "tags": [
+      "media",
+      "truth"
+    ]
   },
   {
     "id": "TRUTH-048",
@@ -608,7 +836,13 @@
     "effects": {
       "truthDelta": 2
     },
-    "flavor": "Socks for enormous feet sell out instantly."
+    "flavor": "Socks for enormous feet sell out instantly.",
+    "tags": [
+      "bigfoot",
+      "cryptid",
+      "media",
+      "truth"
+    ]
   },
   {
     "id": "TRUTH-049",
@@ -620,7 +854,12 @@
     "effects": {
       "truthDelta": 3
     },
-    "flavor": "All shook up… and tuned in."
+    "flavor": "All shook up… and tuned in.",
+    "tags": [
+      "elvis",
+      "media",
+      "truth"
+    ]
   },
   {
     "id": "TRUTH-050",
@@ -632,7 +871,13 @@
     "effects": {
       "truthDelta": 4
     },
-    "flavor": "Running for Senate (again)."
+    "flavor": "Running for Senate (again).",
+    "tags": [
+      "bat-boy",
+      "cryptid",
+      "media",
+      "truth"
+    ]
   },
   {
     "id": "TRUTH-051",
@@ -646,7 +891,13 @@
         "opponent": 1
       }
     },
-    "flavor": "Security was no match for flip-flops and fury."
+    "flavor": "Security was no match for flip-flops and fury.",
+    "tags": [
+      "attack",
+      "florida-man",
+      "truth",
+      "ufo"
+    ]
   },
   {
     "id": "TRUTH-052",
@@ -658,7 +909,13 @@
     "effects": {
       "pressureDelta": 2
     },
-    "flavor": "Campaign slogan: 'More Screams, Less Taxes.'"
+    "flavor": "Campaign slogan: 'More Screams, Less Taxes.'",
+    "tags": [
+      "bat-boy",
+      "cryptid",
+      "truth",
+      "zone"
+    ]
   },
   {
     "id": "TRUTH-053",
@@ -670,7 +927,12 @@
     "effects": {
       "truthDelta": 3
     },
-    "flavor": "Sunday service includes suspicious sequins."
+    "flavor": "Sunday service includes suspicious sequins.",
+    "tags": [
+      "elvis",
+      "media",
+      "truth"
+    ]
   },
   {
     "id": "TRUTH-054",
@@ -684,7 +946,13 @@
         "opponent": 1
       }
     },
-    "flavor": "Best at bedtime stories, worst at curfew."
+    "flavor": "Best at bedtime stories, worst at curfew.",
+    "tags": [
+      "alien",
+      "attack",
+      "media",
+      "truth"
+    ]
   },
   {
     "id": "TRUTH-055",
@@ -696,7 +964,13 @@
     "effects": {
       "pressureDelta": 2
     },
-    "flavor": "Thank you, fried much."
+    "flavor": "Thank you, fried much.",
+    "tags": [
+      "elvis",
+      "roswell",
+      "truth",
+      "zone"
+    ]
   },
   {
     "id": "TRUTH-056",
@@ -708,7 +982,12 @@
     "effects": {
       "truthDelta": 1
     },
-    "flavor": "Powered entirely by gator energy drinks."
+    "flavor": "Powered entirely by gator energy drinks.",
+    "tags": [
+      "florida-man",
+      "media",
+      "truth"
+    ]
   },
   {
     "id": "TRUTH-057",
@@ -720,7 +999,13 @@
     "effects": {
       "truthDelta": 1
     },
-    "flavor": "Comment section full of ghosts."
+    "flavor": "Comment section full of ghosts.",
+    "tags": [
+      "ghost",
+      "haunted",
+      "media",
+      "truth"
+    ]
   },
   {
     "id": "TRUTH-058",
@@ -734,7 +1019,11 @@
         "opponent": 2
       }
     },
-    "flavor": "Sprinkles cover more than sugar."
+    "flavor": "Sprinkles cover more than sugar.",
+    "tags": [
+      "attack",
+      "truth"
+    ]
   },
   {
     "id": "TRUTH-059",
@@ -746,7 +1035,13 @@
     "effects": {
       "truthDelta": 3
     },
-    "flavor": "Major: Paranormal Political Science."
+    "flavor": "Major: Paranormal Political Science.",
+    "tags": [
+      "bat-boy",
+      "cryptid",
+      "media",
+      "truth"
+    ]
   },
   {
     "id": "TRUTH-060",
@@ -758,7 +1053,12 @@
     "effects": {
       "pressureDelta": 2
     },
-    "flavor": "Corn dogs and hound dogs."
+    "flavor": "Corn dogs and hound dogs.",
+    "tags": [
+      "elvis",
+      "truth",
+      "zone"
+    ]
   },
   {
     "id": "TRUTH-061",
@@ -770,7 +1070,13 @@
     "effects": {
       "truthDelta": 1
     },
-    "flavor": "The aliens subscribed instantly."
+    "flavor": "The aliens subscribed instantly.",
+    "tags": [
+      "florida-man",
+      "media",
+      "truth",
+      "ufo"
+    ]
   },
   {
     "id": "TRUTH-062",
@@ -784,7 +1090,11 @@
         "opponent": 2
       }
     },
-    "flavor": "Hallelujah, the files are open."
+    "flavor": "Hallelujah, the files are open.",
+    "tags": [
+      "attack",
+      "truth"
+    ]
   },
   {
     "id": "TRUTH-063",
@@ -798,7 +1108,13 @@
         "opponent": 2
       }
     },
-    "flavor": "Final rose withheld for national security."
+    "flavor": "Final rose withheld for national security.",
+    "tags": [
+      "attack",
+      "bat-boy",
+      "cryptid",
+      "truth"
+    ]
   },
   {
     "id": "TRUTH-064",
@@ -813,7 +1129,13 @@
         "opponentPercent": 0.12
       }
     },
-    "flavor": "His space suit sparkles."
+    "flavor": "His space suit sparkles.",
+    "tags": [
+      "attack",
+      "elvis",
+      "media",
+      "truth"
+    ]
   },
   {
     "id": "TRUTH-065",
@@ -828,7 +1150,13 @@
         "opponentPercent": 0.1
       }
     },
-    "flavor": "Turns out interns shouldn't have clearance."
+    "flavor": "Turns out interns shouldn't have clearance.",
+    "tags": [
+      "attack",
+      "media",
+      "truth",
+      "ufo"
+    ]
   },
   {
     "id": "TRUTH-066",
@@ -840,7 +1168,13 @@
     "effects": {
       "pressureDelta": 2
     },
-    "flavor": "Membership includes free capes."
+    "flavor": "Membership includes free capes.",
+    "tags": [
+      "bat-boy",
+      "cryptid",
+      "truth",
+      "zone"
+    ]
   },
   {
     "id": "TRUTH-067",
@@ -852,7 +1186,12 @@
     "effects": {
       "pressureDelta": 2
     },
-    "flavor": "Fill up on miracles."
+    "flavor": "Fill up on miracles.",
+    "tags": [
+      "elvis",
+      "truth",
+      "zone"
+    ]
   },
   {
     "id": "TRUTH-068",
@@ -864,7 +1203,13 @@
     "effects": {
       "pressureDelta": 2
     },
-    "flavor": "Mosquitoes included."
+    "flavor": "Mosquitoes included.",
+    "tags": [
+      "florida-man",
+      "location",
+      "truth",
+      "zone"
+    ]
   },
   {
     "id": "TRUTH-069",
@@ -876,7 +1221,14 @@
     "effects": {
       "pressureDelta": 2
     },
-    "flavor": "Ghosts pay rent in ectoplasm."
+    "flavor": "Ghosts pay rent in ectoplasm.",
+    "tags": [
+      "ghost",
+      "haunted",
+      "location",
+      "truth",
+      "zone"
+    ]
   },
   {
     "id": "TRUTH-070",
@@ -888,7 +1240,11 @@
     "effects": {
       "pressureDelta": 3
     },
-    "flavor": "Hallelujah, the aliens are among us!"
+    "flavor": "Hallelujah, the aliens are among us!",
+    "tags": [
+      "truth",
+      "zone"
+    ]
   },
   {
     "id": "TRUTH-071",
@@ -900,7 +1256,12 @@
     "effects": {
       "pressureDelta": 2
     },
-    "flavor": "Funnel cakes taste out of this world."
+    "flavor": "Funnel cakes taste out of this world.",
+    "tags": [
+      "truth",
+      "ufo",
+      "zone"
+    ]
   },
   {
     "id": "TRUTH-072",
@@ -912,7 +1273,12 @@
     "effects": {
       "pressureDelta": 2
     },
-    "flavor": "Thank you, very hidden."
+    "flavor": "Thank you, very hidden.",
+    "tags": [
+      "elvis",
+      "truth",
+      "zone"
+    ]
   },
   {
     "id": "TRUTH-073",
@@ -924,7 +1290,13 @@
     "effects": {
       "pressureDelta": 3
     },
-    "flavor": "Tickets include blurry binoculars."
+    "flavor": "Tickets include blurry binoculars.",
+    "tags": [
+      "bigfoot",
+      "cryptid",
+      "truth",
+      "zone"
+    ]
   },
   {
     "id": "TRUTH-074",
@@ -936,7 +1308,12 @@
     "effects": {
       "pressureDelta": 2
     },
-    "flavor": "Hot off the paranormal presses."
+    "flavor": "Hot off the paranormal presses.",
+    "tags": [
+      "media",
+      "truth",
+      "zone"
+    ]
   },
   {
     "id": "TRUTH-075",
@@ -948,7 +1325,14 @@
     "effects": {
       "pressureDelta": 3
     },
-    "flavor": "Roller coasters scream back."
+    "flavor": "Roller coasters scream back.",
+    "tags": [
+      "ghost",
+      "haunted",
+      "location",
+      "truth",
+      "zone"
+    ]
   },
   {
     "id": "TRUTH-076",
@@ -960,7 +1344,12 @@
     "effects": {
       "pressureDelta": 2
     },
-    "flavor": "Gator wrestling, Elvis impersonator optional."
+    "flavor": "Gator wrestling, Elvis impersonator optional.",
+    "tags": [
+      "florida-man",
+      "truth",
+      "zone"
+    ]
   },
   {
     "id": "TRUTH-077",
@@ -972,7 +1361,13 @@
     "effects": {
       "pressureDelta": 2
     },
-    "flavor": "Bartender vanished in 1893, still pouring."
+    "flavor": "Bartender vanished in 1893, still pouring.",
+    "tags": [
+      "ghost",
+      "haunted",
+      "truth",
+      "zone"
+    ]
   },
   {
     "id": "TRUTH-078",
@@ -984,7 +1379,12 @@
     "effects": {
       "pressureDelta": 2
     },
-    "flavor": "We sell postcards and plausible deniability."
+    "flavor": "We sell postcards and plausible deniability.",
+    "tags": [
+      "roswell",
+      "truth",
+      "zone"
+    ]
   },
   {
     "id": "TRUTH-079",
@@ -996,7 +1396,14 @@
     "effects": {
       "pressureDelta": 2
     },
-    "flavor": "Tourist trap with prophetic wings."
+    "flavor": "Tourist trap with prophetic wings.",
+    "tags": [
+      "cryptid",
+      "location",
+      "mothman",
+      "truth",
+      "zone"
+    ]
   },
   {
     "id": "TRUTH-080",
@@ -1008,7 +1415,14 @@
     "effects": {
       "pressureDelta": 2
     },
-    "flavor": "Fog horn occasionally says your name."
+    "flavor": "Fog horn occasionally says your name.",
+    "tags": [
+      "ghost",
+      "haunted",
+      "location",
+      "truth",
+      "zone"
+    ]
   },
   {
     "id": "TRUTH-081",
@@ -1020,7 +1434,11 @@
     "effects": {
       "pressureDelta": 2
     },
-    "flavor": "Files stacked by string color."
+    "flavor": "Files stacked by string color.",
+    "tags": [
+      "truth",
+      "zone"
+    ]
   },
   {
     "id": "TRUTH-082",
@@ -1032,7 +1450,13 @@
     "effects": {
       "pressureDelta": 2
     },
-    "flavor": "Size 28 evidence, mind the puddles."
+    "flavor": "Size 28 evidence, mind the puddles.",
+    "tags": [
+      "bigfoot",
+      "cryptid",
+      "truth",
+      "zone"
+    ]
   },
   {
     "id": "TRUTH-083",
@@ -1044,7 +1468,12 @@
     "effects": {
       "pressureDelta": 2
     },
-    "flavor": "Love me tender, pay me weekly."
+    "flavor": "Love me tender, pay me weekly.",
+    "tags": [
+      "elvis",
+      "truth",
+      "zone"
+    ]
   },
   {
     "id": "TRUTH-084",
@@ -1056,7 +1485,11 @@
     "effects": {
       "pressureDelta": 3
     },
-    "flavor": "Blankets, binoculars, and bleeping."
+    "flavor": "Blankets, binoculars, and bleeping.",
+    "tags": [
+      "truth",
+      "zone"
+    ]
   },
   {
     "id": "TRUTH-085",
@@ -1068,7 +1501,11 @@
     "effects": {
       "pressureDelta": 2
     },
-    "flavor": "Blue ribbon for best geometry."
+    "flavor": "Blue ribbon for best geometry.",
+    "tags": [
+      "truth",
+      "zone"
+    ]
   },
   {
     "id": "TRUTH-086",
@@ -1082,7 +1519,11 @@
         "opponent": 2
       }
     },
-    "flavor": "Your honor, we respectfully unredact."
+    "flavor": "Your honor, we respectfully unredact.",
+    "tags": [
+      "attack",
+      "truth"
+    ]
   },
   {
     "id": "TRUTH-087",
@@ -1096,7 +1537,14 @@
         "opponent": 1
       }
     },
-    "flavor": "Season 3 unlocks your third eye."
+    "flavor": "Season 3 unlocks your third eye.",
+    "tags": [
+      "attack",
+      "bureaucracy",
+      "coverup",
+      "media",
+      "truth"
+    ]
   },
   {
     "id": "TRUTH-088",
@@ -1110,7 +1558,12 @@
         "opponent": 2
       }
     },
-    "flavor": "Sequins are blinding…and binding."
+    "flavor": "Sequins are blinding…and binding.",
+    "tags": [
+      "attack",
+      "elvis",
+      "truth"
+    ]
   },
   {
     "id": "TRUTH-089",
@@ -1124,7 +1577,11 @@
         "opponent": 2
       }
     },
-    "flavor": "Beep boop, nice try, spooks."
+    "flavor": "Beep boop, nice try, spooks.",
+    "tags": [
+      "attack",
+      "truth"
+    ]
   },
   {
     "id": "TRUTH-090",
@@ -1138,7 +1595,11 @@
         "opponent": 2
       }
     },
-    "flavor": "Green tint, clear intent."
+    "flavor": "Green tint, clear intent.",
+    "tags": [
+      "attack",
+      "truth"
+    ]
   },
   {
     "id": "TRUTH-091",
@@ -1152,7 +1613,14 @@
         "opponent": 3
       }
     },
-    "flavor": "Microphones mysteriously smeared with mud."
+    "flavor": "Microphones mysteriously smeared with mud.",
+    "tags": [
+      "attack",
+      "bigfoot",
+      "cryptid",
+      "media",
+      "truth"
+    ]
   },
   {
     "id": "TRUTH-092",
@@ -1166,7 +1634,13 @@
         "opponent": 3
       }
     },
-    "flavor": "The warning no one can ignore."
+    "flavor": "The warning no one can ignore.",
+    "tags": [
+      "attack",
+      "cryptid",
+      "mothman",
+      "truth"
+    ]
   },
   {
     "id": "TRUTH-093",
@@ -1180,7 +1654,11 @@
         "opponent": 2
       }
     },
-    "flavor": "Lines lit, lies dimmed."
+    "flavor": "Lines lit, lies dimmed.",
+    "tags": [
+      "attack",
+      "truth"
+    ]
   },
   {
     "id": "TRUTH-094",
@@ -1192,7 +1670,11 @@
     "effects": {
       "truthDelta": 2
     },
-    "flavor": "Receipts loaded; caps locked."
+    "flavor": "Receipts loaded; caps locked.",
+    "tags": [
+      "media",
+      "truth"
+    ]
   },
   {
     "id": "TRUTH-095",
@@ -1204,7 +1686,11 @@
     "effects": {
       "truthDelta": 2
     },
-    "flavor": "Smile, you're de-escalated."
+    "flavor": "Smile, you're de-escalated.",
+    "tags": [
+      "media",
+      "truth"
+    ]
   },
   {
     "id": "TRUTH-096",
@@ -1216,7 +1702,11 @@
     "effects": {
       "truthDelta": 2
     },
-    "flavor": "Live rebuttal beats late retraction."
+    "flavor": "Live rebuttal beats late retraction.",
+    "tags": [
+      "media",
+      "truth"
+    ]
   },
   {
     "id": "TRUTH-097",
@@ -1230,7 +1720,11 @@
         "opponent": 3
       }
     },
-    "flavor": "Oops, the simulation dropped a frame."
+    "flavor": "Oops, the simulation dropped a frame.",
+    "tags": [
+      "attack",
+      "truth"
+    ]
   },
   {
     "id": "TRUTH-098",
@@ -1244,7 +1738,12 @@
         "opponent": 3
       }
     },
-    "flavor": "Git push: disclosure."
+    "flavor": "Git push: disclosure.",
+    "tags": [
+      "attack",
+      "truth",
+      "ufo"
+    ]
   },
   {
     "id": "TRUTH-099",
@@ -1256,7 +1755,11 @@
     "effects": {
       "truthDelta": 2
     },
-    "flavor": "One micro-donation at a time."
+    "flavor": "One micro-donation at a time.",
+    "tags": [
+      "media",
+      "truth"
+    ]
   },
   {
     "id": "TRUTH-100",
@@ -1268,7 +1771,11 @@
     "effects": {
       "truthDelta": 4
     },
-    "flavor": "Take me to your committee chair."
+    "flavor": "Take me to your committee chair.",
+    "tags": [
+      "media",
+      "truth"
+    ]
   },
   {
     "id": "TRUTH-101",
@@ -1282,7 +1789,11 @@
         "opponent": 3
       }
     },
-    "flavor": "Three hackers, zero hygiene, one friend on the inside."
+    "flavor": "Three hackers, zero hygiene, one friend on the inside.",
+    "tags": [
+      "attack",
+      "truth"
+    ]
   },
   {
     "id": "TRUTH-102",
@@ -1296,7 +1807,11 @@
         "opponent": 2
       }
     },
-    "flavor": "If it's stamped 'secret', it's stapled to our to-do list."
+    "flavor": "If it's stamped 'secret', it's stapled to our to-do list.",
+    "tags": [
+      "attack",
+      "truth"
+    ]
   },
   {
     "id": "TRUTH-103",
@@ -1310,7 +1825,12 @@
         "opponent": 2
       }
     },
-    "flavor": "Ink by the people, for the people."
+    "flavor": "Ink by the people, for the people.",
+    "tags": [
+      "attack",
+      "media",
+      "truth"
+    ]
   },
   {
     "id": "TRUTH-104",
@@ -1324,7 +1844,11 @@
         "opponent": 3
       }
     },
-    "flavor": "Microscopes donated, miracles improvised."
+    "flavor": "Microscopes donated, miracles improvised.",
+    "tags": [
+      "attack",
+      "truth"
+    ]
   },
   {
     "id": "TRUTH-105",
@@ -1336,7 +1860,11 @@
     "effects": {
       "truthDelta": 2
     },
-    "flavor": "Batteries not included. Lies excluded."
+    "flavor": "Batteries not included. Lies excluded.",
+    "tags": [
+      "media",
+      "truth"
+    ]
   },
   {
     "id": "TRUTH-106",
@@ -1348,7 +1876,11 @@
     "effects": {
       "truthDelta": 2
     },
-    "flavor": "Industrial-grade hats for industrial-sized cover-ups."
+    "flavor": "Industrial-grade hats for industrial-sized cover-ups.",
+    "tags": [
+      "media",
+      "truth"
+    ]
   },
   {
     "id": "TRUTH-107",
@@ -1360,7 +1892,12 @@
     "effects": {
       "truthDelta": 2
     },
-    "flavor": "Punches in with a glittery glove."
+    "flavor": "Punches in with a glittery glove.",
+    "tags": [
+      "elvis",
+      "media",
+      "truth"
+    ]
   },
   {
     "id": "TRUTH-108",
@@ -1372,7 +1909,13 @@
     "effects": {
       "truthDelta": 3
     },
-    "flavor": "Screams in AP style."
+    "flavor": "Screams in AP style.",
+    "tags": [
+      "bat-boy",
+      "cryptid",
+      "media",
+      "truth"
+    ]
   },
   {
     "id": "TRUTH-109",
@@ -1384,7 +1927,11 @@
     "effects": {
       "truthDelta": 2
     },
-    "flavor": "Tail between their legs, allegedly."
+    "flavor": "Tail between their legs, allegedly.",
+    "tags": [
+      "media",
+      "truth"
+    ]
   },
   {
     "id": "TRUTH-110",
@@ -1398,7 +1945,12 @@
         "opponent": 1
       }
     },
-    "flavor": "He used it to open soda first."
+    "flavor": "He used it to open soda first.",
+    "tags": [
+      "attack",
+      "florida-man",
+      "truth"
+    ]
   },
   {
     "id": "TRUTH-111",
@@ -1410,7 +1962,11 @@
     "effects": {
       "truthDelta": 3
     },
-    "flavor": "Blink and you'll still see it."
+    "flavor": "Blink and you'll still see it.",
+    "tags": [
+      "media",
+      "truth"
+    ]
   },
   {
     "id": "TRUTH-112",
@@ -1422,7 +1978,12 @@
     "effects": {
       "truthDelta": 2
     },
-    "flavor": "Reads only paperbacks—no fingerprints."
+    "flavor": "Reads only paperbacks—no fingerprints.",
+    "tags": [
+      "elvis",
+      "media",
+      "truth"
+    ]
   },
   {
     "id": "TRUTH-113",
@@ -1434,7 +1995,11 @@
     "effects": {
       "truthDelta": 3
     },
-    "flavor": "He anonymously CC'd everyone."
+    "flavor": "He anonymously CC'd everyone.",
+    "tags": [
+      "media",
+      "truth"
+    ]
   },
   {
     "id": "TRUTH-114",
@@ -1446,7 +2011,13 @@
     "effects": {
       "truthDelta": 1
     },
-    "flavor": "Wingspan: entire windshield."
+    "flavor": "Wingspan: entire windshield.",
+    "tags": [
+      "cryptid",
+      "media",
+      "mothman",
+      "truth"
+    ]
   },
   {
     "id": "TRUTH-115",
@@ -1458,7 +2029,13 @@
     "effects": {
       "truthDelta": 2
     },
-    "flavor": "Verdict echoes for eternity."
+    "flavor": "Verdict echoes for eternity.",
+    "tags": [
+      "ghost",
+      "haunted",
+      "media",
+      "truth"
+    ]
   },
   {
     "id": "TRUTH-116",
@@ -1470,7 +2047,12 @@
     "effects": {
       "truthDelta": 3
     },
-    "flavor": "Headline: 'Love Me Tender, Tell Me Everything'."
+    "flavor": "Headline: 'Love Me Tender, Tell Me Everything'.",
+    "tags": [
+      "elvis",
+      "media",
+      "truth"
+    ]
   },
   {
     "id": "TRUTH-117",
@@ -1482,7 +2064,11 @@
     "effects": {
       "truthDelta": 1
     },
-    "flavor": "First question: favorite ice cream?"
+    "flavor": "First question: favorite ice cream?",
+    "tags": [
+      "media",
+      "truth"
+    ]
   },
   {
     "id": "TRUTH-118",
@@ -1494,7 +2080,13 @@
     "effects": {
       "truthDelta": 2
     },
-    "flavor": "Stapled with bravado."
+    "flavor": "Stapled with bravado.",
+    "tags": [
+      "bat-boy",
+      "cryptid",
+      "media",
+      "truth"
+    ]
   },
   {
     "id": "TRUTH-119",
@@ -1508,7 +2100,11 @@
         "opponent": 2
       }
     },
-    "flavor": "Knew you'd play this."
+    "flavor": "Knew you'd play this.",
+    "tags": [
+      "attack",
+      "truth"
+    ]
   },
   {
     "id": "TRUTH-120",
@@ -1520,7 +2116,11 @@
     "effects": {
       "pressureDelta": 2
     },
-    "flavor": "Text too big to redact."
+    "flavor": "Text too big to redact.",
+    "tags": [
+      "truth",
+      "zone"
+    ]
   },
   {
     "id": "TRUTH-121",
@@ -1532,7 +2132,13 @@
     "effects": {
       "pressureDelta": 2
     },
-    "flavor": "After-school programs for aspiring screamers."
+    "flavor": "After-school programs for aspiring screamers.",
+    "tags": [
+      "bat-boy",
+      "cryptid",
+      "truth",
+      "zone"
+    ]
   },
   {
     "id": "TRUTH-122",
@@ -1544,7 +2150,12 @@
     "effects": {
       "pressureDelta": 2
     },
-    "flavor": "Vows exchanged, lies annulled."
+    "flavor": "Vows exchanged, lies annulled.",
+    "tags": [
+      "elvis",
+      "truth",
+      "zone"
+    ]
   },
   {
     "id": "TRUTH-123",
@@ -1556,7 +2167,11 @@
     "effects": {
       "pressureDelta": 2
     },
-    "flavor": "Bring blankets, witness meteors and memos."
+    "flavor": "Bring blankets, witness meteors and memos.",
+    "tags": [
+      "truth",
+      "zone"
+    ]
   },
   {
     "id": "TRUTH-124",
@@ -1568,7 +2183,11 @@
     "effects": {
       "pressureDelta": 2
     },
-    "flavor": "Single-origin skepticism."
+    "flavor": "Single-origin skepticism.",
+    "tags": [
+      "truth",
+      "zone"
+    ]
   },
   {
     "id": "TRUTH-125",
@@ -1580,7 +2199,13 @@
     "effects": {
       "pressureDelta": 3
     },
-    "flavor": "Shhh… the books whisper back."
+    "flavor": "Shhh… the books whisper back.",
+    "tags": [
+      "ghost",
+      "haunted",
+      "truth",
+      "zone"
+    ]
   },
   {
     "id": "TRUTH-126",
@@ -1592,7 +2217,11 @@
     "effects": {
       "pressureDelta": 2
     },
-    "flavor": "Airwaves have nothing to hide."
+    "flavor": "Airwaves have nothing to hide.",
+    "tags": [
+      "truth",
+      "zone"
+    ]
   },
   {
     "id": "TRUTH-127",
@@ -1604,7 +2233,11 @@
     "effects": {
       "pressureDelta": 3
     },
-    "flavor": "Waiver includes claws and clauses."
+    "flavor": "Waiver includes claws and clauses.",
+    "tags": [
+      "truth",
+      "zone"
+    ]
   },
   {
     "id": "TRUTH-128",
@@ -1616,7 +2249,12 @@
     "effects": {
       "pressureDelta": 2
     },
-    "flavor": "Playlists of leaks and licks."
+    "flavor": "Playlists of leaks and licks.",
+    "tags": [
+      "media",
+      "truth",
+      "zone"
+    ]
   },
   {
     "id": "TRUTH-129",
@@ -1628,7 +2266,12 @@
     "effects": {
       "pressureDelta": 3
     },
-    "flavor": "House always wins—unless truth shows up."
+    "flavor": "House always wins—unless truth shows up.",
+    "tags": [
+      "elvis",
+      "truth",
+      "zone"
+    ]
   },
   {
     "id": "TRUTH-130",
@@ -1640,7 +2283,12 @@
     "effects": {
       "pressureDelta": 2
     },
-    "flavor": "Tonight on 'Open Secrets': everything."
+    "flavor": "Tonight on 'Open Secrets': everything.",
+    "tags": [
+      "media",
+      "truth",
+      "zone"
+    ]
   },
   {
     "id": "TRUTH-131",
@@ -1652,7 +2300,14 @@
     "effects": {
       "pressureDelta": 3
     },
-    "flavor": "Leave only footprints; hear many more."
+    "flavor": "Leave only footprints; hear many more.",
+    "tags": [
+      "ghost",
+      "haunted",
+      "location",
+      "truth",
+      "zone"
+    ]
   },
   {
     "id": "TRUTH-132",
@@ -1666,7 +2321,11 @@
         "opponent": 2
       }
     },
-    "flavor": "The loudest tiny whistle ever printed."
+    "flavor": "The loudest tiny whistle ever printed.",
+    "tags": [
+      "attack",
+      "truth"
+    ]
   },
   {
     "id": "TRUTH-133",
@@ -1680,7 +2339,12 @@
         "opponent": 2
       }
     },
-    "flavor": "First question, final answer."
+    "flavor": "First question, final answer.",
+    "tags": [
+      "attack",
+      "media",
+      "truth"
+    ]
   },
   {
     "id": "TRUTH-134",
@@ -1694,7 +2358,11 @@
         "opponent": 3
       }
     },
-    "flavor": "Redaction ink runs in the rain."
+    "flavor": "Redaction ink runs in the rain.",
+    "tags": [
+      "attack",
+      "truth"
+    ]
   },
   {
     "id": "TRUTH-135",
@@ -1708,7 +2376,11 @@
         "opponent": 2
       }
     },
-    "flavor": "Credentials printed on recycled secrets."
+    "flavor": "Credentials printed on recycled secrets.",
+    "tags": [
+      "attack",
+      "truth"
+    ]
   },
   {
     "id": "TRUTH-136",
@@ -1722,7 +2394,11 @@
         "opponent": 2
       }
     },
-    "flavor": "1,000 comments, one conclusion."
+    "flavor": "1,000 comments, one conclusion.",
+    "tags": [
+      "attack",
+      "truth"
+    ]
   },
   {
     "id": "TRUTH-137",
@@ -1737,7 +2413,13 @@
       },
       "discardOpponent": 1
     },
-    "flavor": "Stage lights melt alibis."
+    "flavor": "Stage lights melt alibis.",
+    "tags": [
+      "attack",
+      "bureaucracy",
+      "coverup",
+      "truth"
+    ]
   },
   {
     "id": "TRUTH-138",
@@ -1751,7 +2433,12 @@
         "opponent": 2
       }
     },
-    "flavor": "We interrupt your regularly scheduled denial."
+    "flavor": "We interrupt your regularly scheduled denial.",
+    "tags": [
+      "attack",
+      "media",
+      "truth"
+    ]
   },
   {
     "id": "TRUTH-139",
@@ -1765,7 +2452,11 @@
         "opponent": 2
       }
     },
-    "flavor": "Microphones swarm like bees."
+    "flavor": "Microphones swarm like bees.",
+    "tags": [
+      "attack",
+      "truth"
+    ]
   },
   {
     "id": "TRUTH-140",
@@ -1779,7 +2470,11 @@
         "opponent": 3
       }
     },
-    "flavor": "Signed by Judge Public Opinion."
+    "flavor": "Signed by Judge Public Opinion.",
+    "tags": [
+      "attack",
+      "truth"
+    ]
   },
   {
     "id": "TRUTH-141",
@@ -1793,7 +2488,13 @@
         "opponent": 2
       }
     },
-    "flavor": "Laminate of destiny."
+    "flavor": "Laminate of destiny.",
+    "tags": [
+      "attack",
+      "elvis",
+      "media",
+      "truth"
+    ]
   },
   {
     "id": "TRUTH-142",
@@ -1807,7 +2508,12 @@
         "opponent": 2
       }
     },
-    "flavor": "Chants harmonize with sirens."
+    "flavor": "Chants harmonize with sirens.",
+    "tags": [
+      "attack",
+      "protest",
+      "truth"
+    ]
   },
   {
     "id": "TRUTH-143",
@@ -1821,7 +2527,11 @@
         "opponent": 1
       }
     },
-    "flavor": "Ring once if it's a cover-up."
+    "flavor": "Ring once if it's a cover-up.",
+    "tags": [
+      "attack",
+      "truth"
+    ]
   },
   {
     "id": "TRUTH-144",
@@ -1833,7 +2543,13 @@
     "effects": {
       "truthDelta": 2
     },
-    "flavor": "Boo! Also, bookkeeping."
+    "flavor": "Boo! Also, bookkeeping.",
+    "tags": [
+      "ghost",
+      "haunted",
+      "media",
+      "truth"
+    ]
   },
   {
     "id": "TRUTH-145",
@@ -1845,7 +2561,11 @@
     "effects": {
       "truthDelta": 2
     },
-    "flavor": "Stapled, stamped, safe."
+    "flavor": "Stapled, stamped, safe.",
+    "tags": [
+      "media",
+      "truth"
+    ]
   },
   {
     "id": "TRUTH-146",
@@ -1857,7 +2577,11 @@
     "effects": {
       "truthDelta": 2
     },
-    "flavor": "Press 1 to spill, press 2 to bill."
+    "flavor": "Press 1 to spill, press 2 to bill.",
+    "tags": [
+      "media",
+      "truth"
+    ]
   },
   {
     "id": "TRUTH-147",
@@ -1869,7 +2593,11 @@
     "effects": {
       "truthDelta": 2
     },
-    "flavor": "Umbrella policy: extraterrestrial."
+    "flavor": "Umbrella policy: extraterrestrial.",
+    "tags": [
+      "media",
+      "truth"
+    ]
   },
   {
     "id": "TRUTH-148",
@@ -1881,7 +2609,11 @@
     "effects": {
       "truthDelta": 3
     },
-    "flavor": "Objection sustained, publicity gained."
+    "flavor": "Objection sustained, publicity gained.",
+    "tags": [
+      "media",
+      "truth"
+    ]
   },
   {
     "id": "TRUTH-149",
@@ -1893,7 +2625,13 @@
     "effects": {
       "truthDelta": 4
     },
-    "flavor": "A platform of planks and footprints."
+    "flavor": "A platform of planks and footprints.",
+    "tags": [
+      "bigfoot",
+      "cryptid",
+      "media",
+      "truth"
+    ]
   },
   {
     "id": "TRUTH-150",
@@ -1905,7 +2643,12 @@
     "effects": {
       "truthDelta": 4
     },
-    "flavor": "Long live the King—and the headline."
+    "flavor": "Long live the King—and the headline.",
+    "tags": [
+      "elvis",
+      "media",
+      "truth"
+    ]
   },
   {
     "id": "TRUTH-151",
@@ -1917,7 +2660,12 @@
     "effects": {
       "truthDelta": 2
     },
-    "flavor": "Hound dogs approved."
+    "flavor": "Hound dogs approved.",
+    "tags": [
+      "elvis",
+      "media",
+      "truth"
+    ]
   },
   {
     "id": "TRUTH-152",
@@ -1931,7 +2679,13 @@
         "opponent": 3
       }
     },
-    "flavor": "Top story: screamingly credible."
+    "flavor": "Top story: screamingly credible.",
+    "tags": [
+      "attack",
+      "bat-boy",
+      "cryptid",
+      "truth"
+    ]
   },
   {
     "id": "TRUTH-153",
@@ -1943,7 +2697,12 @@
     "effects": {
       "truthDelta": 1
     },
-    "flavor": "Hot rock, hotter takes."
+    "flavor": "Hot rock, hotter takes.",
+    "tags": [
+      "florida-man",
+      "media",
+      "truth"
+    ]
   },
   {
     "id": "TRUTH-154",
@@ -1957,7 +2716,14 @@
         "opponent": 2
       }
     },
-    "flavor": "Bring your own highlighter."
+    "flavor": "Bring your own highlighter.",
+    "tags": [
+      "attack",
+      "bureaucracy",
+      "coverup",
+      "media",
+      "truth"
+    ]
   },
   {
     "id": "TRUTH-155",
@@ -1969,7 +2735,11 @@
     "effects": {
       "truthDelta": 3
     },
-    "flavor": "'Do not call back.' *Beep.*"
+    "flavor": "'Do not call back.' *Beep.*",
+    "tags": [
+      "media",
+      "truth"
+    ]
   },
   {
     "id": "TRUTH-156",
@@ -1981,7 +2751,11 @@
     "effects": {
       "truthDelta": 1
     },
-    "flavor": "Geometry class finally pays off."
+    "flavor": "Geometry class finally pays off.",
+    "tags": [
+      "media",
+      "truth"
+    ]
   },
   {
     "id": "TRUTH-157",
@@ -1993,7 +2767,12 @@
     "effects": {
       "truthDelta": 2
     },
-    "flavor": "All donations tax-deductible from reality."
+    "flavor": "All donations tax-deductible from reality.",
+    "tags": [
+      "elvis",
+      "media",
+      "truth"
+    ]
   },
   {
     "id": "TRUTH-158",
@@ -2005,7 +2784,12 @@
     "effects": {
       "truthDelta": 1
     },
-    "flavor": "Please merge truthfully."
+    "flavor": "Please merge truthfully.",
+    "tags": [
+      "media",
+      "truth",
+      "ufo"
+    ]
   },
   {
     "id": "TRUTH-159",
@@ -2019,7 +2803,13 @@
         "opponent": 2
       }
     },
-    "flavor": "Has the receipts, keeps the screams."
+    "flavor": "Has the receipts, keeps the screams.",
+    "tags": [
+      "attack",
+      "bat-boy",
+      "cryptid",
+      "truth"
+    ]
   },
   {
     "id": "TRUTH-160",
@@ -2031,7 +2821,11 @@
     "effects": {
       "truthDelta": 1
     },
-    "flavor": "Meeting minutes by planchette."
+    "flavor": "Meeting minutes by planchette.",
+    "tags": [
+      "media",
+      "truth"
+    ]
   },
   {
     "id": "TRUTH-161",
@@ -2043,7 +2837,12 @@
     "effects": {
       "truthDelta": 3
     },
-    "flavor": "Return address: The Heartbreak Hotel."
+    "flavor": "Return address: The Heartbreak Hotel.",
+    "tags": [
+      "elvis",
+      "media",
+      "truth"
+    ]
   },
   {
     "id": "TRUTH-162",
@@ -2055,7 +2854,11 @@
     "effects": {
       "truthDelta": 2
     },
-    "flavor": "Violation: obvious saucer."
+    "flavor": "Violation: obvious saucer.",
+    "tags": [
+      "media",
+      "truth"
+    ]
   },
   {
     "id": "TRUTH-163",
@@ -2067,7 +2870,12 @@
     "effects": {
       "truthDelta": 1
     },
-    "flavor": "Ribs and revelations."
+    "flavor": "Ribs and revelations.",
+    "tags": [
+      "florida-man",
+      "media",
+      "truth"
+    ]
   },
   {
     "id": "TRUTH-164",
@@ -2079,7 +2887,13 @@
     "effects": {
       "truthDelta": 3
     },
-    "flavor": "Accepted with a polite shriek."
+    "flavor": "Accepted with a polite shriek.",
+    "tags": [
+      "bat-boy",
+      "cryptid",
+      "media",
+      "truth"
+    ]
   },
   {
     "id": "TRUTH-165",
@@ -2091,7 +2905,13 @@
     "effects": {
       "truthDelta": 2
     },
-    "flavor": "No cameras, only camcorders."
+    "flavor": "No cameras, only camcorders.",
+    "tags": [
+      "area51",
+      "elvis",
+      "media",
+      "truth"
+    ]
   },
   {
     "id": "TRUTH-166",
@@ -2105,7 +2925,12 @@
         "opponent": 1
       }
     },
-    "flavor": "The cloud is just a sky hard drive."
+    "flavor": "The cloud is just a sky hard drive.",
+    "tags": [
+      "attack",
+      "media",
+      "truth"
+    ]
   },
   {
     "id": "TRUTH-167",
@@ -2119,7 +2944,11 @@
         "opponent": 1
       }
     },
-    "flavor": "Cupcakes with classified sprinkles."
+    "flavor": "Cupcakes with classified sprinkles.",
+    "tags": [
+      "attack",
+      "truth"
+    ]
   },
   {
     "id": "TRUTH-168",
@@ -2131,7 +2960,12 @@
     "effects": {
       "pressureDelta": 2
     },
-    "flavor": "Questions answered, hips simulated."
+    "flavor": "Questions answered, hips simulated.",
+    "tags": [
+      "elvis",
+      "truth",
+      "zone"
+    ]
   },
   {
     "id": "TRUTH-169",
@@ -2143,7 +2977,11 @@
     "effects": {
       "truthDelta": 1
     },
-    "flavor": "Attached wings, unattached verdict."
+    "flavor": "Attached wings, unattached verdict.",
+    "tags": [
+      "media",
+      "truth"
+    ]
   },
   {
     "id": "TRUTH-170",
@@ -2157,7 +2995,11 @@
         "opponent": 3
       }
     },
-    "flavor": "Contents: oops, everything."
+    "flavor": "Contents: oops, everything.",
+    "tags": [
+      "attack",
+      "truth"
+    ]
   },
   {
     "id": "TRUTH-171",
@@ -2171,7 +3013,11 @@
         "opponent": 2
       }
     },
-    "flavor": "Eyes everywhere, budget nowhere."
+    "flavor": "Eyes everywhere, budget nowhere.",
+    "tags": [
+      "attack",
+      "truth"
+    ]
   },
   {
     "id": "TRUTH-172",
@@ -2183,7 +3029,11 @@
     "effects": {
       "truthDelta": 2
     },
-    "flavor": "Dares accepted by democracy."
+    "flavor": "Dares accepted by democracy.",
+    "tags": [
+      "media",
+      "truth"
+    ]
   },
   {
     "id": "TRUTH-173",
@@ -2195,7 +3045,12 @@
     "effects": {
       "pressureDelta": 2
     },
-    "flavor": "Open late, secrets later."
+    "flavor": "Open late, secrets later.",
+    "tags": [
+      "elvis",
+      "truth",
+      "zone"
+    ]
   },
   {
     "id": "TRUTH-174",
@@ -2207,7 +3062,13 @@
     "effects": {
       "pressureDelta": 2
     },
-    "flavor": "Homework: screaming practice."
+    "flavor": "Homework: screaming practice.",
+    "tags": [
+      "bat-boy",
+      "cryptid",
+      "truth",
+      "zone"
+    ]
   },
   {
     "id": "TRUTH-175",
@@ -2219,7 +3080,13 @@
     "effects": {
       "pressureDelta": 2
     },
-    "flavor": "Next arrival: transparency."
+    "flavor": "Next arrival: transparency.",
+    "tags": [
+      "ghost",
+      "haunted",
+      "truth",
+      "zone"
+    ]
   },
   {
     "id": "TRUTH-176",
@@ -2231,7 +3098,11 @@
     "effects": {
       "pressureDelta": 2
     },
-    "flavor": "Ink smudges improve credibility."
+    "flavor": "Ink smudges improve credibility.",
+    "tags": [
+      "truth",
+      "zone"
+    ]
   },
   {
     "id": "TRUTH-177",
@@ -2243,7 +3114,11 @@
     "effects": {
       "pressureDelta": 3
     },
-    "flavor": "Souvenir shops sell periscopes."
+    "flavor": "Souvenir shops sell periscopes.",
+    "tags": [
+      "truth",
+      "zone"
+    ]
   },
   {
     "id": "TRUTH-178",
@@ -2255,7 +3130,12 @@
     "effects": {
       "pressureDelta": 2
     },
-    "flavor": "Recorded live in an undisclosed basement."
+    "flavor": "Recorded live in an undisclosed basement.",
+    "tags": [
+      "media",
+      "truth",
+      "zone"
+    ]
   },
   {
     "id": "TRUTH-179",
@@ -2267,7 +3147,11 @@
     "effects": {
       "pressureDelta": 2
     },
-    "flavor": "Gently used evidence."
+    "flavor": "Gently used evidence.",
+    "tags": [
+      "truth",
+      "zone"
+    ]
   },
   {
     "id": "TRUTH-180",
@@ -2279,7 +3163,14 @@
     "effects": {
       "pressureDelta": 2
     },
-    "flavor": "Beam bends around secrets."
+    "flavor": "Beam bends around secrets.",
+    "tags": [
+      "ghost",
+      "haunted",
+      "location",
+      "truth",
+      "zone"
+    ]
   },
   {
     "id": "TRUTH-181",
@@ -2291,7 +3182,12 @@
     "effects": {
       "pressureDelta": 3
     },
-    "flavor": "Choir hums suspiciously familiar melodies."
+    "flavor": "Choir hums suspiciously familiar melodies.",
+    "tags": [
+      "elvis",
+      "truth",
+      "zone"
+    ]
   },
   {
     "id": "TRUTH-182",
@@ -2303,7 +3199,13 @@
     "effects": {
       "pressureDelta": 2
     },
-    "flavor": "Files arranged by shriek pitch."
+    "flavor": "Files arranged by shriek pitch.",
+    "tags": [
+      "bat-boy",
+      "cryptid",
+      "truth",
+      "zone"
+    ]
   },
   {
     "id": "TRUTH-183",
@@ -2317,7 +3219,12 @@
         "opponent": 2
       }
     },
-    "flavor": "Mic check, lie wreck."
+    "flavor": "Mic check, lie wreck.",
+    "tags": [
+      "attack",
+      "media",
+      "truth"
+    ]
   },
   {
     "id": "TRUTH-184",
@@ -2331,7 +3238,11 @@
         "opponent": 2
       }
     },
-    "flavor": "Eyes in the sky, pies on the porch."
+    "flavor": "Eyes in the sky, pies on the porch.",
+    "tags": [
+      "attack",
+      "truth"
+    ]
   },
   {
     "id": "TRUTH-185",
@@ -2345,7 +3256,11 @@
         "opponent": 2
       }
     },
-    "flavor": "Ink beats intimidation."
+    "flavor": "Ink beats intimidation.",
+    "tags": [
+      "attack",
+      "truth"
+    ]
   },
   {
     "id": "TRUTH-186",
@@ -2359,7 +3274,11 @@
         "opponent": 3
       }
     },
-    "flavor": "Receipts stapled to reality."
+    "flavor": "Receipts stapled to reality.",
+    "tags": [
+      "attack",
+      "truth"
+    ]
   },
   {
     "id": "TRUTH-187",
@@ -2373,7 +3292,11 @@
         "opponent": 2
       }
     },
-    "flavor": "Static speaks volumes."
+    "flavor": "Static speaks volumes.",
+    "tags": [
+      "attack",
+      "truth"
+    ]
   },
   {
     "id": "TRUTH-188",
@@ -2387,7 +3310,11 @@
         "opponent": 2
       }
     },
-    "flavor": "Spin class for facts."
+    "flavor": "Spin class for facts.",
+    "tags": [
+      "attack",
+      "truth"
+    ]
   },
   {
     "id": "TRUTH-189",
@@ -2401,7 +3328,11 @@
         "opponent": 3
       }
     },
-    "flavor": "Paper cuts to the narrative."
+    "flavor": "Paper cuts to the narrative.",
+    "tags": [
+      "attack",
+      "truth"
+    ]
   },
   {
     "id": "TRUTH-190",
@@ -2415,7 +3346,11 @@
         "opponent": 2
       }
     },
-    "flavor": "Synchronised citations."
+    "flavor": "Synchronised citations.",
+    "tags": [
+      "attack",
+      "truth"
+    ]
   },
   {
     "id": "TRUTH-191",
@@ -2429,7 +3364,13 @@
         "opponent": 2
       }
     },
-    "flavor": "Wings over weak points."
+    "flavor": "Wings over weak points.",
+    "tags": [
+      "attack",
+      "cryptid",
+      "mothman",
+      "truth"
+    ]
   },
   {
     "id": "TRUTH-192",
@@ -2441,7 +3382,11 @@
     "effects": {
       "pressureDelta": 1
     },
-    "flavor": "Paper wins this round."
+    "flavor": "Paper wins this round.",
+    "tags": [
+      "truth",
+      "zone"
+    ]
   },
   {
     "id": "TRUTH-193",
@@ -2453,7 +3398,11 @@
     "effects": {
       "truthDelta": 2
     },
-    "flavor": "We saw that coming."
+    "flavor": "We saw that coming.",
+    "tags": [
+      "media",
+      "truth"
+    ]
   },
   {
     "id": "TRUTH-194",
@@ -2465,7 +3414,11 @@
     "effects": {
       "pressureDelta": 2
     },
-    "flavor": "Light pierces ledger lines."
+    "flavor": "Light pierces ledger lines.",
+    "tags": [
+      "truth",
+      "zone"
+    ]
   },
   {
     "id": "TRUTH-195",
@@ -2477,7 +3430,13 @@
     "effects": {
       "truthDelta": 3
     },
-    "flavor": "Overruled by the afterlife."
+    "flavor": "Overruled by the afterlife.",
+    "tags": [
+      "ghost",
+      "haunted",
+      "media",
+      "truth"
+    ]
   },
   {
     "id": "TRUTH-196",
@@ -2489,7 +3448,11 @@
     "effects": {
       "pressureDelta": 2
     },
-    "flavor": "Threads that pull threads."
+    "flavor": "Threads that pull threads.",
+    "tags": [
+      "truth",
+      "zone"
+    ]
   },
   {
     "id": "TRUTH-197",
@@ -2501,7 +3464,12 @@
     "effects": {
       "pressureDelta": 2
     },
-    "flavor": "Small bills fund big stories."
+    "flavor": "Small bills fund big stories.",
+    "tags": [
+      "media",
+      "truth",
+      "zone"
+    ]
   },
   {
     "id": "TRUTH-198",
@@ -2515,7 +3483,11 @@
         "opponent": 2
       }
     },
-    "flavor": "Password: OpenEverything."
+    "flavor": "Password: OpenEverything.",
+    "tags": [
+      "attack",
+      "truth"
+    ]
   },
   {
     "id": "TRUTH-199",
@@ -2527,7 +3499,12 @@
     "effects": {
       "truthDelta": 3
     },
-    "flavor": "Contents: one sequined future."
+    "flavor": "Contents: one sequined future.",
+    "tags": [
+      "elvis",
+      "media",
+      "truth"
+    ]
   },
   {
     "id": "TRUTH-200",
@@ -2539,6 +3516,10 @@
     "effects": {
       "truthDelta": 4
     },
-    "flavor": "The last page of the last secret file."
+    "flavor": "The last page of the last secret file.",
+    "tags": [
+      "media",
+      "truth"
+    ]
   }
 ]

--- a/tsconfig.jest.json
+++ b/tsconfig.jest.json
@@ -1,0 +1,11 @@
+{
+  "extends": "./tsconfig.node.json",
+  "compilerOptions": {
+    "module": "CommonJS",
+    "moduleResolution": "Node",
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true
+  },
+  "include": ["scripts/**/*.ts", "__tests__/**/*.ts"]
+}
+


### PR DESCRIPTION
## Summary
- add reusable tag mapping utilities and a CLI to normalize card tags across decks
- configure Jest with ts-jest and create coverage-focused tests for tagging heuristics and idempotence
- regenerate core and expansion card JSON files with consistent faction, type, expansion, and thematic tags

## Testing
- npm run tag:check
- npx jest
- bun test --coverage --coverage-reporter=text

------
https://chatgpt.com/codex/tasks/task_e_68e0c6a8d0208320b092e6d7713d7a59