### PR TITLE
Add news buffers to game state models

### DIFF
--- a/UPDATES_LOG.md
+++ b/UPDATES_LOG.md
@@ -2,6 +2,11 @@
 
 This document provides a chronological record of gameplay-impacting changes merged into State Shift Strategy. Each entry should include the merge date and a brief, human-readable summary so future contributors can quickly understand how the game has evolved.
 
+## 2025-10-05 – Expand game state tracking buffers
+- Add headline, extra edition, and turn buffer placeholders to both MVP and main game state models so upcoming newspaper flows
+  can read consistent structures.
+- Ensure clones, reducers, and initializers keep the new arrays in sync and persist them through saves.
+
 ## 2025-10-05 – Unify newspaper data pools
 - Move the public newspaper dataset to the new root location and expose shared pool loading helpers so newspaper generators can read the expanded copy deck consistently.
 

--- a/src/components/dev/CardEffectValidator.tsx
+++ b/src/components/dev/CardEffectValidator.tsx
@@ -52,7 +52,13 @@ const CardEffectValidatorPanel: React.FC = () => {
       truth: testGameState.truth,
       playsThisTurn: 0,
       turnPlays: [],
+      turnBuffer: [],
       log: engineLog,
+      headlineLog: [],
+      extraExtraFeed: [],
+      winner: null,
+      victoryType: null,
+      finalEdition: null,
       players: {
         P1: {
           id: 'P1',

--- a/src/components/game/EffectTestPanel.tsx
+++ b/src/components/game/EffectTestPanel.tsx
@@ -37,7 +37,13 @@ const EffectTestPanel: React.FC = () => {
     truth: gameState.truth,
     playsThisTurn: 0,
     turnPlays: [],
+    turnBuffer: [],
     log: engineLog,
+    headlineLog: [],
+    extraExtraFeed: [],
+    winner: null,
+    victoryType: null,
+    finalEdition: null,
     players: {
       P1: {
         id: 'P1',

--- a/src/data/enhancedAIStrategy.ts
+++ b/src/data/enhancedAIStrategy.ts
@@ -1,5 +1,6 @@
 import type { GameCard } from '@/rules/mvp';
 import { resolveCardMVP, type CardPlayResolution, type GameSnapshot } from '@/systems/cardResolution';
+import type { TurnPlay } from '@/game/combo.types';
 import { CARD_DATABASE } from './cardDatabase';
 import { getAiTuningConfig, type AiTuningConfig } from './aiTuning';
 import {
@@ -1168,6 +1169,35 @@ export class EnhancedAIStrategist implements AIStrategist {
       controlledStates: playerControlledStates,
       playerControlledStates,
       aiControlledStates,
+      log: Array.isArray(gameState.log) ? [...gameState.log] : [],
+      headlineLog: Array.isArray(gameState.headlineLog) ? [...gameState.headlineLog] : [],
+      extraExtraFeed: Array.isArray(gameState.extraExtraFeed) ? [...gameState.extraExtraFeed] : [],
+      turnPlays: Array.isArray(gameState.turnPlays)
+        ? gameState.turnPlays.map((play: TurnPlay) => ({
+            ...play,
+            metadata: play.metadata ? { ...play.metadata } : undefined,
+          }))
+        : [],
+      turnBuffer: Array.isArray(gameState.turnBuffer)
+        ? gameState.turnBuffer.map((play: TurnPlay) => ({
+            ...play,
+            metadata: play.metadata ? { ...play.metadata } : undefined,
+          }))
+        : [],
+      winner:
+        gameState.winner === 'truth'
+        || gameState.winner === 'government'
+        || gameState.winner === 'draw'
+        ? gameState.winner
+        : null,
+      victoryType:
+        gameState.victoryType === 'states'
+        || gameState.victoryType === 'ip'
+        || gameState.victoryType === 'truth'
+        || gameState.victoryType === 'agenda'
+        ? gameState.victoryType
+        : null,
+      finalEdition: gameState.finalEdition ?? null,
     };
 
     if (Array.isArray(gameState.playerHand)) {

--- a/src/hooks/__tests__/processAiActions.test.ts
+++ b/src/hooks/__tests__/processAiActions.test.ts
@@ -42,6 +42,7 @@ const baseState = (overrides: Partial<GameState> = {}): GameState => ({
   comboTruthDeltaThisRound: 0,
   playHistory: [],
   turnPlays: [],
+  turnBuffer: [],
   frontPageTriplet: null,
   controlledStates: [],
   aiControlledStates: [],
@@ -51,6 +52,8 @@ const baseState = (overrides: Partial<GameState> = {}): GameState => ({
   eventManager: undefined,
   showNewspaper: false,
   log: [],
+  headlineLog: [],
+  extraExtraFeed: [],
   agendaIssue: { id: 'ufo', label: 'Cosmic Cover Stories', description: 'Placeholder', tags: [] },
   agendaIssueCounters: {},
   agendaRoundCounters: {},
@@ -98,6 +101,9 @@ const baseState = (overrides: Partial<GameState> = {}): GameState => ({
   editorRuntime: null,
   preGameAdditions: null,
   tabloidRelicsRuntime: null,
+  winner: null,
+  victoryType: null,
+  finalEdition: null,
   ...overrides,
 });
 

--- a/src/hooks/aiHelpers.ts
+++ b/src/hooks/aiHelpers.ts
@@ -427,6 +427,7 @@ export const applyAiCardPlay = (
     cardsPlayedThisRound: [...prev.cardsPlayedThisRound, playedCardRecord],
     playHistory: [...prev.playHistory, playedCardRecord],
     turnPlays: [...prev.turnPlays, ...turnPlayEntries],
+    turnBuffer: [...prev.turnBuffer, ...turnPlayEntries],
     log: logEntries,
     paranormalHotspots: updatedHotspots,
     cardsPlayedThisTurn: prev.cardsPlayedThisTurn + 1,

--- a/src/hooks/comboAdapter.ts
+++ b/src/hooks/comboAdapter.ts
@@ -90,8 +90,20 @@ export const evaluateCombosForTurn = (
     pressureByState: buildPressureByState(state),
     stateDefense: buildStateDefense(state),
     playsThisTurn: state.cardsPlayedThisTurn,
-    turnPlays: state.turnPlays.map(play => ({ ...play })),
+    turnPlays: state.turnPlays.map(play => ({
+      ...play,
+      metadata: play.metadata ? { ...play.metadata } : undefined,
+    })),
+    turnBuffer: state.turnBuffer.map(play => ({
+      ...play,
+      metadata: play.metadata ? { ...play.metadata } : undefined,
+    })),
     log: [...state.log],
+    headlineLog: [...state.headlineLog],
+    extraExtraFeed: [...state.extraExtraFeed],
+    winner: state.winner,
+    victoryType: state.victoryType,
+    finalEdition: state.finalEdition ?? null,
   } satisfies EngineGameState;
 
   const logStart = engineState.log.length;

--- a/src/hooks/gameStateTypes.ts
+++ b/src/hooks/gameStateTypes.ts
@@ -11,6 +11,7 @@ import type { HotspotKind, WeightedHotspotCandidate } from '@/systems/paranormal
 import type { StateCombinationEffects } from '@/data/stateCombinations';
 import type { EditorDef, EditorId } from '@/expansions/editors/EditorsEngine';
 import type { TabloidRelicRuntimeState } from '@/expansions/tabloidRelics/RelicTypes';
+import type { GameOverReport } from '@/types/finalEdition';
 
 export interface CardPlayRecord {
   card: GameCard;
@@ -52,6 +53,7 @@ export interface GameState {
   playHistory: CardPlayRecord[];
   frontPageTriplet: PlayedCardMetaLite[] | null;
   turnPlays: TurnPlay[];
+  turnBuffer: TurnPlay[];
   comboTruthDeltaThisRound: number;
   controlledStates: string[];
   aiControlledStates: string[];
@@ -85,6 +87,8 @@ export interface GameState {
   eventManager?: EventManager;
   showNewspaper: boolean;
   log: string[];
+  headlineLog: string[];
+  extraExtraFeed: string[];
   agendaIssue: AgendaIssueState;
   agendaIssueCounters: Record<string, number>;
   agendaRoundCounters: Record<string, number>;
@@ -134,6 +138,9 @@ export interface GameState {
   editorRuntime?: GameEditorRuntimeState | null;
   preGameAdditions?: GameEditorPreGameAdditions | null;
   tabloidRelicsRuntime?: TabloidRelicRuntimeState | null;
+  winner: 'truth' | 'government' | 'draw' | null;
+  victoryType: 'states' | 'ip' | 'truth' | 'agenda' | null;
+  finalEdition?: GameOverReport | null;
 }
 
 export interface GameEditorRuntimeState {

--- a/src/hooks/useGameState.ts
+++ b/src/hooks/useGameState.ts
@@ -83,6 +83,7 @@ import {
 import { assignStateBonuses } from '@/game/stateBonuses';
 import { applyStateBonusAssignmentToState } from './stateBonusAssignment';
 import { clearNewsBuffer, getNewsTriplet, pushToNewsBuffer } from '@/state/game/roundNewsBuffer';
+import type { GameOverReport } from '@/types/finalEdition';
 
 const omitClashKey = (key: string, value: unknown) => (key === 'clash' ? undefined : value);
 
@@ -2286,6 +2287,7 @@ export const useGameState = (aiDifficultyOverride?: AIDifficulty) => {
       paranormalHotspots: {},
       playHistory: [],
       turnPlays: [],
+      turnBuffer: [],
       controlledStates: [],
       aiControlledStates: [],
       activeHotspot: null,
@@ -2332,6 +2334,8 @@ export const useGameState = (aiDifficultyOverride?: AIDifficulty) => {
         `AI Difficulty: ${aiDifficulty}`,
         `Weekly Issue: ${initialIssue.label}`,
       ],
+      headlineLog: [],
+      extraExtraFeed: [],
       secretAgenda: undefined,
       aiSecretAgenda: undefined,
       secretAgendaDifficulty: null,
@@ -2351,6 +2355,9 @@ export const useGameState = (aiDifficultyOverride?: AIDifficulty) => {
       editorRuntime: null,
       preGameAdditions: null,
       tabloidRelicsRuntime: null,
+      winner: null,
+      victoryType: null,
+      finalEdition: null,
     };
   });
 
@@ -2532,6 +2539,7 @@ export const useGameState = (aiDifficultyOverride?: AIDifficulty) => {
       frontPageTriplet: null,
       playHistory: [],
       turnPlays: [],
+      turnBuffer: [],
       stateCombinationBonusIP: 0,
       activeStateCombinationIds: [],
       stateCombinationEffects: createDefaultCombinationEffects(),
@@ -2603,6 +2611,8 @@ export const useGameState = (aiDifficultyOverride?: AIDifficulty) => {
         `Issue Spotlight: ${issueState.description}`,
         ...(secretAgendasEnabled ? [] : ['Secret agendas disabled for this campaign']),
       ],
+      headlineLog: [],
+      extraExtraFeed: [],
       drawMode,
       cardDrawState: {
         cardsPlayedLastTurn: 0,
@@ -2612,6 +2622,9 @@ export const useGameState = (aiDifficultyOverride?: AIDifficulty) => {
       aiSecretAgenda: undefined,
       secretAgendaDifficulty: null,
       secretAgendasEnabled,
+      winner: null,
+      victoryType: null,
+      finalEdition: null,
     }));
     console.log('🎮 [initGame] Game state updated successfully');
     if (secretAgendasEnabled && agendaId) {
@@ -2752,6 +2765,7 @@ export const useGameState = (aiDifficultyOverride?: AIDifficulty) => {
         cardsPlayedThisRound: [...prev.cardsPlayedThisRound, playedCardRecord],
         playHistory: [...prev.playHistory, playedCardRecord],
         turnPlays: [...prev.turnPlays, ...turnPlayEntries],
+        turnBuffer: [...prev.turnBuffer, ...turnPlayEntries],
         targetState: resolution.targetState,
         selectedCard: resolution.selectedCard,
         log: [...prev.log, ...resolution.logEntries],
@@ -2969,6 +2983,7 @@ export const useGameState = (aiDifficultyOverride?: AIDifficulty) => {
         targetState: resolution.targetState,
         selectedCard: resolution.selectedCard,
         log: [...prev.log, ...resolution.logEntries],
+        turnBuffer: [...prev.turnBuffer, ...(pendingTurnPlays ?? [])],
         agendaIssueCounters: counterSnapshot.issueCounters,
         agendaRoundCounters: counterSnapshot.roundCounters,
         paranormalHotspots: updatedHotspots,
@@ -3020,6 +3035,7 @@ export const useGameState = (aiDifficultyOverride?: AIDifficulty) => {
           cardsPlayedThisRound: [...prev.cardsPlayedThisRound, record],
           playHistory: [...prev.playHistory, record],
           turnPlays: [...prev.turnPlays, ...(pendingTurnPlays ?? [])],
+          turnBuffer: [...prev.turnBuffer, ...(pendingTurnPlays ?? [])],
           selectedCard: null,
           targetState: null,
           animating: false,
@@ -3077,6 +3093,7 @@ export const useGameState = (aiDifficultyOverride?: AIDifficulty) => {
           cardsPlayedThisRound: [...prev.cardsPlayedThisRound, record],
           playHistory: [...prev.playHistory, record],
           turnPlays: [...prev.turnPlays, ...(pendingTurnPlays ?? [])],
+          turnBuffer: [...prev.turnBuffer, ...(pendingTurnPlays ?? [])],
           selectedCard: null,
           targetState: null,
           animating: false,
@@ -3557,13 +3574,14 @@ export const useGameState = (aiDifficultyOverride?: AIDifficulty) => {
             lastTurnWithoutPlay: prev.cardsPlayedThisTurn === 0,
           },
           log: logEntries,
-        turnPlays: [],
-        states: statesAfterHotspot,
-        paranormalHotspots: hotspotsAfterHotspot,
-        activeCampaignArcs,
-        pendingArcEvents,
-        tabloidRelicsRuntime: prev.tabloidRelicsRuntime ?? null,
-      };
+          turnPlays: [],
+          turnBuffer: [],
+          states: statesAfterHotspot,
+          paranormalHotspots: hotspotsAfterHotspot,
+          activeCampaignArcs,
+          pendingArcEvents,
+          tabloidRelicsRuntime: prev.tabloidRelicsRuntime ?? null,
+        };
 
         const ownershipLogEntries = reconcileStateBonusOwnership(prev, nextState);
         if (ownershipLogEntries.length > 0) {
@@ -3622,6 +3640,7 @@ export const useGameState = (aiDifficultyOverride?: AIDifficulty) => {
         aiIP: comboResult.updatedPlayerIp,
         cardsPlayedThisTurn: 0,
         turnPlays: [],
+        turnBuffer: [],
         comboTruthDeltaThisRound: prev.comboTruthDeltaThisRound + comboResult.truthDelta,
         log: [...comboLog, 'AI turn completed'],
         states: clearedStates,
@@ -4844,6 +4863,9 @@ export const useGameState = (aiDifficultyOverride?: AIDifficulty) => {
           turnPlays: Array.isArray(saveData.turnPlays)
             ? saveData.turnPlays
             : [],
+          turnBuffer: Array.isArray((saveData as { turnBuffer?: unknown }).turnBuffer)
+            ? (saveData as { turnBuffer: GameState['turnBuffer'] }).turnBuffer
+            : [],
           comboTruthDeltaThisRound:
             typeof saveData.comboTruthDeltaThisRound === 'number' ? saveData.comboTruthDeltaThisRound : 0,
           stateCombinationBonusIP:
@@ -4894,6 +4916,25 @@ export const useGameState = (aiDifficultyOverride?: AIDifficulty) => {
           editorDef: restoredEditor ?? null,
           editorRuntime: normalizedEditorRuntime ?? null,
           preGameAdditions: normalizedPreGameAdditions ?? null,
+          headlineLog: Array.isArray((saveData as { headlineLog?: unknown }).headlineLog)
+            ? ((saveData as { headlineLog: string[] }).headlineLog ?? []).filter(entry => typeof entry === 'string')
+            : [],
+          extraExtraFeed: Array.isArray((saveData as { extraExtraFeed?: unknown }).extraExtraFeed)
+            ? ((saveData as { extraExtraFeed: string[] }).extraExtraFeed ?? []).filter(entry => typeof entry === 'string')
+            : [],
+          winner: (saveData as { winner?: unknown }).winner === 'truth'
+            || (saveData as { winner?: unknown }).winner === 'government'
+            || (saveData as { winner?: unknown }).winner === 'draw'
+            ? ((saveData as { winner: 'truth' | 'government' | 'draw' }).winner ?? null)
+            : null,
+          victoryType: ((): GameState['victoryType'] => {
+            const raw = (saveData as { victoryType?: unknown }).victoryType;
+            if (raw === 'states' || raw === 'ip' || raw === 'truth' || raw === 'agenda') {
+              return raw;
+            }
+            return null;
+          })(),
+          finalEdition: (saveData as { finalEdition?: GameOverReport | null }).finalEdition ?? null,
         };
       });
 

--- a/src/mvp/engine.ts
+++ b/src/mvp/engine.ts
@@ -310,6 +310,7 @@ export function startTurn(state: GameState): GameState {
     },
     playsThisTurn: 0,
     turnPlays: [],
+    turnBuffer: [],
     log: logEntries,
   };
 }
@@ -390,6 +391,7 @@ export function playCard(
   const interimState: GameState = {
     ...cloned,
     turnPlays: [...cloned.turnPlays, playEntry],
+    turnBuffer: [...cloned.turnBuffer, playEntry],
     players: {
       ...cloned.players,
       [currentId]: updatedPlayer,
@@ -460,6 +462,7 @@ export function resolve(
   return {
     ...resolved,
     turnPlays: [...resolved.turnPlays, resolveEntry],
+    turnBuffer: [...resolved.turnBuffer, resolveEntry],
   };
 }
 
@@ -604,6 +607,9 @@ export function endTurn(
     turn: logEnhancedState.turn + 1,
     playsThisTurn: 0,
     turnPlays: [],
+    turnBuffer: [],
+    winner: winResult.winner ?? null,
+    victoryType: winResult.reason ?? null,
   };
 
   const summary: EndTurnSummary = {

--- a/src/mvp/validator.ts
+++ b/src/mvp/validator.ts
@@ -51,6 +51,12 @@ export type GameState = {
   playsThisTurn: number;
   turnPlays: TurnPlay[];
   log: string[];
+  headlineLog: string[];
+  extraExtraFeed: string[];
+  turnBuffer: TurnPlay[];
+  winner: PlayerId | 'draw' | null;
+  victoryType: 'states' | 'truth' | 'ip' | null;
+  finalEdition?: unknown | null;
   tabloidRelicsRuntime?: TabloidRelicRuntimeState | null;
 };
 
@@ -561,6 +567,12 @@ export function cloneGameState(state: GameState): GameState {
   return {
     ...state,
     log: [...state.log],
+    headlineLog: [...state.headlineLog],
+    extraExtraFeed: [...state.extraExtraFeed],
+    turnBuffer: state.turnBuffer.map(play => ({
+      ...play,
+      metadata: play.metadata ? { ...play.metadata } : undefined,
+    })),
     turnPlays: state.turnPlays.map(play => ({
       ...play,
       metadata: play.metadata ? { ...play.metadata } : undefined,

--- a/src/systems/cardResolution.ts
+++ b/src/systems/cardResolution.ts
@@ -247,7 +247,13 @@ const toEngineState = (
     stateDefense,
     playsThisTurn: 0,
     turnPlays: [],
+    turnBuffer: [],
     log,
+    headlineLog: [],
+    extraExtraFeed: [],
+    winner: null,
+    victoryType: null,
+    finalEdition: null,
   };
 };
 

--- a/src/test/effectSystemValidation.ts
+++ b/src/test/effectSystemValidation.ts
@@ -30,7 +30,13 @@ export function validateFixedEffectSystem() {
       truth: 50,
       playsThisTurn: 0,
       turnPlays: [],
+      turnBuffer: [],
       log,
+      headlineLog: [],
+      extraExtraFeed: [],
+      winner: null,
+      victoryType: null,
+      finalEdition: null,
       players: {
         P1: {
           id: 'P1',


### PR DESCRIPTION
## Summary
- expand the primary and MVP game state models with headline, extra edition, turn buffer, winner, and victory type fields
- initialize and propagate the new fields through useGameState, combo adapters, AI helpers, validators, and MVP engine cloning so saves and resets stay consistent
- document the addition in the updates log for future gameplay tracking

## Testing
- npm run lint *(fails: existing lint issues in repository)*
- bun test --coverage --coverage-reporter=text

------
https://chatgpt.com/codex/tasks/task_e_68e26136ad80832084fb1e521ea3fc24