### PR TITLE
Guard localStorage lookups in restricted environments

### DIFF
--- a/UPDATES_LOG.md
+++ b/UPDATES_LOG.md
@@ -2,6 +2,10 @@
 
 This document provides a chronological record of gameplay-impacting changes merged into State Shift Strategy. Each entry should include the merge date and a brief, human-readable summary so future contributors can quickly understand how the game has evolved.
 
+## 2025-10-05 – Harden local storage fallbacks
+- Guard settings and faction persistence against blocked storage so new games keep default options without crashing.
+- Add helper coverage to verify localStorage failures resolve safely.
+
 ## 2025-10-05 – Safeguard AI zone plays without targets
 - Prevent the AI from resolving zone cards that lack a valid target state and add regression coverage to keep turns flowing.
 

--- a/__tests__/storage.test.ts
+++ b/__tests__/storage.test.ts
@@ -1,0 +1,93 @@
+import { afterEach, describe, expect, it, mock } from 'bun:test';
+import { safeGetLocalStorageItem, safeSetLocalStorageItem } from '../src/utils/storage';
+
+type MutableGlobal = typeof globalThis & {
+  window?: Window & typeof globalThis;
+};
+
+const getMutableGlobal = (): MutableGlobal => globalThis as MutableGlobal;
+
+const originalWindow = getMutableGlobal().window;
+
+afterEach(() => {
+  const globalRef = getMutableGlobal();
+  if (originalWindow === undefined) {
+    delete globalRef.window;
+  } else {
+    globalRef.window = originalWindow;
+  }
+});
+
+describe('safe localStorage helpers', () => {
+  it('returns null when window is not available', () => {
+    const globalRef = getMutableGlobal();
+    delete globalRef.window;
+
+    expect(safeGetLocalStorageItem('missing')).toBeNull();
+    expect(safeSetLocalStorageItem('missing', 'value')).toBe(false);
+  });
+
+  it('reads and writes when localStorage is available', () => {
+    const store = new Map<string, string>();
+    const fakeWindow = {
+      localStorage: {
+        getItem: (key: string) => store.get(key) ?? null,
+        setItem: (key: string, value: string) => {
+          store.set(key, value);
+        },
+        clear: () => {
+          store.clear();
+        },
+        removeItem: (key: string) => {
+          store.delete(key);
+        },
+        key: (index: number) => Array.from(store.keys())[index] ?? null,
+        length: 0,
+      },
+    } as unknown as Window & typeof globalThis;
+
+    const globalRef = getMutableGlobal();
+    globalRef.window = fakeWindow;
+
+    expect(safeSetLocalStorageItem('alpha', 'bravo')).toBe(true);
+    expect(safeGetLocalStorageItem('alpha')).toBe('bravo');
+  });
+
+  it('swallows getItem errors and logs a warning', () => {
+    const warn = mock(() => {});
+    const logger: Pick<Console, 'warn'> = { warn };
+    const error = new Error('blocked');
+    const fakeWindow = {
+      localStorage: {
+        getItem: () => {
+          throw error;
+        },
+      },
+    } as unknown as Window & typeof globalThis;
+
+    const globalRef = getMutableGlobal();
+    globalRef.window = fakeWindow;
+
+    expect(safeGetLocalStorageItem('alpha', { logger })).toBeNull();
+    expect(warn.mock.calls.length).toBe(1);
+  });
+
+  it('swallows setItem errors and logs a warning', () => {
+    const warn = mock(() => {});
+    const logger: Pick<Console, 'warn'> = { warn };
+    const error = new Error('denied');
+    const fakeWindow = {
+      localStorage: {
+        setItem: () => {
+          throw error;
+        },
+      },
+    } as unknown as Window & typeof globalThis;
+
+    const globalRef = getMutableGlobal();
+    globalRef.window = fakeWindow;
+
+    expect(safeSetLocalStorageItem('alpha', 'bravo', { logger })).toBe(false);
+    expect(warn.mock.calls.length).toBe(1);
+  });
+});

--- a/src/hooks/useGameState.ts
+++ b/src/hooks/useGameState.ts
@@ -46,6 +46,7 @@ import { getEnabledExpansionIdsSnapshot } from '@/data/expansions/state';
 import { queueHotspotResolveToast, queueHotspotExpireToast } from '@/ui/hotspots.toasts';
 import { getHotspotIdleLog } from '@/state/useGameLog';
 import { planDiscardOutcome } from '@/utils/discardPlanner';
+import { safeGetLocalStorageItem } from '@/utils/storage';
 import type {
   ActiveCampaignArcState,
   ActiveParanormalHotspot,
@@ -2414,7 +2415,7 @@ export const useGameState = (aiDifficultyOverride?: AIDifficulty) => {
     // Get draw mode and agenda preferences from localStorage
     let drawMode: DrawMode = 'standard';
     let secretAgendasEnabled = true;
-    const savedSettings = localStorage.getItem('gameSettings');
+    const savedSettings = safeGetLocalStorageItem('gameSettings');
     if (savedSettings) {
       try {
         const parsed = JSON.parse(savedSettings) as {

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -32,6 +32,7 @@ import { Maximize, Menu, Minimize, UserCircle2 } from 'lucide-react';
 import { useCardCollection } from '@/hooks/useCardCollection';
 import { useSynergyDetection } from '@/hooks/useSynergyDetection';
 import { planDiscardOutcome } from '@/utils/discardPlanner';
+import { safeSetLocalStorageItem } from '@/utils/storage';
 import {
   aggregateStateCombinationEffects,
   applyDefenseBonusToStates,
@@ -857,9 +858,7 @@ const Index = () => {
 
   const persistFaction = useCallback((faction: 'truth' | 'government') => {
     setLastSelectedFaction(faction);
-    if (typeof window !== 'undefined') {
-      window.localStorage.setItem('shadowgov-last-faction', faction);
-    }
+    safeSetLocalStorageItem('shadowgov-last-faction', faction);
   }, []);
 
   const handleRelicOverlayClose = useCallback(() => {

--- a/src/utils/storage.ts
+++ b/src/utils/storage.ts
@@ -1,0 +1,61 @@
+export interface SafeStorageOptions {
+  logger?: Pick<Console, 'warn'>;
+}
+
+const resolveLogger = (options?: SafeStorageOptions): Pick<Console, 'warn'> | null => {
+  if (options?.logger && typeof options.logger.warn === 'function') {
+    return options.logger;
+  }
+
+  if (typeof console !== 'undefined' && typeof console.warn === 'function') {
+    return console;
+  }
+
+  return null;
+};
+
+export const safeGetLocalStorageItem = (
+  key: string,
+  options?: SafeStorageOptions,
+): string | null => {
+  if (typeof window === 'undefined') {
+    return null;
+  }
+
+  try {
+    const storage = window.localStorage;
+    if (!storage || typeof storage.getItem !== 'function') {
+      return null;
+    }
+
+    return storage.getItem(key);
+  } catch (error) {
+    const logger = resolveLogger(options);
+    logger?.warn?.(`[storage] Failed to read "${key}" from localStorage`, error);
+    return null;
+  }
+};
+
+export const safeSetLocalStorageItem = (
+  key: string,
+  value: string,
+  options?: SafeStorageOptions,
+): boolean => {
+  if (typeof window === 'undefined') {
+    return false;
+  }
+
+  try {
+    const storage = window.localStorage;
+    if (!storage || typeof storage.setItem !== 'function') {
+      return false;
+    }
+
+    storage.setItem(key, value);
+    return true;
+  } catch (error) {
+    const logger = resolveLogger(options);
+    logger?.warn?.(`[storage] Failed to write "${key}" to localStorage`, error);
+    return false;
+  }
+};


### PR DESCRIPTION
## Summary
- add a shared storage helper that verifies window availability and swallows localStorage access errors
- use the helper when reading saved game settings and persisting the last selected faction so blocked storage keeps defaults
- add regression coverage for the helper and log the gameplay-impacting change

## Testing
- npm run lint *(fails: repository contains numerous pre-existing lint errors unrelated to this change)*
- bun test --coverage --coverage-reporter=text

------
https://chatgpt.com/codex/tasks/task_e_68e2392b46c08320bebb6deccf65c32c