### PR TITLE
Fix discard toggle hook ordering

### DIFF
--- a/UPDATES_LOG.md
+++ b/UPDATES_LOG.md
@@ -2,6 +2,9 @@
 
 This document provides a chronological record of gameplay-impacting changes merged into State Shift Strategy. Each entry should include the merge date and a brief, human-readable summary so future contributors can quickly understand how the game has evolved.
 
+## 2025-10-05 – Stabilize discard toggling during menus
+- Move the discard hook and related gating logic before intro/menu early returns so switching between intro and menu no longer triggers React hook order errors.
+
 ## 2025-10-05 – Harden local storage fallbacks
 - Guard settings and faction persistence against blocked storage so new games keep default options without crashing.
 - Add helper coverage to verify localStorage failures resolve safely.

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -2415,9 +2415,32 @@ const Index = () => {
     }
   }, [showIntro, showMenu, audio]);
 
+  const isPlayerActionLocked =
+    gameState.phase !== 'action' || gameState.animating || gameState.currentPlayer !== 'human';
+  const handInteractionDisabled = isPlayerActionLocked || gameState.cardsPlayedThisTurn >= 3;
+  const canQueueDiscards =
+    !handInteractionDisabled &&
+    gameState.currentPlayer === 'human' &&
+    gameState.phase === 'action' &&
+    !gameState.animating;
+  const handleToggleDiscard = useCallback(
+    (cardId: string) => {
+      if (!canQueueDiscards) {
+        return;
+      }
+      setPendingDiscards(prev => {
+        if (prev.includes(cardId)) {
+          return prev.filter(id => id !== cardId);
+        }
+        return [...prev, cardId];
+      });
+    },
+    [canQueueDiscards]
+  );
+
   if (showIntro) {
     return (
-      <div 
+      <div
         className="min-h-screen bg-government-dark flex items-center justify-center cursor-pointer"
         onClick={() => {
           setShowIntro(false);
@@ -2537,29 +2560,6 @@ const Index = () => {
       />
     );
   }
-
-  const isPlayerActionLocked =
-    gameState.phase !== 'action' || gameState.animating || gameState.currentPlayer !== 'human';
-  const handInteractionDisabled = isPlayerActionLocked || gameState.cardsPlayedThisTurn >= 3;
-  const canQueueDiscards =
-    !handInteractionDisabled &&
-    gameState.currentPlayer === 'human' &&
-    gameState.phase === 'action' &&
-    !gameState.animating;
-  const handleToggleDiscard = useCallback(
-    (cardId: string) => {
-      if (!canQueueDiscards) {
-        return;
-      }
-      setPendingDiscards(prev => {
-        if (prev.includes(cardId)) {
-          return prev.filter(id => id !== cardId);
-        }
-        return [...prev, cardId];
-      });
-    },
-    [canQueueDiscards]
-  );
 
   const playerAgenda = gameState.secretAgenda;
   const aiControlledStates = gameState.states.filter(s => s.owner === 'ai').length;


### PR DESCRIPTION
## Summary
- move the discard toggle hook and related gating calculations above the intro/menu early returns in Index.tsx
- record the gameplay-facing fix in the updates log

## Testing
- npm run lint *(fails: existing repository lint violations unrelated to this change)*
- bun test --coverage --coverage-reporter=text

------
https://chatgpt.com/codex/tasks/task_e_68e2433dedc88320915efb2076da3e68