### PR TITLE
Allow game state audit to warn on contested pressure

### DIFF
--- a/src/mvp/gameStateAudit.ts
+++ b/src/mvp/gameStateAudit.ts
@@ -27,7 +27,7 @@ const validatePlayer = (
   state: GameState,
   playerId: PlayerId,
   playersStates: Map<PlayerId, Set<string>>,
-): GameStateAuditFinding => {
+): GameStateAuditFinding[] => {
   const player = state.players[playerId];
   assertState(Boolean(player), `Missing player entry for ${playerId}`);
 
@@ -56,6 +56,8 @@ const validatePlayer = (
   }
 
   const normalizedStates = new Set<string>();
+  const findings: GameStateAuditFinding[] = [];
+
   for (const rawStateId of playerState.states) {
     assertState(typeof rawStateId === 'string', `Player ${playerId} has non-string state entry`);
     const stateId = rawStateId.trim();
@@ -81,10 +83,12 @@ const validatePlayer = (
 
     const opponentId = playerId === 'P1' ? 'P2' : 'P1';
     const opponentPressure = (pressure as Record<PlayerId, number>)[opponentId];
-    assertState(
-      opponentPressure === 0,
-      `Controlled state '${stateId}' must not retain opponent pressure (${opponentId})`,
-    );
+    if (opponentPressure > 0) {
+      findings.push({
+        level: 'warning',
+        message: `State '${stateId}' controlled by ${playerId} is contested by ${opponentId} pressure ${opponentPressure}`,
+      });
+    }
 
     const defense = state.stateDefense?.[stateId];
     assertState(isFiniteNumber(defense), `Missing defense value for controlled state '${stateId}'`);
@@ -93,12 +97,14 @@ const validatePlayer = (
 
   playersStates.set(playerId, normalizedStates);
 
-  return {
+  findings.push({
     level: 'info',
     message: `Player ${playerId} controls ${normalizedStates.size} state${
       normalizedStates.size === 1 ? '' : 's'
     } with ${playerState.ip} IP`,
-  };
+  });
+
+  return findings;
 };
 
 export function auditGameState(state: GameState): GameStateAuditFinding[] {
@@ -125,7 +131,7 @@ export function auditGameState(state: GameState): GameStateAuditFinding[] {
   const playerStates = new Map<PlayerId, Set<string>>();
   const findings: GameStateAuditFinding[] = [];
   for (const playerId of PLAYER_IDS) {
-    findings.push(validatePlayer(state, playerId, playerStates));
+    findings.push(...validatePlayer(state, playerId, playerStates));
   }
 
   const p1States = playerStates.get('P1') ?? new Set<string>();

--- a/src/systems/__tests__/gameStateAudit.test.ts
+++ b/src/systems/__tests__/gameStateAudit.test.ts
@@ -50,7 +50,35 @@ describe('auditGameState', () => {
       expect.arrayContaining([
         expect.objectContaining({
           level: 'info',
+          message: expect.stringContaining("Player P1 controls 1 state"),
+        }),
+        expect.objectContaining({
+          level: 'info',
           message: expect.stringContaining('Turn 1 audit completed'),
+        }),
+      ]),
+    );
+  });
+
+  it('returns a warning when a controlled state is contested by opponent pressure', () => {
+    const state = createGameState({
+      players: {
+        P1: createPlayer({ id: 'P1', faction: 'truth', states: ['CA'] }),
+        P2: createPlayer({ id: 'P2', faction: 'government' }),
+      },
+      pressureByState: {
+        CA: { P1: 0, P2: 3 },
+      },
+      stateDefense: { CA: 1 },
+    });
+
+    const findings = auditGameState(state);
+
+    expect(findings).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          level: 'warning',
+          message: "State 'CA' controlled by P1 is contested by P2 pressure 3",
         }),
       ]),
     );
@@ -74,6 +102,21 @@ describe('auditGameState', () => {
     });
 
     expect(() => auditGameState(state)).toThrow(/Missing pressure entry/);
+  });
+
+  it('throws when pressure values are invalid', () => {
+    const state = createGameState({
+      players: {
+        P1: createPlayer({ id: 'P1', faction: 'truth', states: ['AZ'] }),
+        P2: createPlayer({ id: 'P2', faction: 'government' }),
+      },
+      pressureByState: {
+        AZ: { P1: -1, P2: 0 },
+      },
+      stateDefense: { AZ: 1 },
+    });
+
+    expect(() => auditGameState(state)).toThrow(/cannot be negative/);
   });
 
   it('throws when player IP becomes negative', () => {


### PR DESCRIPTION
## Summary
- allow controlled states with lingering opponent pressure to report warnings instead of failing the audit
- return all player findings from the audit so contested warnings are exposed alongside the summary info
- re-enable the game state audit tests and cover contested pressure along with validation of invalid data

## Testing
- npm run lint *(fails: existing repository lint violations unrelated to this change)*
- bun test --coverage --coverage-reporter=text *(fails: pre-existing extraExtra integration snapshot expectation)*

------
https://chatgpt.com/codex/tasks/task_e_68e28b15066883208aeabc327da97f36