### PR TITLE
Adjust IP victory condition threshold to 200

### DIFF
--- a/DESIGN_DOC_MVP.md
+++ b/DESIGN_DOC_MVP.md
@@ -4,7 +4,7 @@ Paranoid Times — Design \& Regelbok (MVP)
 
 
 
-Paranoid Times er et satirisk kartspill om å vinne narrativet, plystre bort motstanderens ressurser og “punsje” politisk press inn i delstater. Kortene er “nyheter” og aksjoner som skaper målbare effekter i spillets verden: IP (Influence Points), Truth (0–100%), og Pressure per stat. Førstemann til 10 stater, Truth-terskel, eller 300 IP vinner.
+Paranoid Times er et satirisk kartspill om å vinne narrativet, plystre bort motstanderens ressurser og “punsje” politisk press inn i delstater. Kortene er “nyheter” og aksjoner som skaper målbare effekter i spillets verden: IP (Influence Points), Truth (0–100%), og Pressure per stat. Førstemann til 10 stater, Truth-terskel, eller 200 IP vinner.
 
 
 
@@ -60,7 +60,7 @@ Truth ≥ 90% (Truth-spilleren) / Truth ≤ 10% (Government-spilleren), eller
 
 
 
-Du har 300 IP.
+Du har 200 IP.
 
 
 
@@ -539,7 +539,7 @@ Bytt currentPlayer, turn++.
 
 
 
-winCheck(s): kall etter endTurn: 10 stater / Truth-terskel / 300 IP.
+winCheck(s): kall etter endTurn: 10 stater / Truth-terskel / 200 IP.
 
 
 

--- a/UPDATES_LOG.md
+++ b/UPDATES_LOG.md
@@ -2,6 +2,10 @@
 
 This document provides a chronological record of gameplay-impacting changes merged into State Shift Strategy. Each entry should include the merge date and a brief, human-readable summary so future contributors can quickly understand how the game has evolved.
 
+## 2025-10-05 – Lower IP victory threshold to 200
+- Drop the economic victory target from 300 IP to 200 across rules, tutorial copy, and in-game HUD messaging.
+- Update the IP victory condition logic, onboarding flows, and documentation so both factions now race to 200 IP.
+
 ## 2025-10-05 – Launch Extra Feed and final overlay refresh
 - Replace the legacy victory screen with a final edition overlay that pairs the campaign recap with a live-generated newspaper spread.
 - Surface turn-driven Extra Extra bulletins beside the main board using full `ArticleBlock` data instead of strings.

--- a/docs/TECHNICAL_README.md
+++ b/docs/TECHNICAL_README.md
@@ -13,7 +13,7 @@
 - [Newspaper debugging](#newspaper-debugging)
 
 ## Game loop fundamentals
-The MVP design defines a duel between the Truth Seekers and the Government, each managing Influence Points (IP), a shared Truth meter, and pressure on individual U.S. states. Win conditions include controlling 10 states, pushing Truth to faction-specific thresholds, or accumulating 300 IP.【F:DESIGN_DOC_MVP.md†L7-L63】 These core concepts are implemented directly in the runtime engine:
+The MVP design defines a duel between the Truth Seekers and the Government, each managing Influence Points (IP), a shared Truth meter, and pressure on individual U.S. states. Win conditions include controlling 10 states, pushing Truth to faction-specific thresholds, or accumulating 200 IP.【F:DESIGN_DOC_MVP.md†L7-L63】 These core concepts are implemented directly in the runtime engine:
 
 - **Turn start:** `startTurn` clones game state, uses `computeTurnIpIncome` to award `5 + controlledStates` IP, applies reserve maintenance, evaluates the swing-tax/catch-up module, logs every adjustment, and refills the active player's hand to five cards.【F:src/mvp/engine.ts†L50-L114】
 - **Card play gating:** `canPlay` enforces the three-card-per-turn limit, IP costs, and ZONE targeting rules before a card resolves.【F:src/mvp/engine.ts†L71-L99】

--- a/docs/analysis/paranoid-times-gap-analysis.md
+++ b/docs/analysis/paranoid-times-gap-analysis.md
@@ -1,7 +1,7 @@
 # Paranoid Times Gap Analysis and Improvement Plan
 
 ## Current MVP snapshot
-- **Core loop:** The MVP pits Truth Seekers against the Government in a two-player duel that tracks Influence Points (IP), the shared Truth meter, and pressure on U.S. states, with victory triggered by 10 captured states, Truth thresholds, or 300 IP.【F:DESIGN_DOC_MVP.md†L7-L63】【F:docs/TECHNICAL_README.md†L11-L19】
+- **Core loop:** The MVP pits Truth Seekers against the Government in a two-player duel that tracks Influence Points (IP), the shared Truth meter, and pressure on U.S. states, with victory triggered by 10 captured states, Truth thresholds, or 200 IP.【F:DESIGN_DOC_MVP.md†L7-L63】【F:docs/TECHNICAL_README.md†L11-L19】
 - **Economy:** Each turn grants 5 IP plus 1 IP per controlled state before players can spend resources to play up to three cards.【F:DESIGN_DOC_MVP.md†L99-L134】【F:src/mvp/engine.ts†L50-L99】
 - **Card catalog:** Cards are limited to three types (ATTACK, MEDIA, ZONE) with tightly scripted effects and costs that peak at four IP removed, four percent Truth swing, or four pressure per play.【F:DESIGN_DOC_MVP.md†L25-L189】
 - **Combo hooks:** The runtime already supports lightweight combo detection that can reward extra IP or visual flourishes after turn wrap-up.【F:docs/TECHNICAL_README.md†L35-L36】

--- a/public/how-to-play-mvp.md
+++ b/public/how-to-play-mvp.md
@@ -7,7 +7,7 @@ Victory is evaluated in priority order at every checkpoint. Achieve any of the f
 
 1. **Complete your Secret Agenda** – each faction starts with a hidden objective; certain cards or tabloid events can expose the AI’s plan, and finishing yours ends the campaign instantly.
 2. **Truth Extremes** – Truth Seekers win at ≥95% Truth, Government wins at ≤5%.
-3. **Resource Dominance** – Bank 300 Influence Points (IP).
+3. **Resource Dominance** – Bank 200 Influence Points (IP).
 4. **Territorial Control** – Hold 10 U.S. states at once.
 
 These same conditions apply to the AI, so watch its progress meters as closely as your own.

--- a/src/components/game/InteractiveOnboarding.tsx
+++ b/src/components/game/InteractiveOnboarding.tsx
@@ -31,7 +31,7 @@ const InteractiveOnboarding = ({ isActive, onComplete, onSkip, gameState }: Inte
     {
       id: 'welcome',
       title: '🎯 Welcome to Shadow Government!',
-      description: 'You are a player choosing between Government or Truth Seekers. Win by controlling 10 states, reaching 300 IP, or achieving your faction\'s truth threshold.',
+      description: 'You are a player choosing between Government or Truth Seekers. Win by controlling 10 states, reaching 200 IP, or achieving your faction\'s truth threshold.',
       target: '#game-header',
       skipable: true
     },
@@ -70,7 +70,7 @@ const InteractiveOnboarding = ({ isActive, onComplete, onSkip, gameState }: Inte
     {
       id: 'victory',
       title: '🏆 Victory Conditions',
-      description: 'Win by controlling 10 states, reaching 300 IP, or hitting your truth threshold (95% for Truth, 5% for Government). Watch these in the header!',
+      description: 'Win by controlling 10 states, reaching 200 IP, or hitting your truth threshold (95% for Truth, 5% for Government). Watch these in the header!',
       target: '#victory-conditions'
     }
   ];

--- a/src/components/game/VictoryConditions.tsx
+++ b/src/components/game/VictoryConditions.tsx
@@ -34,17 +34,17 @@ export const VictoryConditions: React.FC<VictoryConditionsProps> = ({
         <div className="mt-2">
           {isMobile ? (
             <div className="text-xs font-mono">
-              States: {controlledStates}/10 | Truth: {truth}% | IP: {ip}/300
+              States: {controlledStates}/10 | Truth: {truth}% | IP: {ip}/200
             </div>
           ) : (
             <div className="text-xs space-y-1 font-mono">
               <div>• Control 10 states</div>
-              <div>• Reach 300 IP</div>
+              <div>• Reach 200 IP</div>
               <div>• Truth ≥95% / ≤5%</div>
               <div className="border-t border-newspaper-bg/30 pt-1 mt-1">
                 <div className="text-center text-xs">States: {controlledStates}/10</div>
                 <div className="text-center text-xs">Truth: {truth}%</div>
-                <div className="text-center text-xs">IP: {ip}/300</div>
+                <div className="text-center text-xs">IP: {ip}/200</div>
               </div>
             </div>
           )}

--- a/src/data/tutorialSystem.ts
+++ b/src/data/tutorialSystem.ts
@@ -64,7 +64,7 @@ export const TUTORIAL_SEQUENCES: TutorialSequence[] = [
       {
         id: 'ip_display',
         title: 'Influence Points (IP)',
-        description: 'IP is your operational currency. Gain it from controlled states, state combos, and events, then spend it to deploy cards. Banking 300 IP before the AI does secures an economic victory.',
+        description: 'IP is your operational currency. Gain it from controlled states, state combos, and events, then spend it to deploy cards. Banking 200 IP before the AI does secures an economic victory.',
         targetElement: '.ip-display',
         position: 'left',
         delay: 3000
@@ -141,7 +141,7 @@ export const TUTORIAL_SEQUENCES: TutorialSequence[] = [
       {
         id: 'victory_conditions',
         title: 'Path to Victory',
-        description: 'Victory checks run in priority order: 1) spike the Truth meter to ≥95% (Truth) or ≤5% (Government), 2) bank 300 IP, 3) control 10 states. Secret Agendas now fuel that Truth surge based on difficulty—plan around the swing before the AI does.',
+        description: 'Victory checks run in priority order: 1) spike the Truth meter to ≥95% (Truth) or ≤5% (Government), 2) bank 200 IP, 3) control 10 states. Secret Agendas now fuel that Truth surge based on difficulty—plan around the swing before the AI does.',
         position: 'center',
         delay: 4000
       }

--- a/src/data/victoryConditions.ts
+++ b/src/data/victoryConditions.ts
@@ -99,14 +99,14 @@ export const BASE_VICTORY_CONDITIONS: VictoryCondition[] = [
   {
     id: 'ip_victory',
     name: 'Resource Dominance',
-    description: 'Accumulate 300 IP',
+    description: 'Accumulate 200 IP',
     priority: 3,
     faction: 'both',
     checkCondition: (gameState: any) => {
-      return gameState.ip >= 300;
+      return gameState.ip >= 200;
     },
     getProgress: (gameState: any) => {
-      return Math.max(0, Math.min(100, (gameState.ip / 300) * 100));
+      return Math.max(0, Math.min(100, (gameState.ip / 200) * 100));
     }
   },
 

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -838,10 +838,10 @@ const Index = () => {
     } else if (gameState.truth <= 5 && gameState.faction === 'government') {
       winner = 'government';
       victoryType = 'truth';
-    } else if (gameState.ip >= 300) {
+    } else if (gameState.ip >= 200) {
       winner = gameState.faction;
       victoryType = 'ip';
-    } else if (gameState.aiIP >= 300) {
+    } else if (gameState.aiIP >= 200) {
       winner = gameState.faction === 'government' ? 'truth' : 'government';
       victoryType = 'ip';
     } else if (gameState.controlledStates.length >= 10) {
@@ -2167,7 +2167,7 @@ const Index = () => {
           </p>
           <ul className="space-y-1 font-mono">
             <li>• Control 10 states</li>
-            <li>• Reach 300 IP</li>
+            <li>• Reach 200 IP</li>
             <li>• Truth ≥95% / ≤5%</li>
           </ul>
           <div className="grid grid-cols-3 gap-2 text-center text-[11px]">
@@ -2181,7 +2181,7 @@ const Index = () => {
             </div>
             <div className="rounded border border-newspaper-border/40 bg-newspaper-bg/30 px-2 py-1">
               <div className="text-[9px] uppercase tracking-wide text-newspaper-text/60">IP</div>
-              <div className="text-sm font-mono text-newspaper-text">{gameState.ip}/300</div>
+              <div className="text-sm font-mono text-newspaper-text">{gameState.ip}/200</div>
             </div>
           </div>
         </>


### PR DESCRIPTION
## Summary
- lower the IP victory condition threshold from 300 to 200 within the core victory manager and HUD displays
- refresh onboarding copy, tutorials, and player-facing documentation to describe the new 200 IP goal
- record the change in the updates log for future reference

## Testing
- `npm run lint` *(fails: repository has pre-existing lint violations unrelated to this change)*
- `bun test --coverage --coverage-reporter=text`


------
https://chatgpt.com/codex/tasks/task_e_68e27ba2b96c8320964851138b667335