### PR TITLE
Handle AI turn recovery after planning failures

### DIFF
--- a/UPDATES_LOG.md
+++ b/UPDATES_LOG.md
@@ -26,6 +26,10 @@ This document provides a chronological record of gameplay-impacting changes merg
 - Load news article pools on app startup to prevent empty or stale final editions when the archives are still initializing.
 - Skip composing the final newspaper until pool data is ready and clear the preview to avoid stale spreads during loading.
 
+## 2025-10-05 – Harden AI turn recovery
+- Reset the AI turn progress flag when planning fails so the player immediately regains control.
+- Invoke a safe end-turn fallback if the AI remains the active player after an error to avoid stalled sessions.
+
 ## 2025-10-05 – Harden card collection fallbacks
 - Guard the card collection search filters against missing descriptions so textless cards no longer crash the overlay.
 - Show a friendly placeholder description when a discovered card lacks rules text and cover it with regression tests.

--- a/src/hooks/__tests__/useGameState.aiErrorRecovery.test.ts
+++ b/src/hooks/__tests__/useGameState.aiErrorRecovery.test.ts
@@ -1,0 +1,168 @@
+import React from 'react';
+import { describe, it, expect, beforeEach, afterEach, afterAll, mock } from 'bun:test';
+import TestRenderer, { act } from 'react-test-renderer';
+
+mock.module('@/ai/enhancedController', () => ({
+  chooseTurnActions: () => {
+    throw new Error('AI planning failed');
+  },
+}));
+
+mock.module('@/data/aiFactory', () => ({
+  AIFactory: {
+    createStrategist: () => ({
+      personality: { name: 'Mock Strategist' },
+      recordAiPlayOutcome: () => {},
+    }),
+  },
+}));
+
+mock.module('@/contexts/AchievementContext', () => ({
+  useAchievements: () => ({
+    manager: {
+      onNewGameStart: () => {},
+    },
+    stats: {
+      total_states_controlled: 0,
+      max_states_controlled_single_game: 0,
+      max_ip_reached: 0,
+      max_truth_reached: 0,
+      min_truth_reached: 100,
+    },
+    unlockedAchievements: [],
+    lockedAchievements: [],
+    newlyUnlocked: [],
+    updateStats: () => {},
+    onGameStart: () => {},
+    onGameEnd: () => {},
+    onCardPlayed: () => {},
+    onCombosResolved: () => {},
+    exportData: () => ({}),
+    importData: () => true,
+    resetProgress: () => {},
+    clearNewlyUnlocked: () => {},
+  }),
+}));
+
+import { useGameState } from '@/hooks/useGameState';
+
+type HookResult<T> = {
+  current: T | undefined;
+};
+
+const renderHook = <T,>(callback: () => T) => {
+  const result: HookResult<T> = { current: undefined };
+
+  const TestComponent = () => {
+    result.current = callback();
+    return null;
+  };
+
+  const renderer = TestRenderer.create(React.createElement(TestComponent));
+
+  return {
+    result,
+    rerender: () => renderer.update(React.createElement(TestComponent)),
+    unmount: () => renderer.unmount(),
+  };
+};
+
+const createLocalStorageMock = (): Storage => {
+  const store = new Map<string, string>();
+  return {
+    get length() {
+      return store.size;
+    },
+    clear: () => {
+      store.clear();
+    },
+    getItem: (key: string) => (store.has(key) ? store.get(key)! : null),
+    key: (index: number) => Array.from(store.keys())[index] ?? null,
+    removeItem: (key: string) => {
+      store.delete(key);
+    },
+    setItem: (key: string, value: string) => {
+      store.set(key, value);
+    },
+  } as Storage;
+};
+
+const originalSetTimeout = globalThis.setTimeout;
+const originalClearTimeout = globalThis.clearTimeout;
+const originalRandom = Math.random;
+
+const timers = new Map<number, () => void>();
+let nextTimerId = 1;
+
+describe('useGameState AI error recovery', () => {
+  beforeEach(() => {
+    timers.clear();
+    nextTimerId = 1;
+    Math.random = () => 0;
+    globalThis.localStorage = createLocalStorageMock();
+
+    globalThis.setTimeout = ((callback: (...args: any[]) => void, _delay?: number, ...args: any[]) => {
+      const id = nextTimerId++;
+      const wrapped = () => callback(...args);
+      timers.set(id, wrapped);
+      queueMicrotask(() => {
+        const pending = timers.get(id);
+        if (pending) {
+          timers.delete(id);
+          pending();
+        }
+      });
+      return id as unknown as ReturnType<typeof setTimeout>;
+    }) as typeof setTimeout;
+
+    globalThis.clearTimeout = ((id: number) => {
+      timers.delete(Number(id));
+    }) as typeof clearTimeout;
+  });
+
+  afterEach(() => {
+    Math.random = originalRandom;
+    globalThis.setTimeout = originalSetTimeout;
+    globalThis.clearTimeout = originalClearTimeout;
+    timers.clear();
+    if (!Reflect.deleteProperty(globalThis as Record<string, unknown>, 'localStorage')) {
+      (globalThis as Partial<typeof globalThis>).localStorage = undefined;
+    }
+  });
+
+  afterAll(() => {
+    mock.restore();
+  });
+
+  it('resets AI turn progress and returns control to the player when planning fails', async () => {
+    const hook = renderHook(() => useGameState());
+
+    await act(async () => {
+      hook.result.current?.setGameState(prev => ({
+        ...prev,
+        phase: 'ai_turn',
+        currentPlayer: 'ai' as const,
+        aiTurnInProgress: false,
+        aiStrategist: {
+          personality: { name: 'Mock Strategist' },
+          recordAiPlayOutcome: () => {},
+        },
+        aiDeck: [],
+        aiHand: [],
+        states: [],
+        log: [],
+      }));
+    });
+
+    let aiTurnPromise: Promise<void> | undefined;
+    await act(async () => {
+      aiTurnPromise = hook.result.current?.executeAITurn();
+    });
+
+    await expect(aiTurnPromise).resolves.toBeUndefined();
+
+    const latestState = hook.result.current?.gameState;
+    expect(latestState?.aiTurnInProgress).toBe(false);
+    expect(latestState?.currentPlayer).toBe('human');
+  });
+});

--- a/src/hooks/useGameState.ts
+++ b/src/hooks/useGameState.ts
@@ -3910,157 +3910,90 @@ export const useGameState = (aiDifficultyOverride?: AIDifficulty) => {
       return;
     }
 
+    let aiTurnStarted = false;
+    let encounteredError = false;
+
     setGameState(prev => {
       if (sessionGuard !== gameSessionRef.current) {
         return prev;
       }
 
-      return prev.isGameOver ? prev : { ...prev, aiTurnInProgress: true };
+      if (prev.isGameOver) {
+        return prev;
+      }
+
+      aiTurnStarted = true;
+      return { ...prev, aiTurnInProgress: true };
     });
 
-    await new Promise<GameState>(resolve => {
-      setGameState(prev => {
-        if (sessionGuard !== gameSessionRef.current) {
-          resolve(prev);
-          return prev;
-        }
+    try {
+      await new Promise<GameState>(resolve => {
+        setGameState(prev => {
+          if (sessionGuard !== gameSessionRef.current) {
+            resolve(prev);
+            return prev;
+          }
 
-        if (prev.isGameOver) {
-          resolve(prev);
-          return prev;
-        }
+          if (prev.isGameOver) {
+            resolve(prev);
+            return prev;
+          }
 
-        const aiControlledStates = prev.states
-          .filter(state => state.owner === 'ai')
-          .map(state => state.abbreviation);
+          const aiControlledStates = prev.states
+            .filter(state => state.owner === 'ai')
+            .map(state => state.abbreviation);
 
-        const aiControlledStateCount = getControlledStateCount(aiControlledStates);
-        const aiStateIncome = aiControlledStateCount;
-        const aiBaseIncome = 5;
-        const aiTotalIncome = aiBaseIncome + aiStateIncome;
+          const aiControlledStateCount = getControlledStateCount(aiControlledStates);
+          const aiStateIncome = aiControlledStateCount;
+          const aiBaseIncome = 5;
+          const aiTotalIncome = aiBaseIncome + aiStateIncome;
 
-        const aiFaction = prev.faction === 'government' ? 'truth' : 'government';
-        const aiCardsNeeded = Math.max(0, HAND_LIMIT - prev.aiHand.length);
-        const { drawn: aiDrawnCards, deck: aiRemainingDeck } = drawCardsFromDeck(prev.aiDeck, aiCardsNeeded, aiFaction);
-        const aiHandSizeAfterDraw = prev.aiHand.length + aiDrawnCards.length;
+          const aiFaction = prev.faction === 'government' ? 'truth' : 'government';
+          const aiCardsNeeded = Math.max(0, HAND_LIMIT - prev.aiHand.length);
+          const { drawn: aiDrawnCards, deck: aiRemainingDeck } = drawCardsFromDeck(prev.aiDeck, aiCardsNeeded, aiFaction);
+          const aiHandSizeAfterDraw = prev.aiHand.length + aiDrawnCards.length;
 
-        const nextState: GameState = {
-          ...prev,
-          aiHand: [...prev.aiHand, ...aiDrawnCards],
-          aiDeck: aiRemainingDeck,
-          aiIP: prev.aiIP + aiTotalIncome,
-          log: [
-            ...prev.log,
-            `AI Income: ${aiBaseIncome} base + ${aiStateIncome} from ${aiControlledStateCount} states = ${aiTotalIncome} IP`,
-            `AI drew ${aiDrawnCards.length} card${aiDrawnCards.length === 1 ? '' : 's'} (hand ${aiHandSizeAfterDraw}/${HAND_LIMIT})`,
-          ],
-        };
+          const nextState: GameState = {
+            ...prev,
+            aiHand: [...prev.aiHand, ...aiDrawnCards],
+            aiDeck: aiRemainingDeck,
+            aiIP: prev.aiIP + aiTotalIncome,
+            log: [
+              ...prev.log,
+              `AI Income: ${aiBaseIncome} base + ${aiStateIncome} from ${aiControlledStateCount} states = ${aiTotalIncome} IP`,
+              `AI drew ${aiDrawnCards.length} card${aiDrawnCards.length === 1 ? '' : 's'} (hand ${aiHandSizeAfterDraw}/${HAND_LIMIT})`,
+            ],
+          };
 
-        resolve(nextState);
-        return nextState;
+          resolve(nextState);
+          return nextState;
+        });
       });
-    });
 
-    if (sessionGuard !== gameSessionRef.current) {
-      return;
-    }
-
-    const prePlanningState = await readLatestState();
-    if (prePlanningState.isGameOver) {
-      return;
-    }
-
-    await new Promise(resolve => setTimeout(resolve, Math.random() * 1000 + 500));
-
-    if (sessionGuard !== gameSessionRef.current) {
-      return;
-    }
-
-    const planningState = await readLatestState();
-
-    if (sessionGuard !== gameSessionRef.current) {
-      return;
-    }
-
-    if (!planningState.aiStrategist) {
-      setGameState(prev => {
-        if (sessionGuard !== gameSessionRef.current) {
-          return prev;
-        }
-
-        return prev.isGameOver ? prev : { ...prev, aiTurnInProgress: false };
-      });
-      return;
-    }
-
-    if (planningState.isGameOver) {
-      return;
-    }
-
-    const turnPlan = chooseTurnActions({
-      strategist: planningState.aiStrategist,
-      gameState: planningState as any,
-      maxActions: 3,
-      priorityThreshold: 0.3,
-    });
-
-    if (turnPlan.actions.length === 0 && turnPlan.sequenceDetails.length) {
-      setGameState(prev => {
-        if (sessionGuard !== gameSessionRef.current) {
-          return prev;
-        }
-
-        return {
-          ...prev,
-          log: [...prev.log, ...buildStrategyLogEntries(undefined, turnPlan.sequenceDetails)],
-        };
-      });
-    }
-
-    const actionOutcome = await processAiActions({
-      actions: turnPlan.actions,
-      sequenceDetails: turnPlan.sequenceDetails,
-      readLatestState,
-      playCard: params => {
-        const playCardFn = playAICardRef.current;
-        return playCardFn ? playCardFn(params) : readLatestState();
-      },
-      waitBetweenActions: () => new Promise(resolve => setTimeout(resolve, 800 + Math.random() * 400)),
-    });
-
-    if (sessionGuard !== gameSessionRef.current) {
-      return;
-    }
-
-    if (actionOutcome.gameOver) {
-      return;
-    }
-
-    const latestState = await readLatestState();
-    if (latestState.isGameOver) {
-      return;
-    }
-
-    if (sessionGuard !== gameSessionRef.current) {
-      return;
-    }
-
-    if (pendingAiTimeoutRef.current) {
-      clearTimeout(pendingAiTimeoutRef.current);
-    }
-
-    const timeoutSessionGuard = gameSessionRef.current;
-    pendingAiTimeoutRef.current = setTimeout(() => {
-      if (timeoutSessionGuard !== gameSessionRef.current) {
+      if (sessionGuard !== gameSessionRef.current) {
         return;
       }
 
-      pendingAiTimeoutRef.current = null;
+      const prePlanningState = await readLatestState();
+      if (prePlanningState.isGameOver) {
+        return;
+      }
 
-      const stateSnapshot = gameStateRef.current;
-      if (!stateSnapshot || stateSnapshot.isGameOver || stateSnapshot.currentPlayer !== 'ai') {
+      await new Promise(resolve => setTimeout(resolve, Math.random() * 1000 + 500));
+
+      if (sessionGuard !== gameSessionRef.current) {
+        return;
+      }
+
+      const planningState = await readLatestState();
+
+      if (sessionGuard !== gameSessionRef.current) {
+        return;
+      }
+
+      if (!planningState.aiStrategist) {
         setGameState(prev => {
-          if (timeoutSessionGuard !== gameSessionRef.current) {
+          if (sessionGuard !== gameSessionRef.current) {
             return prev;
           }
 
@@ -4069,19 +4002,122 @@ export const useGameState = (aiDifficultyOverride?: AIDifficulty) => {
         return;
       }
 
-      if (timeoutSessionGuard !== gameSessionRef.current) {
+      if (planningState.isGameOver) {
         return;
       }
 
-      endTurnRef.current?.();
-      setGameState(prev => {
+      const turnPlan = chooseTurnActions({
+        strategist: planningState.aiStrategist,
+        gameState: planningState as any,
+        maxActions: 3,
+        priorityThreshold: 0.3,
+      });
+
+      if (turnPlan.actions.length === 0 && turnPlan.sequenceDetails.length) {
+        setGameState(prev => {
+          if (sessionGuard !== gameSessionRef.current) {
+            return prev;
+          }
+
+          return {
+            ...prev,
+            log: [...prev.log, ...buildStrategyLogEntries(undefined, turnPlan.sequenceDetails)],
+          };
+        });
+      }
+
+      const actionOutcome = await processAiActions({
+        actions: turnPlan.actions,
+        sequenceDetails: turnPlan.sequenceDetails,
+        readLatestState,
+        playCard: params => {
+          const playCardFn = playAICardRef.current;
+          return playCardFn ? playCardFn(params) : readLatestState();
+        },
+        waitBetweenActions: () => new Promise(resolve => setTimeout(resolve, 800 + Math.random() * 400)),
+      });
+
+      if (sessionGuard !== gameSessionRef.current) {
+        return;
+      }
+
+      if (actionOutcome.gameOver) {
+        return;
+      }
+
+      const latestState = await readLatestState();
+      if (latestState.isGameOver) {
+        return;
+      }
+
+      if (sessionGuard !== gameSessionRef.current) {
+        return;
+      }
+
+      if (pendingAiTimeoutRef.current) {
+        clearTimeout(pendingAiTimeoutRef.current);
+      }
+
+      const timeoutSessionGuard = gameSessionRef.current;
+      pendingAiTimeoutRef.current = setTimeout(() => {
         if (timeoutSessionGuard !== gameSessionRef.current) {
+          return;
+        }
+
+        pendingAiTimeoutRef.current = null;
+
+        const stateSnapshot = gameStateRef.current;
+        if (!stateSnapshot || stateSnapshot.isGameOver || stateSnapshot.currentPlayer !== 'ai') {
+          setGameState(prev => {
+            if (timeoutSessionGuard !== gameSessionRef.current) {
+              return prev;
+            }
+
+            return prev.isGameOver ? prev : { ...prev, aiTurnInProgress: false };
+          });
+          return;
+        }
+
+        if (timeoutSessionGuard !== gameSessionRef.current) {
+          return;
+        }
+
+        endTurnRef.current?.();
+        setGameState(prev => {
+          if (timeoutSessionGuard !== gameSessionRef.current) {
+            return prev;
+          }
+
+          return prev.isGameOver ? prev : { ...prev, aiTurnInProgress: false };
+        });
+      }, 1000);
+    } catch (error) {
+      encounteredError = true;
+      console.error('Failed to execute AI turn', error);
+    } finally {
+      if (!aiTurnStarted) {
+        return;
+      }
+
+      setGameState(prev => {
+        if (sessionGuard !== gameSessionRef.current) {
           return prev;
         }
 
-        return prev.isGameOver ? prev : { ...prev, aiTurnInProgress: false };
+        if (prev.isGameOver || !prev.aiTurnInProgress) {
+          return prev;
+        }
+
+        return { ...prev, aiTurnInProgress: false };
       });
-    }, 1000);
+
+      if (encounteredError && sessionGuard === gameSessionRef.current) {
+        const stateSnapshot = gameStateRef.current;
+        if (stateSnapshot && !stateSnapshot.isGameOver && stateSnapshot.currentPlayer === 'ai') {
+          endTurnRef.current?.();
+        }
+      }
+    }
   }, []);
 
   const closeNewspaper = useCallback(() => {


### PR DESCRIPTION
## Summary
- wrap AI turn execution in try/catch/finally to reset the in-progress flag and fall back to ending the turn when planning fails
- add a regression test that exercises an AI planning exception and verifies the player regains control
- record the gameplay-facing change in the updates log

## Testing
- npm run lint *(fails: repository has pre-existing lint violations)*
- bun test --coverage --coverage-reporter=text

------
https://chatgpt.com/codex/tasks/task_e_68e2c3f584e48320b93c231a32b8551b