### PR TITLE
Use safe storage helpers in interactive onboarding

### DIFF
--- a/UPDATES_LOG.md
+++ b/UPDATES_LOG.md
@@ -2,6 +2,9 @@
 
 This document provides a chronological record of gameplay-impacting changes merged into State Shift Strategy. Each entry should include the merge date and a brief, human-readable summary so future contributors can quickly understand how the game has evolved.
 
+## 2025-10-05 – Harden onboarding storage writes
+- Use the safe localStorage setter for onboarding completion and skip flags so the tutorial still dismisses when storage access is blocked and logs a warning when persistence fails.
+
 ## 2025-10-05 – Index onboarding storage safeguards
 - Use the safe storage helpers for faction selection, IP tracking, and onboarding checks so the intro flow still works when localStorage is blocked.
 

--- a/src/components/game/InteractiveOnboarding.tsx
+++ b/src/components/game/InteractiveOnboarding.tsx
@@ -4,6 +4,7 @@ import { Button } from '@/components/ui/button';
 import { Progress } from '@/components/ui/progress';
 import { Badge } from '@/components/ui/badge';
 import { ArrowRight, ArrowLeft, X, CheckCircle2, Play } from 'lucide-react';
+import { safeSetLocalStorageItem } from '@/utils/storage';
 
 interface OnboardingStep {
   id: string;
@@ -108,14 +109,26 @@ const InteractiveOnboarding = ({ isActive, onComplete, onSkip, gameState }: Inte
     }
   };
 
+  const logStorageFailure = (key: string) => {
+    if (typeof console !== 'undefined' && typeof console.warn === 'function') {
+      console.warn(`[onboarding] Failed to persist "${key}" flag to localStorage.`);
+    }
+  };
+
   const completeOnboarding = () => {
     setCompletedSteps(prev => [...prev, onboardingSteps[currentStep].id]);
-    localStorage.setItem('shadowgov-onboarding-complete', 'true');
+    const didPersist = safeSetLocalStorageItem('shadowgov-onboarding-complete', 'true');
+    if (!didPersist) {
+      logStorageFailure('shadowgov-onboarding-complete');
+    }
     onComplete();
   };
 
   const skipOnboarding = () => {
-    localStorage.setItem('shadowgov-onboarding-skipped', 'true');
+    const didPersist = safeSetLocalStorageItem('shadowgov-onboarding-skipped', 'true');
+    if (!didPersist) {
+      logStorageFailure('shadowgov-onboarding-skipped');
+    }
     onSkip();
   };
 


### PR DESCRIPTION
## Summary
- persist onboarding completion and skip flags with the safe storage helper and warn when writing fails
- keep the onboarding overlay dismissal flow independent from localStorage availability
- document the onboarding storage hardening in the updates log

## Testing
- npm run lint *(fails: existing lint violations across unrelated files)*
- bun test --coverage --coverage-reporter=text

------
https://chatgpt.com/codex/tasks/task_e_68e24fb601a48320b27b06419ecce94c