### PR TITLE
Update options button headline on start screen

### DIFF
--- a/src/ui/start/StartScreen.tsx
+++ b/src/ui/start/StartScreen.tsx
@@ -129,7 +129,7 @@ const StartScreen = ({
             className="ad-card"
             onClick={handleArticleAction(onOptions)}
           >
-            Top Secret Settings
+            CLASSIFIED CONTROL ROOM!
           </button>
           <button
             type="button"


### PR DESCRIPTION
## Summary
- update the start screen options button copy to a more sensational headline for the options dialog

## Testing
- npm run lint (fails: existing repository lint errors)
- bun test --coverage --coverage-reporter=text

------
https://chatgpt.com/codex/tasks/task_e_68e0dd4654288320ac4fb08bd97c39fb