### PR TITLE
Surface extra edition bulletins in victory reports

### DIFF
--- a/UPDATES_LOG.md
+++ b/UPDATES_LOG.md
@@ -6,6 +6,10 @@ This document provides a chronological record of gameplay-impacting changes merg
 - Load news article pools on app startup to prevent empty or stale final editions when the archives are still initializing.
 - Skip composing the final newspaper until pool data is ready and clear the preview to avoid stale spreads during loading.
 
+## 2025-10-05 – Surface extra bulletins in final editions
+- Retire the in-play Extra Extra strip so the primary board regains vertical space during matches.
+- Feed archived bulletin articles into the final edition builder and render them in the victory newspaper spread with fallback copy.
+
 ## 2025-10-05 – Rebuild Paranoid Times article bank
 - Replace the templated article dump with bespoke Truth and Government stories for every card across core sets and expansions.
 - Switch article metadata to the `faction` field and normalise legacy values inside the loader so the UI matches card factions.

--- a/__tests__/integration/extraExtra.test.ts
+++ b/__tests__/integration/extraExtra.test.ts
@@ -107,7 +107,7 @@ describe('extra extra integration', () => {
 
     const { state: endedState } = endTurn(state, []);
 
-    expect(endedState.extraExtraFeed).toEqual([`${expectedArticle.hed} — ${expectedArticle.dek}`]);
+    expect(endedState.extraExtraFeed).toEqual([expectedArticle]);
     expect(endedState.headlineLog).toEqual([
       'Turn 1 recap: Truth plays 3, Government plays 0',
     ]);

--- a/__tests__/utils/finalEdition.test.ts
+++ b/__tests__/utils/finalEdition.test.ts
@@ -25,6 +25,7 @@ describe('buildFinalEdition report summary', () => {
     states: [createState('AL', 'player'), createState('AK', 'player'), createState('AZ', 'ai')],
     faction: 'truth',
     playHistory: [],
+    extraExtraFeed: [],
   } as const;
 
   it('reports a Truth victory with final stats when the player wins', async () => {
@@ -44,6 +45,7 @@ describe('buildFinalEdition report summary', () => {
     expect(report.statesTruth).toBe(2);
     expect(report.statesGov).toBe(1);
     expect(report.playerFaction).toBe('truth');
+    expect(report.extraExtraFeed).toEqual([]);
   });
 
   it('reports a Government victory with the same base stats when the player loses', async () => {
@@ -62,5 +64,6 @@ describe('buildFinalEdition report summary', () => {
     expect(report.ipAI).toBe(0);
     expect(report.statesTruth).toBe(2);
     expect(report.statesGov).toBe(1);
+    expect(report.extraExtraFeed).toEqual([]);
   });
 });

--- a/src/components/game/FinalEditionLayout.tsx
+++ b/src/components/game/FinalEditionLayout.tsx
@@ -9,6 +9,7 @@ import {
   type NewspaperTone,
   getNewspaperBadgeClass,
 } from './newspaperLayout';
+import type { ArticleBlock } from '@/news/headlineEngine';
 import type { GameOverReport, FinalEditionEventHighlight, MVPReport } from '@/types/finalEdition';
 import {
   getFactionDisplayName,
@@ -46,7 +47,7 @@ const formatVictoryHeadline = (report: GameOverReport): string => {
 
 const formatVictorySubhead = (report: GameOverReport): string => {
   const rounds = report.rounds > 0 ? `${report.rounds} rounds` : 'a lightning opener';
-  const truth = `${Math.round(report.finalTruth)}% truth`; 
+  const truth = `${Math.round(report.finalTruth)}% truth`;
   if (report.winner === 'draw') {
     return `Stalemate declared after ${rounds}; truth settles at ${truth}.`;
   }
@@ -59,6 +60,45 @@ const formatVictorySubhead = (report: GameOverReport): string => {
         ? 'broadcast dominance'
         : 'covert agenda reveal';
   return `${victor} closes the season via ${method} after ${rounds}; monitors register ${truth}.`;
+};
+
+const getBulletinLabel = (tone: ArticleBlock['tone']): string => {
+  switch (tone) {
+    case 'truth':
+      return 'Truth Network Bulletin';
+    case 'government':
+      return 'Government Wire Advisory';
+    default:
+      return 'Breaking Desk Update';
+  }
+};
+
+const getBulletinBadgeClass = (
+  tone: ArticleBlock['tone'],
+  editionTone: NewspaperTone,
+): string => {
+  if (tone === 'truth') {
+    return 'border-truth-red/60 bg-truth-red/10 text-truth-red';
+  }
+  if (tone === 'government') {
+    return 'border-government-blue/60 bg-government-blue/10 text-government-blue';
+  }
+  return editionTone === 'victory'
+    ? 'border-victory-foreground/40 bg-victory-foreground/10 text-victory-foreground'
+    : 'border-newspaper-border/60 bg-newspaper-bg/70 text-newspaper-text/70';
+};
+
+const getBulletinHeadlineClass = (
+  tone: ArticleBlock['tone'],
+  editionTone: NewspaperTone,
+): string => {
+  if (tone === 'truth') {
+    return 'text-truth-red';
+  }
+  if (tone === 'government') {
+    return 'text-government-blue';
+  }
+  return editionTone === 'victory' ? 'text-victory-accent' : 'text-newspaper-headline';
 };
 
 interface AgendaPresentation {
@@ -211,6 +251,7 @@ const FinalEditionLayout = ({ report }: FinalEditionLayoutProps) => {
     tone === 'victory'
       ? 'mt-1 text-2xl font-black tracking-tight text-victory-accent drop-shadow-[0_2px_8px_rgba(0,0,0,0.35)]'
       : 'mt-1 text-2xl font-black tracking-tight text-newspaper-headline';
+  const bulletinArticles = report.extraExtraFeed.slice(-4).reverse();
   const highlightCardClass =
     tone === 'victory'
       ? 'rounded-md border border-victory-foreground/30 bg-gradient-to-br from-victory-start/80 via-victory-mid/74 to-victory-end/80 text-victory-foreground shadow-[0_16px_36px_rgba(0,0,0,0.35)]'
@@ -505,6 +546,65 @@ const FinalEditionLayout = ({ report }: FinalEditionLayoutProps) => {
           </div>
         </NewspaperSection>
       </section>
+
+      <NewspaperSection tone={tone} className="p-5">
+        <div className="flex items-center justify-between">
+          <h2 className={sectionHeadingClass}>Extra Extra Bulletins</h2>
+          <Badge className={cn(badgeClass, 'rounded-full px-3 py-0.5 text-[11px] tracking-[0.3em]')}>
+            {bulletinArticles.length}
+          </Badge>
+        </div>
+        {bulletinArticles.length > 0 ? (
+          <div className="mt-4 space-y-4">
+            {bulletinArticles.map((article, index) => {
+              const badgeToneClass = getBulletinBadgeClass(article.tone, tone);
+              const headlineToneClass = getBulletinHeadlineClass(article.tone, tone);
+              return (
+                <article key={`${article.hed}-${index}`} className={cn(highlightCardClass, 'p-4 space-y-3')}>
+                  <div
+                    className={cn(
+                      'inline-flex items-center rounded-full border px-3 py-0.5 text-[10px] font-semibold uppercase tracking-[0.32em]',
+                      badgeToneClass,
+                    )}
+                  >
+                    {getBulletinLabel(article.tone)}
+                  </div>
+                  <header className="space-y-1">
+                    <h3
+                      className={cn(
+                        'font-headline text-lg font-black uppercase tracking-[0.16em]',
+                        headlineToneClass,
+                      )}
+                    >
+                      {article.hed}
+                    </h3>
+                    {article.dek ? (
+                      <p className={cn('text-sm italic', primaryBodyClass)}>{article.dek}</p>
+                    ) : null}
+                  </header>
+                  {article.bullets.length > 0 ? (
+                    <ul className={cn('space-y-1 text-[12px] leading-relaxed', mutedBodyClass)}>
+                      {article.bullets.slice(0, 4).map((bullet, bulletIndex) => (
+                        <li key={`${bulletIndex}-${bullet.slice(0, 24)}`} className="list-disc pl-4">
+                          {bullet}
+                        </li>
+                      ))}
+                    </ul>
+                  ) : null}
+                  <footer className={cn('text-[10px] uppercase tracking-[0.32em]', subtleBodyClass)}>
+                    <div>{article.byline}</div>
+                    <div>{article.source}</div>
+                  </footer>
+                </article>
+              );
+            })}
+          </div>
+        ) : (
+          <p className={cn('mt-4 rounded border border-dashed px-3 py-4 text-sm italic', mutedBodyClass)}>
+            No newsroom bulletins were filed during this match.
+          </p>
+        )}
+      </NewspaperSection>
 
       <NewspaperSection tone={tone} className="p-5">
         <h2 className={sectionHeadingClass}>After-Action Notes</h2>

--- a/src/components/game/__tests__/FinalEditionLayout.extraFeed.test.tsx
+++ b/src/components/game/__tests__/FinalEditionLayout.extraFeed.test.tsx
@@ -1,0 +1,137 @@
+import { describe, expect, test } from 'bun:test';
+import { create } from 'react-test-renderer';
+
+import type { GameOverReport } from '@/types/finalEdition';
+import type { ArticleBlock } from '@/news/headlineEngine';
+
+const ensureLocalStorage = () => {
+  if (typeof globalThis.localStorage !== 'undefined') {
+    return;
+  }
+
+  const storage = new Map<string, string>();
+  globalThis.localStorage = {
+    getItem: key => (storage.has(key) ? storage.get(key)! : null),
+    setItem: (key, value) => {
+      storage.set(key, value);
+    },
+    removeItem: key => {
+      storage.delete(key);
+    },
+    clear: () => {
+      storage.clear();
+    },
+    key: index => Array.from(storage.keys())[index] ?? null,
+    get length() {
+      return storage.size;
+    },
+  } as Storage;
+};
+
+const extractText = (node: unknown): string[] => {
+  if (node == null) {
+    return [];
+  }
+
+  if (typeof node === 'string') {
+    return [node];
+  }
+
+  if (Array.isArray(node)) {
+    return node.flatMap(extractText);
+  }
+
+  if (typeof node === 'object' && 'children' in node && Array.isArray((node as { children?: unknown[] }).children)) {
+    return ((node as { children?: unknown[] }).children ?? []).flatMap(extractText);
+  }
+
+  return [];
+};
+
+const createArticle = (overrides: Partial<ArticleBlock> = {}): ArticleBlock => ({
+  tone: 'truth',
+  hed: 'Truth Ops Uncover Vault',
+  dek: 'Operatives expose covert caches under the capitol plaza.',
+  bullets: ['Field teams broadcast live intel.', 'Opposition command scrambles response units.'],
+  byline: 'Operative Dispatch',
+  source: 'Truth Network',
+  ...overrides,
+});
+
+const createReport = (overrides: Partial<GameOverReport> = {}): GameOverReport => ({
+  winner: 'truth',
+  victoryType: 'truth',
+  rounds: 4,
+  finalTruth: 68,
+  ipPlayer: 142,
+  ipAI: 97,
+  statesGov: 18,
+  statesTruth: 32,
+  playerFaction: 'truth',
+  playerSecretAgenda: undefined,
+  aiSecretAgenda: undefined,
+  mvp: null,
+  runnerUp: null,
+  legendaryUsed: [],
+  topEvents: [],
+  comboHighlights: [],
+  sightings: [],
+  extraExtraFeed: [createArticle()],
+  recordedAt: new Date('2025-10-05T12:00:00Z').getTime(),
+  ...overrides,
+});
+
+describe('FinalEditionLayout extra extra bulletins', () => {
+  test('renders bulletin articles when present', async () => {
+    ensureLocalStorage();
+
+    const { default: FinalEditionLayout } = await import('../FinalEditionLayout');
+    const report = createReport({
+      extraExtraFeed: [
+        createArticle({
+          tone: 'truth',
+          hed: 'Operatives Break Radio Silence',
+          dek: 'Truth Network floods the airwaves.',
+          bullets: ['Broadcast uplink secured.', 'Counter narrative jammed.'],
+          byline: 'Field Desk',
+          source: 'Truth Relay',
+        }),
+        createArticle({
+          tone: 'government',
+          hed: 'Shadow Bureau Deploys Countermeasures',
+          dek: 'Government doubles down on containment orders.',
+          bullets: ['Lockdown protocols enforced.', 'Assets redeployed to coastal hubs.'],
+          byline: 'Briefing Room',
+          source: 'Government Wire',
+        }),
+      ],
+    });
+
+    const renderer = create(<FinalEditionLayout report={report} />);
+    const output = extractText(renderer.toJSON()).join(' ');
+    const normalized = output.replace(/\s+/g, ' ').trim();
+
+    expect(normalized).toContain('Extra Extra Bulletins');
+    expect(normalized).toContain('Truth Network Bulletin');
+    expect(normalized).toContain('Operatives Break Radio Silence');
+    expect(normalized).toContain('Government Wire Advisory');
+    expect(normalized).toContain('Shadow Bureau Deploys Countermeasures');
+
+    renderer.unmount();
+  });
+
+  test('shows fallback copy when no bulletins are recorded', async () => {
+    ensureLocalStorage();
+
+    const { default: FinalEditionLayout } = await import('../FinalEditionLayout');
+    const report = createReport({ extraExtraFeed: [] });
+
+    const renderer = create(<FinalEditionLayout report={report} />);
+    const output = extractText(renderer.toJSON()).join(' ');
+    const normalized = output.replace(/\s+/g, ' ').trim();
+
+    expect(normalized).toContain('No newsroom bulletins were filed during this match.');
+
+    renderer.unmount();
+  });
+});

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -19,7 +19,6 @@ import { useAudioContext } from '@/contexts/AudioContext';
 import { useCardAnimation } from '@/hooks/useCardAnimation';
 import CardAnimationLayer from '@/components/game/CardAnimationLayer';
 import FloatingNumbers from '@/components/effects/FloatingNumbers';
-import ExtraFeed from '@/components/news/ExtraFeed';
 import FinalEditionOverlay from '@/components/news/FinalEditionOverlay';
 import FalloutOverlay from '@/expansions/tabloidRelics/RelicUI';
 
@@ -877,6 +876,7 @@ const Index = () => {
           faction: gameState.faction,
           playHistory: gameState.playHistory,
           currentEvents: gameState.currentEvents ?? [],
+          extraExtraFeed: gameState.extraExtraFeed,
         },
         winner,
         victoryType,
@@ -2631,7 +2631,6 @@ const Index = () => {
             onInspectCard={(card) => setInspectedPlayedCard(card)}
           />
         </div>
-        <ExtraFeed articles={gameState.extraExtraFeed} />
       </div>
       <CardPreviewOverlay card={hoveredCard ? { ...hoveredCard, text: hoveredCard.text || '' } : null} />
     </div>

--- a/src/types/finalEdition.ts
+++ b/src/types/finalEdition.ts
@@ -1,3 +1,4 @@
+import type { ArticleBlock } from '@/news/headlineEngine';
 import type { ParanormalSighting } from '@/types/paranormal';
 import type { ArcProgressSummary } from './campaign';
 
@@ -80,6 +81,7 @@ export interface FinalEditionReport {
   topEvents: FinalEditionEventHighlight[];
   comboHighlights: FinalEditionComboHighlight[];
   sightings: ParanormalSighting[];
+  extraExtraFeed: ArticleBlock[];
   recordedAt: number;
 }
 

--- a/src/utils/finalEdition.ts
+++ b/src/utils/finalEdition.ts
@@ -417,7 +417,7 @@ const summarizeAgenda = (
 export interface BuildFinalEditionOptions {
   state: Pick<
     GameState,
-    'round' | 'truth' | 'ip' | 'aiIP' | 'states' | 'faction' | 'playHistory'
+    'round' | 'truth' | 'ip' | 'aiIP' | 'states' | 'faction' | 'playHistory' | 'extraExtraFeed'
   > & {
     currentEvents?: GameEvent[];
   };
@@ -477,6 +477,7 @@ export const buildFinalEdition = ({
     topEvents,
     comboHighlights,
     sightings: [...paranormalSightings],
+    extraExtraFeed: [...state.extraExtraFeed],
     recordedAt: timestamp,
   };
 };


### PR DESCRIPTION
## Summary
- remove the on-board Extra Extra bulletin strip to clear space on the in-play layout
- extend the final edition report model to carry extraExtraFeed articles and render them in the victory newspaper
- update fixtures, add regression coverage for the new bulletin section, and document the gameplay-facing change

## Testing
- npm run lint *(fails: existing lint violations in repository)*
- bun test --coverage --coverage-reporter=text


------
https://chatgpt.com/codex/tasks/task_e_68e298d69ebc83208c73cd285dcd9d1a