### PR TITLE
Handle card collection storage failures gracefully

### DIFF
--- a/docs/TECHNICAL_README.md
+++ b/docs/TECHNICAL_README.md
@@ -149,6 +149,10 @@ compiled articles, and the verb pools chosen for each card, matching the `Genera
 
 ⚠️ Not run (static QA review only).
 
+### QA regression notes
+
+- **Card collection storage fallback:** `useCardCollection` now wraps all localStorage access in the repository's safe helpers so browsers that block storage (Safari private mode, embedded webviews, strict content blockers) only emit a console warning. Gameplay discovery effects continue to run in `Index.tsx` because they consume the in-memory hook state, so verify the UI by triggering a new card discovery with storage disabled and confirming the overlay still appears without runtime errors.
+
 ##### Pacific Quantum Coast (`CA`, `WA`, `OR`, `AK`, `HI`)
 **Bonuses**
 - `pacific_bonus_tsunami_briefing_buoys` — *PACIFIC BUOY FLASHES TOP-SECRET WAVE ALERTS* — Buoy lights blink clearance codes in Morse while surfers nod solemnly and paddle toward the anomaly. Effects: Truth +2, IP +1, Pressure +0.

--- a/src/hooks/useCardCollection.ts
+++ b/src/hooks/useCardCollection.ts
@@ -1,6 +1,7 @@
 import { useState, useEffect } from 'react';
 import type { GameCard } from '@/rules/mvp';
 import { CARD_DATABASE } from '@/data/cardDatabase';
+import { safeGetLocalStorageItem, safeSetLocalStorageItem } from '@/utils/storage';
 
 interface CardCollectionData {
   discoveredCards: Set<string>;
@@ -19,29 +20,37 @@ export const useCardCollection = () => {
 
   // Load from localStorage on mount
   useEffect(() => {
-    const saved = localStorage.getItem(STORAGE_KEY);
-    if (saved) {
-      try {
-        const data = JSON.parse(saved);
-        setCollection({
-          discoveredCards: new Set(data.discoveredCards || []),
-          playedCards: new Map(Object.entries(data.playedCards || {})),
-          lastUpdated: data.lastUpdated || Date.now()
-        });
-      } catch (error) {
-        console.error('Failed to load card collection:', error);
+    try {
+      const saved = safeGetLocalStorageItem(STORAGE_KEY, { logger: console });
+      if (!saved) {
+        return;
       }
+
+      const data = JSON.parse(saved);
+      setCollection({
+        discoveredCards: new Set(data.discoveredCards || []),
+        playedCards: new Map(Object.entries(data.playedCards || {})),
+        lastUpdated: data.lastUpdated || Date.now()
+      });
+    } catch (error) {
+      console.warn('Card collection storage unavailable; continuing without persistence.', error);
     }
   }, []);
 
   // Save to localStorage whenever collection changes
   useEffect(() => {
-    const dataToSave = {
-      discoveredCards: Array.from(collection.discoveredCards),
-      playedCards: Object.fromEntries(collection.playedCards),
-      lastUpdated: collection.lastUpdated
-    };
-    localStorage.setItem(STORAGE_KEY, JSON.stringify(dataToSave));
+    try {
+      const dataToSave = {
+        discoveredCards: Array.from(collection.discoveredCards),
+        playedCards: Object.fromEntries(collection.playedCards),
+        lastUpdated: collection.lastUpdated
+      };
+
+      const serialized = JSON.stringify(dataToSave);
+      safeSetLocalStorageItem(STORAGE_KEY, serialized, { logger: console });
+    } catch (error) {
+      console.warn('Failed to persist card collection; continuing without storage.', error);
+    }
   }, [collection]);
 
   const discoverCard = (cardId: string) => {


### PR DESCRIPTION
## Summary
- wrap the card collection hook's storage access in the repository safe helpers so the UI keeps running when localStorage is blocked
- fall back to in-memory state when persistence fails while continuing to support discovery effects
- document the new storage fallback expectation in the QA regression notes

## Testing
- npm run lint *(fails: repository has pre-existing lint violations unrelated to this change)*
- bun test --coverage --coverage-reporter=text


------
https://chatgpt.com/codex/tasks/task_e_68e23e5efd148320b4c54ae24389ccd3