### PR TITLE
Clarify escalating discard penalties

### DIFF
--- a/docs/TECHNICAL_README.md
+++ b/docs/TECHNICAL_README.md
@@ -19,7 +19,7 @@ The MVP design defines a duel between the Truth Seekers and the Government, each
 - **Card play gating:** `canPlay` enforces the three-card-per-turn limit, IP costs, and ZONE targeting rules before a card resolves.【F:src/mvp/engine.ts†L71-L99】
 - **Playing a card:** `playCard` removes the card from hand, deducts IP, logs the play, and calls `resolve` to apply effects.【F:src/mvp/engine.ts†L101-L215】
 - **Effect resolution:** `resolve` relies on `applyEffectsMvp` to adjust IP, Truth, and pressure while tracking capture metadata for end-of-turn summaries.【F:src/mvp/engine.ts†L157-L215】【F:src/engine/applyEffects-mvp.ts†L53-L157】
-- **Turn end:** Discards are processed with the “first one free, extras cost 1 IP each” rule, combo hooks are evaluated, logs are appended, and control passes to the other player.【F:src/mvp/engine.ts†L217-L348】
+- **Turn end:** Discards follow the “first one free, then 10 IP with +5 IP per extra card” scale (10, 15, 20, …), combo hooks are evaluated, logs are appended, and control passes to the other player.【F:src/mvp/engine.ts†L217-L348】
 - **Victory checks:** `winCheck` confirms state, Truth, and IP victory thresholds after every turn wrap-up, matching the MVP specification but using 95%/5% Truth buffers for runtime tuning.【F:src/mvp/engine.ts†L367-L395】【F:DESIGN_DOC_MVP.md†L55-L63】
 
 ### Campaign event manager and state bonuses

--- a/src/content/mvpRules.ts
+++ b/src/content/mvpRules.ts
@@ -65,7 +65,7 @@ export const MVP_RULES_SECTIONS: MvpRulesSection[] = [
       'Start: Gain 5 IP plus +1 IP for every state you control, then draw back up to 5 cards.',
       'Main: Play up to three cards, paying their IP costs and choosing targets when required.',
       'Capture Check: Any state where your Pressure meets or beats Defense flips to your control.',
-      'End: Optionally discard 1 card for free; additional discards cost 1 IP each.',
+      'End: Optionally discard 1 card for free; each extra discard costs 10 IP, then +5 IP per additional card (10, 15, 20, …).',
     ],
   },
   {


### PR DESCRIPTION
## Summary
- clarify the turn-end discard rule in the MVP rules content to reflect escalating IP costs
- align the technical README’s turn-end description with the updated discard scaling

## Testing
- npm run lint *(fails: existing repository lint debt around any usage and parsing errors)*
- bun test --coverage --coverage-reporter=text

------
https://chatgpt.com/codex/tasks/task_e_68e21e0dc598832094f57a90a579609c