### PR TITLE
Enable queued discards with cost preview

### DIFF
--- a/__tests__/discardPlanner.test.ts
+++ b/__tests__/discardPlanner.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'bun:test';
+import { planDiscardOutcome } from '../src/utils/discardPlanner';
+import type { GameCard } from '../src/rules/mvp';
+
+const createCard = (id: string, overrides: Partial<GameCard> = {}): GameCard => ({
+  id,
+  name: id.toUpperCase(),
+  type: 'MEDIA',
+  cost: 1,
+  faction: 'truth',
+  rarity: 'common',
+  text: '',
+  ...overrides,
+});
+
+describe('planDiscardOutcome', () => {
+  it('moves multiple queued cards to the discard pile and charges escalating IP', () => {
+    const hand = [createCard('alpha'), createCard('bravo'), createCard('charlie')];
+    const discardPile = [createCard('legacy')];
+
+    const outcome = planDiscardOutcome(hand, discardPile, ['alpha', 'charlie']);
+
+    expect(outcome.discardedCount).toBe(2);
+    expect(outcome.ipCost).toBe(10);
+    expect(outcome.costBreakdown).toEqual([0, 10]);
+    expect(outcome.remainingHand.map(card => card.id)).toEqual(['bravo']);
+    expect(outcome.updatedDiscardPile.map(card => card.id)).toEqual(['legacy', 'alpha', 'charlie']);
+    expect(outcome.logEntry).toContain('Discarded 2 cards');
+  });
+
+  it('ignores unknown ids and never reduces IP when nothing is queued', () => {
+    const hand = [createCard('delta'), createCard('echo')];
+    const discardPile: GameCard[] = [];
+
+    const outcome = planDiscardOutcome(hand, discardPile, ['unknown', 'delta']);
+
+    expect(outcome.discardedCount).toBe(1);
+    expect(outcome.ipCost).toBe(0);
+    expect(outcome.remainingHand.map(card => card.id)).toEqual(['echo']);
+    expect(outcome.updatedDiscardPile.map(card => card.id)).toEqual(['delta']);
+    expect(outcome.logEntry).toContain('first free');
+  });
+});

--- a/src/components/game/CardDetailOverlay.tsx
+++ b/src/components/game/CardDetailOverlay.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
-import { X, Target, Zap, Megaphone } from 'lucide-react';
+import { X, Target, Zap, Megaphone, Trash2 } from 'lucide-react';
 import type { GameCard } from '@/rules/mvp';
 import { MVP_CARD_TYPES, type MVPCardType } from '@/rules/mvp';
 import CardImage from '@/components/game/CardImage';
@@ -20,6 +20,9 @@ interface CardDetailOverlayProps {
   onClose: () => void;
   onPlayCard: () => void;
   swipeHandlers?: any;
+  isDiscardQueued?: boolean;
+  onToggleDiscard?: () => void;
+  discardEnabled?: boolean;
 }
 
 const TabloidCardDetail: React.FC<CardDetailOverlayProps> = ({
@@ -29,12 +32,16 @@ const TabloidCardDetail: React.FC<CardDetailOverlayProps> = ({
   onClose,
   onPlayCard,
   swipeHandlers,
+  isDiscardQueued,
+  onToggleDiscard,
+  discardEnabled = true,
 }) => {
   const isMobile = useIsMobile();
   if (!card) return null;
 
   const displayType = normalizeTabloidCardType(card.type);
   const ActionIcon = displayType === 'ZONE' ? Target : displayType === 'ATTACK' ? Zap : Megaphone;
+  const discardButtonDisabled = disabled || !onToggleDiscard || !discardEnabled;
 
   return (
     <div
@@ -79,6 +86,21 @@ const TabloidCardDetail: React.FC<CardDetailOverlayProps> = ({
             {displayType === 'ZONE' ? 'SELECT & TARGET' : 'DEPLOY ASSET'}
           </Button>
 
+          <Button
+            type="button"
+            onClick={() => onToggleDiscard?.()}
+            disabled={discardButtonDisabled}
+            className={cn(
+              'w-full sm:w-auto px-5 py-2 rounded-tabloid border uppercase tracking-[0.3em] text-xs flex items-center gap-2 font-mono transition-transform duration-200',
+              discardButtonDisabled
+                ? 'border-orange-500/20 bg-black/40 text-white/40 cursor-not-allowed'
+                : 'border-orange-400/80 bg-orange-500/80 text-black hover:bg-orange-400 hover:-translate-y-0.5'
+            )}
+          >
+            <Trash2 className="h-4 w-4" />
+            {isDiscardQueued ? 'UNQUEUE DISCARD' : 'QUEUE DISCARD'}
+          </Button>
+
           <div className="flex flex-wrap items-center justify-center gap-2 text-xs uppercase tracking-widest text-white/80">
             <span>
               {canAfford ? 'CLEARED FOR DEPLOYMENT' : `NEED ${card.cost} IP`}
@@ -98,6 +120,9 @@ const LegacyCardDetail: React.FC<CardDetailOverlayProps> = ({
   onClose,
   onPlayCard,
   swipeHandlers,
+  isDiscardQueued,
+  onToggleDiscard,
+  discardEnabled = true,
 }) => {
   const isMobile = useIsMobile();
   if (!card) return null;
@@ -158,6 +183,7 @@ const LegacyCardDetail: React.FC<CardDetailOverlayProps> = ({
   const faction = getLegacyFaction(card);
   const displayType = normalizeLegacyCardType(card.type);
   const flavorText = getFlavorText(card) ?? 'No intelligence available.';
+  const discardButtonDisabled = disabled || !onToggleDiscard || !discardEnabled;
 
   return (
     <div
@@ -236,26 +262,44 @@ const LegacyCardDetail: React.FC<CardDetailOverlayProps> = ({
         </div>
 
         <div className="flex-shrink-0 p-4 border-t border-border bg-card/95">
-          <Button
-            onClick={onPlayCard}
-            disabled={disabled || !canAfford}
-            className={`enhanced-button w-full font-mono relative overflow-hidden transition-all duration-300 ${
-              isMobile ? 'text-base py-4' : 'text-sm py-3'
-            } ${!canAfford ? 'opacity-50 cursor-not-allowed' : 'hover:shadow-lg'}`}
-          >
-            <span className="relative z-10 flex items-center justify-center gap-2">
-              {displayType === 'ZONE' && <Target className={isMobile ? 'w-5 h-5' : 'w-4 h-4'} />}
-              {displayType === 'ATTACK' && <Zap className={isMobile ? 'w-5 h-5' : 'w-4 h-4'} />}
-              {displayType === 'MEDIA' && <Megaphone className={isMobile ? 'w-5 h-5' : 'w-4 h-4'} />}
-              {displayType === 'ZONE' ? 'SELECT & TARGET' : 'DEPLOY ASSET'}
-            </span>
+          <div className="space-y-2">
+            <Button
+              onClick={onPlayCard}
+              disabled={disabled || !canAfford}
+              className={`enhanced-button w-full font-mono relative overflow-hidden transition-all duration-300 ${
+                isMobile ? 'text-base py-4' : 'text-sm py-3'
+              } ${!canAfford ? 'opacity-50 cursor-not-allowed' : 'hover:shadow-lg'}`}
+            >
+              <span className="relative z-10 flex items-center justify-center gap-2">
+                {displayType === 'ZONE' && <Target className={isMobile ? 'w-5 h-5' : 'w-4 h-4'} />}
+                {displayType === 'ATTACK' && <Zap className={isMobile ? 'w-5 h-5' : 'w-4 h-4'} />}
+                {displayType === 'MEDIA' && <Megaphone className={isMobile ? 'w-5 h-5' : 'w-4 h-4'} />}
+                {displayType === 'ZONE' ? 'SELECT & TARGET' : 'DEPLOY ASSET'}
+              </span>
 
-            {!canAfford && (
-              <div className="absolute inset-0 flex items-center justify-center bg-destructive/10">
-                <span className="text-xs text-destructive font-medium">Need {card.cost} IP</span>
-              </div>
-            )}
-          </Button>
+              {!canAfford && (
+                <div className="absolute inset-0 flex items-center justify-center bg-destructive/10">
+                  <span className="text-xs text-destructive font-medium">Need {card.cost} IP</span>
+                </div>
+              )}
+            </Button>
+
+            <Button
+              type="button"
+              onClick={() => onToggleDiscard?.()}
+              disabled={discardButtonDisabled}
+              variant="outline"
+              className={cn(
+                'w-full font-mono flex items-center justify-center gap-2 text-xs uppercase tracking-[0.3em]',
+                discardButtonDisabled
+                  ? 'opacity-50 cursor-not-allowed'
+                  : 'border-orange-400 text-orange-500 hover:bg-orange-500/10'
+              )}
+            >
+              <Trash2 className="h-4 w-4" />
+              {isDiscardQueued ? 'UNQUEUE DISCARD' : 'QUEUE DISCARD'}
+            </Button>
+          </div>
         </div>
       </div>
     </div>

--- a/src/components/game/EnhancedGameHand.tsx
+++ b/src/components/game/EnhancedGameHand.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useRef } from 'react';
+import React, { useState, useRef, useMemo } from 'react';
 import clsx from 'clsx';
 import CardDetailOverlay from './CardDetailOverlay';
 import BaseCard from '@/components/game/cards/BaseCard';
@@ -7,7 +7,7 @@ import type { GameCard, MVPCardType } from '@/rules/mvp';
 import { MVP_CARD_TYPES } from '@/rules/mvp';
 import { useAudioContext } from '@/contexts/AudioContext';
 import { toast } from '@/hooks/use-toast';
-import { Loader2 } from 'lucide-react';
+import { Loader2, Trash2 } from 'lucide-react';
 import { useHapticFeedback } from '@/hooks/useHapticFeedback';
 import { useSwipeGestures } from '@/hooks/useSwipeGestures';
 import { useIsMobile } from '@/hooks/use-mobile';
@@ -22,6 +22,9 @@ interface EnhancedGameHandProps {
   currentIP: number;
   loadingCard?: string | null;
   onCardHover?: (card: (GameCard & { _hoverPosition?: { x: number; y: number } }) | null) => void;
+  discardQueue?: string[];
+  onToggleDiscard?: (cardId: string) => void;
+  discardEnabled?: boolean;
 }
 
 const EnhancedGameHand: React.FC<EnhancedGameHandProps> = ({
@@ -32,7 +35,10 @@ const EnhancedGameHand: React.FC<EnhancedGameHandProps> = ({
   onSelectCard,
   currentIP,
   loadingCard,
-  onCardHover
+  onCardHover,
+  discardQueue = [],
+  onToggleDiscard,
+  discardEnabled = true
 }) => {
   const [playingCard, setPlayingCard] = useState<string | null>(null);
   const [examinedCard, setExaminedCard] = useState<string | null>(null);
@@ -40,6 +46,9 @@ const EnhancedGameHand: React.FC<EnhancedGameHandProps> = ({
   const { triggerHaptic } = useHapticFeedback();
   const isMobile = useIsMobile();
   const handRef = useRef<HTMLDivElement>(null);
+  const discardQueueSet = useMemo(() => new Set(discardQueue), [discardQueue]);
+  const examinedCardData = examinedCard ? cards.find(c => c.id === examinedCard) ?? null : null;
+  const examinedIsQueued = examinedCard ? discardQueueSet.has(examinedCard) : false;
 
   const normalizeCardType = (type: string): MVPCardType => {
     return MVP_CARD_TYPES.includes(type as MVPCardType) ? type as MVPCardType : 'MEDIA';
@@ -126,6 +135,8 @@ const EnhancedGameHand: React.FC<EnhancedGameHandProps> = ({
             const isLoading = loadingCard === card.id;
             const canAfford = canAffordCard(card);
             const displayType = normalizeCardType(card.type);
+            const isQueuedForDiscard = discardQueueSet.has(card.id);
+            const discardToggleDisabled = disabled || !discardEnabled || !onToggleDiscard;
 
             const overlay = (
               <>
@@ -133,14 +144,19 @@ const EnhancedGameHand: React.FC<EnhancedGameHandProps> = ({
                   <div
                     className={clsx(
                       'pointer-events-none absolute inset-0 z-20 flex flex-col items-center justify-center bg-black/60 text-white backdrop-blur-sm',
-                      isSelected && !isPlaying && !isLoading && 'bg-yellow-400/15 text-yellow-100'
+                      isSelected && !isPlaying && !isLoading && 'bg-yellow-400/15 text-yellow-100',
+                      isQueuedForDiscard && !isPlaying && !isLoading && !isSelected && 'bg-orange-500/15 text-orange-100'
                     )}
                     style={{ borderRadius: 'calc(var(--pt-radius) * var(--card-scale))' }}
                   >
                     <Loader2
                       className={clsx(
                         'mb-1 h-5 w-5',
-                        isSelected ? 'animate-pulse text-yellow-200' : 'animate-spin text-primary'
+                        isSelected
+                          ? 'animate-pulse text-yellow-200'
+                          : isQueuedForDiscard
+                            ? 'animate-pulse text-orange-300'
+                            : 'animate-spin text-primary'
                       )}
                     />
                     <span className="text-xs font-mono font-bold">
@@ -148,7 +164,9 @@ const EnhancedGameHand: React.FC<EnhancedGameHandProps> = ({
                         ? 'DEPLOYING'
                         : isSelected && displayType === 'ZONE'
                           ? 'TARGETING'
-                          : 'PROCESSING'}
+                          : isQueuedForDiscard
+                            ? 'QUEUED'
+                            : 'PROCESSING'}
                     </span>
                   </div>
                 )}
@@ -161,6 +179,17 @@ const EnhancedGameHand: React.FC<EnhancedGameHandProps> = ({
 
                 {isSelected && displayType !== 'ZONE' && (
                   <div className="absolute -top-1 -right-1 h-3 w-3 rounded-full bg-yellow-300 ring-2 ring-yellow-200" />
+                )}
+
+                {isQueuedForDiscard && !isSelected && !isPlaying && !isLoading && (
+                  <div className="pointer-events-none absolute inset-0 z-10 rounded-[calc(var(--pt-radius) * var(--card-scale))] border-2 border-orange-400/80" />
+                )}
+
+                {isQueuedForDiscard && (
+                  <div className="absolute -top-1 -left-1 flex items-center gap-1 rounded-full bg-orange-500 px-2 py-0.5 text-[0.6rem] font-bold text-black shadow-lg">
+                    <Trash2 className="h-3 w-3" />
+                    <span>QUEUED</span>
+                  </div>
                 )}
 
                 <div className="pointer-events-none">
@@ -224,10 +253,49 @@ const EnhancedGameHand: React.FC<EnhancedGameHandProps> = ({
                     'drop-shadow-[0_12px_22px_rgba(0,0,0,0.32)] transition-transform duration-200',
                     !disabled && canAfford && 'group-hover/card:-translate-y-1 group-hover/card:drop-shadow-[0_22px_30px_rgba(0,0,0,0.35)]',
                     (isPlaying || isLoading) && 'ring-2 ring-primary shadow-primary/40',
-                    isSelected && 'ring-2 ring-yellow-400 shadow-yellow-400/40'
+                    isSelected && 'ring-2 ring-yellow-400 shadow-yellow-400/40',
+                    isQueuedForDiscard && !(isPlaying || isLoading) && !isSelected && 'ring-2 ring-orange-400 shadow-orange-400/40'
                   )}
                   overlay={overlay}
                 />
+                {onToggleDiscard && (
+                  <span
+                    role="button"
+                    tabIndex={discardToggleDisabled ? -1 : 0}
+                    aria-pressed={isQueuedForDiscard}
+                    aria-label={isQueuedForDiscard ? 'Remove from discard queue' : 'Queue card for discard'}
+                    className={clsx(
+                      'absolute left-2 bottom-2 z-30 flex items-center gap-1 rounded-full bg-black/70 px-2 py-1 text-[0.55rem] font-mono uppercase tracking-[0.25em] text-white shadow-lg transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-orange-400',
+                      discardToggleDisabled && 'cursor-not-allowed opacity-40',
+                      !discardToggleDisabled && 'cursor-pointer hover:bg-orange-400 hover:text-black'
+                    )}
+                    onClick={(event) => {
+                      event.preventDefault();
+                      event.stopPropagation();
+                      if (discardToggleDisabled) {
+                        return;
+                      }
+                      audio.playSFX('click');
+                      triggerHaptic(isQueuedForDiscard ? 'light' : 'selection');
+                      onToggleDiscard(card.id);
+                    }}
+                    onKeyDown={(event) => {
+                      if (event.key === 'Enter' || event.key === ' ') {
+                        event.preventDefault();
+                        event.stopPropagation();
+                        if (discardToggleDisabled) {
+                          return;
+                        }
+                        audio.playSFX('click');
+                        triggerHaptic(isQueuedForDiscard ? 'light' : 'selection');
+                        onToggleDiscard(card.id);
+                      }
+                    }}
+                  >
+                    <Trash2 className="h-3 w-3" />
+                    {isQueuedForDiscard ? 'Queued' : 'Queue'}
+                  </span>
+                )}
               </button>
             );
           })
@@ -237,15 +305,15 @@ const EnhancedGameHand: React.FC<EnhancedGameHandProps> = ({
       {/* Card Detail Overlay - Redesigned */}
       {examinedCard && (
         <CardDetailOverlay
-          card={cards.find(c => c.id === examinedCard) || null}
-          canAfford={cards.find(c => c.id === examinedCard) ? canAffordCard(cards.find(c => c.id === examinedCard)!) : false}
+          card={examinedCardData}
+          canAfford={examinedCardData ? canAffordCard(examinedCardData) : false}
           disabled={disabled}
           onClose={() => {
             setExaminedCard(null);
             triggerHaptic('light');
           }}
           onPlayCard={() => {
-            const card = cards.find(c => c.id === examinedCard);
+            const card = examinedCardData;
             if (!card) return;
             
             if (!canAffordCard(card)) {
@@ -278,6 +346,16 @@ const EnhancedGameHand: React.FC<EnhancedGameHandProps> = ({
               handlePlayCard(card.id);
             }
           }}
+          isDiscardQueued={examinedIsQueued}
+          onToggleDiscard={() => {
+            if (!onToggleDiscard || !examinedCardData || disabled || !discardEnabled) {
+              return;
+            }
+            audio.playSFX('click');
+            triggerHaptic(examinedIsQueued ? 'light' : 'selection');
+            onToggleDiscard(examinedCardData.id);
+          }}
+          discardEnabled={!disabled && discardEnabled}
           swipeHandlers={isMobile ? swipeHandlers : undefined}
         />
       )}

--- a/src/hooks/gameStateTypes.ts
+++ b/src/hooks/gameStateTypes.ts
@@ -41,7 +41,9 @@ export interface GameState {
   ip: number;
   aiIP: number;
   hand: GameCard[];
+  discardPile: GameCard[];
   aiHand: GameCard[];
+  aiDiscardPile: GameCard[];
   isGameOver: boolean;
   deck: GameCard[];
   aiDeck: GameCard[];

--- a/src/hooks/useGameState.ts
+++ b/src/hooks/useGameState.ts
@@ -45,6 +45,7 @@ import { VisualEffectsCoordinator } from '@/utils/visualEffects';
 import { getEnabledExpansionIdsSnapshot } from '@/data/expansions/state';
 import { queueHotspotResolveToast, queueHotspotExpireToast } from '@/ui/hotspots.toasts';
 import { getHotspotIdleLog } from '@/state/useGameLog';
+import { planDiscardOutcome } from '@/utils/discardPlanner';
 import type {
   ActiveCampaignArcState,
   ActiveParanormalHotspot,
@@ -2503,8 +2504,10 @@ export const useGameState = (aiDifficultyOverride?: AIDifficulty) => {
       ip: adjustedStartingIp,
       aiIP: aiStartingIP,
       hand: startingHand,
+      discardPile: [],
       deck: remainingDeck,
       aiHand: aiStartingHand,
+      aiDiscardPile: [],
       aiDeck: aiRemainingDeck,
       controlledStates: initialControl.player,
       aiControlledStates: initialControl.ai,
@@ -3124,7 +3127,7 @@ export const useGameState = (aiDifficultyOverride?: AIDifficulty) => {
     });
   }, []);
 
-  const endTurn = useCallback(() => {
+  const endTurn = useCallback((plannedDiscards: string[] = []) => {
     let hotspotSourceToRegister: 'truth' | 'government' | 'neutral' | null = null;
     let shouldScheduleNewspaperReveal = false;
     const sessionGuard = gameSessionRef.current;
@@ -3133,6 +3136,53 @@ export const useGameState = (aiDifficultyOverride?: AIDifficulty) => {
       if (prev.isGameOver) return prev;
 
       const isHumanTurn = prev.currentPlayer === 'human';
+      const normalizedDiscards = Array.isArray(plannedDiscards)
+        ? plannedDiscards.filter(id => typeof id === 'string')
+        : [];
+
+      const humanDiscardOutcome =
+        isHumanTurn && normalizedDiscards.length > 0
+          ? planDiscardOutcome(prev.hand, prev.discardPile ?? [], normalizedDiscards)
+          : null;
+      const aiDiscardOutcome =
+        !isHumanTurn && normalizedDiscards.length > 0
+          ? planDiscardOutcome(prev.aiHand, prev.aiDiscardPile ?? [], normalizedDiscards)
+          : null;
+
+      const handAfterDiscards = humanDiscardOutcome ? humanDiscardOutcome.remainingHand : prev.hand;
+      const aiHandAfterDiscards = aiDiscardOutcome ? aiDiscardOutcome.remainingHand : prev.aiHand;
+      const discardPileAfter = humanDiscardOutcome ? humanDiscardOutcome.updatedDiscardPile : prev.discardPile ?? [];
+      const aiDiscardPileAfter = aiDiscardOutcome
+        ? aiDiscardOutcome.updatedDiscardPile
+        : prev.aiDiscardPile ?? [];
+      const ipAfterDiscards = humanDiscardOutcome ? Math.max(0, prev.ip - humanDiscardOutcome.ipCost) : prev.ip;
+      const aiIpAfterDiscards = aiDiscardOutcome ? Math.max(0, prev.aiIP - aiDiscardOutcome.ipCost) : prev.aiIP;
+
+      const discardLogEntries: string[] = [];
+      if (humanDiscardOutcome?.logEntry) {
+        discardLogEntries.push(humanDiscardOutcome.logEntry);
+      }
+      if (aiDiscardOutcome?.logEntry) {
+        const aiEntry = aiDiscardOutcome.logEntry;
+        discardLogEntries.push(`AI ${aiEntry.charAt(0).toLowerCase()}${aiEntry.slice(1)}`);
+      }
+
+      const baseLog = discardLogEntries.length > 0 ? [...prev.log, ...discardLogEntries] : prev.log;
+
+      const stateForCombos: GameState =
+        humanDiscardOutcome || aiDiscardOutcome || baseLog !== prev.log
+          ? {
+              ...prev,
+              hand: handAfterDiscards,
+              aiHand: aiHandAfterDiscards,
+              ip: ipAfterDiscards,
+              aiIP: aiIpAfterDiscards,
+              discardPile: discardPileAfter,
+              aiDiscardPile: aiDiscardPileAfter,
+              log: baseLog,
+            }
+          : prev;
+
       const statesAfterHotspot = prev.states.map(state => ({ ...state }));
       let hotspotsAfterHotspot: Record<string, ActiveParanormalHotspot> = { ...prev.paranormalHotspots };
       const hotspotLogs: string[] = [];
@@ -3167,7 +3217,7 @@ export const useGameState = (aiDifficultyOverride?: AIDifficulty) => {
         }
       }
 
-      const comboResult = evaluateCombosForTurn(prev, isHumanTurn ? 'human' : 'ai');
+      const comboResult = evaluateCombosForTurn(stateForCombos, isHumanTurn ? 'human' : 'ai');
       achievements.onCombosResolved(isHumanTurn ? 'human' : 'ai', comboResult.evaluation);
       const fxEnabled = getComboSettings().fxEnabled;
 
@@ -3451,7 +3501,7 @@ export const useGameState = (aiDifficultyOverride?: AIDifficulty) => {
         const pendingCardDraw = bonusCardDraw + comboDrawBonus;
 
         const comboLog =
-          comboResult.logEntries.length > 0 ? [...prev.log, ...comboResult.logEntries] : [...prev.log];
+          comboResult.logEntries.length > 0 ? [...baseLog, ...comboResult.logEntries] : [...baseLog];
 
         const humanIpAfterCombos = comboResult.updatedPlayerIp;
         const aiIpAfterCombos = comboResult.updatedOpponentIp;
@@ -3474,6 +3524,10 @@ export const useGameState = (aiDifficultyOverride?: AIDifficulty) => {
 
         let nextState: GameState = {
           ...prev,
+          hand: handAfterDiscards,
+          aiHand: aiHandAfterDiscards,
+          discardPile: discardPileAfter,
+          aiDiscardPile: aiDiscardPileAfter,
           turn: prev.turn + 1,
           phase: 'ai_turn',
           currentPlayer: 'ai',
@@ -3532,8 +3586,8 @@ export const useGameState = (aiDifficultyOverride?: AIDifficulty) => {
 
       const comboLog =
         comboResult.logEntries.length > 0
-          ? [...prev.log, ...comboResult.logEntries, ...hotspotLogs]
-          : [...prev.log, ...hotspotLogs];
+          ? [...baseLog, ...comboResult.logEntries, ...hotspotLogs]
+          : [...baseLog, ...hotspotLogs];
 
       const clearedStates = statesAfterHotspot.map(state => ({
         ...state,
@@ -3543,6 +3597,10 @@ export const useGameState = (aiDifficultyOverride?: AIDifficulty) => {
 
       const nextStateBase: GameState = {
         ...prev,
+        hand: handAfterDiscards,
+        aiHand: aiHandAfterDiscards,
+        discardPile: discardPileAfter,
+        aiDiscardPile: aiDiscardPileAfter,
         round: prev.round + 1,
         phase: 'newspaper',
         currentPlayer: 'human',

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -31,6 +31,7 @@ import NewCardsPresentation from '@/components/game/NewCardsPresentation';
 import { Maximize, Menu, Minimize, UserCircle2 } from 'lucide-react';
 import { useCardCollection } from '@/hooks/useCardCollection';
 import { useSynergyDetection } from '@/hooks/useSynergyDetection';
+import { planDiscardOutcome } from '@/utils/discardPlanner';
 import {
   aggregateStateCombinationEffects,
   applyDefenseBonusToStates,
@@ -675,6 +676,7 @@ const Index = () => {
     return 'government';
   });
   const [loadingCard, setLoadingCard] = useState<string | null>(null);
+  const [pendingDiscards, setPendingDiscards] = useState<string[]>([]);
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
   const [subtitle, setSubtitle] = useState('Truth Seeker Operative');
   
@@ -726,6 +728,17 @@ const Index = () => {
   const { animatePlayCard, isAnimating } = useCardAnimation();
   const { discoverCard, playCard: recordCardPlay } = useCardCollection();
   const { checkSynergies, getActiveCombinations, getTotalBonusIP } = useSynergyDetection();
+  const discardPreview = useMemo(
+    () => planDiscardOutcome(gameState.hand, gameState.discardPile ?? [], pendingDiscards),
+    [gameState.hand, gameState.discardPile, pendingDiscards]
+  );
+  const queuedDiscardNames = useMemo(
+    () =>
+      discardPreview.discardedCards
+        .map(card => card.name?.trim() || card.id)
+        .filter(Boolean),
+    [discardPreview.discardedCards]
+  );
   const {
     issues: pressArchive,
     archiveEdition,
@@ -1955,14 +1968,37 @@ const Index = () => {
       return;
     }
 
+    const plannedIds = pendingDiscards;
+    const plan = discardPreview;
+
     setIsEndingTurn(true);
-    endTurn();
+    endTurn(plannedIds);
+
+    if (plan.discardedCount > 0) {
+      const cardLabels = plan.discardedCards
+        .map(card => card.name?.trim() || card.id)
+        .filter(Boolean);
+      const costSummary = plan.ipCost > 0 ? `−${plan.ipCost} IP` : 'free';
+      const details = cardLabels.length > 0 ? ` · ${cardLabels.join(', ')}` : '';
+      toast.success(`🗂️ Discarded ${plan.discardedCount} card${plan.discardedCount === 1 ? '' : 's'} (${costSummary})${details}`, {
+        duration: 3500,
+        style: { background: '#1f2937', color: '#f3f4f6', border: '1px solid #2563eb', fontFamily: 'monospace' }
+      });
+    }
+
+    setPendingDiscards([]);
     audio.playSFX('turnEnd');
     // Play card draw sound after a short delay
     setTimeout(() => {
       audio.playSFX('cardDraw');
     }, 500);
-  }, [audio, endTurn, isEndingTurn]);
+  }, [
+    audio,
+    discardPreview,
+    endTurn,
+    isEndingTurn,
+    pendingDiscards,
+  ]);
 
   // Update Index.tsx to use enhanced components and add keyboard shortcuts
   useEffect(() => {
@@ -2031,6 +2067,17 @@ const Index = () => {
       setIsEndingTurn(false);
     }
   }, [gameState.phase, gameState.currentPlayer, gameState.animating]);
+
+  useEffect(() => {
+    setPendingDiscards(prev => {
+      if (prev.length === 0) {
+        return prev;
+      }
+      const handIds = new Set(gameState.hand.map(card => card.id));
+      const filtered = prev.filter(id => handIds.has(id));
+      return filtered.length === prev.length ? prev : filtered;
+    });
+  }, [gameState.hand]);
 
   const handleSaveGame = () => {
     if (saveGame) {
@@ -2263,6 +2310,8 @@ const Index = () => {
       // Use animated card play
       await playCardAnimated(cardId, animatePlayCard, resolvedTargetStateId);
 
+      setPendingDiscards(prev => (prev.length ? prev.filter(id => id !== cardId) : prev));
+
       // Track card in collection
       recordCardPlay(cardId);
       
@@ -2493,6 +2542,25 @@ const Index = () => {
   const isPlayerActionLocked =
     gameState.phase !== 'action' || gameState.animating || gameState.currentPlayer !== 'human';
   const handInteractionDisabled = isPlayerActionLocked || gameState.cardsPlayedThisTurn >= 3;
+  const canQueueDiscards =
+    !handInteractionDisabled &&
+    gameState.currentPlayer === 'human' &&
+    gameState.phase === 'action' &&
+    !gameState.animating;
+  const handleToggleDiscard = useCallback(
+    (cardId: string) => {
+      if (!canQueueDiscards) {
+        return;
+      }
+      setPendingDiscards(prev => {
+        if (prev.includes(cardId)) {
+          return prev.filter(id => id !== cardId);
+        }
+        return [...prev, cardId];
+      });
+    },
+    [canQueueDiscards]
+  );
 
   const playerAgenda = gameState.secretAgenda;
   const aiControlledStates = gameState.states.filter(s => s.owner === 'ai').length;
@@ -3001,9 +3069,55 @@ const Index = () => {
           currentIP={gameState.ip}
           loadingCard={loadingCard}
           onCardHover={setHoveredCard}
+          discardQueue={pendingDiscards}
+          onToggleDiscard={handleToggleDiscard}
+          discardEnabled={canQueueDiscards}
         />
       </div>
       <footer className="border-t border-newspaper-border/60 px-3 pb-3 pt-2 sm:pt-3">
+        <div className="mb-2 rounded border border-newspaper-border/60 bg-newspaper-border/10 px-3 py-2 text-[0.65rem] font-mono text-newspaper-border">
+          {pendingDiscards.length === 0 ? (
+            <span>First discard each turn is free. Extra discards cost 10 IP, then +5 IP per card.</span>
+          ) : (
+            <div className="space-y-1 text-newspaper-bg">
+              <div className="text-[0.6rem] font-semibold uppercase tracking-[0.35em] text-newspaper-border">
+                Queued Discards ({pendingDiscards.length})
+              </div>
+              {queuedDiscardNames.length > 0 && (
+                <div className="truncate text-newspaper-bg/80">
+                  {queuedDiscardNames.join(', ')}
+                </div>
+              )}
+              <div>
+                IP impact:{' '}
+                <span
+                  className={clsx(
+                    'font-semibold',
+                    discardPreview.ipCost > 0 ? 'text-truth-red' : 'text-emerald-500'
+                  )}
+                >
+                  {discardPreview.ipCost > 0 ? `-${discardPreview.ipCost} IP` : 'Free'}
+                </span>
+              </div>
+              {discardPreview.costBreakdown.length > 0 && (
+                <div className="text-newspaper-bg/60">
+                  Cost steps:{' '}
+                  {discardPreview.costBreakdown
+                    .map((cost, index) =>
+                      index === 0
+                        ? '1st: 0 (free)'
+                        : (() => {
+                            const position = index + 1;
+                            const suffix = position === 2 ? 'nd' : position === 3 ? 'rd' : 'th';
+                            return `${position}${suffix}: ${cost}`;
+                          })()
+                    )
+                    .join(' · ')}
+                </div>
+              )}
+            </div>
+          )}
+        </div>
         <Button
           id="end-turn-button"
           onClick={handleEndTurn}

--- a/src/utils/discardPlanner.ts
+++ b/src/utils/discardPlanner.ts
@@ -1,0 +1,112 @@
+import type { GameCard } from '@/rules/mvp';
+
+export interface DiscardPlanOutcome {
+  remainingHand: GameCard[];
+  updatedDiscardPile: GameCard[];
+  discardedCards: GameCard[];
+  discardedCount: number;
+  ipCost: number;
+  costBreakdown: number[];
+  logEntry: string | null;
+}
+
+const FIRST_EXTRA_DISCARD_COST = 10;
+const ADDITIONAL_DISCARD_STEP = 5;
+
+const normalizeDiscards = (ids: string[]): string[] => ids.filter(id => typeof id === 'string' && id.trim().length > 0);
+
+export const planDiscardOutcome = (
+  hand: GameCard[],
+  discardPile: GameCard[],
+  discards: string[],
+): DiscardPlanOutcome => {
+  const plannedIds = normalizeDiscards(discards);
+  if (plannedIds.length === 0) {
+    return {
+      remainingHand: [...hand],
+      updatedDiscardPile: [...discardPile],
+      discardedCards: [],
+      discardedCount: 0,
+      ipCost: 0,
+      costBreakdown: [],
+      logEntry: null,
+    };
+  }
+
+  const discardCounts = new Map<string, number>();
+  for (const id of plannedIds) {
+    discardCounts.set(id, (discardCounts.get(id) ?? 0) + 1);
+  }
+
+  const remainingHand: GameCard[] = [];
+  const updatedDiscardPile: GameCard[] = [...discardPile];
+  const discardedCards: GameCard[] = [];
+
+  for (const card of hand) {
+    const count = discardCounts.get(card.id) ?? 0;
+    if (count > 0) {
+      discardCounts.set(card.id, count - 1);
+      discardedCards.push(card);
+      updatedDiscardPile.push(card);
+    } else {
+      remainingHand.push(card);
+    }
+  }
+
+  const discardedCount = discardedCards.length;
+  if (discardedCount === 0) {
+    return {
+      remainingHand,
+      updatedDiscardPile,
+      discardedCards,
+      discardedCount: 0,
+      ipCost: 0,
+      costBreakdown: [],
+      logEntry: null,
+    };
+  }
+
+  const costBreakdown: number[] = [];
+  for (let index = 0; index < discardedCount; index += 1) {
+    if (index === 0) {
+      costBreakdown.push(0);
+      continue;
+    }
+    const incrementalCost = FIRST_EXTRA_DISCARD_COST + (index - 1) * ADDITIONAL_DISCARD_STEP;
+    costBreakdown.push(incrementalCost);
+  }
+
+  const ipCost = costBreakdown.reduce((total, cost) => total + cost, 0);
+  const logEntry = `Discarded ${discardedCount} card${discardedCount === 1 ? '' : 's'}${
+    ipCost > 0 ? ` (paid ${ipCost} IP)` : ' (first free)'
+  }`;
+
+  return {
+    remainingHand,
+    updatedDiscardPile,
+    discardedCards,
+    discardedCount,
+    ipCost,
+    costBreakdown,
+    logEntry,
+  };
+};
+
+export const previewDiscardCost = (plannedDiscards: string[]): { totalCost: number; breakdown: number[] } => {
+  const normalized = normalizeDiscards(plannedDiscards);
+  if (normalized.length <= 1) {
+    return { totalCost: 0, breakdown: normalized.map(() => 0) };
+  }
+
+  const breakdown: number[] = [];
+  for (let index = 0; index < normalized.length; index += 1) {
+    if (index === 0) {
+      breakdown.push(0);
+      continue;
+    }
+    breakdown.push(FIRST_EXTRA_DISCARD_COST + (index - 1) * ADDITIONAL_DISCARD_STEP);
+  }
+
+  const totalCost = breakdown.reduce((total, value) => total + value, 0);
+  return { totalCost, breakdown };
+};


### PR DESCRIPTION
## Summary
- add a discard planning helper to consistently remove queued cards and compute escalating IP costs
- update the game state hook and main page to accept queued discards, preview IP impact, and clear the selection when the turn ends
- extend the hand UI and card details overlay with discard toggles and highlighting for queued cards, plus add coverage for the discard planner

## Testing
- npm run lint *(fails: repository has pre-existing lint violations – see log)*
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68e222c113348320a51ca66965357d68