### PR TITLE
Add headline engine and final edition test coverage

### DIFF
--- a/__tests__/integration/extraExtra.test.ts
+++ b/__tests__/integration/extraExtra.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it, mock } from 'bun:test';
+import type { Card, GameState } from '../../src/mvp/validator';
+import type { TurnLog } from '../../src/news/headlineEngine';
+
+const stubPools = {
+  mastheads: ['Test Masthead'],
+  ads: ['Ad A', 'Ad B', 'Ad C'],
+  subheads: {
+    generic: ['Generic Sub'],
+    attack: ['Attack Sub'],
+    media: ['Media Sub'],
+    zone: ['Zone Sub'],
+  },
+  bylines: ['Byline'],
+  sources: ['Source'],
+  attackVerbs: ['EXPOSE'],
+  mediaVerbs: ['AMPLIFIES'],
+  zoneVerbs: ['SURGES'],
+  weather: ['Calm Skies'],
+} as const;
+
+mock.module('@/news/newsPools', () => ({
+  getPools: () => stubPools,
+}));
+
+mock.module('@/engine/applyEffects-mvp', () => ({
+  applyEffectsMvp: (state: GameState) => state,
+}));
+
+mock.module('@/game/comboEngine', () => ({
+  applyComboRewards: (state: GameState) => state,
+  evaluateCombos: () => ({ results: [], totalReward: {}, logs: [] }),
+  getComboSettings: () => ({ enabled: false, fxEnabled: false, comboToggles: {}, maxCombosPerTurn: 0 }),
+  formatComboReward: () => '',
+}));
+
+const loadMvpEngine = () => import('../../src/mvp/engine');
+const loadHeadlineEngine = () => import('../../src/news/headlineEngine');
+
+const createCard = (id: string): Card => ({
+  id,
+  name: `Card ${id}`,
+  type: 'MEDIA',
+  faction: 'truth',
+  rarity: 'common',
+  cost: 0,
+  text: '',
+  effects: { truthDelta: 2 },
+});
+
+describe('extra extra integration', () => {
+  it('appends a headline + subhead after three plays in a turn', async () => {
+    const { playCard, endTurn } = await loadMvpEngine();
+    const { summarize, generateExtraExtra } = await loadHeadlineEngine();
+
+    const cards = [createCard('alpha'), createCard('bravo'), createCard('charlie')];
+
+    let state: GameState = {
+      turn: 1,
+      currentPlayer: 'P1',
+      truth: 50,
+      players: {
+        P1: {
+          id: 'P1',
+          faction: 'truth',
+          deck: [],
+          hand: [...cards],
+          discard: [],
+          ip: 0,
+          states: [],
+        },
+        P2: {
+          id: 'P2',
+          faction: 'government',
+          deck: [],
+          hand: [],
+          discard: [],
+          ip: 0,
+          states: [],
+        },
+      },
+      pressureByState: {},
+      stateDefense: {},
+      playsThisTurn: 0,
+      turnPlays: [],
+      log: [],
+      headlineLog: [],
+      extraExtraFeed: [],
+      turnBuffer: [],
+      winner: null,
+      victoryType: null,
+      finalEdition: null,
+      tabloidRelicsRuntime: null,
+    };
+
+    for (const card of cards) {
+      state = playCard(state, card.id);
+    }
+
+    const pendingLog: TurnLog = {
+      round: state.turn,
+      turn: state.turn,
+      plays: state.turnBuffer,
+    };
+    const totals = summarize([pendingLog]);
+    const expectedArticle = generateExtraExtra('mvp:P1:1', [pendingLog], totals);
+
+    const { state: endedState } = endTurn(state, []);
+
+    expect(endedState.extraExtraFeed).toEqual([`${expectedArticle.hed} — ${expectedArticle.dek}`]);
+    expect(endedState.headlineLog).toEqual([
+      'Turn 1 recap: Truth plays 3, Government plays 0',
+    ]);
+  });
+});

--- a/__tests__/news/headlineEngine.test.ts
+++ b/__tests__/news/headlineEngine.test.ts
@@ -1,0 +1,241 @@
+import { describe, expect, it, mock } from 'bun:test';
+import type { TurnLog, TurnTotals } from '../../src/news/headlineEngine';
+
+const stubPools = {
+  mastheads: ['Test Masthead'],
+  ads: ['Ad A', 'Ad B', 'Ad C', 'Ad D'],
+  subheads: {
+    generic: ['Generic Sub'],
+    attack: ['Attack Sub'],
+    media: ['Media Sub'],
+    zone: ['Zone Sub'],
+  },
+  bylines: ['Byline'],
+  sources: ['Source'],
+  attackVerbs: ['EXPOSE'],
+  mediaVerbs: ['AMPLIFIES'],
+  zoneVerbs: ['SURGES'],
+  weather: ['Calm Skies'],
+} as const;
+
+mock.module('@/news/newsPools', () => ({
+  getPools: () => stubPools,
+}));
+
+const loadEngine = () => import('../../src/news/headlineEngine');
+
+describe('headlineEngine utilities', () => {
+  it('summarize aggregates faction totals and ignores invalid values', async () => {
+    const { summarize } = await loadEngine();
+    const turns: TurnLog[] = [
+      {
+        round: 1,
+        turn: 1,
+        plays: [
+          {
+            id: 't1',
+            name: 'Truth Strike',
+            type: 'ATTACK',
+            faction: 'truth',
+            truth: 2,
+            ip: 1,
+            captures: 1,
+            damage: 3,
+          },
+          {
+            id: 'g1',
+            name: 'Gov Briefing',
+            type: 'MEDIA',
+            faction: 'government',
+            truth: -2,
+            ip: 4,
+          },
+        ],
+      },
+      {
+        round: 1,
+        turn: 2,
+        plays: [
+          {
+            id: 't2',
+            name: 'Truth Rally',
+            type: 'MEDIA',
+            faction: 'truth',
+            truth: 1.5,
+            ip: NaN,
+          },
+          {
+            id: 'g2',
+            name: 'Gov Sweep',
+            type: 'ZONE',
+            faction: 'government',
+            captures: 2,
+            damage: -4,
+          },
+        ],
+      },
+    ];
+
+    const totals = summarize(turns);
+
+    expect(totals.truth).toEqual({
+      plays: 2,
+      attack: 1,
+      media: 1,
+      zone: 0,
+      truth: 3.5,
+      ip: 1,
+      captures: 1,
+      damage: 3,
+    });
+    expect(totals.government).toEqual({
+      plays: 2,
+      attack: 0,
+      media: 1,
+      zone: 1,
+      truth: 0,
+      ip: 4,
+      captures: 2,
+      damage: 0,
+    });
+  });
+
+  it('dominantFromTotals selects leading tone or draw for small deltas', async () => {
+    const { dominantFromTotals } = await loadEngine();
+
+    const truthEdge: TurnTotals = {
+      truth: {
+        plays: 3,
+        attack: 2,
+        media: 1,
+        zone: 0,
+        truth: 6,
+        ip: 0,
+        captures: 0,
+        damage: 0,
+      },
+      government: {
+        plays: 3,
+        attack: 0,
+        media: 2,
+        zone: 1,
+        truth: 1,
+        ip: 0,
+        captures: 0,
+        damage: 0,
+      },
+    };
+
+    const nearDraw: TurnTotals = {
+      truth: {
+        plays: 1,
+        attack: 0,
+        media: 1,
+        zone: 0,
+        truth: 0.5,
+        ip: 0,
+        captures: 0,
+        damage: 0,
+      },
+      government: {
+        plays: 1,
+        attack: 0,
+        media: 1,
+        zone: 0,
+        truth: 0.4,
+        ip: 0,
+        captures: 0,
+        damage: 0,
+      },
+    };
+
+    expect(dominantFromTotals(truthEdge)).toBe('truth');
+    expect(dominantFromTotals(nearDraw)).toBe('draw');
+    expect(
+      dominantFromTotals({
+        truth: truthEdge.government,
+        government: truthEdge.truth,
+      }),
+    ).toBe('government');
+  });
+
+  it('buildHed formats tone-specific headlines', async () => {
+    const { buildHed } = await loadEngine();
+    const totals: TurnTotals = {
+      truth: {
+        plays: 4,
+        attack: 2,
+        media: 1,
+        zone: 1,
+        truth: 4,
+        ip: 6,
+        captures: 2,
+        damage: 0,
+      },
+      government: {
+        plays: 3,
+        attack: 1,
+        media: 2,
+        zone: 0,
+        truth: 1,
+        ip: 3,
+        captures: 0,
+        damage: 0,
+      },
+    };
+    const rng = () => 0;
+
+    expect(buildHed('truth', totals, rng)).toBe('OPERATIVES EXPOSE 2 STATES');
+    expect(buildHed('government', totals, rng)).toBe('PRESS OFFICE FILES “AMPLIFIES” GRID');
+    expect(buildHed('draw', totals, rng)).toBe('STANDOFF CALLS IT “EXPOSE” 2 STATES');
+  });
+
+  it('generateExtraExtra produces deterministic articles for identical seeds', async () => {
+    const { generateExtraExtra, summarize } = await loadEngine();
+    const turns: TurnLog[] = [
+      {
+        round: 2,
+        turn: 1,
+        plays: [
+          {
+            id: 't1',
+            name: 'Truth Broadcast',
+            type: 'MEDIA',
+            faction: 'truth',
+            truth: 2,
+            ip: 1,
+          },
+          {
+            id: 't2',
+            name: 'Truth Broadcast 2',
+            type: 'MEDIA',
+            faction: 'truth',
+            truth: 2,
+          },
+          {
+            id: 'g1',
+            name: 'Gov Counter',
+            type: 'ATTACK',
+            faction: 'government',
+            damage: 1,
+          },
+        ],
+      },
+    ];
+
+    const totals = summarize(turns);
+
+    const first = generateExtraExtra('seed:alpha', turns, totals);
+    const second = generateExtraExtra('seed:alpha', turns, totals);
+
+    expect(second).toEqual(first);
+    expect(first).toMatchObject({
+      tone: 'truth',
+      hed: 'TRUTH NETWORK AMPLIFIES TRUTH +4%',
+      dek: 'Media Sub',
+      byline: 'Byline',
+      source: 'Source',
+    });
+    expect(first.bullets.length).toBeGreaterThan(0);
+  });
+});

--- a/__tests__/utils/finalEdition.test.ts
+++ b/__tests__/utils/finalEdition.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it, mock } from 'bun:test';
+
+mock.module('@/game/comboEngine', () => ({
+  applyComboRewards: (state: unknown) => state,
+  evaluateCombos: () => ({ results: [], totalReward: {}, logs: [] }),
+  getComboSettings: () => ({ enabled: false, fxEnabled: false, comboToggles: {}, maxCombosPerTurn: 0 }),
+  formatComboReward: () => '',
+}));
+
+const loadFinalEdition = () => import('../../src/utils/finalEdition');
+
+const createState = (id: string, owner: 'player' | 'ai' | 'neutral') => ({
+  id,
+  name: id,
+  abbreviation: id,
+  owner,
+});
+
+describe('buildFinalEdition report summary', () => {
+  const baseState = {
+    round: 5,
+    truth: 100,
+    ip: 0,
+    aiIP: 0,
+    states: [createState('AL', 'player'), createState('AK', 'player'), createState('AZ', 'ai')],
+    faction: 'truth',
+    playHistory: [],
+  } as const;
+
+  it('reports a Truth victory with final stats when the player wins', async () => {
+    const { buildFinalEdition } = await loadFinalEdition();
+
+    const report = buildFinalEdition({
+      state: baseState,
+      winner: 'truth',
+      victoryType: 'truth',
+    });
+
+    expect(report.winner).toBe('truth');
+    expect(report.victoryType).toBe('truth');
+    expect(report.finalTruth).toBe(100);
+    expect(report.ipPlayer).toBe(0);
+    expect(report.ipAI).toBe(0);
+    expect(report.statesTruth).toBe(2);
+    expect(report.statesGov).toBe(1);
+    expect(report.playerFaction).toBe('truth');
+  });
+
+  it('reports a Government victory with the same base stats when the player loses', async () => {
+    const { buildFinalEdition } = await loadFinalEdition();
+
+    const report = buildFinalEdition({
+      state: baseState,
+      winner: 'government',
+      victoryType: 'truth',
+    });
+
+    expect(report.winner).toBe('government');
+    expect(report.victoryType).toBe('truth');
+    expect(report.finalTruth).toBe(100);
+    expect(report.ipPlayer).toBe(0);
+    expect(report.ipAI).toBe(0);
+    expect(report.statesTruth).toBe(2);
+    expect(report.statesGov).toBe(1);
+  });
+});


### PR DESCRIPTION
## Summary
- add headlineEngine coverage for summarize, dominantFromTotals, buildHed, and deterministic generateExtraExtra behavior
- add an integration smoke test to confirm three plays trigger an Extra Extra entry with the expected headline and subhead
- add final edition report tests for both victory and defeat scenarios to verify tone and stat fields

## Testing
- bun test --coverage --coverage-reporter=text
- npm run lint *(fails: repository-wide lint debt outside the new tests)*

------
https://chatgpt.com/codex/tasks/task_e_68e27305b2488320af40a7e2ad6a3f42