### PR TITLE
Rotate tabloid relic selection to avoid repeated triggers

### DIFF
--- a/UPDATES_LOG.md
+++ b/UPDATES_LOG.md
@@ -26,6 +26,10 @@ This document provides a chronological record of gameplay-impacting changes merg
 - Load news article pools on app startup to prevent empty or stale final editions when the archives are still initializing.
 - Skip composing the final newspaper until pool data is ready and clear the preview to avoid stale spreads during loading.
 
+## 2025-10-05 – Rotate tabloid relic triggers
+- Teach the Tabloid Relic engine to rotate between matching rules so consecutive issues queue different relics when possible.
+- Persist selection history and surface rotation logs to keep relic selection balanced across rounds.
+
 ## 2025-10-05 – Modularize truth strike reporting
 - Swap the truth-faction attack and media body banks for modular templates with dynamic motives, settings, and reactions to reduce repetition.
 - Teach the newspaper composer to render templated story segments alongside legacy string entries.

--- a/__tests__/expansions/tabloidRelics/RelicEngine.test.ts
+++ b/__tests__/expansions/tabloidRelics/RelicEngine.test.ts
@@ -1,0 +1,187 @@
+import { beforeEach, describe, expect, it } from 'bun:test';
+import type { GameEvent } from '@/data/eventDatabase';
+import { hydrateExpansionFeatures } from '@/data/expansions/features';
+import type { CardPlayRecord } from '@/hooks/gameStateTypes';
+import type {
+  RelicIssueSnapshot,
+  TabloidRelicRuntimeState,
+} from '@/expansions/tabloidRelics/RelicTypes';
+
+const loadRelicEngine = () => import('@/expansions/tabloidRelics/RelicEngine');
+
+const createEvent = (id: string): GameEvent => ({
+  id,
+  title: `Event ${id}`,
+  content: 'content',
+  type: 'truth',
+  rarity: 'common',
+  weight: 1,
+  effects: { truth: 9 },
+});
+
+const createMediaPlay = (round: number): CardPlayRecord => ({
+  card: {
+    id: `media-${round}`,
+    name: `Media ${round}`,
+    type: 'MEDIA',
+    faction: 'truth',
+    cost: 0,
+  },
+  player: 'human',
+  faction: 'truth',
+  targetState: null,
+  truthDelta: 0,
+  ipDelta: 0,
+  aiIpDelta: 0,
+  capturedStates: [],
+  capturedStateIds: [],
+  damageDealt: 0,
+  round,
+  turn: round,
+  timestamp: Date.now(),
+  logEntries: [],
+});
+
+const createSnapshot = (
+  round: number,
+  runtime: TabloidRelicRuntimeState | null,
+): RelicIssueSnapshot => ({
+  round,
+  turn: round,
+  truth: 40,
+  ip: 10,
+  aiIP: 30,
+  comboTruthDelta: -6,
+  faction: 'truth',
+  events: [createEvent(`evt-${round}`)],
+  plays: [createMediaPlay(round * 2 - 1), createMediaPlay(round * 2)],
+  runtime,
+  editorActive: false,
+});
+
+beforeEach(() => {
+  hydrateExpansionFeatures({
+    tabloidRelics: true,
+    editors: false,
+  });
+});
+
+describe('RelicEngine.ingestIssue rotation', () => {
+  it('rotates through available relics when multiple candidates match', async () => {
+    const { RelicEngine } = await loadRelicEngine();
+
+    const first = RelicEngine.ingestIssue(createSnapshot(1, null));
+    const firstQueued = first.runtime?.entries.at(-1)?.ruleId;
+
+    const second = RelicEngine.ingestIssue(createSnapshot(2, first.runtime ?? null));
+    const secondQueued = second.runtime?.entries.at(-1)?.ruleId;
+
+    const third = RelicEngine.ingestIssue(createSnapshot(3, second.runtime ?? null));
+    const thirdQueued = third.runtime?.entries.at(-1)?.ruleId;
+
+    expect([firstQueued, secondQueued, thirdQueued]).toEqual([
+      'black_budget_briefing',
+      'red_string_reactor',
+      'pressroom_lockdown',
+    ]);
+    expect(third.runtime?.selectionHistory.slice(0, 3)).toEqual([
+      'pressroom_lockdown',
+      'red_string_reactor',
+      'black_budget_briefing',
+    ]);
+    expect(third.logEntries).toContain(
+      'Tabloid Relic rotation (most recent first): pressroom_lockdown -> red_string_reactor -> black_budget_briefing',
+    );
+  });
+
+  it('preserves selection history when relic queues empty so rotation resumes later', async () => {
+    const { RelicEngine } = await loadRelicEngine();
+
+    let result = RelicEngine.ingestIssue(createSnapshot(1, null));
+    result = RelicEngine.ingestIssue(createSnapshot(2, result.runtime ?? null));
+    result = RelicEngine.ingestIssue(createSnapshot(3, result.runtime ?? null));
+
+    const firstHistory = result.runtime?.selectionHistory.slice(0, 3);
+    expect(firstHistory).toEqual([
+      'pressroom_lockdown',
+      'red_string_reactor',
+      'black_budget_briefing',
+    ]);
+
+    let roundState = RelicEngine.applyRoundStart({
+      state: {
+        faction: 'truth',
+        truth: 10,
+        ip: 0,
+        aiIP: 0,
+        round: 3,
+        turn: 3,
+        editorId: null,
+        editorDef: null,
+        tabloidRelicsRuntime: result.runtime ?? null,
+      },
+    });
+
+    roundState = RelicEngine.applyRoundStart({
+      state: {
+        faction: 'truth',
+        truth: roundState.truth,
+        ip: roundState.ip,
+        aiIP: roundState.aiIp,
+        round: 4,
+        turn: 4,
+        editorId: null,
+        editorDef: null,
+        tabloidRelicsRuntime: roundState.runtime ?? null,
+      },
+    });
+
+    roundState = RelicEngine.applyRoundStart({
+      state: {
+        faction: 'truth',
+        truth: roundState.truth,
+        ip: roundState.ip,
+        aiIP: roundState.aiIp,
+        round: 5,
+        turn: 5,
+        editorId: null,
+        editorDef: null,
+        tabloidRelicsRuntime: roundState.runtime ?? null,
+      },
+    });
+
+    roundState = RelicEngine.applyRoundStart({
+      state: {
+        faction: 'truth',
+        truth: roundState.truth,
+        ip: roundState.ip,
+        aiIP: roundState.aiIp,
+        round: 6,
+        turn: 6,
+        editorId: null,
+        editorDef: null,
+        tabloidRelicsRuntime: roundState.runtime ?? null,
+      },
+    });
+
+    expect(roundState.runtime?.entries).toHaveLength(0);
+    expect(roundState.runtime?.selectionHistory.slice(0, 3)).toEqual([
+      'pressroom_lockdown',
+      'red_string_reactor',
+      'black_budget_briefing',
+    ]);
+
+    const resumed = RelicEngine.ingestIssue(
+      createSnapshot(7, roundState.runtime ?? null),
+    );
+    const resumedQueued = resumed.runtime?.entries.at(-1)?.ruleId;
+
+    expect(resumedQueued).toBe('inkwell_of_intrigue');
+    expect(resumed.runtime?.selectionHistory.slice(0, 4)).toEqual([
+      'inkwell_of_intrigue',
+      'pressroom_lockdown',
+      'red_string_reactor',
+      'black_budget_briefing',
+    ]);
+  });
+});

--- a/src/expansions/tabloidRelics/RelicEngine.ts
+++ b/src/expansions/tabloidRelics/RelicEngine.ts
@@ -76,14 +76,43 @@ const sanitizeRules = (raw: RelicRulesFile): RelicRuleDefinition[] => {
 
 const RULES: RelicRuleDefinition[] = sanitizeRules(relicRules as RelicRulesFile);
 
-const cloneRuntime = (runtime: TabloidRelicRuntimeState | null | undefined): TabloidRelicRuntimeState | null => {
+const SELECTION_HISTORY_LIMIT = 6;
+
+const pickCandidateWithRotation = (
+  candidates: RelicRuleDefinition[],
+  history: readonly string[],
+): RelicRuleDefinition => {
+  if (candidates.length === 1) {
+    return candidates[0];
+  }
+
+  const ranked = candidates.map((rule, index) => {
+    const recencyIndex = history.indexOf(rule.id);
+    const score = recencyIndex === -1 ? Number.POSITIVE_INFINITY : recencyIndex;
+    return { rule, score, index };
+  });
+
+  ranked.sort((a, b) => {
+    if (b.score !== a.score) {
+      return b.score - a.score;
+    }
+    return a.index - b.index;
+  });
+
+  return ranked[0]?.rule ?? candidates[0];
+};
+
+const cloneRuntime = (
+  runtime: TabloidRelicRuntimeState | null | undefined,
+): TabloidRelicRuntimeState | null => {
   if (!runtime) {
-    return { entries: [], lastIssueRound: 0 };
+    return { entries: [], lastIssueRound: 0, selectionHistory: [] };
   }
   return {
     entries: runtime.entries.map(entry => ({ ...entry })),
     lastIssueRound: runtime.lastIssueRound,
     lastUpdatedTurn: runtime.lastUpdatedTurn,
+    selectionHistory: [...(runtime.selectionHistory ?? [])],
   };
 };
 
@@ -229,10 +258,16 @@ export const RelicEngine = {
 
     const candidates = RULES.filter(rule => evaluateTrigger(rule, snapshot));
     if (!candidates.length) {
-      return { runtime: runtime && runtime.entries.length ? runtime : null, logEntries };
+      const shouldPersistRuntime = Boolean(runtime && (runtime.entries.length || runtime.selectionHistory.length));
+      return { runtime: shouldPersistRuntime ? runtime : null, logEntries };
     }
 
-    const selected = candidates[0];
+    const history = runtime?.selectionHistory ?? [];
+    const selected = pickCandidateWithRotation(candidates, history);
+    const nextHistory = [selected.id, ...history.filter(ruleId => ruleId !== selected.id)].slice(
+      0,
+      SELECTION_HISTORY_LIMIT,
+    );
     const amplifiedEffects = amplifyEffects(selected, snapshot.editorActive);
     const entry: TabloidRelicRuntimeEntry = {
       uid: `${selected.id}-${Date.now().toString(36)}`,
@@ -257,12 +292,16 @@ export const RelicEngine = {
       entries: sanitizedEntries,
       lastIssueRound: snapshot.round,
       lastUpdatedTurn: snapshot.turn,
+      selectionHistory: nextHistory,
     };
 
     logEntries.push(`Tabloid Relic queued: ${selected.label} (${selected.rarity})`);
+    if (candidates.length > 1) {
+      logEntries.push(`Tabloid Relic rotation (most recent first): ${nextHistory.join(' -> ')}`);
+    }
 
     return {
-      runtime: nextRuntime.entries.length ? nextRuntime : null,
+      runtime: nextRuntime.entries.length || nextRuntime.selectionHistory.length ? nextRuntime : null,
       logEntries,
     };
   },
@@ -371,9 +410,16 @@ export const RelicEngine = {
       }
     }
 
-    const nextRuntime: TabloidRelicRuntimeState | null = activeEntries.length
-      ? { entries: activeEntries, lastIssueRound: runtime.lastIssueRound, lastUpdatedTurn: state.turn }
-      : null;
+    const shouldPersistHistory = Boolean(runtime?.selectionHistory?.length);
+    const nextRuntime: TabloidRelicRuntimeState | null =
+      activeEntries.length || shouldPersistHistory
+        ? {
+            entries: activeEntries,
+            lastIssueRound: runtime?.lastIssueRound ?? 0,
+            lastUpdatedTurn: state.turn,
+            selectionHistory: [...(runtime?.selectionHistory ?? [])],
+          }
+        : null;
 
     const resolvedTruthClampMin = truthClampMin ?? 0;
     const resolvedTruthClampMax = truthClampMax ?? 100;

--- a/src/expansions/tabloidRelics/RelicTypes.ts
+++ b/src/expansions/tabloidRelics/RelicTypes.ts
@@ -79,6 +79,7 @@ export interface TabloidRelicRuntimeState {
   readonly entries: TabloidRelicRuntimeEntry[];
   readonly lastIssueRound: number;
   readonly lastUpdatedTurn?: number;
+  readonly selectionHistory: readonly string[];
 }
 
 export interface RelicHostState {

--- a/src/mvp/validator.ts
+++ b/src/mvp/validator.ts
@@ -562,6 +562,7 @@ export function cloneGameState(state: GameState): GameState {
         entries: state.tabloidRelicsRuntime.entries.map(entry => ({ ...entry })),
         lastIssueRound: state.tabloidRelicsRuntime.lastIssueRound,
         lastUpdatedTurn: state.tabloidRelicsRuntime.lastUpdatedTurn,
+        selectionHistory: [...(state.tabloidRelicsRuntime.selectionHistory ?? [])],
       }
     : state.tabloidRelicsRuntime ?? null;
 


### PR DESCRIPTION
## Summary
- rotate tabloid relic selection using recent history so consecutive issues prefer different rules and log the rotation order
- persist relic selection history in runtime clones to keep rotation working across round transitions
- add targeted RelicEngine rotation tests and document the gameplay change in the updates log

## Testing
- npm run lint *(fails: existing lint errors in unrelated files)*
- bun test --coverage --coverage-reporter=text


------
https://chatgpt.com/codex/tasks/task_e_68e2b4a307e083208b1f00a84a03200b