### PR TITLE
Use safe storage helper for options

### DIFF
--- a/UPDATES_LOG.md
+++ b/UPDATES_LOG.md
@@ -2,6 +2,9 @@
 
 This document provides a chronological record of gameplay-impacting changes merged into State Shift Strategy. Each entry should include the merge date and a brief, human-readable summary so future contributors can quickly understand how the game has evolved.
 
+## 2025-10-05 – Harden options storage reads
+- Use the safe localStorage helper when loading saved options so the game falls back to defaults when storage is unavailable.
+
 ## 2025-10-05 – Harden tutorial progress storage
 - Ensure the tutorial manager uses safe localStorage helpers so blocked storage falls back to in-memory defaults without breaking onboarding.
 - Wrap tutorial reset logic in guards so clearing progress never crashes when storage access fails.

--- a/src/components/game/Options.tsx
+++ b/src/components/game/Options.tsx
@@ -15,6 +15,7 @@ import type { ComboCategory, ComboSettings } from '@/game/combo.types';
 import { Badge } from '@/components/ui/badge';
 import { DEFAULT_UI_SCALE, coerceUiScale, parseUiScale } from '@/lib/ui-scale';
 import { cn } from '@/lib/utils';
+import { safeGetLocalStorageItem } from '@/utils/storage';
 import {
   Select,
   SelectContent,
@@ -155,9 +156,7 @@ const Options = ({ onClose, onBackToMainMenu, onSaveGame }: OptionsProps) => {
       uiScale: DEFAULT_UI_SCALE,
     };
 
-    const stored = typeof localStorage !== 'undefined'
-      ? localStorage.getItem(SETTINGS_STORAGE_KEY)
-      : null;
+    const stored = safeGetLocalStorageItem(SETTINGS_STORAGE_KEY);
 
     if (stored) {
       try {


### PR DESCRIPTION
## Summary
- use the shared safeGetLocalStorageItem helper when loading saved options so the menu respects storage limitations
- document the storage hardening in the updates log

## Testing
- npm run lint *(fails: existing repository lint violations)*
- bun test --coverage --coverage-reporter=text


------
https://chatgpt.com/codex/tasks/task_e_68e251659e508320853cd4cc74499ded