### PR TITLE
Add victory styling variant for final report layout

### DIFF
--- a/src/components/effects/TabloidVictoryScreen.tsx
+++ b/src/components/effects/TabloidVictoryScreen.tsx
@@ -6,6 +6,7 @@ import FinalEditionLayout from '@/components/game/FinalEditionLayout';
 import GameOverEditionLayout from '@/components/game/GameOverEditionLayout';
 import type { GameOverReport } from '@/types/finalEdition';
 import { getVictoryConditionLabel } from '@/utils/finalEdition';
+import { cn } from '@/lib/utils';
 
 interface TabloidVictoryScreenProps {
   isVisible: boolean;
@@ -47,6 +48,7 @@ const TabloidVictoryScreen = ({
   }
 
   const isVictory = report.winner === report.playerFaction;
+  const layoutVariant = isVictory ? 'victory' : 'default';
   const bannerLabel = report.winner === 'draw'
     ? 'Stalemate'
     : isVictory
@@ -67,6 +69,22 @@ const TabloidVictoryScreen = ({
     `Truth ${Math.round(report.finalTruth)}%`,
   ].join(' • ');
 
+  const readEditionButtonClass = isVictory
+    ? 'border border-emerald-200/80 bg-gradient-to-r from-emerald-400 via-emerald-500 to-emerald-600 text-emerald-950 font-semibold shadow-[0_18px_48px_rgba(16,185,129,0.35)] transition-colors hover:from-emerald-300 hover:via-emerald-400 hover:to-emerald-500 hover:text-emerald-950 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-emerald-200'
+    : 'border border-newspaper-border bg-newspaper-bg/90 text-newspaper-text transition hover:bg-white/80 hover:text-newspaper-headline focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-newspaper-border/60';
+
+  const archiveButtonClass = isVictory
+    ? 'border border-dashed border-emerald-200/70 bg-emerald-500/15 text-emerald-100 transition-colors hover:bg-emerald-400/20 hover:text-emerald-950 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-emerald-200 disabled:border-emerald-200/40 disabled:bg-emerald-500/10 disabled:text-emerald-100/60'
+    : 'border border-dashed border-newspaper-border/70 bg-newspaper-bg/70 text-newspaper-text transition hover:bg-white/80 hover:text-newspaper-headline focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-newspaper-border/60 disabled:opacity-60';
+
+  const creditsButtonClass = isVictory
+    ? 'text-emerald-100/80 transition hover:text-emerald-50 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-emerald-200'
+    : 'text-newspaper-text/80 transition hover:text-newspaper-text focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-newspaper-border/60';
+
+  const menuButtonClass = isVictory
+    ? 'border border-emerald-200/80 bg-emerald-500/25 text-emerald-50 transition-colors hover:bg-emerald-400/30 hover:text-emerald-950 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-emerald-200'
+    : 'border border-newspaper-border bg-newspaper-bg/90 text-newspaper-text transition hover:bg-white/80 hover:text-newspaper-headline focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-newspaper-border/60';
+
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-slate-950/85 p-6">
       <GameOverEditionLayout
@@ -76,12 +94,13 @@ const TabloidVictoryScreen = ({
         metaLine={`Final Campaign Report • ${editionDate}`}
         tagline={tagline}
         onClose={onClose}
+        variant={layoutVariant}
         footer={(
           <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
             <div className="flex flex-wrap justify-center gap-2 md:justify-start">
               <Button
                 onClick={onViewFinalEdition}
-                className="border border-newspaper-border bg-newspaper-bg/90 text-newspaper-text transition hover:bg-white/80 hover:text-newspaper-headline"
+                className={cn(readEditionButtonClass)}
               >
                 <Newspaper className="mr-2 h-4 w-4" />
                 Read Final Newspaper
@@ -91,7 +110,7 @@ const TabloidVictoryScreen = ({
                   onClick={onArchive}
                   disabled={isArchived}
                   variant="outline"
-                  className="border border-dashed border-newspaper-border/70 bg-newspaper-bg/70 text-newspaper-text transition hover:bg-white/80 hover:text-newspaper-headline disabled:opacity-60"
+                  className={cn(archiveButtonClass)}
                 >
                   {isArchived ? 'Archived' : 'Archive to Player Hub'}
                 </Button>
@@ -100,14 +119,14 @@ const TabloidVictoryScreen = ({
             <div className="flex flex-wrap justify-center gap-2 md:justify-end">
               <Button
                 variant="ghost"
-                className="text-newspaper-text/80 transition hover:text-newspaper-text"
+                className={cn(creditsButtonClass)}
                 onClick={() => setShowCredits(true)}
               >
                 Roll Credits
               </Button>
               <Button
                 variant="secondary"
-                className="border border-newspaper-border bg-newspaper-bg/90 text-newspaper-text transition hover:bg-white/80 hover:text-newspaper-headline"
+                className={cn(menuButtonClass)}
                 onClick={onMainMenu}
               >
                 Return to Menu

--- a/src/components/game/GameOverEditionLayout.tsx
+++ b/src/components/game/GameOverEditionLayout.tsx
@@ -12,6 +12,7 @@ interface GameOverEditionLayoutProps {
   children: ReactNode;
   footer?: ReactNode;
   className?: string;
+  variant?: 'default' | 'victory';
 }
 
 const GameOverEditionLayout = ({
@@ -24,49 +25,125 @@ const GameOverEditionLayout = ({
   children,
   footer,
   className,
+  variant = 'default',
 }: GameOverEditionLayoutProps) => {
   return (
     <div
       className={cn(
-        'relative flex h-full max-h-[92vh] w-full max-w-5xl flex-col overflow-hidden rounded-[1.5rem] border-4 border-newspaper-border bg-newspaper-bg text-newspaper-text shadow-2xl before:absolute before:-inset-6 before:-z-10 before:rounded-[2rem] before:bg-[radial-gradient(circle_at_top,_rgba(16,185,129,0.28),_transparent_70%)] before:opacity-80 before:blur-xl before:content-[""] after:pointer-events-none after:absolute after:-inset-12 after:-z-20 after:rounded-[2.75rem] after:bg-[radial-gradient(circle,_rgba(16,185,129,0.18),_transparent_75%)] after:opacity-80 after:blur-[90px] after:content-[""]',
+        'relative flex h-full max-h-[92vh] w-full max-w-5xl flex-col overflow-hidden rounded-[1.5rem] border-4 shadow-2xl before:absolute before:-inset-6 before:-z-10 before:rounded-[2rem] before:blur-xl before:content-[""] after:pointer-events-none after:absolute after:-inset-12 after:-z-20 after:rounded-[2.75rem] after:blur-[90px] after:content-[""]',
+        variant === 'victory'
+          ? 'border-emerald-400/50 bg-slate-950/95 text-emerald-50 shadow-[0_25px_120px_rgba(16,185,129,0.35)] before:bg-[radial-gradient(circle_at_top,_rgba(52,211,153,0.45),_rgba(20,184,166,0.18)_55%,_transparent_85%)] before:opacity-90 after:bg-[radial-gradient(circle,_rgba(16,185,129,0.32),_transparent_78%)] after:opacity-95'
+          : 'border-newspaper-border bg-newspaper-bg text-newspaper-text before:bg-[radial-gradient(circle_at_top,_rgba(16,185,129,0.28),_transparent_70%)] before:opacity-80 after:bg-[radial-gradient(circle,_rgba(16,185,129,0.18),_transparent_75%)] after:opacity-80',
         className,
       )}
     >
-      <header className="relative border-b-4 border-double border-newspaper-border bg-newspaper-header/95 px-6 py-6">
+      <header
+        className={cn(
+          'relative border-b-4 border-double px-6 py-6',
+          variant === 'victory'
+            ? 'border-emerald-300/50 bg-gradient-to-b from-emerald-500/95 via-emerald-600/95 to-emerald-700/95 text-emerald-50 shadow-[inset_0_-8px_30px_rgba(15,118,110,0.45)]'
+            : 'border-newspaper-border bg-newspaper-header/95 text-newspaper-text',
+        )}
+      >
         <button
           type="button"
           onClick={onClose}
-          aria-label="Close victory report"
-          className="absolute right-4 top-4 rounded-full border-2 border-newspaper-text/40 bg-newspaper-bg/40 p-1 text-newspaper-text transition hover:bg-newspaper-bg"
+          aria-label="Close final report"
+          className={cn(
+            'absolute right-4 top-4 rounded-full border-2 p-1 transition focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2',
+            variant === 'victory'
+              ? 'border-emerald-200/60 bg-emerald-500/20 text-emerald-50 hover:bg-emerald-400/25 focus-visible:outline-emerald-200'
+              : 'border-newspaper-text/40 bg-newspaper-bg/40 text-newspaper-text hover:bg-newspaper-bg focus-visible:outline-newspaper-border/60',
+          )}
         >
-          <X className="h-5 w-5" />
+          <X className={cn('h-5 w-5', variant === 'victory' ? 'drop-shadow-[0_0_8px_rgba(16,185,129,0.6)]' : undefined)} />
         </button>
         <div className="flex flex-col items-center gap-2 text-center">
-          <span className="text-[11px] font-semibold uppercase tracking-[0.6em] text-newspaper-text/60">
+          <span
+            className={cn(
+              'text-[11px] font-semibold uppercase tracking-[0.6em]',
+              variant === 'victory' ? 'text-emerald-100/80 drop-shadow-[0_0_8px_rgba(16,185,129,0.35)]' : 'text-newspaper-text/60',
+            )}
+          >
             ShadowGov Press Bureau
           </span>
-          <p className="text-xs font-semibold uppercase tracking-[0.35em] text-newspaper-text/70">{kicker}</p>
+          <p
+            className={cn(
+              'text-xs font-semibold uppercase tracking-[0.35em]',
+              variant === 'victory' ? 'text-emerald-100/90 drop-shadow-[0_0_6px_rgba(16,185,129,0.35)]' : 'text-newspaper-text/70',
+            )}
+          >
+            {kicker}
+          </p>
           <div className="flex items-center gap-3">
-            {bannerIcon ? <span className="text-newspaper-headline">{bannerIcon}</span> : null}
-            <h2 className="text-3xl font-black uppercase tracking-[0.25em] text-newspaper-text sm:text-4xl">
+            {bannerIcon ? (
+              <span
+                className={cn(
+                  variant === 'victory'
+                    ? 'text-emerald-100 drop-shadow-[0_0_12px_rgba(16,185,129,0.45)]'
+                    : 'text-newspaper-headline',
+                )}
+              >
+                {bannerIcon}
+              </span>
+            ) : null}
+            <h2
+              className={cn(
+                'text-3xl font-black uppercase tracking-[0.25em] sm:text-4xl',
+                variant === 'victory'
+                  ? 'text-emerald-50 drop-shadow-[0_6px_18px_rgba(15,118,110,0.65)]'
+                  : 'text-newspaper-text',
+              )}
+            >
               {bannerLabel}
             </h2>
           </div>
-          <p className="text-[11px] font-semibold uppercase tracking-[0.35em] text-newspaper-text/60">{metaLine}</p>
+          <p
+            className={cn(
+              'text-[11px] font-semibold uppercase tracking-[0.35em]',
+              variant === 'victory' ? 'text-emerald-100/80' : 'text-newspaper-text/60',
+            )}
+          >
+            {metaLine}
+          </p>
           {tagline ? (
-            <p className="text-[11px] font-semibold uppercase tracking-[0.32em] text-newspaper-text/50">{tagline}</p>
+            <p
+              className={cn(
+                'text-[11px] font-semibold uppercase tracking-[0.32em]',
+                variant === 'victory' ? 'text-emerald-100/70' : 'text-newspaper-text/50',
+              )}
+            >
+              {tagline}
+            </p>
           ) : null}
         </div>
       </header>
 
-      <main className="flex-1 overflow-y-auto bg-slate-950/95 px-6 py-6">
-        <div className="mx-auto max-w-4xl text-emerald-100">
+      <main
+        className={cn(
+          'flex-1 overflow-y-auto px-6 py-6',
+          variant === 'victory' ? 'bg-slate-950/90' : 'bg-slate-950/95',
+        )}
+      >
+        <div
+          className={cn(
+            'mx-auto max-w-4xl',
+            variant === 'victory' ? 'text-emerald-100 drop-shadow-[0_0_12px_rgba(16,185,129,0.35)]' : 'text-emerald-100',
+          )}
+        >
           {children}
         </div>
       </main>
 
       {footer ? (
-        <footer className="border-t-4 border-newspaper-border bg-newspaper-header/95 px-6 py-5 text-newspaper-text">
+        <footer
+          className={cn(
+            'border-t-4 px-6 py-5',
+            variant === 'victory'
+              ? 'border-emerald-300/40 bg-slate-950/80 text-emerald-100'
+              : 'border-newspaper-border bg-newspaper-header/95 text-newspaper-text',
+          )}
+        >
           {footer}
         </footer>
       ) : null}


### PR DESCRIPTION
## Summary
- add a `variant` prop to the game over layout that switches to the brighter victory gradients, typography, and focus styles
- update the tabloid victory screen to opt into the new styling when the player wins and refresh the action button palette

## Testing
- npm run lint *(fails: repository currently has pre-existing lint violations unrelated to this change)*
- bun test --coverage --coverage-reporter=text *(fails: extension loader expects `localStorage` in the test environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e1195628cc8320aeb9a27309c2fe06