### PR TITLE
Harden tutorial storage fallbacks

### DIFF
--- a/UPDATES_LOG.md
+++ b/UPDATES_LOG.md
@@ -2,6 +2,10 @@
 
 This document provides a chronological record of gameplay-impacting changes merged into State Shift Strategy. Each entry should include the merge date and a brief, human-readable summary so future contributors can quickly understand how the game has evolved.
 
+## 2025-10-05 – Harden tutorial progress storage
+- Ensure the tutorial manager uses safe localStorage helpers so blocked storage falls back to in-memory defaults without breaking onboarding.
+- Wrap tutorial reset logic in guards so clearing progress never crashes when storage access fails.
+
 ## 2025-10-05 – Harden onboarding storage writes
 - Use the safe localStorage setter for onboarding completion and skip flags so the tutorial still dismisses when storage access is blocked and logs a warning when persistence fails.
 

--- a/src/data/tutorialSystem.ts
+++ b/src/data/tutorialSystem.ts
@@ -1,3 +1,7 @@
+import { safeGetLocalStorageItem, safeSetLocalStorageItem } from '@/utils/storage';
+
+const TUTORIAL_STORAGE_KEY = 'shadow_government_tutorial_progress';
+
 export interface TutorialStep {
   id: string;
   title: string;
@@ -241,14 +245,21 @@ export class TutorialManager {
 
   // Load tutorial progress from localStorage
   loadProgress() {
-    const saved = localStorage.getItem('shadow_government_tutorial_progress');
-    if (saved) {
-      try {
-        const data = JSON.parse(saved);
-        this.completedSequences = data.completedSequences || [];
-      } catch (e) {
-        console.warn('Failed to load tutorial progress:', e);
-      }
+    const saved = safeGetLocalStorageItem(TUTORIAL_STORAGE_KEY, { logger: console });
+
+    if (!saved) {
+      this.completedSequences = [];
+      return;
+    }
+
+    try {
+      const data = JSON.parse(saved);
+      this.completedSequences = Array.isArray(data.completedSequences)
+        ? data.completedSequences
+        : [];
+    } catch (error) {
+      console.warn('Failed to load tutorial progress:', error);
+      this.completedSequences = [];
     }
   }
 
@@ -258,7 +269,17 @@ export class TutorialManager {
       completedSequences: this.completedSequences,
       timestamp: Date.now()
     };
-    localStorage.setItem('shadow_government_tutorial_progress', JSON.stringify(data));
+    const serialized = JSON.stringify(data);
+
+    const didPersist = safeSetLocalStorageItem(
+      TUTORIAL_STORAGE_KEY,
+      serialized,
+      { logger: console }
+    );
+
+    if (!didPersist) {
+      console.warn('Failed to persist tutorial progress to localStorage.');
+    }
   }
 
   // Check if tutorial sequence is available
@@ -546,8 +567,19 @@ export class TutorialManager {
   // Reset all tutorial progress
   resetProgress() {
     this.completedSequences = [];
-    this.saveProgress();
-    localStorage.removeItem('shadow_government_tutorial_progress');
+
+    if (typeof window === 'undefined') {
+      return;
+    }
+
+    try {
+      const storage = window.localStorage;
+      if (storage && typeof storage.removeItem === 'function') {
+        storage.removeItem(TUTORIAL_STORAGE_KEY);
+      }
+    } catch (error) {
+      console.warn('Failed to reset tutorial progress:', error);
+    }
   }
 
   // Get tutorial statistics


### PR DESCRIPTION
## Summary
- switch the tutorial manager to the shared safe localStorage helpers so progress loads and saves gracefully when storage access fails
- guard tutorial reset logic behind window checks and try/catch so clearing progress never crashes but still logs warnings for debugging
- document the storage hardening in the updates log

## Testing
- npm run lint *(fails: repository has pre-existing lint violations unrelated to this change)*
- bun test --coverage --coverage-reporter=text

------
https://chatgpt.com/codex/tasks/task_e_68e250840b8c8320b2841e6c1a538b4b