### PR TITLE
Guard weather badge storage access

### DIFF
--- a/UPDATES_LOG.md
+++ b/UPDATES_LOG.md
@@ -2,6 +2,9 @@
 
 This document provides a chronological record of gameplay-impacting changes merged into State Shift Strategy. Each entry should include the merge date and a brief, human-readable summary so future contributors can quickly understand how the game has evolved.
 
+## 2025-10-05 – Weather badge storage safety
+- Use the safe localStorage helper for the start screen weather badge so blocked storage no longer breaks the intro UI.
+
 ## 2025-10-05 – Stabilize discard toggling during menus
 - Move the discard hook and related gating logic before intro/menu early returns so switching between intro and menu no longer triggers React hook order errors.
 

--- a/src/ui/start/WeatherBadge.tsx
+++ b/src/ui/start/WeatherBadge.tsx
@@ -1,11 +1,11 @@
 import { useEffect, useState } from 'react';
 import { fetchRealWeather } from '@/system/weather/fetchRealWeather';
 import { humorize } from '@/system/weather/tabloidWeather';
+import { safeGetLocalStorageItem } from '@/utils/storage';
 
 function getUseRealWeatherSetting(): boolean {
-  if (typeof window === 'undefined') return false;
-  const s = localStorage.getItem('useRealWeather');
-  return s ? s === 'true' : false;
+  const storedValue = safeGetLocalStorageItem('useRealWeather');
+  return storedValue ? storedValue === 'true' : false;
 }
 
 export function WeatherBadge() {


### PR DESCRIPTION
## Summary
- use the shared safe localStorage helper when reading the weather badge preference
- document the UI hardening in the updates log

## Testing
- npm run lint *(fails: existing repo lint violations unrelated to this change)*
- bun test --coverage --coverage-reporter=text

------
https://chatgpt.com/codex/tasks/task_e_68e24d2af15c8320843fcfbbad2eb350