### PR TITLE
Apply victory palette to final edition newspaper

### DIFF
--- a/src/components/game/FinalEditionLayout.tsx
+++ b/src/components/game/FinalEditionLayout.tsx
@@ -3,10 +3,11 @@ import { Badge } from '@/components/ui/badge';
 import { Progress } from '@/components/ui/progress';
 import { cn } from '@/lib/utils';
 import {
-  NEWSPAPER_BADGE_CLASS,
   NEWSPAPER_META_CLASS,
   NEWSPAPER_SECTION_HEADING_CLASS,
   NewspaperSection,
+  type NewspaperTone,
+  getNewspaperBadgeClass,
 } from './newspaperLayout';
 import type { GameOverReport, FinalEditionEventHighlight, MVPReport } from '@/types/finalEdition';
 import {
@@ -166,37 +167,6 @@ const CardArt = ({
   );
 };
 
-const renderMvpPanel = (label: string, mvp?: MVPReport | null) => {
-  if (!mvp) {
-    return null;
-  }
-  return (
-    <NewspaperSection className="h-full space-y-4 p-5">
-      <div className="flex items-center justify-between">
-        <h4 className={NEWSPAPER_SECTION_HEADING_CLASS}>{label}</h4>
-        <Badge className={cn(NEWSPAPER_BADGE_CLASS, 'rounded-full px-3 py-0.5 tracking-[0.3em] text-[11px]')}>
-          {mvp.impactLabel}
-        </Badge>
-      </div>
-      <div className="flex flex-col gap-4 sm:flex-row">
-        <CardArt cardId={mvp.cardId} showPlaceholder className="sm:w-32" />
-        <div className="flex-1 space-y-3">
-          <div>
-            <h3 className="text-xl font-black uppercase tracking-[0.12em] text-newspaper-headline">{mvp.cardName}</h3>
-            <p className="mt-1 text-sm text-newspaper-text/80">{mvp.highlight}</p>
-          </div>
-          <div className="grid gap-2 text-xs font-semibold uppercase tracking-[0.2em] text-newspaper-text/70 sm:grid-cols-2">
-            <div>Truth Delta: {Math.round(mvp.truthDelta)}%</div>
-            <div>IP Swing: {mvp.ipDelta >= 0 ? '+' : ''}{Math.round(mvp.ipDelta)}</div>
-            <div>States Captured: {mvp.capturedStates.length > 0 ? mvp.capturedStates.join(', ') : '—'}</div>
-            <div>Damage: {Math.round(mvp.damageDealt)}</div>
-          </div>
-        </div>
-      </div>
-    </NewspaperSection>
-  );
-};
-
 const FinalEditionLayout = ({ report }: FinalEditionLayoutProps) => {
   const headline = formatVictoryHeadline(report);
   const subhead = formatVictorySubhead(report);
@@ -218,53 +188,139 @@ const FinalEditionLayout = ({ report }: FinalEditionLayoutProps) => {
   const editionDate = new Date(report.recordedAt).toLocaleDateString();
   const showExtraStamp = report.victoryType === 'agenda' && report.winner !== 'draw';
 
+  const tone: NewspaperTone = playerOutcome === 'Victory' ? 'victory' : 'default';
+  const badgeClass = getNewspaperBadgeClass(tone);
+  const sectionHeadingClass = cn(
+    NEWSPAPER_SECTION_HEADING_CLASS,
+    tone === 'victory' ? 'text-victory-foreground/75' : undefined,
+  );
+  const metaClass = cn(NEWSPAPER_META_CLASS, tone === 'victory' ? 'text-victory-foreground/70' : undefined);
+  const accentHeadlineClass =
+    tone === 'victory'
+      ? 'text-victory-accent drop-shadow-[0_2px_8px_rgba(0,0,0,0.35)]'
+      : 'text-newspaper-headline';
+  const primaryBodyClass = tone === 'victory' ? 'text-victory-foreground/85' : 'text-newspaper-text/80';
+  const mutedBodyClass = tone === 'victory' ? 'text-victory-foreground/75' : 'text-newspaper-text/70';
+  const subtleBodyClass = tone === 'victory' ? 'text-victory-foreground/65' : 'text-newspaper-text/60';
+  const statLabelClass = tone === 'victory' ? 'text-victory-foreground/75' : 'text-newspaper-text/70';
+  const statTileClass =
+    tone === 'victory'
+      ? 'rounded border border-victory-foreground/35 bg-gradient-to-br from-victory-start/82 via-victory-mid/78 to-victory-end/82 p-3 text-victory-foreground shadow-[0_12px_30px_rgba(0,0,0,0.35)]'
+      : 'rounded border border-dashed border-newspaper-border/60 bg-newspaper-bg/70 p-3';
+  const statValueClass =
+    tone === 'victory'
+      ? 'mt-1 text-2xl font-black tracking-tight text-victory-accent drop-shadow-[0_2px_8px_rgba(0,0,0,0.35)]'
+      : 'mt-1 text-2xl font-black tracking-tight text-newspaper-headline';
+  const highlightCardClass =
+    tone === 'victory'
+      ? 'rounded-md border border-victory-foreground/30 bg-gradient-to-br from-victory-start/80 via-victory-mid/74 to-victory-end/80 text-victory-foreground shadow-[0_16px_36px_rgba(0,0,0,0.35)]'
+      : 'rounded-md border border-newspaper-border/70 bg-white/75 text-newspaper-text shadow-sm';
+  const dashedPanelClass =
+    tone === 'victory'
+      ? 'rounded-md border border-dashed border-victory-foreground/40 bg-victory-foreground/10 p-3 shadow-[0_10px_28px_rgba(0,0,0,0.3)]'
+      : 'rounded-md border border-dashed border-newspaper-border/60 bg-newspaper-bg/70 p-3';
+  const progressTrackClass = tone === 'victory' ? 'mt-2 h-1.5 bg-victory-foreground/20' : 'mt-2 h-1.5 bg-newspaper-header/30';
+
+  const renderMvpPanel = (label: string, mvp?: MVPReport | null) => {
+    if (!mvp) {
+      return null;
+    }
+    return (
+      <NewspaperSection tone={tone} className="h-full space-y-4 p-5">
+        <div className="flex items-center justify-between">
+          <h4 className={sectionHeadingClass}>{label}</h4>
+          <Badge className={cn(badgeClass, 'rounded-full px-3 py-0.5 tracking-[0.3em] text-[11px]')}>
+            {mvp.impactLabel}
+          </Badge>
+        </div>
+        <div className="flex flex-col gap-4 sm:flex-row">
+          <CardArt
+            cardId={mvp.cardId}
+            showPlaceholder
+            className={cn('sm:w-32', tone === 'victory' ? 'border-victory-foreground/40 bg-victory-foreground/10' : undefined)}
+          />
+          <div className="flex-1 space-y-3">
+            <div>
+              <h3 className={cn('text-xl font-black uppercase tracking-[0.12em]', accentHeadlineClass)}>{mvp.cardName}</h3>
+              <p className={cn('mt-1 text-sm', primaryBodyClass)}>{mvp.highlight}</p>
+            </div>
+            <div
+              className={cn(
+                'grid gap-2 text-xs font-semibold uppercase tracking-[0.2em] sm:grid-cols-2',
+                mutedBodyClass,
+              )}
+            >
+              <div>Truth Delta: {Math.round(mvp.truthDelta)}%</div>
+              <div>
+                IP Swing: {mvp.ipDelta >= 0 ? '+' : ''}
+                {Math.round(mvp.ipDelta)}
+              </div>
+              <div>States Captured: {mvp.capturedStates.length > 0 ? mvp.capturedStates.join(', ') : '—'}</div>
+              <div>Damage: {Math.round(mvp.damageDealt)}</div>
+            </div>
+          </div>
+        </div>
+      </NewspaperSection>
+    );
+  };
+
   return (
-    <div className="space-y-6 text-newspaper-text">
-      <NewspaperSection className="relative overflow-hidden px-6 py-6 sm:px-8">
+    <div className={cn('space-y-6', tone === 'victory' ? 'text-victory-foreground' : 'text-newspaper-text')}>
+      <NewspaperSection tone={tone} className="relative overflow-hidden px-6 py-6 sm:px-8">
         {showExtraStamp ? (
           <div className="stamp stamp--breaking absolute left-6 top-5">EXTRA</div>
         ) : null}
         <div className="flex flex-wrap items-center justify-between gap-3">
-          <div className={NEWSPAPER_META_CLASS}>Final Edition • {editionDate}</div>
-          <div className="flex flex-wrap items-center gap-2 text-[10px] font-semibold uppercase tracking-[0.35em] text-newspaper-text/70">
+          <div className={metaClass}>Final Edition • {editionDate}</div>
+          <div
+            className={cn(
+              'flex flex-wrap items-center gap-2 text-[10px] font-semibold uppercase tracking-[0.35em]',
+              tone === 'victory' ? 'text-victory-foreground/80' : 'text-newspaper-text/70',
+            )}
+          >
             {playerOutcome !== 'Stalemate' ? (
-              <Badge className={cn(NEWSPAPER_BADGE_CLASS, 'rounded-full px-3 py-1')}>
+              <Badge className={cn(badgeClass, 'rounded-full px-3 py-1')}>
                 {playerOutcome}
               </Badge>
             ) : null}
-            <Badge className={cn(NEWSPAPER_BADGE_CLASS, 'rounded-full px-3 py-1')}>
+            <Badge className={cn(badgeClass, 'rounded-full px-3 py-1')}>
               {victoryConditionLabel}
             </Badge>
-            <Badge className={cn(NEWSPAPER_BADGE_CLASS, 'rounded-full px-3 py-1')}>
+            <Badge className={cn(badgeClass, 'rounded-full px-3 py-1')}>
               {playerFactionLabel}
             </Badge>
           </div>
         </div>
-        <h1 className="mt-3 text-3xl font-black uppercase tracking-[0.12em] text-newspaper-headline sm:text-4xl">
+        <h1 className={cn('mt-3 text-3xl font-black uppercase tracking-[0.12em] sm:text-4xl', accentHeadlineClass)}>
           {headline}
         </h1>
-        <p className="mt-2 text-lg font-semibold italic text-newspaper-text/80">{subhead}</p>
-        <p className="mt-3 text-xs font-semibold uppercase tracking-[0.4em] text-newspaper-text/60">{outcomeSummary}</p>
-        <div className="mt-5 grid gap-3 text-xs font-semibold uppercase tracking-[0.3em] text-newspaper-text/70 sm:grid-cols-4">
-          <div className="rounded border border-dashed border-newspaper-border/60 bg-newspaper-bg/70 p-3">
-            <div>Rounds</div>
-            <div className="mt-1 text-2xl font-black tracking-tight text-newspaper-headline">
+        <p className={cn('mt-2 text-lg font-semibold italic', primaryBodyClass)}>{subhead}</p>
+        <p className={cn('mt-3 text-xs font-semibold uppercase tracking-[0.4em]', subtleBodyClass)}>{outcomeSummary}</p>
+        <div
+          className={cn(
+            'mt-5 grid gap-3 text-xs font-semibold uppercase tracking-[0.3em] sm:grid-cols-4',
+            mutedBodyClass,
+          )}
+        >
+          <div className={statTileClass}>
+            <div className={statLabelClass}>Rounds</div>
+            <div className={statValueClass}>
               {report.rounds > 0 ? report.rounds : '—'}
             </div>
           </div>
-          <div className="rounded border border-dashed border-newspaper-border/60 bg-newspaper-bg/70 p-3">
-            <div>Truth Meter</div>
-            <div className="mt-1 text-2xl font-black tracking-tight text-newspaper-headline">{Math.round(report.finalTruth)}%</div>
+          <div className={statTileClass}>
+            <div className={statLabelClass}>Truth Meter</div>
+            <div className={statValueClass}>{Math.round(report.finalTruth)}%</div>
           </div>
-          <div className="rounded border border-dashed border-newspaper-border/60 bg-newspaper-bg/70 p-3">
-            <div>State Control</div>
-            <div className="mt-1 text-2xl font-black tracking-tight text-newspaper-headline">
+          <div className={statTileClass}>
+            <div className={statLabelClass}>State Control</div>
+            <div className={statValueClass}>
               Truth {report.statesTruth} · Gov {report.statesGov}
             </div>
           </div>
-          <div className="rounded border border-dashed border-newspaper-border/60 bg-newspaper-bg/70 p-3">
-            <div>Influence Points</div>
-            <div className="mt-1 text-2xl font-black tracking-tight text-newspaper-headline">{influenceSummary}</div>
+          <div className={statTileClass}>
+            <div className={statLabelClass}>Influence Points</div>
+            <div className={statValueClass}>{influenceSummary}</div>
           </div>
         </div>
       </NewspaperSection>
@@ -274,10 +330,10 @@ const FinalEditionLayout = ({ report }: FinalEditionLayoutProps) => {
         {renderMvpPanel('Runner-Up', report.runnerUp)}
       </section>
 
-      <NewspaperSection className="p-5">
+      <NewspaperSection tone={tone} className="p-5">
         <div className="flex items-center justify-between">
-          <h2 className={NEWSPAPER_SECTION_HEADING_CLASS}>Key Events</h2>
-          <Badge className={cn(NEWSPAPER_BADGE_CLASS, 'rounded-full px-3 py-0.5 text-[11px] tracking-[0.3em]')}>
+          <h2 className={sectionHeadingClass}>Key Events</h2>
+          <Badge className={cn(badgeClass, 'rounded-full px-3 py-0.5 text-[11px] tracking-[0.3em]')}>
             {eventHighlights.length}
           </Badge>
         </div>
@@ -295,59 +351,75 @@ const FinalEditionLayout = ({ report }: FinalEditionLayoutProps) => {
               ? arcSummary.status === 'finale'
                 ? 'border-secret-red text-secret-red'
                 : arcSummary.status === 'cliffhanger'
-                  ? 'border-newspaper-border text-newspaper-headline'
-                  : 'border-dashed border-newspaper-border/70 text-newspaper-text/70'
+                  ? tone === 'victory'
+                    ? 'border-victory-foreground/60 text-victory-accent'
+                    : 'border-newspaper-border text-newspaper-headline'
+                  : tone === 'victory'
+                    ? 'border-dashed border-victory-foreground/40 text-victory-foreground/75'
+                    : 'border-dashed border-newspaper-border/70 text-newspaper-text/70'
               : '';
 
             return (
-              <div key={event.id} className="rounded-md border border-newspaper-border/70 bg-white/75 p-4 shadow-sm">
+              <div key={event.id} className={cn(highlightCardClass, 'p-4')}>
                 <div className="flex flex-col gap-3 sm:flex-row">
-                  <CardArt cardId={event.cardId} className="sm:w-28" />
+                  <CardArt
+                    cardId={event.cardId}
+                    className={cn('sm:w-28', tone === 'victory' ? 'border-victory-foreground/40 bg-victory-foreground/10' : undefined)}
+                  />
                   <div className="flex-1 space-y-3">
                     <div className="flex flex-wrap items-center justify-between gap-2">
-                      <h3 className="text-lg font-black uppercase tracking-[0.12em] text-newspaper-headline">{event.headline}</h3>
+                      <h3 className={cn('text-lg font-black uppercase tracking-[0.12em]', accentHeadlineClass)}>
+                        {event.headline}
+                      </h3>
                       <Badge
                         variant="outline"
-                        className={cn(NEWSPAPER_BADGE_CLASS, 'rounded-full px-3 py-0.5 text-[10px] tracking-[0.3em]')}
+                        className={cn(badgeClass, 'rounded-full px-3 py-0.5 text-[10px] tracking-[0.3em]')}
                       >
                         {event.faction.toUpperCase()} · {event.rarity.toUpperCase()}
                       </Badge>
                     </div>
                     <div className="space-y-2">
-                      <p className="text-sm text-newspaper-text/80">{event.summary}</p>
+                      <p className={cn('text-sm', primaryBodyClass)}>{event.summary}</p>
                       {event.kicker ? (
-                        <p className="text-xs italic text-newspaper-text/60">{event.kicker}</p>
+                        <p className={cn('text-xs italic', subtleBodyClass)}>{event.kicker}</p>
                       ) : null}
-                      <div className="text-xs font-semibold uppercase tracking-[0.25em] text-newspaper-text/60">
+                      <div className={cn('text-xs font-semibold uppercase tracking-[0.25em]', subtleBodyClass)}>
                         {renderImpactBadges(event)}
                       </div>
                     </div>
                     {arcSummary ? (
-                      <div className="rounded-md border border-dashed border-newspaper-border/60 bg-newspaper-bg/70 p-3">
-                        <div className="flex flex-wrap items-center justify-between gap-2 text-[10px] font-semibold uppercase tracking-[0.28em] text-newspaper-text/70">
+                      <div className={cn(dashedPanelClass, 'space-y-2')}>
+                        <div
+                          className={cn(
+                            'flex flex-wrap items-center justify-between gap-2 text-[10px] font-semibold uppercase tracking-[0.28em]',
+                            mutedBodyClass,
+                          )}
+                        >
                           <span>Campaign Arc</span>
                           <div className="flex items-center gap-2">
-                            <span>Chapter {arcSummary.chapter}/{arcSummary.totalChapters}</span>
+                            <span>
+                              Chapter {arcSummary.chapter}/{arcSummary.totalChapters}
+                            </span>
                             {arcStatusLabel ? (
-                              <span className={`rounded-full border px-2 py-0.5 ${arcStatusClass}`}>
+                              <span className={cn('rounded-full border px-2 py-0.5', arcStatusClass)}>
                                 {arcStatusLabel}
                               </span>
                             ) : null}
                           </div>
                         </div>
-                        <p className="mt-2 text-sm font-semibold text-newspaper-headline">{arcSummary.arcName}</p>
-                        <Progress value={arcSummary.progressPercent} className="mt-2 h-1.5 bg-newspaper-header/30" />
-                        <p className="mt-2 text-xs italic text-newspaper-text/60">{arcSummary.tagline}</p>
+                        <p className={cn('text-sm font-semibold', accentHeadlineClass)}>{arcSummary.arcName}</p>
+                        <Progress value={arcSummary.progressPercent} className={progressTrackClass} />
+                        <p className={cn('text-xs italic', subtleBodyClass)}>{arcSummary.tagline}</p>
                         {arcSummary.events.length ? (
-                          <ul className="mt-2 space-y-1 text-xs text-newspaper-text/70">
+                          <ul className={cn('mt-2 space-y-1 text-xs', mutedBodyClass)}>
                             {arcSummary.events.slice(0, 2).map(arcEvent => (
                               <li key={arcEvent.id}>
-                                <span className="font-semibold text-newspaper-headline">{arcEvent.headline}</span>
-                                <span className="block italic text-newspaper-text/60">{arcEvent.subhead}</span>
+                                <span className={cn('font-semibold', accentHeadlineClass)}>{arcEvent.headline}</span>
+                                <span className={cn('block italic', subtleBodyClass)}>{arcEvent.subhead}</span>
                               </li>
                             ))}
                             {arcSummary.events.length > 2 ? (
-                              <li className="text-[10px] uppercase tracking-[0.28em] text-newspaper-text/60">…</li>
+                              <li className={cn('text-[10px] uppercase tracking-[0.28em]', subtleBodyClass)}>…</li>
                             ) : null}
                           </ul>
                         ) : null}
@@ -359,118 +431,129 @@ const FinalEditionLayout = ({ report }: FinalEditionLayoutProps) => {
             );
           })}
           {eventHighlights.length === 0 ? (
-            <p className="text-sm text-newspaper-text/70">No notable events logged this match.</p>
+            <p className={cn('text-sm', mutedBodyClass)}>No notable events logged this match.</p>
           ) : null}
         </div>
       </NewspaperSection>
 
       <section className="grid gap-4 md:grid-cols-2">
-        <NewspaperSection className="p-5">
-          <h2 className={NEWSPAPER_SECTION_HEADING_CLASS}>Combo Highlights</h2>
+        <NewspaperSection tone={tone} className="p-5">
+          <h2 className={sectionHeadingClass}>Combo Highlights</h2>
           <div className="mt-4 space-y-3">
             {comboHighlights.map(combo => (
-              <div key={combo.id} className="rounded-md border border-newspaper-border/60 bg-white/75 p-3 shadow-sm">
+              <div key={combo.id} className={cn(highlightCardClass, 'p-3')}>
                 <div className="flex flex-col gap-3 sm:flex-row">
-                  <CardArt cardId={combo.cardId} className="sm:w-24" />
+                  <CardArt
+                    cardId={combo.cardId}
+                    className={cn('sm:w-24', tone === 'victory' ? 'border-victory-foreground/40 bg-victory-foreground/10' : undefined)}
+                  />
                   <div className="flex-1 space-y-2">
                     <div className="flex items-center justify-between">
-                      <h3 className="text-sm font-black uppercase tracking-[0.16em] text-newspaper-headline">{combo.name}</h3>
+                      <h3 className={cn('text-sm font-black uppercase tracking-[0.16em]', accentHeadlineClass)}>
+                        {combo.name}
+                      </h3>
                       <Badge
                         variant="outline"
-                        className={cn(NEWSPAPER_BADGE_CLASS, 'rounded-full px-3 py-0.5 text-[10px] tracking-[0.3em]')}
+                        className={cn(badgeClass, 'rounded-full px-3 py-0.5 text-[10px] tracking-[0.3em]')}
                       >
                         {combo.rewardLabel}
                       </Badge>
                     </div>
-                    <p className="text-xs font-semibold uppercase tracking-[0.3em] text-newspaper-text/60">
+                    <p className={cn('text-xs font-semibold uppercase tracking-[0.3em]', subtleBodyClass)}>
                       Turn {combo.turn} · {combo.ownerLabel}
                     </p>
                     {combo.description ? (
-                      <p className="text-sm text-newspaper-text/80">{combo.description}</p>
+                      <p className={cn('text-sm', primaryBodyClass)}>{combo.description}</p>
                     ) : null}
                   </div>
                 </div>
               </div>
             ))}
             {comboHighlights.length === 0 ? (
-              <p className="text-sm text-newspaper-text/70">No combo sequences documented.</p>
+              <p className={cn('text-sm', mutedBodyClass)}>No combo sequences documented.</p>
             ) : null}
           </div>
         </NewspaperSection>
 
-        <NewspaperSection className="p-5">
-          <h2 className={NEWSPAPER_SECTION_HEADING_CLASS}>Paranormal Sightings</h2>
+        <NewspaperSection tone={tone} className="p-5">
+          <h2 className={sectionHeadingClass}>Paranormal Sightings</h2>
           <div className="mt-4 space-y-3">
             {sightings.map(sighting => (
-              <div key={sighting.id} className="rounded-md border border-newspaper-border/60 bg-white/75 p-3 shadow-sm">
+              <div key={sighting.id} className={cn(highlightCardClass, 'p-3')}>
                 <div className="flex items-center justify-between gap-2">
-                  <h3 className="text-sm font-black uppercase tracking-[0.16em] text-newspaper-headline">{sighting.headline}</h3>
+                  <h3 className={cn('text-sm font-black uppercase tracking-[0.16em]', accentHeadlineClass)}>
+                    {sighting.headline}
+                  </h3>
                   <Badge
                     variant="outline"
-                    className={cn(NEWSPAPER_BADGE_CLASS, 'rounded-full px-3 py-0.5 text-[10px] tracking-[0.3em]')}
+                    className={cn(badgeClass, 'rounded-full px-3 py-0.5 text-[10px] tracking-[0.3em]')}
                   >
                     {sighting.category.toUpperCase()}
                   </Badge>
                 </div>
-                <p className="mt-1 text-sm text-newspaper-text/80">{sighting.subtext}</p>
+                <p className={cn('mt-1 text-sm', primaryBodyClass)}>{sighting.subtext}</p>
                 {sighting.metadata?.stateName ? (
-                  <p className="mt-1 text-xs font-semibold uppercase tracking-[0.3em] text-newspaper-text/60">
+                  <p className={cn('mt-1 text-xs font-semibold uppercase tracking-[0.3em]', subtleBodyClass)}>
                     {sighting.metadata.stateName}
                   </p>
                 ) : null}
               </div>
             ))}
             {sightings.length === 0 ? (
-              <p className="text-sm text-newspaper-text/70">No anomalous activity logged for this run.</p>
+              <p className={cn('text-sm', mutedBodyClass)}>No anomalous activity logged for this run.</p>
             ) : null}
           </div>
         </NewspaperSection>
       </section>
 
-      <NewspaperSection className="p-5">
-        <h2 className={NEWSPAPER_SECTION_HEADING_CLASS}>After-Action Notes</h2>
-        <div className="mt-3 flex flex-wrap gap-3 text-xs text-newspaper-text/70">
+      <NewspaperSection tone={tone} className="p-5">
+        <h2 className={sectionHeadingClass}>After-Action Notes</h2>
+        <div className={cn('mt-3 flex flex-wrap gap-3 text-xs', mutedBodyClass)}>
           {report.legendaryUsed.length > 0 ? (
-            <Badge variant="outline" className={cn(NEWSPAPER_BADGE_CLASS, 'rounded-full px-3 py-0.5 text-[10px] tracking-[0.3em]')}>
+            <Badge variant="outline" className={cn(badgeClass, 'rounded-full px-3 py-0.5 text-[10px] tracking-[0.3em]')}>
               Legendary Deployments: {report.legendaryUsed.join(', ')}
             </Badge>
           ) : (
-            <Badge variant="outline" className={cn(NEWSPAPER_BADGE_CLASS, 'rounded-full px-3 py-0.5 text-[10px] tracking-[0.3em]')}>
+            <Badge variant="outline" className={cn(badgeClass, 'rounded-full px-3 py-0.5 text-[10px] tracking-[0.3em]')}>
               No legendary cards deployed
             </Badge>
           )}
           {playerAgenda ? (
-            <Badge variant="outline" className={cn(NEWSPAPER_BADGE_CLASS, 'rounded-full px-3 py-0.5 text-[10px] tracking-[0.3em]')}>
+            <Badge variant="outline" className={cn(badgeClass, 'rounded-full px-3 py-0.5 text-[10px] tracking-[0.3em]')}>
               Operative Agenda: {playerAgenda.badgeLabel}
             </Badge>
           ) : null}
           {aiAgenda ? (
-            <Badge variant="outline" className={cn(NEWSPAPER_BADGE_CLASS, 'rounded-full px-3 py-0.5 text-[10px] tracking-[0.3em]')}>
+            <Badge variant="outline" className={cn(badgeClass, 'rounded-full px-3 py-0.5 text-[10px] tracking-[0.3em]')}>
               Opposition Agenda: {aiAgenda.badgeLabel}
             </Badge>
           ) : null}
         </div>
         {agendaBriefings.length > 0 ? (
           <div className="mt-6 space-y-4">
-            <h3 className={NEWSPAPER_SECTION_HEADING_CLASS}>Hidden Agenda Debrief</h3>
+            <h3 className={sectionHeadingClass}>Hidden Agenda Debrief</h3>
             {agendaBriefings.map(({ agenda, label, owner }) => (
-              <article
-                key={owner}
-                className="rounded-md border border-dashed border-newspaper-border/60 bg-newspaper-bg/70 p-4 shadow-sm"
-              >
-                <div className="flex flex-wrap items-center gap-2 text-xs font-semibold uppercase tracking-[0.28em] text-newspaper-text/70">
-                  <span className="text-newspaper-headline">{label}</span>
+              <article key={owner} className={cn(dashedPanelClass, 'p-4 space-y-3')}>
+                <div
+                  className={cn(
+                    'flex flex-wrap items-center gap-2 text-xs font-semibold uppercase tracking-[0.28em]',
+                    mutedBodyClass,
+                  )}
+                >
+                  <span className={accentHeadlineClass}>{label}</span>
                   <Badge
                     variant="outline"
-                    className={cn(NEWSPAPER_BADGE_CLASS, 'rounded-full px-3 py-0.5 text-[10px] tracking-[0.3em]')}
+                    className={cn(badgeClass, 'rounded-full px-3 py-0.5 text-[10px] tracking-[0.3em]')}
                   >
                     {agenda.statusLabel}
                   </Badge>
-                  <span className="text-newspaper-text/60">Progress {agenda.progressLabel}</span>
+                  <span className={subtleBodyClass}>Progress {agenda.progressLabel}</span>
                 </div>
-                <p className="mt-3 text-sm text-newspaper-text/80">{formatAgendaNarrative(agenda, owner)}</p>
+                <p className={cn('text-sm', primaryBodyClass)}>{formatAgendaNarrative(agenda, owner)}</p>
                 {agenda.pullQuote ? (
-                  <blockquote className="mt-3 border-l-2 border-newspaper-border/60 pl-3 text-sm italic text-newspaper-text/60">
+                  <blockquote
+                    className={cn('mt-3 border-l-2 pl-3 text-sm italic', subtleBodyClass, tone === 'victory' ? 'border-victory-foreground/40' : 'border-newspaper-border/60')}
+                  >
                     “{agenda.pullQuote}”
                   </blockquote>
                 ) : null}

--- a/src/components/game/newspaperLayout.tsx
+++ b/src/components/game/newspaperLayout.tsx
@@ -2,6 +2,8 @@ import type { HTMLAttributes } from 'react';
 
 import { cn } from '@/lib/utils';
 
+export type NewspaperTone = 'default' | 'victory';
+
 export const NEWSPAPER_CARD_CLASS =
   'ink-smudge relative flex h-full max-h-[90vh] w-full max-w-[min(95vw,1280px)] flex-col overflow-hidden border-4 border-newspaper-border bg-newspaper-bg text-newspaper-text shadow-2xl';
 
@@ -14,6 +16,9 @@ export const NEWSPAPER_BODY_CLASS =
 export const NEWSPAPER_SECTION_CLASS =
   'rounded-md border border-newspaper-border bg-white/80 shadow-sm';
 
+const NEWSPAPER_SECTION_VICTORY_CLASS =
+  'border-victory-foreground/35 bg-gradient-to-br from-victory-start/85 via-victory-mid/80 to-victory-end/85 text-victory-foreground shadow-[0_16px_40px_rgba(0,0,0,0.35)]';
+
 export const NEWSPAPER_SECTION_HEADING_CLASS =
   'font-mono text-xs uppercase tracking-[0.32em] text-newspaper-text/70';
 
@@ -23,6 +28,25 @@ export const NEWSPAPER_META_CLASS =
 export const NEWSPAPER_BADGE_CLASS =
   'border border-newspaper-border bg-newspaper-header/70 text-[11px] font-semibold uppercase tracking-[0.28em] text-newspaper-headline';
 
-export const NewspaperSection = ({ className, ...props }: HTMLAttributes<HTMLElement>) => {
-  return <section className={cn(NEWSPAPER_SECTION_CLASS, className)} {...props} />;
+const NEWSPAPER_BADGE_VICTORY_CLASS =
+  'border-victory-foreground/50 bg-victory-foreground/10 text-victory-accent shadow-[0_4px_14px_rgba(0,0,0,0.25)]';
+
+export const getNewspaperSectionClass = (tone: NewspaperTone = 'default') => {
+  return tone === 'victory'
+    ? cn(NEWSPAPER_SECTION_CLASS, NEWSPAPER_SECTION_VICTORY_CLASS)
+    : NEWSPAPER_SECTION_CLASS;
+};
+
+export const getNewspaperBadgeClass = (tone: NewspaperTone = 'default') => {
+  return tone === 'victory'
+    ? cn(NEWSPAPER_BADGE_CLASS, NEWSPAPER_BADGE_VICTORY_CLASS)
+    : NEWSPAPER_BADGE_CLASS;
+};
+
+export interface NewspaperSectionProps extends HTMLAttributes<HTMLElement> {
+  tone?: NewspaperTone;
+}
+
+export const NewspaperSection = ({ className, tone = 'default', ...props }: NewspaperSectionProps) => {
+  return <section className={cn(getNewspaperSectionClass(tone), className)} {...props} />;
 };


### PR DESCRIPTION
## Summary
- add a victory tone option to the shared newspaper layout helpers so sections and badges can inherit the new gradient palette
- restyle the FinalEditionLayout stats, highlights, and badges to use the victory utilities while keeping defeat/draw views unchanged

## Testing
- npm run lint *(fails: repository currently has pre-existing lint errors across unrelated files)*
- bun test --coverage --coverage-reporter=text *(fails: existing test suites rely on browser globals such as localStorage and requestAnimationFrame)*

------
https://chatgpt.com/codex/tasks/task_e_68e11a8e834883209e6937d6d10faed5