### PR TITLE
Implement deterministic front page generator

### DIFF
--- a/src/engine/news/articleBank.ts
+++ b/src/engine/news/articleBank.ts
@@ -1,13 +1,30 @@
 import { z } from 'zod';
 
-const cardArticleSchema = z.object({
+export type CardArticle = {
+  id: string;
+  tone: 'truth' | 'gov';
+  tags: string[];
+  headline?: string;
+  subhead?: string;
+  byline?: string;
+  body?: string;
+  imagePrompt?: string;
+};
+
+export type ArticleBank = {
+  getById(cardId: string): CardArticle | null;
+};
+
+type ArticleDataLoader = () => Promise<unknown>;
+
+const cardArticleSchema: z.ZodType<CardArticle> = z.object({
   id: z.string(),
-  tone: z.string(),
-  tags: z.array(z.string()),
-  headline: z.string(),
-  subhead: z.string(),
-  byline: z.string(),
-  body: z.string(),
+  tone: z.union([z.literal('truth'), z.literal('gov')]),
+  tags: z.array(z.string()).default([]),
+  headline: z.string().optional(),
+  subhead: z.string().optional(),
+  byline: z.string().optional(),
+  body: z.string().optional(),
   imagePrompt: z.string().optional(),
 });
 
@@ -15,39 +32,63 @@ const articleFileSchema = z.object({
   articles: z.array(cardArticleSchema),
 });
 
-export type CardArticle = z.infer<typeof cardArticleSchema>;
-
-export interface ArticleBank {
-  articles: CardArticle[];
-  byId: Map<string, CardArticle>;
-}
-
 let cachedArticleBank: Promise<ArticleBank> | null = null;
-type ArticleDataLoader = () => Promise<unknown>;
+let cacheKey: string | null = null;
+let loaderOverride: ArticleDataLoader | null = null;
 
-let customArticleLoader: ArticleDataLoader | null = null;
-
-const resolveArticleLoader = (): ArticleDataLoader => {
-  return customArticleLoader ?? importArticleData;
-};
-
-async function importArticleData() {
+const importArticleData: ArticleDataLoader = async () => {
   const module = await import('../../../paranoid_times_card_articles_ALL.json');
   return (module as { default?: unknown }).default ?? module;
-}
+};
 
-export async function loadArticleBank(): Promise<ArticleBank> {
-  if (!cachedArticleBank) {
-    const loader = resolveArticleLoader();
-    cachedArticleBank = loader().then((rawData) => {
-      const { articles } = articleFileSchema.parse(rawData);
-      const byId = new Map<string, CardArticle>();
+const fetchArticleData = async (url: string): Promise<unknown> => {
+  const response = await fetch(url);
+  if (!response.ok) {
+    throw new Error(`Failed to load article bank from ${url}: ${response.status} ${response.statusText}`);
+  }
+  return response.json();
+};
 
-      for (const article of articles) {
-        byId.set(article.id, article);
+const resolveLoader = (jsonUrl?: string): { loader: ArticleDataLoader; key: string } => {
+  if (loaderOverride) {
+    return { loader: loaderOverride, key: 'override' };
+  }
+
+  if (jsonUrl) {
+    return { loader: () => fetchArticleData(jsonUrl), key: jsonUrl };
+  }
+
+  return { loader: importArticleData, key: 'default' };
+};
+
+const buildArticleBank = (articles: CardArticle[]): ArticleBank => {
+  const byId = new Map<string, CardArticle>();
+  for (const article of articles) {
+    const normalized: CardArticle = {
+      ...article,
+      tags: Array.isArray(article.tags) ? article.tags : [],
+    };
+    byId.set(normalized.id, normalized);
+  }
+
+  return {
+    getById(cardId: string) {
+      if (!cardId) {
+        return null;
       }
+      return byId.get(cardId) ?? null;
+    },
+  } satisfies ArticleBank;
+};
 
-      return { articles, byId } satisfies ArticleBank;
+export async function loadArticleBank(jsonUrl?: string): Promise<ArticleBank> {
+  const { loader, key } = resolveLoader(jsonUrl);
+
+  if (!cachedArticleBank || cacheKey !== key) {
+    cacheKey = key;
+    cachedArticleBank = loader().then(raw => {
+      const { articles } = articleFileSchema.parse(raw);
+      return buildArticleBank(articles);
     });
   }
 
@@ -55,27 +96,13 @@ export async function loadArticleBank(): Promise<ArticleBank> {
 }
 
 export function __setArticleBankLoader(loader: ArticleDataLoader | null): void {
-  customArticleLoader = loader;
+  loaderOverride = loader;
+  cacheKey = null;
   cachedArticleBank = null;
 }
 
 export function __resetArticleBankCache(): void {
-  customArticleLoader = null;
+  loaderOverride = null;
+  cacheKey = null;
   cachedArticleBank = null;
-}
-
-export function getById(bank: ArticleBank, id: string | null | undefined): CardArticle | null {
-  if (!id) {
-    return null;
-  }
-
-  return bank.byId.get(id) ?? null;
-}
-
-export function has(bank: ArticleBank, id: string | null | undefined): boolean {
-  if (!id) {
-    return false;
-  }
-
-  return bank.byId.has(id);
 }

--- a/src/engine/news/mainStory.ts
+++ b/src/engine/news/mainStory.ts
@@ -1,103 +1,180 @@
-import type { CardArticle, ArticleBank } from './articleBank';
-import { getById } from './articleBank';
-import {
-  BYLINE_POOLS,
-  DEFAULT_TAGS,
-  STORY_TEMPLATES,
-  VERB_POOLS,
-  type StoryCardLike,
-  type StoryTemplate,
-  type StoryTone,
-} from './templates';
+import type { CardArticle } from './articleBank';
+import { govTemplates, truthTemplates, type HeadlineTemplate } from './templates';
 
-export interface MainStoryOptions {
-  bank: ArticleBank;
-  cards: StoryCardLike[];
-  activeFaction?: StoryCardLike['faction'];
+export type PlayedCardMeta = {
+  id: string;
+  name: string;
+  type: 'ATTACK' | 'MEDIA' | 'ZONE';
+  faction: 'TRUTH' | 'GOV';
+};
+
+export type GeneratedStory = {
+  headline: string;
+  subhead?: string;
+  tone: 'truth' | 'gov';
+  usedCards: string[];
+  debug?: { commonTags: string[]; subject: string; parts: string[]; templateId: string };
+};
+
+export function generateMainStory(
+  played: PlayedCardMeta[],
+  lookup: (id: string) => CardArticle | null,
+): GeneratedStory {
+  if (played.length === 0) {
+    return {
+      headline: 'SPECIAL DISPATCH: PRINTING GREMLINS AT WORK',
+      subhead: 'Witnesses report escalating weirdness. Officials baffled.',
+      tone: 'truth',
+      usedCards: [],
+      debug: { commonTags: [], subject: 'FRONT PAGE', parts: [], templateId: 'fallback:none' },
+    } satisfies GeneratedStory;
+  }
+
+  const normalizedCards = [...played].sort((a, b) => a.id.localeCompare(b.id));
+  const tone: 'truth' | 'gov' = (normalizedCards[0]?.faction ?? played[0]?.faction) === 'GOV' ? 'gov' : 'truth';
+  const articles = normalizedCards.map(card => lookup(card.id));
+
+  const tagData = collectTagData(articles);
+  const subjectIndex = resolveSubjectIndex(normalizedCards, tagData);
+  const orderedCards = reorderBySubject(normalizedCards, subjectIndex);
+  const orderedArticles = reorderBySubject(articles, subjectIndex);
+  const subjectCard = orderedCards[0] ?? normalizedCards[0];
+
+  const baseSeed = buildSeed(played);
+  const pick = createPicker(baseSeed);
+
+  const templates = tone === 'truth' ? truthTemplates : govTemplates;
+  const template = templates.length ? pick(templates, 'template') : null;
+
+  const { headline, templateId, parts, explicitSubhead } = composeHeadline(
+    template,
+    orderedCards,
+    orderedArticles,
+    tagData.common,
+    pick,
+    tone,
+  );
+
+  const commonTagDisplays = tagData.common.map(tag => tagData.display.get(tag) ?? formatTagForDisplay(tag));
+  const subjectName = (subjectCard?.name ?? 'Front Page').toUpperCase();
+  const subhead = explicitSubhead ?? formatSubhead(tone, commonTagDisplays);
+
+  return {
+    headline,
+    subhead,
+    tone,
+    usedCards: orderedCards.map(card => card.id),
+    debug: {
+      commonTags: commonTagDisplays,
+      subject: subjectName,
+      parts,
+      templateId,
+    },
+  } satisfies GeneratedStory;
 }
 
-export interface MainStoryDebugData {
-  fallback: boolean;
-  selectedCardId: string | null;
-  templateId: string | null;
-  verbChoices: {
-    pool: string[];
-    selected: string | null;
-    seed: string;
+const TECHNICAL_TAGS = new Set(['attack', 'media', 'zone']);
+const MYTHIC_TAGS = new Set(['alien', 'ufo', 'ghost', 'cryptid', 'bigfoot', 'mothman', 'bat-boy', 'elvis']);
+
+const normalizeTag = (tag: string): string => {
+  return tag.trim().replace(/^#/u, '').toLowerCase();
+};
+
+const formatTagForDisplay = (tag: string): string => {
+  return normalizeTag(tag).replace(/[-_]+/g, ' ');
+};
+
+const collectTagData = (articles: (CardArticle | null)[]) => {
+  const perCard: string[][] = [];
+  const display = new Map<string, string>();
+
+  for (const article of articles) {
+    const set = new Set<string>();
+    for (const raw of article?.tags ?? []) {
+      const normalized = normalizeTag(raw);
+      if (!normalized || TECHNICAL_TAGS.has(normalized)) {
+        continue;
+      }
+      set.add(normalized);
+      if (!display.has(normalized)) {
+        display.set(normalized, formatTagForDisplay(raw));
+      }
+    }
+    perCard.push(Array.from(set));
+  }
+
+  let common = new Set<string>();
+  if (perCard.length > 0) {
+    common = new Set(perCard[0]);
+    for (let index = 1; index < perCard.length; index += 1) {
+      const current = new Set(perCard[index]);
+      for (const tag of Array.from(common)) {
+        if (!current.has(tag)) {
+          common.delete(tag);
+        }
+      }
+      if (common.size === 0) {
+        break;
+      }
+    }
+  }
+
+  return {
+    perCard,
+    common: Array.from(common),
+    display,
+  } satisfies {
+    perCard: string[][];
+    common: string[];
+    display: Map<string, string>;
   };
-  commonTags: string[];
-}
-
-export interface MainStoryResult {
-  article: CardArticle;
-  cardId: string | null;
-  debug: MainStoryDebugData;
-}
-
-const normalizeTone = (faction: StoryCardLike['faction']): StoryTone => {
-  const value = (typeof faction === 'string' ? faction : '').toLowerCase();
-  if (value.includes('gov')) {
-    return 'government';
-  }
-  return 'truth';
 };
 
-const normalizeTag = (value: string | null | undefined): string => {
-  if (!value) {
-    return '';
+const resolveSubjectIndex = (played: PlayedCardMeta[], tagData: ReturnType<typeof collectTagData>): number => {
+  if (played.length === 0) {
+    return 0;
   }
-  return value
-    .toString()
-    .trim()
-    .replace(/^#/, '')
-    .toLowerCase()
-    .replace(/[^a-z0-9]+/g, '-')
-    .replace(/^-+|-+$/g, '');
+
+  const names = played.map(card => card.name.toLowerCase());
+  const commonMythic = tagData.common.filter(tag => MYTHIC_TAGS.has(tag));
+
+  for (const mythicTag of commonMythic) {
+    const normalized = mythicTag.replace(/[-_]+/g, ' ');
+    const compact = normalized.replace(/\s+/g, '');
+    for (let index = 0; index < names.length; index += 1) {
+      const name = names[index];
+      if (name.includes(normalized) || name.replace(/\s+/g, '').includes(compact)) {
+        return index;
+      }
+    }
+  }
+
+  if (commonMythic.length > 0) {
+    return 0;
+  }
+
+  let subjectIndex = 0;
+  let bestScore = -1;
+
+  for (let index = 0; index < played.length; index += 1) {
+    const tags = tagData.perCard[index] ?? [];
+    const score = tags.reduce((total, tag) => total + (MYTHIC_TAGS.has(tag) ? 1 : 0), 0);
+    if (score > bestScore) {
+      bestScore = score;
+      subjectIndex = index;
+    }
+  }
+
+  return subjectIndex;
 };
 
-const formatTagLabel = (value: string): string => {
-  const trimmed = value.trim();
-  const withoutHash = trimmed.startsWith('#') ? trimmed.slice(1) : trimmed;
-  const clean = withoutHash.replace(/[^a-z0-9]+/gi, ' ').trim();
-  if (!clean) {
-    return '#ParanoidPress';
+const reorderBySubject = <T>(items: T[], subjectIndex: number): T[] => {
+  if (!items.length) {
+    return items;
   }
-  const words = clean
-    .split(/\s+/)
-    .filter(Boolean)
-    .map(word => word.charAt(0).toUpperCase() + word.slice(1).toLowerCase());
-  return `#${words.join('')}`;
-};
-
-const tagToWords = (value: string): string => {
-  const trimmed = value.trim();
-  const withoutHash = trimmed.startsWith('#') ? trimmed.slice(1) : trimmed;
-  return withoutHash.replace(/[^a-z0-9]+/gi, ' ').replace(/\s+/g, ' ').trim();
-};
-
-const formatList = (items: string[]): string => {
-  const filtered = items.map(item => item.trim()).filter(Boolean);
-  if (filtered.length === 0) {
-    return '';
-  }
-  if (filtered.length === 1) {
-    return filtered[0];
-  }
-  if (filtered.length === 2) {
-    return `${filtered[0]} and ${filtered[1]}`;
-  }
-  return `${filtered.slice(0, -1).join(', ')}, and ${filtered[filtered.length - 1]}`;
-};
-
-const ensureSentence = (value: string): string => {
-  const trimmed = value.trim();
-  if (!trimmed) {
-    return trimmed;
-  }
-  if (/[.!?]$/.test(trimmed)) {
-    return trimmed;
-  }
-  return `${trimmed}.`;
+  const subject = items[subjectIndex];
+  const rest = items.filter((_item, index) => index !== subjectIndex);
+  return subject !== undefined ? [subject, ...rest] : [...items];
 };
 
 const hashString = (value: string): number => {
@@ -109,307 +186,58 @@ const hashString = (value: string): number => {
   return hash >>> 0;
 };
 
-const pickDeterministicIndex = (length: number, seed: string, salt: string): number => {
-  if (length <= 0) {
-    return 0;
-  }
-  const hashed = hashString(`${seed}:${salt}`);
-  return hashed % length;
+const createPicker = (seed: string) => {
+  return <T>(arr: T[], seedKey: string): T => {
+    if (!Array.isArray(arr) || arr.length === 0) {
+      throw new Error('Cannot pick from an empty array');
+    }
+    const key = `${seed}:${seedKey}`;
+    const index = hashString(key) % arr.length;
+    return arr[index] as T;
+  };
 };
 
-const dedupeStrings = (values: Array<string | null | undefined>): string[] => {
-  const seen = new Set<string>();
-  const result: string[] = [];
-  for (const value of values) {
-    if (!value) {
-      continue;
-    }
-    const trimmed = value.trim();
-    if (!trimmed) {
-      continue;
-    }
-    if (!seen.has(trimmed)) {
-      seen.add(trimmed);
-      result.push(trimmed);
-    }
-  }
-  return result;
+const buildSeed = (played: PlayedCardMeta[]): string => {
+  const ids = played.map(card => card.id).sort();
+  return ids.join('|') || 'no-cards';
 };
 
-const applyTemplate = (template: string, context: Record<string, string>): string => {
-  return template.replace(/\{([^}]+)\}/g, (_match, key) => {
-    const replacement = context[key];
-    return replacement !== undefined ? replacement : _match;
-  });
-};
-
-const buildBaseSeed = (tone: StoryTone, cards: StoryCardLike[]): string => {
-  const ids = cards.map(card => card.id).filter(Boolean).sort();
-  const idSeed = ids.length ? ids.join('|') : 'no-cards';
-  return `${tone}|${idSeed}`;
-};
-
-const collectTagData = (
-  cards: StoryCardLike[],
-  articleByCard: Map<string, CardArticle>,
-): {
-  common: string[];
-  all: string[];
-  labelMap: Map<string, string>;
-} => {
-  const normalizedSets: Array<Set<string>> = [];
-  const union = new Set<string>();
-  const labelMap = new Map<string, string>();
-
-  for (const card of cards) {
-    const article = articleByCard.get(card.id);
-    const combined = [
-      ...((Array.isArray(card.tags) ? card.tags : []) ?? []),
-      ...((article?.tags ?? []) as string[]),
-    ];
-    const set = new Set<string>();
-    for (const raw of combined) {
-      if (!raw) {
-        continue;
-      }
-      const normalized = normalizeTag(raw);
-      if (!normalized) {
-        continue;
-      }
-      set.add(normalized);
-      union.add(normalized);
-      if (!labelMap.has(normalized)) {
-        labelMap.set(normalized, raw);
-      }
-    }
-    if (set.size > 0) {
-      normalizedSets.push(set);
-    }
-  }
-
-  let intersection = new Set<string>();
-  if (normalizedSets.length > 0) {
-    intersection = new Set<string>(normalizedSets[0]);
-    for (let index = 1; index < normalizedSets.length; index += 1) {
-      const current = normalizedSets[index];
-      intersection = new Set<string>([...intersection].filter(tag => current.has(tag)));
-      if (intersection.size === 0) {
-        break;
-      }
-    }
-  }
-
-  const common = [...intersection].sort();
-  const all = [...union].sort();
-
-  return { common, all, labelMap };
-};
-
-const buildContext = (
-  tone: StoryTone,
-  cards: StoryCardLike[],
-  selectedCard: StoryCardLike | null,
+const composeHeadline = (
+  template: HeadlineTemplate | null,
+  cards: PlayedCardMeta[],
+  articles: (CardArticle | null)[],
   commonTags: string[],
-  labelMap: Map<string, string>,
-  verb: string,
-): {
-  context: Record<string, string>;
-  articleTags: string[];
-} => {
-  const defaultHashtag = tone === 'truth' ? '#LeakSeason' : '#NarrativeContainment';
-  const tagLabels = commonTags.map(tag => formatTagLabel(labelMap.get(tag) ?? tag));
-  const tagWords = tagLabels.map(tag => tagToWords(tag));
-  const fallbackTagLabel = tagLabels[0] ?? defaultHashtag;
-  const fallbackWords = tagWords[0] ?? tagToWords(defaultHashtag);
-
-  const cardNames = cards
-    .map(card => card.name ?? card.id)
-    .filter((name): name is string => Boolean(name && name.trim()));
-  const cardNamesUpper = cardNames.map(name => name.toUpperCase());
-  const cardListPlain = cardNames.length ? formatList(cardNames) : 'field operatives';
-  const cardListUpper = cardNamesUpper.length ? formatList(cardNamesUpper) : 'FIELD OPERATIVES';
-
-  const primaryName = (selectedCard?.name ?? cardNames[0] ?? 'Classified Operation').trim() || 'Classified Operation';
-  const primaryNameUpper = primaryName.toUpperCase();
-
-  const tagHeadline = fallbackWords ? fallbackWords.toUpperCase() : fallbackTagLabel.replace(/^#/, '').toUpperCase();
-  const tagSummary = tagLabels.length
-    ? tagLabels.join(', ')
-    : tone === 'truth'
-      ? '#HotLead'
-      : '#SituationNormal';
-  const tagPhrase = tagWords.length
-    ? formatList(tagWords.map(word => word.toLowerCase()))
-    : tone === 'truth'
-      ? 'classified transmissions'
-      : 'containment protocols';
-
-  const context: Record<string, string> = {
-    primaryName,
-    primaryNameUpper,
-    cardListPlain,
-    cardList: cardListUpper,
-    verb,
-    tagLine: fallbackTagLabel,
-    tagHeadline,
-    tagSummary,
-    tagPhrase,
-  };
-
-  const articleTagSet = new Set<string>();
-  for (const tag of labelMap.values()) {
-    const formatted = formatTagLabel(tag);
-    articleTagSet.add(formatted);
-  }
-  if (articleTagSet.size === 0) {
-    for (const tag of DEFAULT_TAGS[tone]) {
-      articleTagSet.add(tag);
-    }
+  pick: <T>(arr: T[], seedKey: string) => T,
+  tone: 'truth' | 'gov',
+): { headline: string; templateId: string; parts: string[]; explicitSubhead?: string } => {
+  if (!template) {
+    const subjectName = (cards[0]?.name ?? 'Front Page').toUpperCase();
+    const fallback = tone === 'truth' ? 'ALERTED' : 'STATUS REPORT';
+    const headline = `${subjectName} ${fallback}`;
+    return { headline, templateId: 'fallback:none', parts: [] };
   }
 
-  return {
-    context,
-    articleTags: Array.from(articleTagSet),
-  };
-};
-
-const buildFallbackArticle = (
-  tone: StoryTone,
-  template: StoryTemplate,
-  context: Record<string, string>,
-  byline: string,
-  seed: string,
-  articleTags: string[],
-): CardArticle => {
-  const headline = applyTemplate(template.headline, context).toUpperCase();
-  const deck = ensureSentence(applyTemplate(template.deck, context));
-  const bodySentences = template.body.map(sentence => ensureSentence(applyTemplate(sentence, context)));
-  const body = bodySentences.join(' ');
-  const imagePrompt = applyTemplate(template.imagePrompt, context);
-
-  return {
-    id: `generated-${tone}-${hashString(`${seed}:${headline}`)}`,
-    tone,
-    tags: dedupeStrings([...articleTags, ...DEFAULT_TAGS[tone]]),
-    headline,
-    subhead: deck,
-    byline,
-    body,
-    imagePrompt,
-  } satisfies CardArticle;
-};
-
-export function generateMainStory(options: MainStoryOptions): MainStoryResult {
-  const cards = Array.isArray(options.cards) ? options.cards.filter(card => Boolean(card?.id)) : [];
-  const tone = normalizeTone(options.activeFaction ?? cards[0]?.faction);
-  const seed = buildBaseSeed(tone, cards);
-
-  const articleByCard = new Map<string, CardArticle>();
-  for (const card of cards) {
-    const article = getById(options.bank, card.id);
-    if (article) {
-      articleByCard.set(card.id, article);
-    }
-  }
-
-  const tagData = collectTagData(cards, articleByCard);
-  const verbPool = VERB_POOLS[tone] ?? [];
-  const verbSeed = `${seed}:verb`;
-  const verbIndex = pickDeterministicIndex(verbPool.length || 1, seed, 'verb');
-  const selectedVerb = verbPool.length ? verbPool[verbIndex] : tone === 'truth' ? 'EXPOSES' : 'CONTAINS';
-
-  const articleCandidates = cards
-    .map(card => ({ card, article: articleByCard.get(card.id) }))
-    .filter((entry): entry is { card: StoryCardLike; article: CardArticle } => Boolean(entry.article))
-    .sort((a, b) => a.card.id.localeCompare(b.card.id));
-
-  let selectedCard: StoryCardLike | null = null;
-  let selectedArticle: CardArticle | null = null;
-  if (articleCandidates.length > 0) {
-    const index = pickDeterministicIndex(articleCandidates.length, seed, 'article');
-    const choice = articleCandidates[index];
-    selectedCard = choice.card;
-    selectedArticle = choice.article;
-  } else if (cards.length > 0) {
-    const fallbackIndex = pickDeterministicIndex(cards.length, seed, 'fallback-card');
-    selectedCard = cards.slice().sort((a, b) => a.id.localeCompare(b.id))[fallbackIndex];
-  }
-
-  const bylinePool = BYLINE_POOLS[tone] ?? [];
-  const bylineIndex = pickDeterministicIndex(bylinePool.length || 1, seed, 'byline');
-  const fallbackByline = bylinePool.length ? bylinePool[bylineIndex] : tone === 'truth' ? 'By: Field Operatives' : 'By: Clearance Desk';
-
-  const debugBase: MainStoryDebugData = {
-    fallback: false,
-    selectedCardId: selectedCard?.id ?? null,
-    templateId: null,
-    verbChoices: {
-      pool: verbPool,
-      selected: null,
-      seed: verbSeed,
-    },
-    commonTags: tagData.common.map(tag => formatTagLabel(tagData.labelMap.get(tag) ?? tag)),
-  };
-
-  if (selectedArticle) {
-    const mergedTags = dedupeStrings([
-      ...selectedArticle.tags,
-      ...tagData.all.map(tag => formatTagLabel(tagData.labelMap.get(tag) ?? tag)),
-      ...DEFAULT_TAGS[tone],
-    ]);
-    const article: CardArticle = {
-      ...selectedArticle,
-      tone,
-      tags: mergedTags,
-      subhead: selectedArticle.subhead?.trim() || ensureSentence(selectedArticle.body.slice(0, 120)),
-      byline: selectedArticle.byline?.trim() || fallbackByline,
-      imagePrompt:
-        selectedArticle.imagePrompt ??
-        (tone === 'truth'
-          ? `tabloid collage spotlighting ${selectedArticle.headline}`
-          : `sterile dossier photography referencing ${selectedArticle.headline}`),
-    };
+  try {
+    const result = template.compose({ cards, articles, commonTags, pick });
+    const parts = result.debugNote ? result.debugNote.split('|').filter(Boolean) : [];
     return {
-      article,
-      cardId: selectedCard?.id ?? null,
-      debug: debugBase,
-    } satisfies MainStoryResult;
-  }
-
-  const templatePool = STORY_TEMPLATES[tone] ?? [];
-  const templateIndex = pickDeterministicIndex(templatePool.length || 1, seed, 'template');
-  const template = templatePool.length ? templatePool[templateIndex] : STORY_TEMPLATES[tone === 'truth' ? 'truth' : 'government'][0];
-
-  const { context, articleTags } = buildContext(
-    tone,
-    cards,
-    selectedCard,
-    tagData.common,
-    tagData.labelMap,
-    selectedVerb,
-  );
-
-  const fallbackArticle = buildFallbackArticle(
-    tone,
-    template,
-    context,
-    fallbackByline,
-    seed,
-    articleTags,
-  );
-
-  return {
-    article: fallbackArticle,
-    cardId: selectedCard?.id ?? null,
-    debug: {
-      ...debugBase,
-      fallback: true,
+      headline: result.headline.trim(),
       templateId: template.id,
-      verbChoices: {
-        pool: verbPool,
-        selected: selectedVerb,
-        seed: verbSeed,
-      },
-    },
-  } satisfies MainStoryResult;
-}
+      parts,
+      explicitSubhead: result.subhead?.trim(),
+    };
+  } catch (error) {
+    console.warn('Failed to compose headline via template', template.id, error);
+    const subjectName = (cards[0]?.name ?? 'Front Page').toUpperCase();
+    return { headline: `${subjectName} STATUS UPDATE`, templateId: `${template.id}:error`, parts: [] };
+  }
+};
+
+const formatSubhead = (tone: 'truth' | 'gov', tags: string[]): string => {
+  if (tone === 'truth') {
+    const snippet = tags.slice(0, 2).filter(Boolean).map(tag => tag.toLowerCase()).join(', ');
+    const tagPart = snippet ? ` (${snippet})` : '';
+    return `Witnesses report escalating weirdness${tagPart}. Officials baffled.`;
+  }
+  return 'Transparency achieved via prudent opacity. Further questions will be taken later, retroactively.';
+};

--- a/src/index.css
+++ b/src/index.css
@@ -3339,3 +3339,38 @@ html, body, #root {
   0%, 100% { opacity: 0.8; }
   50% { opacity: 1; }
 }
+
+.frontpage-main .headline {
+  font-size: clamp(28px, 4vw, 44px);
+  font-weight: 800;
+  letter-spacing: 0.5px;
+  text-transform: uppercase;
+}
+
+.frontpage-main .subhead {
+  font-style: italic;
+  opacity: 0.8;
+}
+
+.frontpage-secondary .section-title {
+  margin-top: 24px;
+  font-weight: 700;
+}
+
+.frontpage .grid-2 {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 16px;
+}
+
+.frontpage .pill {
+  font-size: 12px;
+  padding: 2px 8px;
+  border: 1px solid currentColor;
+  border-radius: 999px;
+  text-transform: uppercase;
+}
+
+.frontpage .muted {
+  opacity: 0.75;
+}

--- a/src/ui/newspaper/FrontPage.tsx
+++ b/src/ui/newspaper/FrontPage.tsx
@@ -1,0 +1,114 @@
+import { useEffect, useMemo, useState } from 'react';
+
+import { loadArticleBank, type ArticleBank, type CardArticle } from '@/engine/news/articleBank';
+import { generateMainStory, type GeneratedStory, type PlayedCardMeta } from '@/engine/news/mainStory';
+import { cn } from '@/lib/utils';
+
+const ARTICLE_BANK_PATH = '/data/paranoid_times_card_articles_ALL.json';
+
+const DEFAULT_FALLBACK = {
+  headline: 'SPECIAL DISPATCH: PRINTING GREMLINS AT WORK',
+  subhead: 'Witnesses report escalating weirdness. Officials baffled.',
+};
+
+type SecondaryStory = {
+  card: PlayedCardMeta;
+  article: CardArticle | null;
+};
+
+export interface FrontPageProps {
+  cards: PlayedCardMeta[];
+  className?: string;
+  headlineFallback?: { headline: string; subhead: string };
+}
+
+const FrontPage = ({ cards, className, headlineFallback = DEFAULT_FALLBACK }: FrontPageProps) => {
+  const [articleBank, setArticleBank] = useState<ArticleBank | null>(null);
+  const [mainStory, setMainStory] = useState<GeneratedStory | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    loadArticleBank(ARTICLE_BANK_PATH)
+      .then(bank => {
+        if (!cancelled) {
+          setArticleBank(bank);
+        }
+      })
+      .catch(error => {
+        console.warn('Failed to load article bank for front page', error);
+        if (!cancelled) {
+          setArticleBank(null);
+        }
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  useEffect(() => {
+    if (cards.length !== 3) {
+      setMainStory(null);
+      return;
+    }
+
+    try {
+      const story = generateMainStory(cards, id => articleBank?.getById(id) ?? null);
+      setMainStory(story);
+    } catch (error) {
+      console.warn('Failed to compose main story', error);
+      setMainStory(null);
+    }
+  }, [articleBank, cards]);
+
+  const secondaryStories = useMemo<SecondaryStory[]>(
+    () =>
+      cards.map(card => ({
+        card,
+        article: articleBank?.getById(card.id) ?? null,
+      })),
+    [articleBank, cards],
+  );
+
+  const headline = mainStory?.headline ?? headlineFallback.headline;
+  const subhead = mainStory?.subhead ?? headlineFallback.subhead;
+
+  return (
+    <div className={cn('frontpage', className)}>
+      <section className="frontpage-main space-y-2">
+        <div className="kicker text-[10px] font-semibold uppercase tracking-[0.35em] text-newspaper-text/60">
+          Front Page Dispatch
+        </div>
+        <h1 className="headline">{headline}</h1>
+        {subhead ? <p className="subhead">{subhead}</p> : null}
+      </section>
+
+      <section className="frontpage-secondary mt-6 space-y-3">
+        <h2 className="section-title text-sm">SECONDARY REPORTS</h2>
+        <div className="grid-2">
+          {secondaryStories.map(({ card, article }) => {
+            const bodyText = article?.body?.trim();
+            return (
+              <article
+                key={card.id}
+                className="secondary-article space-y-2 rounded border border-newspaper-border/60 bg-white/70 p-3"
+              >
+                <div className="pill text-newspaper-text/80">[{card.type}]</div>
+                <h3 className="text-lg font-semibold leading-snug text-newspaper-headline">
+                  {article?.headline ?? card.name}
+                </h3>
+                {article?.subhead ? (
+                  <p className="muted text-sm italic text-newspaper-text/70">{article.subhead}</p>
+                ) : null}
+                {bodyText ? <p className="text-sm leading-relaxed text-newspaper-text/80">{bodyText}</p> : null}
+              </article>
+            );
+          })}
+        </div>
+      </section>
+    </div>
+  );
+};
+
+export default FrontPage;


### PR DESCRIPTION
## Summary
- implement a deterministic main-story generator with faction templates and subject selection logic
- add a dedicated FrontPage component with updated newspaper hierarchy and supporting styles
- wire the IssueGenerator and TabloidNewspaperV2 UI to the new generator and refresh the associated tests

## Testing
- bun test --coverage --coverage-reporter=text
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e0cec031408320ae8e76c451a8b999