### PR TITLE
Add victory gradient theme tokens for intro card

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -87,7 +87,14 @@ All colors MUST be HSL.
     --government-dark: 220 100% 8%;
     --truth-red: 0 85% 55%;
     --secret-red: 0 100% 40%;
-    
+
+    /* Victory celebration palette */
+    --victory-gradient-start: 52.76 98.31% 76.86%;
+    --victory-gradient-mid: 0 84.24% 60.2%;
+    --victory-gradient-end: 0 73.71% 41.76%;
+    --victory-foreground: 0 0% 5%;
+    --victory-accent: 54.92 96.72% 88.04%;
+
     /* Newspaper colors */
     --newspaper-bg: 45 15% 98%;
     --newspaper-text: 0 0% 5%;

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -2381,17 +2381,17 @@ const Index = () => {
             <div className="absolute -top-4 left-1/2 -translate-x-1/2 bg-black text-yellow-300 px-4 py-1 uppercase tracking-[0.35em] text-[0.65rem] sm:text-xs font-semibold shadow-[6px_6px_0_rgba(0,0,0,0.65)]">
               Paranoid Times Exclusive
             </div>
-            <div className="bg-gradient-to-br from-yellow-200 via-red-500 to-red-700 px-10 py-8 border-[6px] border-black shadow-[14px_14px_0_rgba(0,0,0,0.8)] text-black">
-              <div className="text-[0.85rem] sm:text-sm uppercase tracking-[0.4em] text-black/80 font-semibold">
+            <div className="bg-gradient-to-br from-victory-start via-victory-mid to-victory-end px-10 py-8 border-[6px] border-black shadow-[14px_14px_0_rgba(0,0,0,0.8)] text-victory-foreground">
+              <div className="text-[0.85rem] sm:text-sm uppercase tracking-[0.4em] text-victory-foreground/80 font-semibold">
                 Tonight&rsquo;s Cover Story
               </div>
               <div className="mt-3 text-4xl sm:text-5xl font-black uppercase leading-[0.9] drop-shadow-[4px_4px_0_rgba(0,0,0,0.6)]">
                 You Won&rsquo;t Believe
               </div>
-              <div className="text-4xl sm:text-5xl font-black uppercase leading-[0.9] text-yellow-100 drop-shadow-[4px_4px_0_rgba(0,0,0,0.6)]">
+              <div className="text-4xl sm:text-5xl font-black uppercase leading-[0.9] text-victory-accent drop-shadow-[4px_4px_0_rgba(0,0,0,0.6)]">
                 What Happens Next...
               </div>
-              <div className="mt-4 text-base sm:text-lg font-semibold italic tracking-wide text-black/90">
+              <div className="mt-4 text-base sm:text-lg font-semibold italic tracking-wide text-victory-foreground/90">
                 Shadow bureau insiders spill every last secret.
               </div>
             </div>

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -67,6 +67,13 @@ export default {
         "government-dark": "hsl(var(--government-dark))",
         "truth-red": "hsl(var(--truth-red))",
         "secret-red": "hsl(var(--secret-red))",
+        victory: {
+          start: "hsl(var(--victory-gradient-start))",
+          mid: "hsl(var(--victory-gradient-mid))",
+          end: "hsl(var(--victory-gradient-end))",
+          foreground: "hsl(var(--victory-foreground))",
+          accent: "hsl(var(--victory-accent))",
+        },
         "newspaper-bg": "hsl(var(--newspaper-bg))",
         "newspaper-text": "hsl(var(--newspaper-text))",
         "newspaper-header": "hsl(var(--newspaper-header))",


### PR DESCRIPTION
## Summary
- add reusable victory gradient and accent variables to the global CSS theme
- expose the new palette through Tailwind utilities and refactor the intro card to consume it

## Testing
- npm run lint *(fails: existing repository lint violations unrelated to this change)*
- bun test --coverage --coverage-reporter=text


------
https://chatgpt.com/codex/tasks/task_e_68e11898ec1c8320b79aaa2277589703