### PR TITLE
Guard difficulty persistence against storage errors

### DIFF
--- a/UPDATES_LOG.md
+++ b/UPDATES_LOG.md
@@ -2,6 +2,9 @@
 
 This document provides a chronological record of gameplay-impacting changes merged into State Shift Strategy. Each entry should include the merge date and a brief, human-readable summary so future contributors can quickly understand how the game has evolved.
 
+## 2025-10-05 – Guard difficulty storage access
+- Use the safe localStorage helpers for difficulty reads and writes so blocked storage falls back to the NORMAL difficulty without crashing callers.
+
 ## 2025-10-05 – Harden options storage reads
 - Use the safe localStorage helper when loading saved options so the game falls back to defaults when storage is unavailable.
 

--- a/src/state/settings.ts
+++ b/src/state/settings.ts
@@ -1,4 +1,5 @@
 import type { Difficulty } from "../ai";
+import { safeGetLocalStorageItem, safeSetLocalStorageItem } from "@/utils/storage";
 
 const OPTIONS_STORAGE_KEY = "gameSettings";
 
@@ -26,8 +27,8 @@ const readStoredGameSettings = (): StoredGameSettings | null => {
 };
 
 export function getDifficulty(): Difficulty {
-  const storage = typeof localStorage !== "undefined" ? localStorage : null;
-  const raw = storage?.getItem("shadowgov:difficulty") ?? "NORMAL";
+  const raw =
+    safeGetLocalStorageItem("shadowgov:difficulty", { logger: console }) ?? "NORMAL";
   switch (raw) {
     case "EASY":
     case "NORMAL":
@@ -46,9 +47,9 @@ export function setDifficultyFromLabel(label: string) {
     "HARD - Top Secret": "HARD",
     "TOP SECRET+ - Meta-Cheating": "TOP_SECRET_PLUS",
   };
-  if (typeof localStorage !== "undefined") {
-    localStorage.setItem("shadowgov:difficulty", map[label] ?? "NORMAL");
-  }
+  safeSetLocalStorageItem("shadowgov:difficulty", map[label] ?? "NORMAL", {
+    logger: console,
+  });
 }
 
 export function areParanormalEffectsEnabled(): boolean {


### PR DESCRIPTION
## Summary
- use the shared safe storage helpers for difficulty reads and writes so storage errors fall back to NORMAL
- document the hardened difficulty storage behavior in the updates log

## Testing
- npm run lint *(fails: pre-existing repository lint violations)*
- bun test --coverage --coverage-reporter=text


------
https://chatgpt.com/codex/tasks/task_e_68e25241ffec8320a4c0e017b9e13ce8