### PR TITLE
Document escalating discard costs

### DIFF
--- a/DESIGN_DOC_MVP.md
+++ b/DESIGN_DOC_MVP.md
@@ -133,7 +133,7 @@ Slutt på tur
 
 
 
-Ytterligere discards samme sluttfase koster 1 IP per kort.
+Neste kort i samme sluttfase koster 10 IP, deretter 15 IP for det tredje, 20 IP for det fjerde (fortsetter +5 IP per ekstra kort).
 
 
 
@@ -239,7 +239,7 @@ Kast 1 valgfritt kort gratis.
 
 
 
-Kast flere kort samme sluttfase → betal 1 IP per ekstra kort.
+Kast kort nummer to for 10 IP, nummer tre for 15 IP, nummer fire for 20 IP (fortsetter +5 IP for hvert ekstra kort samme sluttfase).
 
 
 
@@ -531,7 +531,7 @@ endTurn(s):
 
 
 
-Spilleren kan kaste 1 kort gratis (ekstra koster 1 IP hver).
+Spilleren kan kaste 1 kort gratis, deretter betale 10/15/20 IP (+5 IP videre) for flere discards i samme sluttfase.
 
 
 
@@ -643,7 +643,7 @@ ZONE (Common, 4 IP): +1 Pressure på OH → når Defense 3 neste runde med flere
 
 
 
-Slutt: Du discarder 1 dødt kort gratis.
+Slutt: Du discarder 1 dødt kort gratis; ekstra kort koster 10/15/20 IP videre opp +5 IP per kort.
 
 
 
@@ -739,7 +739,7 @@ Dev-sjekk:
 
 
 
-&nbsp;EndTurn: 1 gratis discard, ekstra koster 1 IP.
+&nbsp;EndTurn: 1 gratis discard, deretter 10/15/20 IP (+5 IP videre) for ekstra kort samme sluttfase.
 
 
 

--- a/docs/TECHNICAL_README.md
+++ b/docs/TECHNICAL_README.md
@@ -19,7 +19,7 @@ The MVP design defines a duel between the Truth Seekers and the Government, each
 - **Card play gating:** `canPlay` enforces the three-card-per-turn limit, IP costs, and ZONE targeting rules before a card resolves.【F:src/mvp/engine.ts†L71-L99】
 - **Playing a card:** `playCard` removes the card from hand, deducts IP, logs the play, and calls `resolve` to apply effects.【F:src/mvp/engine.ts†L101-L215】
 - **Effect resolution:** `resolve` relies on `applyEffectsMvp` to adjust IP, Truth, and pressure while tracking capture metadata for end-of-turn summaries.【F:src/mvp/engine.ts†L157-L215】【F:src/engine/applyEffects-mvp.ts†L53-L157】
-- **Turn end:** Discards follow the “first one free, then 10 IP with +5 IP per extra card” scale (10, 15, 20, …), combo hooks are evaluated, logs are appended, and control passes to the other player.【F:src/mvp/engine.ts†L217-L348】
+- **Turn end:** Discards grant one free slot, then charge 10 IP for the second card, 15 IP for the third, 20 IP for the fourth (continuing the +5 IP ladder), before combo hooks resolve, logs append, and control passes to the other player.【F:src/mvp/engine.ts†L217-L348】
 - **Victory checks:** `winCheck` confirms state, Truth, and IP victory thresholds after every turn wrap-up, matching the MVP specification but using 95%/5% Truth buffers for runtime tuning.【F:src/mvp/engine.ts†L367-L395】【F:DESIGN_DOC_MVP.md†L55-L63】
 
 ### Campaign event manager and state bonuses


### PR DESCRIPTION
## Summary
- document the revised turn-end discard pricing ladder in the technical README
- update the MVP design doc to describe the free first discard followed by 10/15/20 IP charges across every end-of-turn summary

## Testing
- npm run lint *(fails: repository has pre-existing lint errors unrelated to this docs-only update)*
- bun test --coverage --coverage-reporter=text

------
https://chatgpt.com/codex/tasks/task_e_68e21feffa908320b3ab7d04dade8ee9