### PR TITLE
Add structured extra feed and final edition overlay

### DIFF
--- a/UPDATES_LOG.md
+++ b/UPDATES_LOG.md
@@ -2,6 +2,11 @@
 
 This document provides a chronological record of gameplay-impacting changes merged into State Shift Strategy. Each entry should include the merge date and a brief, human-readable summary so future contributors can quickly understand how the game has evolved.
 
+## 2025-10-05 – Launch Extra Feed and final overlay refresh
+- Replace the legacy victory screen with a final edition overlay that pairs the campaign recap with a live-generated newspaper spread.
+- Surface turn-driven Extra Extra bulletins beside the main board using full `ArticleBlock` data instead of strings.
+- Persist structured extra feed entries across engines and saves so weather, ads, and bullet lists render consistently.
+
 ## 2025-10-05 – Sync victory overlays with final editions
 - Persist MVP win checks into the game state so victory screens know the winner and trigger type automatically.
 - Build final newspaper reports through the shared helper and surface them via the victory overlay and extra edition reader.

--- a/src/components/news/ExtraFeed.tsx
+++ b/src/components/news/ExtraFeed.tsx
@@ -1,0 +1,95 @@
+import type { ArticleBlock } from '@/news/headlineEngine';
+import { cn } from '@/lib/utils';
+
+interface ExtraFeedProps {
+  articles: ArticleBlock[];
+  className?: string;
+  emptyMessage?: string;
+}
+
+const getKickerLabel = (tone: ArticleBlock['tone']): string => {
+  switch (tone) {
+    case 'truth':
+      return 'Truth Network Bulletin';
+    case 'government':
+      return 'Official Government Wire';
+    default:
+      return 'Breaking Desk Update';
+  }
+};
+
+const toneHeadlineClass: Record<ArticleBlock['tone'], string> = {
+  truth: 'text-truth-red',
+  government: 'text-government-blue',
+  draw: 'text-newspaper-headline',
+};
+
+const toneBadgeClass: Record<ArticleBlock['tone'], string> = {
+  truth: 'border-truth-red/60 bg-truth-red/10 text-truth-red',
+  government: 'border-government-blue/60 bg-government-blue/10 text-government-blue',
+  draw: 'border-newspaper-border/60 bg-newspaper-bg/70 text-newspaper-headline',
+};
+
+const ExtraFeed = ({ articles, className, emptyMessage = 'No desk bulletins yet. Play more cards to trigger breaking news.' }: ExtraFeedProps) => {
+  const visibleArticles = articles.slice(-4).reverse();
+
+  return (
+    <section
+      aria-label="Extra Extra news feed"
+      className={cn(
+        'flex flex-col gap-3 rounded-2xl border-2 border-dashed border-newspaper-border/70 bg-white/70 p-4 text-newspaper-text shadow-sm',
+        className,
+      )}
+    >
+      <header className="flex items-center justify-between">
+        <h2 className="text-xs font-black uppercase tracking-[0.48em] text-newspaper-text/70">Extra! Extra!</h2>
+        <span className="rounded-full border border-newspaper-border/50 bg-newspaper-bg/80 px-2 py-1 text-[10px] font-semibold uppercase tracking-[0.32em] text-newspaper-text/60">
+          News Desk
+        </span>
+      </header>
+
+      {visibleArticles.length === 0 ? (
+        <p className="rounded border border-dashed border-newspaper-border/50 bg-white/60 px-3 py-4 text-[13px] italic text-newspaper-text/70">
+          {emptyMessage}
+        </p>
+      ) : (
+        <div className="space-y-3">
+          {visibleArticles.map((article, index) => {
+            const badgeClass = toneBadgeClass[article.tone];
+            const headlineClass = toneHeadlineClass[article.tone];
+            return (
+              <article
+                key={`${article.hed}-${index}`}
+                className="rounded-xl border border-newspaper-border/60 bg-newspaper-bg/70 p-3 shadow-inner"
+              >
+                <div className={cn('inline-flex items-center rounded-full border px-3 py-1 text-[9px] font-semibold uppercase tracking-[0.42em]', badgeClass)}>
+                  {getKickerLabel(article.tone)}
+                </div>
+                <h3 className={cn('mt-2 font-headline text-xl uppercase tracking-tight text-newspaper-headline', headlineClass)}>
+                  {article.hed}
+                </h3>
+                {article.dek ? (
+                  <p className="mt-1 text-sm italic text-newspaper-text/80">{article.dek}</p>
+                ) : null}
+                {article.bullets.length > 0 ? (
+                  <ul className="mt-2 list-disc space-y-1 pl-5 text-[12px] text-newspaper-text/80">
+                    {article.bullets.slice(0, 4).map((bullet, bulletIndex) => (
+                      <li key={`${bulletIndex}-${bullet.slice(0, 24)}`}>{bullet}</li>
+                    ))}
+                  </ul>
+                ) : null}
+                <footer className="mt-3 text-[10px] uppercase tracking-[0.32em] text-newspaper-text/60">
+                  <div>{article.byline}</div>
+                  <div>{article.source}</div>
+                </footer>
+              </article>
+            );
+          })}
+        </div>
+      )}
+    </section>
+  );
+};
+
+export default ExtraFeed;
+

--- a/src/components/news/FinalEditionOverlay.tsx
+++ b/src/components/news/FinalEditionOverlay.tsx
@@ -1,0 +1,236 @@
+import { useMemo, useState } from 'react';
+import { Trophy, Sparkles, Newspaper } from 'lucide-react';
+
+import { Button } from '@/components/ui/button';
+import EndCredits from '@/components/game/EndCredits';
+import GameOverEditionLayout from '@/components/game/GameOverEditionLayout';
+import FinalEditionLayout from '@/components/game/FinalEditionLayout';
+import type { GameOverReport } from '@/types/finalEdition';
+import type { FinalEdition } from '@/news/headlineEngine';
+import { getVictoryConditionLabel } from '@/utils/finalEdition';
+import { cn } from '@/lib/utils';
+
+interface FinalEditionOverlayProps {
+  isVisible: boolean;
+  edition: FinalEdition | null;
+  report: GameOverReport | null;
+  playerFaction: 'truth' | 'government';
+  victoryType: 'states' | 'ip' | 'truth' | 'agenda' | null;
+  onContinue: () => void;
+  onRestart: () => void;
+  onViewFinalEdition: () => void;
+  onArchive?: () => void;
+  isArchived?: boolean;
+}
+
+const toneHeadlineClass: Record<FinalEdition['article']['tone'], string> = {
+  truth: 'text-truth-red',
+  government: 'text-government-blue',
+  draw: 'text-newspaper-headline',
+};
+
+const toneBadgeClass: Record<FinalEdition['article']['tone'], string> = {
+  truth: 'border-truth-red/60 bg-truth-red/10 text-truth-red',
+  government: 'border-government-blue/60 bg-government-blue/10 text-government-blue',
+  draw: 'border-newspaper-border/60 bg-newspaper-bg/70 text-newspaper-headline',
+};
+
+const dominantFactionLabel = (edition: FinalEdition): string => {
+  switch (edition.dominantFaction) {
+    case 'truth':
+      return 'Truth Operatives Secure Headlines';
+    case 'government':
+      return 'Government Briefing Controls Narrative';
+    default:
+      return 'Gridlocked Media Duel Continues';
+  }
+};
+
+const FinalEditionArticle = ({ edition, isVictory }: { edition: FinalEdition; isVictory: boolean }) => {
+  const tone = edition.article.tone;
+  const badgeClass = toneBadgeClass[tone];
+  const headlineClass = isVictory
+    ? 'text-victory-accent drop-shadow-[0_3px_16px_rgba(15,118,110,0.55)]'
+    : toneHeadlineClass[tone];
+  const bodyClass = isVictory ? 'text-emerald-50/85' : 'text-newspaper-text/80';
+  const panelClass = isVictory
+    ? 'border-emerald-300/50 bg-gradient-to-br from-emerald-500/25 via-emerald-600/20 to-emerald-700/25 text-emerald-50 shadow-[0_18px_48px_rgba(16,185,129,0.35)]'
+    : 'border-newspaper-border/60 bg-white/80 text-newspaper-text shadow-sm';
+
+  return (
+    <article className={cn('flex h-full flex-col gap-4 rounded-2xl border p-4 transition-colors', panelClass)}>
+      <header className="space-y-2">
+        <div className={cn('inline-flex items-center rounded-full border px-3 py-1 text-[10px] font-semibold uppercase tracking-[0.45em]', badgeClass)}>
+          {dominantFactionLabel(edition)}
+        </div>
+        <h3 className={cn('font-headline text-3xl uppercase tracking-tight', headlineClass)}>{edition.article.hed}</h3>
+        {edition.article.dek ? (
+          <p className={cn('text-base italic', bodyClass)}>{edition.article.dek}</p>
+        ) : null}
+      </header>
+
+      {edition.article.bullets.length > 0 ? (
+        <ul className={cn('space-y-2 rounded-xl border px-4 py-3 text-sm leading-snug', isVictory ? 'border-emerald-300/40 bg-emerald-500/10 text-emerald-50/85' : 'border-newspaper-border/60 bg-newspaper-bg/70 text-newspaper-text/80')}>
+          {edition.article.bullets.slice(0, 5).map((bullet, index) => (
+            <li key={`${index}-${bullet.slice(0, 20)}`} className="list-disc pl-2">
+              {bullet}
+            </li>
+          ))}
+        </ul>
+      ) : null}
+
+      <footer className="grid gap-3 sm:grid-cols-2">
+        <div className={cn('rounded-xl border px-4 py-3 text-xs uppercase tracking-[0.3em]', isVictory ? 'border-emerald-300/40 bg-emerald-500/10 text-emerald-100/80' : 'border-newspaper-border/50 bg-newspaper-bg/60 text-newspaper-text/70')}>
+          <div>{edition.article.byline}</div>
+          <div>{edition.article.source}</div>
+        </div>
+        <div className={cn('rounded-xl border px-4 py-3 text-sm leading-snug', isVictory ? 'border-emerald-300/40 bg-emerald-500/10 text-emerald-50/85' : 'border-newspaper-border/60 bg-newspaper-bg/70 text-newspaper-text/80')}>
+          <div className="text-[10px] font-semibold uppercase tracking-[0.4em] opacity-80">Weather Bureau</div>
+          <p className="mt-1 leading-snug">{edition.weather}</p>
+        </div>
+      </footer>
+
+      {edition.ads.length > 0 ? (
+        <div className={cn('rounded-xl border px-4 py-3 text-sm leading-snug', isVictory ? 'border-emerald-300/40 bg-emerald-500/10 text-emerald-50/80' : 'border-newspaper-border/60 bg-newspaper-bg/70 text-newspaper-text/80')}>
+          <div className="text-[10px] font-semibold uppercase tracking-[0.4em] opacity-75">Classified Dispatch</div>
+          <ul className="mt-2 space-y-1">
+            {edition.ads.slice(0, 3).map((ad, index) => (
+              <li key={`${index}-${ad.slice(0, 24)}`} className="flex items-start gap-2">
+                <span className={cn('mt-1 h-1.5 w-1.5 shrink-0 rounded-full', isVictory ? 'bg-emerald-300/80' : 'bg-newspaper-headline/70')} />
+                <span>{ad}</span>
+              </li>
+            ))}
+          </ul>
+        </div>
+      ) : null}
+    </article>
+  );
+};
+
+const FinalEditionOverlay = ({
+  isVisible,
+  edition,
+  report,
+  playerFaction,
+  victoryType,
+  onContinue,
+  onRestart,
+  onViewFinalEdition,
+  onArchive,
+  isArchived = false,
+}: FinalEditionOverlayProps) => {
+  const [showCredits, setShowCredits] = useState(false);
+
+  const derivedVictoryType = useMemo(() => {
+    if (victoryType) {
+      return getVictoryConditionLabel(victoryType).toUpperCase();
+    }
+    if (report?.victoryType) {
+      return getVictoryConditionLabel(report.victoryType).toUpperCase();
+    }
+    return 'FINAL REPORT';
+  }, [report, victoryType]);
+
+  if (!isVisible || !edition || !report) {
+    return null;
+  }
+
+  if (showCredits) {
+    return (
+      <EndCredits
+        isVisible
+        playerFaction={playerFaction}
+        onClose={() => setShowCredits(false)}
+      />
+    );
+  }
+
+  const isDraw = report.winner === 'draw';
+  const isVictory = report.winner === report.playerFaction;
+  const layoutVariant = isVictory ? 'victory' : 'default';
+  const bannerLabel = isDraw ? 'Stalemate' : isVictory ? 'Victory' : 'Defeat';
+  const editionDate = new Date(report.recordedAt).toLocaleDateString(undefined, {
+    month: 'long',
+    day: 'numeric',
+    year: 'numeric',
+  });
+  const tagline = [
+    report.rounds > 0 ? `${report.rounds} rounds` : 'Lightning opener',
+    `Truth ${Math.round(report.finalTruth)}%`,
+  ].join(' • ');
+
+  const continueButtonClass = isVictory
+    ? 'border border-emerald-200/80 bg-gradient-to-r from-emerald-400 via-emerald-500 to-emerald-600 text-emerald-950 font-semibold shadow-[0_18px_48px_rgba(16,185,129,0.35)] transition-colors hover:from-emerald-300 hover:via-emerald-400 hover:to-emerald-500 hover:text-emerald-950 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-emerald-200'
+    : 'border border-newspaper-border bg-newspaper-bg/90 text-newspaper-text transition hover:bg-white/80 hover:text-newspaper-headline focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-newspaper-border/60';
+
+  const restartButtonClass = isVictory
+    ? 'border border-emerald-200/80 bg-emerald-500/25 text-emerald-50 transition-colors hover:bg-emerald-400/30 hover:text-emerald-950 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-emerald-200'
+    : 'border border-newspaper-border bg-newspaper-bg/90 text-newspaper-text transition hover:bg-white/80 hover:text-newspaper-headline focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-newspaper-border/60';
+
+  const archiveButtonClass = isVictory
+    ? 'border border-dashed border-emerald-200/70 bg-emerald-500/15 text-emerald-100 transition-colors hover:bg-emerald-400/20 hover:text-emerald-950 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-emerald-200 disabled:border-emerald-200/40 disabled:bg-emerald-500/10 disabled:text-emerald-100/60'
+    : 'border border-dashed border-newspaper-border/70 bg-newspaper-bg/70 text-newspaper-text transition hover:bg-white/80 hover:text-newspaper-headline focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-newspaper-border/60 disabled:opacity-60';
+
+  const creditsButtonClass = isVictory
+    ? 'text-emerald-100/80 transition hover:text-emerald-50 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-emerald-200'
+    : 'text-newspaper-text/80 transition hover:text-newspaper-text focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-newspaper-border/60';
+
+  const viewEditionButtonClass = isVictory
+    ? 'border border-emerald-200/80 bg-gradient-to-r from-emerald-400 via-emerald-500 to-emerald-600 text-emerald-950 font-semibold shadow-[0_18px_48px_rgba(16,185,129,0.35)] transition-colors hover:from-emerald-300 hover:via-emerald-400 hover:to-emerald-500 hover:text-emerald-950 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-emerald-200'
+    : 'border border-newspaper-border bg-newspaper-bg/90 text-newspaper-text transition hover:bg-white/80 hover:text-newspaper-headline focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-newspaper-border/60';
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-slate-950/85 p-6">
+      <GameOverEditionLayout
+        bannerLabel={bannerLabel}
+        bannerIcon={isVictory ? <Trophy className="h-6 w-6" /> : <Sparkles className="h-6 w-6" />}
+        kicker={derivedVictoryType}
+        metaLine={`Final Campaign Report • ${editionDate}`}
+        tagline={tagline}
+        onClose={onContinue}
+        variant={layoutVariant}
+        footer={(
+          <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+            <div className="flex flex-wrap justify-center gap-2 md:justify-start">
+              <Button onClick={onContinue} className={cn(continueButtonClass)}>
+                Continue
+              </Button>
+              <Button onClick={onRestart} className={cn(restartButtonClass)}>
+                Return to Menu
+              </Button>
+            </div>
+            <div className="flex flex-wrap justify-center gap-2 md:justify-end">
+              <Button onClick={onViewFinalEdition} className={cn(viewEditionButtonClass)}>
+                <Newspaper className="mr-2 h-4 w-4" />
+                Read Full Dossier
+              </Button>
+              {onArchive ? (
+                <Button
+                  onClick={onArchive}
+                  disabled={isArchived}
+                  variant="outline"
+                  className={cn(archiveButtonClass)}
+                >
+                  {isArchived ? 'Archived' : 'Archive to Player Hub'}
+                </Button>
+              ) : null}
+              <Button variant="ghost" className={cn(creditsButtonClass)} onClick={() => setShowCredits(true)}>
+                Roll Credits
+              </Button>
+            </div>
+          </div>
+        )}
+      >
+        <div className="grid gap-6 lg:grid-cols-[minmax(0,1.1fr)_minmax(0,1fr)]">
+          <FinalEditionArticle edition={edition} isVictory={isVictory} />
+          <div className="rounded-2xl border border-newspaper-border/60 bg-white/85 p-4 shadow-lg">
+            <FinalEditionLayout report={report} />
+          </div>
+        </div>
+      </GameOverEditionLayout>
+    </div>
+  );
+};
+
+export default FinalEditionOverlay;
+

--- a/src/data/enhancedAIStrategy.ts
+++ b/src/data/enhancedAIStrategy.ts
@@ -1171,7 +1171,12 @@ export class EnhancedAIStrategist implements AIStrategist {
       aiControlledStates,
       log: Array.isArray(gameState.log) ? [...gameState.log] : [],
       headlineLog: Array.isArray(gameState.headlineLog) ? [...gameState.headlineLog] : [],
-      extraExtraFeed: Array.isArray(gameState.extraExtraFeed) ? [...gameState.extraExtraFeed] : [],
+      extraExtraFeed: Array.isArray(gameState.extraExtraFeed)
+        ? gameState.extraExtraFeed.map(article => ({
+            ...article,
+            bullets: Array.isArray(article.bullets) ? [...article.bullets] : [],
+          }))
+        : [],
       turnPlays: Array.isArray(gameState.turnPlays)
         ? gameState.turnPlays.map((play: TurnPlay) => ({
             ...play,

--- a/src/hooks/comboAdapter.ts
+++ b/src/hooks/comboAdapter.ts
@@ -100,7 +100,10 @@ export const evaluateCombosForTurn = (
     })),
     log: [...state.log],
     headlineLog: [...state.headlineLog],
-    extraExtraFeed: [...state.extraExtraFeed],
+    extraExtraFeed: state.extraExtraFeed.map(article => ({
+      ...article,
+      bullets: [...article.bullets],
+    })),
     winner: state.winner,
     victoryType: state.victoryType,
     finalEdition: state.finalEdition ?? null,

--- a/src/hooks/gameStateTypes.ts
+++ b/src/hooks/gameStateTypes.ts
@@ -1,6 +1,6 @@
 import type { GameCard } from '@/rules/mvp';
 import type { PlayedCardMetaLite } from '@/state/game/roundNewsBuffer';
-import type { PlayedLite } from '@/news/headlineEngine';
+import type { ArticleBlock, PlayedLite } from '@/news/headlineEngine';
 import type { EventManager, GameEvent, ParanormalHotspotPayload } from '@/data/eventDatabase';
 import type { SecretAgenda } from '@/data/agendaDatabase';
 import type { AgendaIssueState } from '@/data/agendaIssues';
@@ -89,7 +89,7 @@ export interface GameState {
   showNewspaper: boolean;
   log: string[];
   headlineLog: string[];
-  extraExtraFeed: string[];
+  extraExtraFeed: ArticleBlock[];
   agendaIssue: AgendaIssueState;
   agendaIssueCounters: Record<string, number>;
   agendaRoundCounters: Record<string, number>;

--- a/src/hooks/useGameState.ts
+++ b/src/hooks/useGameState.ts
@@ -85,7 +85,7 @@ import { assignStateBonuses } from '@/game/stateBonuses';
 import { applyStateBonusAssignmentToState } from './stateBonusAssignment';
 import { clearNewsBuffer, getNewsTriplet, pushToNewsBuffer } from '@/state/game/roundNewsBuffer';
 import { summarize, generateExtraExtra } from '@/news/headlineEngine';
-import type { TurnLog } from '@/news/headlineEngine';
+import type { ArticleBlock, TurnLog } from '@/news/headlineEngine';
 import type { GameOverReport } from '@/types/finalEdition';
 
 const omitClashKey = (key: string, value: unknown) => (key === 'clash' ? undefined : value);
@@ -158,6 +158,51 @@ const resolveActiveEditorFromState = (state: GameState) => {
   return state.editorDef ?? resolveEditor(state.editorId ?? null) ?? null;
 };
 
+const normalizeArticleBlock = (entry: unknown): ArticleBlock | null => {
+  if (entry && typeof entry === 'object') {
+    const candidate = entry as Partial<ArticleBlock>;
+    const tone = candidate.tone;
+    if (tone === 'truth' || tone === 'government' || tone === 'draw') {
+      const hed = typeof candidate.hed === 'string' ? candidate.hed : '';
+      if (hed.trim().length === 0) {
+        return null;
+      }
+      const dek = typeof candidate.dek === 'string' ? candidate.dek : '';
+      const bullets = Array.isArray(candidate.bullets)
+        ? candidate.bullets.filter((bullet): bullet is string => typeof bullet === 'string')
+        : [];
+      const byline = typeof candidate.byline === 'string' && candidate.byline.trim().length > 0
+        ? candidate.byline
+        : 'By: Field Desk';
+      const source = typeof candidate.source === 'string' && candidate.source.trim().length > 0
+        ? candidate.source
+        : 'Source: Redacted';
+
+      return {
+        tone,
+        hed,
+        dek,
+        bullets,
+        byline,
+        source,
+      } satisfies ArticleBlock;
+    }
+  }
+
+  if (typeof entry === 'string' && entry.trim().length > 0) {
+    return {
+      tone: 'draw',
+      hed: entry.trim(),
+      dek: '',
+      bullets: [],
+      byline: 'By: Field Desk',
+      source: 'Source: Archived Log',
+    } satisfies ArticleBlock;
+  }
+
+  return null;
+};
+
 const emitEditorToastMessages = (messages: string[]): void => {
   if (!messages.length || typeof window === 'undefined') {
     return;
@@ -194,8 +239,7 @@ const applyTurnNews = (prev: GameState, next: GameState, seedPrefix: string): Ga
   let extraExtraFeed = next.extraExtraFeed;
   if (buffer.length >= 3) {
     const article = generateExtraExtra(`${seedPrefix}:${prev.round}:${prev.turn}`, [turnLog], totals);
-    const articleLine = `${article.hed} — ${article.dek}`;
-    extraExtraFeed = [...extraExtraFeed, articleLine];
+    extraExtraFeed = [...extraExtraFeed, article];
   }
 
   return {
@@ -4963,7 +5007,9 @@ export const useGameState = (aiDifficultyOverride?: AIDifficulty) => {
             ? ((saveData as { headlineLog: string[] }).headlineLog ?? []).filter(entry => typeof entry === 'string')
             : [],
           extraExtraFeed: Array.isArray((saveData as { extraExtraFeed?: unknown }).extraExtraFeed)
-            ? ((saveData as { extraExtraFeed: string[] }).extraExtraFeed ?? []).filter(entry => typeof entry === 'string')
+            ? ((saveData as { extraExtraFeed: unknown[] }).extraExtraFeed ?? [])
+                .map(normalizeArticleBlock)
+                .filter((entry): entry is ArticleBlock => entry !== null)
             : [],
           winner: (saveData as { winner?: unknown }).winner === 'truth'
             || (saveData as { winner?: unknown }).winner === 'government'

--- a/src/mvp/engine.ts
+++ b/src/mvp/engine.ts
@@ -649,8 +649,7 @@ export function endTurn(
 
     if (bufferPlays.length >= 3) {
       const article = generateExtraExtra(`mvp:${currentId}:${turnNumber}`, [turnLogEntry], totals);
-      const articleLine = `${article.hed} — ${article.dek}`;
-      extraExtraFeed = [...extraExtraFeed, articleLine];
+      extraExtraFeed = [...extraExtraFeed, article];
     }
   }
 

--- a/src/mvp/validator.ts
+++ b/src/mvp/validator.ts
@@ -1,6 +1,6 @@
 import type { Faction, GameCard, MVPCardType, Rarity } from '@/rules/mvp';
 import type { TurnPlay } from '@/game/combo.types';
-import type { PlayedLite } from '@/news/headlineEngine';
+import type { ArticleBlock, PlayedLite } from '@/news/headlineEngine';
 import type { TabloidRelicRuntimeState } from '@/expansions/tabloidRelics/RelicTypes';
 import { expectedCost, MVP_CARD_TYPES } from '@/rules/mvp';
 
@@ -53,7 +53,7 @@ export type GameState = {
   turnPlays: TurnPlay[];
   log: string[];
   headlineLog: string[];
-  extraExtraFeed: string[];
+  extraExtraFeed: ArticleBlock[];
   turnBuffer: PlayedLite[];
   winner: PlayerId | 'draw' | null;
   victoryType: 'states' | 'truth' | 'ip' | null;
@@ -569,7 +569,14 @@ export function cloneGameState(state: GameState): GameState {
     ...state,
     log: [...state.log],
     headlineLog: [...state.headlineLog],
-    extraExtraFeed: [...state.extraExtraFeed],
+    extraExtraFeed: state.extraExtraFeed.map(article => ({
+      tone: article.tone,
+      hed: article.hed,
+      dek: article.dek,
+      bullets: [...article.bullets],
+      byline: article.byline,
+      source: article.source,
+    })),
     turnBuffer: state.turnBuffer.map(play => ({ ...play })),
     turnPlays: state.turnPlays.map(play => ({
       ...play,

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -19,7 +19,8 @@ import { useAudioContext } from '@/contexts/AudioContext';
 import { useCardAnimation } from '@/hooks/useCardAnimation';
 import CardAnimationLayer from '@/components/game/CardAnimationLayer';
 import FloatingNumbers from '@/components/effects/FloatingNumbers';
-import TabloidVictoryScreen from '@/components/effects/TabloidVictoryScreen';
+import ExtraFeed from '@/components/news/ExtraFeed';
+import FinalEditionOverlay from '@/components/news/FinalEditionOverlay';
 import FalloutOverlay from '@/expansions/tabloidRelics/RelicUI';
 
 import CardPreviewOverlay from '@/components/game/CardPreviewOverlay';
@@ -64,9 +65,11 @@ import { usePressArchive } from '@/hooks/usePressArchive';
 import { useIntelArchive } from '@/hooks/useIntelArchive';
 import type { IntelArchiveDraft } from '@/hooks/useIntelArchive';
 import { upsertParanormalSighting } from '@/utils/paranormalSightings';
-import { buildFinalEdition } from '@/utils/finalEdition';
+import { buildFinalEdition as buildGameOverReport } from '@/utils/finalEdition';
 import type { GameOverReport } from '@/types/finalEdition';
 import type { ArcProgressSummary } from '@/types/campaign';
+import { buildFinalEdition as buildNewsFinalEdition, type FinalEdition, type TurnLog } from '@/news/headlineEngine';
+import { toPlayedLite } from '@/hooks/aiHelpers';
 
 type ContextualEffectType = Parameters<typeof VisualEffectsCoordinator.triggerContextualEffect>[0];
 
@@ -140,6 +143,7 @@ const Index = () => {
   const [showOnboarding, setShowOnboarding] = useState(false);
   const [showInGameOptions, setShowInGameOptions] = useState(false);
   const [finalEdition, setFinalEdition] = useState<GameOverReport | null>(null);
+  const [newsFinalEdition, setNewsFinalEdition] = useState<FinalEdition | null>(null);
   const [readingEdition, setReadingEdition] = useState<GameOverReport | null>(null);
   const [showExtraEdition, setShowExtraEdition] = useState(false);
   const [isEndingTurn, setIsEndingTurn] = useState(false);
@@ -189,6 +193,38 @@ const Index = () => {
         .filter(Boolean),
     [discardPreview.discardedCards]
   );
+  const finalEditionTurnLogs = useMemo<TurnLog[]>(() => {
+    if (!Array.isArray(gameState.playHistory) || gameState.playHistory.length === 0) {
+      return [];
+    }
+
+    const grouped = new Map<string, TurnLog>();
+
+    for (const record of gameState.playHistory) {
+      const lite = toPlayedLite(record);
+      if (!lite) {
+        continue;
+      }
+      const key = `${record.round}:${record.turn}`;
+      const existing = grouped.get(key);
+      if (existing) {
+        existing.plays.push(lite);
+      } else {
+        grouped.set(key, {
+          round: record.round,
+          turn: record.turn,
+          plays: [lite],
+        });
+      }
+    }
+
+    return Array.from(grouped.values()).sort((a, b) => {
+      if (a.round === b.round) {
+        return a.turn - b.turn;
+      }
+      return a.round - b.round;
+    });
+  }, [gameState.playHistory]);
   const {
     issues: pressArchive,
     archiveEdition,
@@ -821,7 +857,7 @@ const Index = () => {
 
     if (winner && victoryType) {
       const comboSummary = getLastComboSummary();
-      const report = buildFinalEdition({
+      const report = buildGameOverReport({
         state: {
           round: gameState.round,
           truth: gameState.truth,
@@ -841,6 +877,21 @@ const Index = () => {
         comboSummary,
       });
 
+      let composedNewsEdition: FinalEdition | null = null;
+      if (finalEditionTurnLogs.length > 0 || gameState.playHistory.length === 0) {
+        try {
+          composedNewsEdition = buildNewsFinalEdition(
+            `${gameState.faction}:${report.recordedAt}`,
+            finalEditionTurnLogs.length > 0
+              ? finalEditionTurnLogs
+              : [{ round: gameState.round, turn: gameState.turn, plays: [] }],
+          );
+        } catch (error) {
+          console.warn('Failed to compose final edition newspaper', error);
+          composedNewsEdition = null;
+        }
+      }
+
       setGameState(prev => ({
         ...prev,
         isGameOver: true,
@@ -850,6 +901,7 @@ const Index = () => {
       }));
 
       setFinalEdition(report);
+      setNewsFinalEdition(composedNewsEdition);
       setReadingEdition(report);
       setIsVictoryOverlayOpen(true);
     }
@@ -870,6 +922,7 @@ const Index = () => {
     gameState.currentEvents,
     gameState.secretAgenda,
     gameState.aiSecretAgenda,
+    finalEditionTurnLogs,
     arcProgressSummaries,
     paranormalSightings,
     setGameState,
@@ -878,10 +931,27 @@ const Index = () => {
   useEffect(() => {
     const edition = gameState.finalEdition;
     if (!edition) {
+      setNewsFinalEdition(null);
       return;
     }
 
     setFinalEdition(edition);
+    if (finalEditionTurnLogs.length > 0 || gameState.playHistory.length === 0) {
+      try {
+        const composed = buildNewsFinalEdition(
+          `${gameState.faction}:${edition.recordedAt}`,
+          finalEditionTurnLogs.length > 0
+            ? finalEditionTurnLogs
+            : [{ round: gameState.round, turn: gameState.turn, plays: [] }],
+        );
+        setNewsFinalEdition(prev => (prev?.seed === composed.seed ? prev : composed));
+      } catch (error) {
+        console.warn('Failed to refresh final edition newspaper', error);
+        setNewsFinalEdition(null);
+      }
+    } else {
+      setNewsFinalEdition(null);
+    }
     if (!readingEdition) {
       setReadingEdition(edition);
     }
@@ -889,7 +959,15 @@ const Index = () => {
       setIsVictoryOverlayOpen(true);
       lastVictoryRef.current = edition.recordedAt;
     }
-  }, [gameState.finalEdition, gameState.winner, readingEdition]);
+  }, [
+    gameState.finalEdition,
+    gameState.winner,
+    readingEdition,
+    finalEditionTurnLogs,
+    gameState.faction,
+    gameState.round,
+    gameState.turn,
+  ]);
 
   // Enhanced synergy detection with coordinated visual effects
   useEffect(() => {
@@ -1583,6 +1661,7 @@ const Index = () => {
     persistFaction(faction);
     setIsVictoryOverlayOpen(false);
     setFinalEdition(null);
+    setNewsFinalEdition(null);
     setReadingEdition(null);
     setShowExtraEdition(false);
     setParanormalSightings([]);
@@ -2511,6 +2590,7 @@ const Index = () => {
             onInspectCard={(card) => setInspectedPlayedCard(card)}
           />
         </div>
+        <ExtraFeed articles={gameState.extraExtraFeed} />
       </div>
       <CardPreviewOverlay card={hoveredCard ? { ...hoveredCard, text: hoveredCard.text || '' } : null} />
     </div>
@@ -2633,21 +2713,24 @@ const Index = () => {
         onPlayCard={() => {}}
       />
 
-      <TabloidVictoryScreen
-        isVisible={isVictoryOverlayOpen && Boolean(finalEdition)}
+      <FinalEditionOverlay
+        isVisible={isVictoryOverlayOpen && Boolean(finalEdition) && Boolean(newsFinalEdition)}
+        edition={newsFinalEdition}
         report={finalEdition}
         playerFaction={gameState.faction}
         victoryType={gameState.victoryType}
-        onClose={() => {
+        onContinue={() => {
           setIsVictoryOverlayOpen(false);
           setFinalEdition(null);
+          setNewsFinalEdition(null);
           setReadingEdition(null);
           setShowMenu(true);
           setShowIntro(true);
         }}
-        onMainMenu={() => {
+        onRestart={() => {
           setIsVictoryOverlayOpen(false);
           setFinalEdition(null);
+          setNewsFinalEdition(null);
           setReadingEdition(null);
           setShowExtraEdition(false);
           setShowMenu(true);
@@ -2676,6 +2759,7 @@ const Index = () => {
             if (closingActiveVictory) {
               setIsVictoryOverlayOpen(false);
               setFinalEdition(null);
+              setNewsFinalEdition(null);
               setShowMenu(true);
               setShowIntro(true);
               setGameState(prev => ({ ...prev, isGameOver: false, finalEdition: null }));


### PR DESCRIPTION
## Summary
- add a reusable ExtraFeed component that renders ArticleBlock kickers, headlines, and bullets beside the main board
- replace the victory screen with a FinalEditionOverlay that combines the campaign recap with the generated final edition layout
- persist structured ArticleBlock entries across engines and hydration so ads and weather data survive saves

## Testing
- npm run lint *(fails: repository has pre-existing lint violations)*
- bun test --coverage --coverage-reporter=text

------
https://chatgpt.com/codex/tasks/task_e_68e26d9ee7008320a469d122cc770757