### PR TITLE
Use safe storage helpers in theme hook

### DIFF
--- a/src/hooks/useTheme.ts
+++ b/src/hooks/useTheme.ts
@@ -1,16 +1,36 @@
 import { useState, useEffect } from 'react';
+import { safeGetLocalStorageItem, safeSetLocalStorageItem } from '@/utils/storage';
 
 export type UiTheme = 'tabloid_bw' | 'government_classic';
 
 export const useUiTheme = () => {
   const [theme, setTheme] = useState<UiTheme>(() => {
-    const saved = localStorage.getItem('sg_ui_theme');
-    return (saved as UiTheme) || 'tabloid_bw';
+    const saved = safeGetLocalStorageItem('sg_ui_theme');
+
+    const isUiTheme = (value: unknown): value is UiTheme =>
+      value === 'tabloid_bw' || value === 'government_classic';
+
+    if (saved && isUiTheme(saved)) {
+      return saved;
+    }
+
+    if (saved) {
+      try {
+        const parsed = JSON.parse(saved);
+        if (isUiTheme(parsed)) {
+          return parsed;
+        }
+      } catch {
+        // ignore parse failures and fall through to default
+      }
+    }
+
+    return 'tabloid_bw';
   });
 
   const updateTheme = (newTheme: UiTheme) => {
     setTheme(newTheme);
-    localStorage.setItem('sg_ui_theme', newTheme);
+    safeSetLocalStorageItem('sg_ui_theme', newTheme);
   };
 
   return [theme, updateTheme] as const;


### PR DESCRIPTION
## Summary
- use the shared safe storage helpers when reading and writing the theme preference
- fall back to the default theme when the stored value is inaccessible or invalid

## Testing
- npm run lint *(fails: repository has numerous pre-existing lint errors unrelated to this change)*
- bun test --coverage --coverage-reporter=text


------
https://chatgpt.com/codex/tasks/task_e_68e24c220dd483208d1abf5482addb9f