### PR TITLE
Add safe localStorage remove helper

### DIFF
--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -33,7 +33,11 @@ import { Maximize, Menu, Minimize, UserCircle2 } from 'lucide-react';
 import { useCardCollection } from '@/hooks/useCardCollection';
 import { useSynergyDetection } from '@/hooks/useSynergyDetection';
 import { planDiscardOutcome } from '@/utils/discardPlanner';
-import { safeGetLocalStorageItem, safeSetLocalStorageItem } from '@/utils/storage';
+import {
+  safeGetLocalStorageItem,
+  safeRemoveLocalStorageItem,
+  safeSetLocalStorageItem,
+} from '@/utils/storage';
 import {
   aggregateStateCombinationEffects,
   applyDefenseBonusToStates,

--- a/src/utils/storage.ts
+++ b/src/utils/storage.ts
@@ -59,3 +59,26 @@ export const safeSetLocalStorageItem = (
     return false;
   }
 };
+
+export const safeRemoveLocalStorageItem = (
+  key: string,
+  options?: SafeStorageOptions,
+): boolean => {
+  if (typeof window === 'undefined') {
+    return false;
+  }
+
+  try {
+    const storage = window.localStorage;
+    if (!storage || typeof storage.removeItem !== 'function') {
+      return false;
+    }
+
+    storage.removeItem(key);
+    return true;
+  } catch (error) {
+    const logger = resolveLogger(options);
+    logger?.warn?.(`[storage] Failed to remove "${key}" from localStorage`, error);
+    return false;
+  }
+};


### PR DESCRIPTION
## Summary
- add a `safeRemoveLocalStorageItem` helper that mirrors the existing safe get/set utilities
- update the Index page import to use the new localStorage removal helper without touching call sites

## Testing
- npm run lint *(fails: existing lint errors unrelated to this change)*
- bun test --coverage --coverage-reporter=text *(fails: existing integration test expects string vs article object)*

------
https://chatgpt.com/codex/tasks/task_e_68e27deda8948320aa890e960d27b2af