### PR TITLE
Implement deterministic tabloid front page generation

### DIFF
--- a/src/components/game/EnhancedUSAMap.tsx
+++ b/src/components/game/EnhancedUSAMap.tsx
@@ -770,9 +770,14 @@ const EnhancedUSAMap: React.FC<EnhancedUSAMapProps> = ({
           };
 
           // Store animation function for cleanup
-          const animationId = requestAnimationFrame(function animationLoop() {
+          const scheduleFrame =
+            typeof window !== 'undefined' && typeof window.requestAnimationFrame === 'function'
+              ? window.requestAnimationFrame.bind(window)
+              : ((cb: FrameRequestCallback) => setTimeout(() => cb(Date.now()), 16)) as unknown as typeof requestAnimationFrame;
+
+          const animationId = scheduleFrame(function animationLoop() {
             animate();
-            hotspotMarker.setAttribute('data-animation-id', String(requestAnimationFrame(animationLoop)));
+            hotspotMarker.setAttribute('data-animation-id', String(scheduleFrame(animationLoop)));
           });
           hotspotMarker.setAttribute('data-animation-id', String(animationId));
 

--- a/src/components/game/TabloidNewspaperLegacy.tsx
+++ b/src/components/game/TabloidNewspaperLegacy.tsx
@@ -4,6 +4,7 @@ import { Button } from '@/components/ui/button';
 import { Progress } from '@/components/ui/progress';
 import { X, TrendingUp, AlertTriangle } from 'lucide-react';
 import type { GameCard } from '@/rules/mvp';
+import type { PlayedCardMeta } from '@/engine/news/mainStory';
 import type { GameEvent } from '@/data/eventDatabase';
 import type { ParanormalSighting } from '@/types/paranormal';
 import type { AgendaIssueState } from '@/data/agendaIssues';
@@ -34,6 +35,7 @@ export interface TabloidNewspaperProps {
   onArcProgress?: (summaries: ArcProgressSummary[]) => void;
   hotspotDirector?: HotspotDirector;
   activeHotspot?: WeightedHotspotCandidate | null;
+  frontPageTriplet?: PlayedCardMeta[] | null;
 }
 
 interface NewspaperData {

--- a/src/components/game/TabloidNewspaperV2.tsx
+++ b/src/components/game/TabloidNewspaperV2.tsx
@@ -282,6 +282,7 @@ const TabloidNewspaperV2 = ({
   onArcProgress,
   hotspotDirector,
   activeHotspot,
+  frontPageTriplet,
 }: TabloidNewspaperProps) => {
   const [data, setData] = useState<NewspaperData | null>(null);
   const [masthead, setMasthead] = useState('THE PARANOID TIMES');
@@ -542,6 +543,15 @@ const TabloidNewspaperV2 = ({
   );
 
   const frontPageCards = useMemo<PlayedCardMeta[]>(() => {
+    if (Array.isArray(frontPageTriplet) && frontPageTriplet.length === 3) {
+      return frontPageTriplet.map(card => ({
+        id: card.id,
+        name: card.name,
+        type: card.type,
+        faction: card.faction,
+      }));
+    }
+
     return playerNarrativeCards.slice(0, 3)
       .map(entry => {
         const rawType = String(entry.card.type ?? '').toUpperCase();
@@ -557,7 +567,7 @@ const TabloidNewspaperV2 = ({
         } satisfies PlayedCardMeta;
       })
       .filter((meta): meta is PlayedCardMeta => Boolean(meta));
-  }, [playerNarrativeCards]);
+  }, [frontPageTriplet, playerNarrativeCards]);
 
   const comboSummary = useMemo(() => getLastComboSummary(), [events, playedCards]);
   const comboReport = useMemo(() => {

--- a/src/components/game/__tests__/EnhancedUSAMap.hotspot.test.tsx
+++ b/src/components/game/__tests__/EnhancedUSAMap.hotspot.test.tsx
@@ -367,8 +367,12 @@ describe('EnhancedUSAMap paranormal hotspots', () => {
       dispatchEvent: vi.fn(),
     });
 
-    window.requestAnimationFrame = (cb: FrameRequestCallback): number => setTimeout(() => cb(Date.now()), 0);
-    window.cancelAnimationFrame = (id: number) => clearTimeout(id);
+    const raf = (cb: FrameRequestCallback): number => setTimeout(() => cb(Date.now()), 0);
+    const caf = (id: number) => clearTimeout(id);
+    window.requestAnimationFrame = raf;
+    window.cancelAnimationFrame = caf;
+    (globalThis as typeof globalThis & { requestAnimationFrame: typeof raf; cancelAnimationFrame: typeof caf }).requestAnimationFrame = raf;
+    (globalThis as typeof globalThis & { requestAnimationFrame: typeof raf; cancelAnimationFrame: typeof caf }).cancelAnimationFrame = caf;
 
     ({ default: EnhancedUSAMap } = await import('../EnhancedUSAMap'));
     const hotspotsModule = await import('@/systems/paranormalHotspots');

--- a/src/components/game/__tests__/TabloidNewspaperV2.frontPage.test.tsx
+++ b/src/components/game/__tests__/TabloidNewspaperV2.frontPage.test.tsx
@@ -226,10 +226,10 @@ describe('TabloidNewspaperV2 front page integration', () => {
     render(<TabloidNewspaperV2 {...baseProps} />);
 
     const headline = await screen.findByRole('heading', { level: 1 });
-    expect(headline.textContent).toContain('SPECIAL EDITION: PRINTING GREMLINS AT WORK');
+    expect(headline.textContent ?? '').toMatch(/ALPHA AGENT/);
 
-    const list = await screen.findByRole('list');
-    const items = within(list).getAllByRole('listitem');
+    const lists = await screen.findAllByRole('list');
+    const items = within(lists[0] as HTMLElement).getAllByRole('listitem');
     expect(items).toHaveLength(3);
     expect(items[0]?.textContent).toContain('[ATTACK]');
   });

--- a/src/data/newspaperData.json
+++ b/src/data/newspaperData.json
@@ -1,0 +1,16 @@
+{
+  "mastheads": ["THE PARANOID TIMES", "MK-ULTRA MAGAZINE"],
+  "subheads": [
+    "All eyes on the Cryptid Culinary Summit.",
+    "Sources insist everything is normal, officially."
+  ],
+  "ads": [
+    "Pastor Rex Miracle Water",
+    "Agent Smitherson’s Classified Shredding"
+  ],
+  "conspiracies": [
+    "Florida Man relocates Bat Boy to Area 51",
+    "Elvis officiates wedding in Roswell"
+  ],
+  "weather": ["Fog of plausible deniability", "Rain of redactions"]
+}

--- a/src/engine/news/__tests__/articleBank.test.ts
+++ b/src/engine/news/__tests__/articleBank.test.ts
@@ -32,7 +32,7 @@ test('provides lookup access for parsed articles', async () => {
   const fetchMock = mock(async () => createResponse({ articles: [article] })) as unknown as typeof fetch;
   (globalThis as { fetch: typeof fetch }).fetch = fetchMock;
 
-  const bank = await loadArticleBank('https://example.com/articles.json');
+  const bank = await loadArticleBank();
 
   expect(fetchMock).toHaveBeenCalledTimes(1);
   const resolved = bank.getById('story-1');
@@ -42,7 +42,7 @@ test('provides lookup access for parsed articles', async () => {
   expect(bank.hasArticles()).toBe(true);
 });
 
-test('returns empty bank when fetch fails', async () => {
+test('falls back to bundled dataset when fetch fails', async () => {
   const fetchMock = mock(async () =>
     createResponse(
       {},
@@ -55,17 +55,18 @@ test('returns empty bank when fetch fails', async () => {
   ) as unknown as typeof fetch;
   (globalThis as { fetch: typeof fetch }).fetch = fetchMock;
 
-  const bank = await loadArticleBank('https://example.com/missing.json');
+  const bank = await loadArticleBank();
 
+  expect(fetchMock).toHaveBeenCalledTimes(2);
   expect(bank.getById('missing')).toBeNull();
-  expect(bank.hasArticles()).toBe(false);
+  expect(bank.hasArticles()).toBe(true);
 });
 
 test('handles payloads without articles gracefully', async () => {
   const fetchMock = mock(async () => createResponse({})) as unknown as typeof fetch;
   (globalThis as { fetch: typeof fetch }).fetch = fetchMock;
 
-  const bank = await loadArticleBank('https://example.com/empty.json');
+  const bank = await loadArticleBank();
 
   expect(bank.getById('any')).toBeNull();
   expect(bank.hasArticles()).toBe(false);

--- a/src/hooks/gameStateTypes.ts
+++ b/src/hooks/gameStateTypes.ts
@@ -1,4 +1,5 @@
 import type { GameCard } from '@/rules/mvp';
+import type { PlayedCardMetaLite } from '@/state/game/roundNewsBuffer';
 import type { EventManager, GameEvent, ParanormalHotspotPayload } from '@/data/eventDatabase';
 import type { SecretAgenda } from '@/data/agendaDatabase';
 import type { AgendaIssueState } from '@/data/agendaIssues';
@@ -47,6 +48,7 @@ export interface GameState {
   cardsPlayedThisTurn: number;
   cardsPlayedThisRound: CardPlayRecord[];
   playHistory: CardPlayRecord[];
+  frontPageTriplet: PlayedCardMetaLite[] | null;
   turnPlays: TurnPlay[];
   comboTruthDeltaThisRound: number;
   controlledStates: string[];

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -3142,6 +3142,7 @@ const Index = () => {
           faction={gameState.faction}
           truth={gameState.truth}
           comboTruthDelta={gameState.comboTruthDeltaThisRound}
+          frontPageTriplet={gameState.frontPageTriplet ?? null}
           sightings={paranormalSightings}
           agendaIssue={gameState.agendaIssue}
           agendaMoments={agendaMoments}

--- a/src/state/game/roundNewsBuffer.ts
+++ b/src/state/game/roundNewsBuffer.ts
@@ -1,0 +1,21 @@
+export type PlayedCardMetaLite = {
+  id: string;
+  name: string;
+  type: 'ATTACK' | 'MEDIA' | 'ZONE';
+  faction: 'TRUTH' | 'GOV';
+};
+
+let buffer: PlayedCardMetaLite[] = [];
+
+export function clearNewsBuffer() {
+  buffer = [];
+}
+
+export function pushToNewsBuffer(card: PlayedCardMetaLite) {
+  buffer.push(card);
+  if (buffer.length > 3) buffer.shift();
+}
+
+export function getNewsTriplet(): PlayedCardMetaLite[] | null {
+  return buffer.length === 3 ? [...buffer] : null;
+}


### PR DESCRIPTION
## Summary
- make the article bank load from base-relative URLs with a bundled JSON fallback and update the associated tests
- wire the newspaper front page to compose headlines from the latest three human plays, including a new round news buffer and shared newspaper data
- support non-browser animation fallbacks and align the tabloid front page tests with the deterministic story output

## Testing
- npm run lint *(fails: pre-existing lint violations across unrelated files)*
- bun test --coverage --coverage-reporter=text


------
https://chatgpt.com/codex/tasks/task_e_68e120bf6db08320b2d8130fd7b32b97