### PR TITLE
Add turn headline summaries

### DIFF
--- a/UPDATES_LOG.md
+++ b/UPDATES_LOG.md
@@ -2,6 +2,10 @@
 
 This document provides a chronological record of gameplay-impacting changes merged into State Shift Strategy. Each entry should include the merge date and a brief, human-readable summary so future contributors can quickly understand how the game has evolved.
 
+## 2025-10-05 – Summarize turn headlines and extras
+- Record per-turn highlights for both MVP engine and the main hook so news systems can consume consistent `PlayedLite` buffers.
+- Generate turn headline summaries and trigger Extra Extra bulletins after three plays to populate `headlineLog` and `extraExtraFeed`.
+
 ## 2025-10-05 – Expand game state tracking buffers
 - Add headline, extra edition, and turn buffer placeholders to both MVP and main game state models so upcoming newspaper flows
   can read consistent structures.

--- a/src/hooks/aiHelpers.ts
+++ b/src/hooks/aiHelpers.ts
@@ -7,6 +7,7 @@ import {
   type CardHotspotResolution,
 } from '@/systems/cardResolution';
 import type { TurnPlay } from '@/game/combo.types';
+import type { PlayedLite } from '@/news/headlineEngine';
 import type { PlayerId } from '@/mvp/validator';
 import type { WeightedHotspotCandidate } from '@/systems/paranormalHotspots';
 
@@ -250,6 +251,41 @@ export const createTurnPlayEntries = (params: {
   ];
 };
 
+export const toPlayedLite = (record: CardPlayRecord): PlayedLite | null => {
+  const type = String(record.card.type ?? '').toUpperCase();
+  if (type !== 'ATTACK' && type !== 'MEDIA' && type !== 'ZONE') {
+    return null;
+  }
+
+  const entry: PlayedLite = {
+    id: record.card.id,
+    name: record.card.name,
+    type: type as PlayedLite['type'],
+    faction: record.faction,
+  };
+
+  const positiveTruth = Math.max(0, record.truthDelta);
+  if (positiveTruth > 0) {
+    entry.truth = positiveTruth;
+  }
+
+  const positiveIp = Math.max(0, record.ipDelta);
+  if (positiveIp > 0) {
+    entry.ip = positiveIp;
+  }
+
+  const captures = record.capturedStateIds.length;
+  if (captures > 0) {
+    entry.captures = captures;
+  }
+
+  if (record.damageDealt > 0) {
+    entry.damage = record.damageDealt;
+  }
+
+  return entry;
+};
+
 const summarizeStrategy = (reasoning?: string, strategyDetails?: string[]): string | undefined => {
   const source = reasoning ?? strategyDetails?.[0];
   if (!source) {
@@ -396,6 +432,8 @@ export const applyAiCardPlay = (
     resolution,
   });
 
+  const turnBufferEntry = toPlayedLite(playedCardRecord);
+
   const updatedHotspots = { ...prev.paranormalHotspots };
   if (resolution.resolvedHotspots) {
     for (const abbr of resolution.resolvedHotspots) {
@@ -427,7 +465,7 @@ export const applyAiCardPlay = (
     cardsPlayedThisRound: [...prev.cardsPlayedThisRound, playedCardRecord],
     playHistory: [...prev.playHistory, playedCardRecord],
     turnPlays: [...prev.turnPlays, ...turnPlayEntries],
-    turnBuffer: [...prev.turnBuffer, ...turnPlayEntries],
+    turnBuffer: turnBufferEntry ? [...prev.turnBuffer, turnBufferEntry] : prev.turnBuffer,
     log: logEntries,
     paranormalHotspots: updatedHotspots,
     cardsPlayedThisTurn: prev.cardsPlayedThisTurn + 1,

--- a/src/hooks/gameStateTypes.ts
+++ b/src/hooks/gameStateTypes.ts
@@ -1,5 +1,6 @@
 import type { GameCard } from '@/rules/mvp';
 import type { PlayedCardMetaLite } from '@/state/game/roundNewsBuffer';
+import type { PlayedLite } from '@/news/headlineEngine';
 import type { EventManager, GameEvent, ParanormalHotspotPayload } from '@/data/eventDatabase';
 import type { SecretAgenda } from '@/data/agendaDatabase';
 import type { AgendaIssueState } from '@/data/agendaIssues';
@@ -53,7 +54,7 @@ export interface GameState {
   playHistory: CardPlayRecord[];
   frontPageTriplet: PlayedCardMetaLite[] | null;
   turnPlays: TurnPlay[];
-  turnBuffer: TurnPlay[];
+  turnBuffer: PlayedLite[];
   comboTruthDeltaThisRound: number;
   controlledStates: string[];
   aiControlledStates: string[];

--- a/src/hooks/useGameState.ts
+++ b/src/hooks/useGameState.ts
@@ -72,6 +72,7 @@ import {
   buildStrategyLogEntries as buildStrategyLogEntriesHelper,
   createPlayedCardRecord,
   createTurnPlayEntries,
+  toPlayedLite,
   type AiCardPlayParams,
 } from './aiHelpers';
 import { evaluateCombosForTurn } from './comboAdapter';
@@ -83,6 +84,8 @@ import {
 import { assignStateBonuses } from '@/game/stateBonuses';
 import { applyStateBonusAssignmentToState } from './stateBonusAssignment';
 import { clearNewsBuffer, getNewsTriplet, pushToNewsBuffer } from '@/state/game/roundNewsBuffer';
+import { summarize, generateExtraExtra } from '@/news/headlineEngine';
+import type { TurnLog } from '@/news/headlineEngine';
 import type { GameOverReport } from '@/types/finalEdition';
 
 const omitClashKey = (key: string, value: unknown) => (key === 'clash' ? undefined : value);
@@ -170,6 +173,37 @@ const emitEditorToastMessages = (messages: string[]): void => {
       (emitter as (value: string) => void)(message);
     }
   }
+};
+
+const applyTurnNews = (prev: GameState, next: GameState, seedPrefix: string): GameState => {
+  const buffer = prev.turnBuffer ?? [];
+  if (buffer.length === 0) {
+    return next.turnBuffer.length === 0 ? next : { ...next, turnBuffer: [] };
+  }
+
+  const turnLog: TurnLog = {
+    round: prev.round,
+    turn: prev.turn,
+    plays: buffer,
+  };
+
+  const totals = summarize([turnLog]);
+  const summaryHeadline = `Turn ${prev.turn} recap: Truth plays ${totals.truth.plays}, Government plays ${totals.government.plays}`;
+  const headlineLog = [...next.headlineLog, summaryHeadline];
+
+  let extraExtraFeed = next.extraExtraFeed;
+  if (buffer.length >= 3) {
+    const article = generateExtraExtra(`${seedPrefix}:${prev.round}:${prev.turn}`, [turnLog], totals);
+    const articleLine = `${article.hed} — ${article.dek}`;
+    extraExtraFeed = [...extraExtraFeed, articleLine];
+  }
+
+  return {
+    ...next,
+    headlineLog,
+    extraExtraFeed,
+    turnBuffer: [],
+  };
 };
 
 const dispatchEditorTelemetry = (payload: EditorTelemetryPayload): void => {
@@ -2752,6 +2786,8 @@ export const useGameState = (aiDifficultyOverride?: AIDifficulty) => {
         : undefined;
       const nextEditorRuntime = editorRuntimePatch ?? runtimeSnapshot ?? prev.editorRuntime ?? null;
 
+      const highlight = toPlayedLite(playedCardRecord);
+
       let nextState: GameState = {
         ...prev,
         hand: prev.hand.filter(c => c.id !== cardId),
@@ -2765,7 +2801,7 @@ export const useGameState = (aiDifficultyOverride?: AIDifficulty) => {
         cardsPlayedThisRound: [...prev.cardsPlayedThisRound, playedCardRecord],
         playHistory: [...prev.playHistory, playedCardRecord],
         turnPlays: [...prev.turnPlays, ...turnPlayEntries],
-        turnBuffer: [...prev.turnBuffer, ...turnPlayEntries],
+        turnBuffer: highlight ? [...prev.turnBuffer, highlight] : prev.turnBuffer,
         targetState: resolution.targetState,
         selectedCard: resolution.selectedCard,
         log: [...prev.log, ...resolution.logEntries],
@@ -2953,7 +2989,6 @@ export const useGameState = (aiDifficultyOverride?: AIDifficulty) => {
         round: prev.round,
         turn: prev.turn,
       });
-
       pendingTurnPlays = createTurnPlayEntries({
         state: prev,
         card: resolvedCard,
@@ -2983,7 +3018,6 @@ export const useGameState = (aiDifficultyOverride?: AIDifficulty) => {
         targetState: resolution.targetState,
         selectedCard: resolution.selectedCard,
         log: [...prev.log, ...resolution.logEntries],
-        turnBuffer: [...prev.turnBuffer, ...(pendingTurnPlays ?? [])],
         agendaIssueCounters: counterSnapshot.issueCounters,
         agendaRoundCounters: counterSnapshot.roundCounters,
         paranormalHotspots: updatedHotspots,
@@ -3028,6 +3062,8 @@ export const useGameState = (aiDifficultyOverride?: AIDifficulty) => {
           timestamp: Date.now(),
           logEntries: [],
         };
+        const highlight = toPlayedLite(record);
+
         let nextState: GameState = {
           ...prev,
           hand: prev.hand.filter(c => c.id !== cardId),
@@ -3035,7 +3071,7 @@ export const useGameState = (aiDifficultyOverride?: AIDifficulty) => {
           cardsPlayedThisRound: [...prev.cardsPlayedThisRound, record],
           playHistory: [...prev.playHistory, record],
           turnPlays: [...prev.turnPlays, ...(pendingTurnPlays ?? [])],
-          turnBuffer: [...prev.turnBuffer, ...(pendingTurnPlays ?? [])],
+          turnBuffer: highlight ? [...prev.turnBuffer, highlight] : prev.turnBuffer,
           selectedCard: null,
           targetState: null,
           animating: false,
@@ -3086,6 +3122,8 @@ export const useGameState = (aiDifficultyOverride?: AIDifficulty) => {
           timestamp: Date.now(),
           logEntries: [],
         };
+        const highlight = toPlayedLite(record);
+
         let nextState: GameState = {
           ...prev,
           hand: prev.hand.filter(c => c.id !== cardId),
@@ -3093,7 +3131,7 @@ export const useGameState = (aiDifficultyOverride?: AIDifficulty) => {
           cardsPlayedThisRound: [...prev.cardsPlayedThisRound, record],
           playHistory: [...prev.playHistory, record],
           turnPlays: [...prev.turnPlays, ...(pendingTurnPlays ?? [])],
-          turnBuffer: [...prev.turnBuffer, ...(pendingTurnPlays ?? [])],
+          turnBuffer: highlight ? [...prev.turnBuffer, highlight] : prev.turnBuffer,
           selectedCard: null,
           targetState: null,
           animating: false,
@@ -3611,6 +3649,8 @@ export const useGameState = (aiDifficultyOverride?: AIDifficulty) => {
         };
         nextState.log.push(`AI ${prev.aiStrategist?.personality.name} is thinking...`);
 
+        nextState = applyTurnNews(prev, nextState, 'human');
+
         return updateSecretAgendaProgress(nextState);
       }
 
@@ -3681,14 +3721,17 @@ export const useGameState = (aiDifficultyOverride?: AIDifficulty) => {
         truthBelow20Streak: truthStreaks.truthBelow20Streak,
       };
 
-        shouldScheduleNewspaperReveal = true;
-        return updateSecretAgendaProgress({
+        const nextStateWithStreaks: GameState = {
           ...nextStateBase,
           truthAbove80Streak: truthStreaks.truthAbove80Streak,
           truthBelow20Streak: truthStreaks.truthBelow20Streak,
           timeBasedGoalCounters,
           activeHotspot: nextActiveHotspot,
-        });
+        };
+
+        shouldScheduleNewspaperReveal = true;
+        const nextStateWithNews = applyTurnNews(prev, nextStateWithStreaks, 'ai');
+        return updateSecretAgendaProgress(nextStateWithNews);
       });
 
     if (shouldScheduleNewspaperReveal) {

--- a/src/mvp/engine.ts
+++ b/src/mvp/engine.ts
@@ -5,6 +5,8 @@ import { applyComboRewards, evaluateCombos, getComboSettings, formatComboReward 
 import type { ComboEvaluation, ComboOptions, ComboSummary, TurnPlay } from '@/game/combo.types';
 import { getStateByAbbreviation, getStateById } from '@/data/usaStates';
 import { RelicEngine } from '@/expansions/tabloidRelics/RelicEngine';
+import { summarize, generateExtraExtra } from '@/news/headlineEngine';
+import type { PlayedLite, TurnLog } from '@/news/headlineEngine';
 import { cloneGameState } from './validator';
 import { auditGameState } from './gameStateAudit';
 import type { Card, EffectsATTACK, EffectsMEDIA, EffectsZONE, GameState, PlayerState } from './validator';
@@ -23,6 +25,35 @@ const drawUpToFive = (player: PlayerState): PlayerState => {
     deck,
     hand,
   };
+};
+
+const createPlayedLiteEntry = (player: PlayerState, card: Card): PlayedLite | null => {
+  if (card.type !== 'ATTACK' && card.type !== 'MEDIA' && card.type !== 'ZONE') {
+    return null;
+  }
+
+  const entry: PlayedLite = {
+    id: card.id,
+    name: card.name,
+    type: card.type,
+    faction: player.faction === 'government' ? 'government' : 'truth',
+  };
+
+  if (card.type === 'MEDIA') {
+    const truthDelta = (card.effects as EffectsMEDIA | undefined)?.truthDelta;
+    if (typeof truthDelta === 'number' && !Number.isNaN(truthDelta) && truthDelta !== 0) {
+      entry.truth = truthDelta;
+    }
+  }
+
+  if (card.type === 'ATTACK') {
+    const damage = (card.effects as EffectsATTACK | undefined)?.ipDelta?.opponent;
+    if (typeof damage === 'number' && !Number.isNaN(damage) && damage > 0) {
+      entry.damage = damage;
+    }
+  }
+
+  return entry;
 };
 
 export type WinResult = { winner?: PlayerId; reason?: 'states' | 'truth' | 'ip' };
@@ -388,10 +419,12 @@ export function playCard(
     targetStateId,
   };
 
+  const liteEntry = createPlayedLiteEntry(player, card);
+
   const interimState: GameState = {
     ...cloned,
     turnPlays: [...cloned.turnPlays, playEntry],
-    turnBuffer: [...cloned.turnBuffer, playEntry],
+    turnBuffer: liteEntry ? [...cloned.turnBuffer, liteEntry] : cloned.turnBuffer,
     players: {
       ...cloned.players,
       [currentId]: updatedPlayer,
@@ -462,7 +495,6 @@ export function resolve(
   return {
     ...resolved,
     turnPlays: [...resolved.turnPlays, resolveEntry],
-    turnBuffer: [...resolved.turnBuffer, resolveEntry],
   };
 }
 
@@ -601,6 +633,27 @@ export function endTurn(
 
   const nextPlayer = otherPlayer(currentId);
 
+  const bufferPlays = cloned.turnBuffer;
+  let headlineLog = cloned.headlineLog;
+  let extraExtraFeed = cloned.extraExtraFeed;
+
+  if (bufferPlays.length > 0) {
+    const turnLogEntry: TurnLog = {
+      round: cloned.turn,
+      turn: turnNumber,
+      plays: bufferPlays,
+    };
+    const totals = summarize([turnLogEntry]);
+    const summaryHeadline = `Turn ${turnNumber} recap: Truth plays ${totals.truth.plays}, Government plays ${totals.government.plays}`;
+    headlineLog = [...headlineLog, summaryHeadline];
+
+    if (bufferPlays.length >= 3) {
+      const article = generateExtraExtra(`mvp:${currentId}:${turnNumber}`, [turnLogEntry], totals);
+      const articleLine = `${article.hed} — ${article.dek}`;
+      extraExtraFeed = [...extraExtraFeed, articleLine];
+    }
+  }
+
   const finalState: GameState = {
     ...logEnhancedState,
     currentPlayer: nextPlayer,
@@ -608,6 +661,8 @@ export function endTurn(
     playsThisTurn: 0,
     turnPlays: [],
     turnBuffer: [],
+    headlineLog,
+    extraExtraFeed,
     winner: winResult.winner ?? null,
     victoryType: winResult.reason ?? null,
   };

--- a/src/mvp/validator.ts
+++ b/src/mvp/validator.ts
@@ -1,5 +1,6 @@
 import type { Faction, GameCard, MVPCardType, Rarity } from '@/rules/mvp';
 import type { TurnPlay } from '@/game/combo.types';
+import type { PlayedLite } from '@/news/headlineEngine';
 import type { TabloidRelicRuntimeState } from '@/expansions/tabloidRelics/RelicTypes';
 import { expectedCost, MVP_CARD_TYPES } from '@/rules/mvp';
 
@@ -53,7 +54,7 @@ export type GameState = {
   log: string[];
   headlineLog: string[];
   extraExtraFeed: string[];
-  turnBuffer: TurnPlay[];
+  turnBuffer: PlayedLite[];
   winner: PlayerId | 'draw' | null;
   victoryType: 'states' | 'truth' | 'ip' | null;
   finalEdition?: unknown | null;
@@ -569,10 +570,7 @@ export function cloneGameState(state: GameState): GameState {
     log: [...state.log],
     headlineLog: [...state.headlineLog],
     extraExtraFeed: [...state.extraExtraFeed],
-    turnBuffer: state.turnBuffer.map(play => ({
-      ...play,
-      metadata: play.metadata ? { ...play.metadata } : undefined,
-    })),
+    turnBuffer: state.turnBuffer.map(play => ({ ...play })),
     turnPlays: state.turnPlays.map(play => ({
       ...play,
       metadata: play.metadata ? { ...play.metadata } : undefined,


### PR DESCRIPTION
## Summary
- push MVP turn highlights into a `PlayedLite` buffer and consume it at end turn to build headline summaries and optional Extra Extra blurbs
- mirror the buffer handling inside the React game hook, appending card plays for both players and clearing it after summarizing
- update the project changelog with the new newspaper headline workflow

## Testing
- npm run lint
- bun test --coverage --coverage-reporter=text

------
https://chatgpt.com/codex/tasks/task_e_68e2647bd3888320b2ac50a754ba4208