### PR TITLE
Document update log workflow for gameplay changes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,3 +14,8 @@ This guidance applies to the entire repository. If any directory later introduce
 ## Tooling notes
 - `scripts/generate-extension-index.mjs` runs automatically via the `predev` and `prebuild` npm lifecycle hooks.
 
+## Update log expectations
+- Whenever a change that affects the game is merged, append a new entry to `UPDATES_LOG.md` at the repository root.
+- Each entry must start with the merge date in `YYYY-MM-DD` format followed by a short, human-readable summary of the change.
+- Keep the log sorted in descending chronological order so the most recent updates appear first.
+

--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@
 
 **Technical overview**: See [docs/TECHNICAL_README.md](docs/TECHNICAL_README.md) for gameplay rules, data pipelines, and audio integration notes.
 
+**Change history**: Review [UPDATES_LOG.md](UPDATES_LOG.md) for a dated summary of gameplay-impacting updates.
+
 ## How can I edit this code?
 
 There are several ways of editing your application.

--- a/UPDATES_LOG.md
+++ b/UPDATES_LOG.md
@@ -1,0 +1,6 @@
+# Updates Log
+
+This document provides a chronological record of gameplay-impacting changes merged into State Shift Strategy. Each entry should include the merge date and a brief, human-readable summary so future contributors can quickly understand how the game has evolved.
+
+## 2025-10-05 – Planned discard feature
+- Track the upcoming discard mechanic update so we remember to document its implementation details when the feature ships.


### PR DESCRIPTION
## Summary
- add a root-level UPDATES_LOG seeded with an entry for the upcoming discard mechanic work
- instruct contributors via AGENTS.md to append dated, human-readable summaries to the log for every merged game change
- link the new log from README.md so future contributors can find it quickly

## Testing
- npm run lint *(fails: existing lint errors unrelated to this change)*
- bun test --coverage --coverage-reporter=text

------
https://chatgpt.com/codex/tasks/task_e_68e227b2bf9483208c6da8ddddd0c7c0