### PR TITLE
Use safe localStorage access in card drawing hook

### DIFF
--- a/src/hooks/useCardDrawing.ts
+++ b/src/hooks/useCardDrawing.ts
@@ -1,5 +1,6 @@
 import { useState, useEffect } from 'react';
 import { calculateCardDraw, getStartingHandSize, type DrawMode, type CardDrawState } from '@/data/cardDrawingSystem';
+import { safeGetLocalStorageItem } from '@/utils/storage';
 
 export interface DrawingSettings {
   drawMode: DrawMode;
@@ -14,11 +15,15 @@ export const useCardDrawing = () => {
 
   // Load settings from localStorage
   useEffect(() => {
-    const savedSettings = localStorage.getItem('gameSettings');
+    const savedSettings = safeGetLocalStorageItem('gameSettings');
     if (savedSettings) {
-      const parsed = JSON.parse(savedSettings);
-      if (parsed.drawMode) {
-        setSettings({ drawMode: parsed.drawMode });
+      try {
+        const parsed = JSON.parse(savedSettings);
+        if (parsed && typeof parsed.drawMode === 'string') {
+          setSettings({ drawMode: parsed.drawMode as DrawMode });
+        }
+      } catch (error) {
+        console.warn('Failed to parse saved card drawing settings:', error);
       }
     }
   }, []);


### PR DESCRIPTION
## Summary
- read stored card drawing preferences with the shared safe localStorage helper
- guard JSON parsing so the hook retains its default draw mode when saved settings cannot be parsed

## Testing
- npm run lint *(fails: existing lint violations across unrelated files)*
- bun test --coverage --coverage-reporter=text


------
https://chatgpt.com/codex/tasks/task_e_68e24ae9e8fc8320965bf4b9df26f6f3