### PR TITLE
Guard card collection against missing text

### DIFF
--- a/UPDATES_LOG.md
+++ b/UPDATES_LOG.md
@@ -26,6 +26,10 @@ This document provides a chronological record of gameplay-impacting changes merg
 - Load news article pools on app startup to prevent empty or stale final editions when the archives are still initializing.
 - Skip composing the final newspaper until pool data is ready and clear the preview to avoid stale spreads during loading.
 
+## 2025-10-05 – Harden card collection fallbacks
+- Guard the card collection search filters against missing descriptions so textless cards no longer crash the overlay.
+- Show a friendly placeholder description when a discovered card lacks rules text and cover it with regression tests.
+
 ## 2025-10-05 – Rotate tabloid relic triggers
 - Teach the Tabloid Relic engine to rotate between matching rules so consecutive issues queue different relics when possible.
 - Persist selection history and surface rotation logs to keep relic selection balanced across rounds.

--- a/__tests__/game/CardCollectionContent.test.ts
+++ b/__tests__/game/CardCollectionContent.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it, mock } from 'bun:test';
+import React from 'react';
+import TestRenderer from 'react-test-renderer';
+import type { GameCard } from '../../src/rules/mvp';
+
+const cardWithoutText: GameCard = {
+  id: 'card-without-text',
+  name: 'Silent Broadcast',
+  type: 'MEDIA',
+  faction: 'Truth',
+  rarity: 'common',
+  cost: 3,
+};
+
+mock.module('@/hooks/useCardCollection', () => ({
+  useCardCollection: () => ({
+    getDiscoveredCards: () => [cardWithoutText],
+    getCardStats: () => ({ discovered: true, timesPlayed: 0 }),
+    getCollectionStats: () => ({
+      totalCards: 1,
+      discoveredCards: 1,
+      completionPercentage: 100,
+      totalPlays: 0,
+    }),
+  }),
+}));
+
+const loadCardCollectionContent = async () => {
+  const module = await import('../../src/components/game/CardCollection');
+  return module.CardCollectionContent;
+};
+
+describe('CardCollectionContent', () => {
+  it('renders without crashing when card text is missing', async () => {
+    const CardCollectionContent = await loadCardCollectionContent();
+
+    expect(() => {
+      TestRenderer.create(React.createElement(CardCollectionContent));
+    }).not.toThrow();
+  });
+
+  it('shows a fallback description when card text is missing', async () => {
+    const CardCollectionContent = await loadCardCollectionContent();
+
+    const renderer = TestRenderer.create(React.createElement(CardCollectionContent));
+    const json = renderer.toJSON();
+
+    expect(JSON.stringify(json)).toContain('No description available.');
+  });
+});

--- a/src/components/game/CardCollection.tsx
+++ b/src/components/game/CardCollection.tsx
@@ -41,9 +41,12 @@ export const CardCollectionContent = ({
     return MVP_CARD_TYPES.includes(type as MVPCardType) ? type as MVPCardType : 'MEDIA';
   };
 
+  const normalizedSearchTerm = searchTerm.toLowerCase();
+
   const filteredCards = discoveredCards.filter(card => {
-    const matchesSearch = card.name.toLowerCase().includes(searchTerm.toLowerCase()) ||
-      card.text.toLowerCase().includes(searchTerm.toLowerCase());
+    const cardText = (card.text ?? '').toLowerCase();
+    const matchesSearch = card.name.toLowerCase().includes(normalizedSearchTerm) ||
+      cardText.includes(normalizedSearchTerm);
     const matchesType = filterType === 'all' || normalizeCardType(card.type) === filterType;
     const matchesRarity = filterRarity === 'all' || card.rarity === filterRarity;
 
@@ -66,6 +69,9 @@ export const CardCollectionContent = ({
   const CardItem = ({ card }: { card: GameCard }) => {
     const cardStats = getCardStats(card.id);
 
+    const rawCardText = card.text ?? '';
+    const cardDescription = rawCardText.trim().length > 0 ? rawCardText : 'No description available.';
+
     return (
       <button
         type="button"
@@ -87,7 +93,7 @@ export const CardCollectionContent = ({
             </div>
           </div>
 
-          <p className="mb-3 text-sm text-slate-300">{card.text}</p>
+          <p className="mb-3 text-sm text-slate-300">{cardDescription}</p>
 
           <div className="flex flex-wrap items-center justify-between gap-3 text-xs text-emerald-200/80">
             <span>Cost: {card.cost} IP</span>


### PR DESCRIPTION
## Summary
- guard the card collection search filters against cards that lack descriptive text and provide a friendly fallback copy in the UI
- add a regression test that renders CardCollectionContent with a textless card to ensure the overlay no longer crashes
- log the card collection hardening work in the gameplay updates log

## Testing
- npm run lint *(fails: existing repository lint violations unrelated to this change)*
- bun test --coverage --coverage-reporter=text


------
https://chatgpt.com/codex/tasks/task_e_68e2bf28ead483208d7d6ce9bb8d5034