### PR TITLE
Load news pools before composing final editions

### DIFF
--- a/UPDATES_LOG.md
+++ b/UPDATES_LOG.md
@@ -2,6 +2,10 @@
 
 This document provides a chronological record of gameplay-impacting changes merged into State Shift Strategy. Each entry should include the merge date and a brief, human-readable summary so future contributors can quickly understand how the game has evolved.
 
+## 2025-10-06 – Delay final editions until news pools load
+- Load news article pools on app startup to prevent empty or stale final editions when the archives are still initializing.
+- Skip composing the final newspaper until pool data is ready and clear the preview to avoid stale spreads during loading.
+
 ## 2025-10-05 – Rebuild Paranoid Times article bank
 - Replace the templated article dump with bespoke Truth and Government stories for every card across core sets and expansions.
 - Switch article metadata to the `faction` field and normalise legacy values inside the loader so the UI matches card factions.

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -73,6 +73,7 @@ import { buildFinalEdition as buildGameOverReport } from '@/utils/finalEdition';
 import type { GameOverReport } from '@/types/finalEdition';
 import type { ArcProgressSummary } from '@/types/campaign';
 import { buildFinalEdition as buildNewsFinalEdition, type FinalEdition, type TurnLog } from '@/news/headlineEngine';
+import { loadNewsPools } from '@/news/newsPools';
 import { toPlayedLite } from '@/hooks/aiHelpers';
 
 type ContextualEffectType = Parameters<typeof VisualEffectsCoordinator.triggerContextualEffect>[0];
@@ -152,6 +153,7 @@ const Index = () => {
   const [showInGameOptions, setShowInGameOptions] = useState(false);
   const [finalEdition, setFinalEdition] = useState<GameOverReport | null>(null);
   const [newsFinalEdition, setNewsFinalEdition] = useState<FinalEdition | null>(null);
+  const [areNewsPoolsReady, setAreNewsPoolsReady] = useState(false);
   const [readingEdition, setReadingEdition] = useState<GameOverReport | null>(null);
   const [showExtraEdition, setShowExtraEdition] = useState(false);
   const [isEndingTurn, setIsEndingTurn] = useState(false);
@@ -886,7 +888,9 @@ const Index = () => {
       });
 
       let composedNewsEdition: FinalEdition | null = null;
-      if (finalEditionTurnLogs.length > 0 || gameState.playHistory.length === 0) {
+      if (!areNewsPoolsReady) {
+        setNewsFinalEdition(null);
+      } else if (finalEditionTurnLogs.length > 0 || gameState.playHistory.length === 0) {
         try {
           composedNewsEdition = buildNewsFinalEdition(
             `${gameState.faction}:${report.recordedAt}`,
@@ -934,6 +938,7 @@ const Index = () => {
     arcProgressSummaries,
     paranormalSightings,
     setGameState,
+    areNewsPoolsReady,
   ]);
 
   useEffect(() => {
@@ -944,6 +949,11 @@ const Index = () => {
     }
 
     setFinalEdition(edition);
+    if (!areNewsPoolsReady) {
+      setNewsFinalEdition(null);
+      return;
+    }
+
     if (finalEditionTurnLogs.length > 0 || gameState.playHistory.length === 0) {
       try {
         const composed = buildNewsFinalEdition(
@@ -975,7 +985,30 @@ const Index = () => {
     gameState.faction,
     gameState.round,
     gameState.turn,
+    areNewsPoolsReady,
   ]);
+
+  useEffect(() => {
+    let isMounted = true;
+
+    const prepareNewsPools = async () => {
+      try {
+        await loadNewsPools();
+        if (isMounted) {
+          setAreNewsPoolsReady(true);
+        }
+      } catch (error) {
+        console.error('Failed to load news pools', error);
+        toast.error('Failed to load news archives for the final edition.');
+      }
+    };
+
+    prepareNewsPools();
+
+    return () => {
+      isMounted = false;
+    };
+  }, []);
 
   // Enhanced synergy detection with coordinated visual effects
   useEffect(() => {


### PR DESCRIPTION
## Summary
- load the news article pools on the index page before composing the final edition newspaper
- gate final edition composition until the pools are ready and clear stale editions while waiting
- document the change in the updates log

## Testing
- npm run lint *(fails: existing lint debt across repository)*
- bun test --coverage --coverage-reporter=text *(fails: existing integration expectation and extension manager side effects)*

------
https://chatgpt.com/codex/tasks/task_e_68e28d7177248320b99786c351b0fa0e