### PR TITLE
Normalize press archive legendary arrays

### DIFF
--- a/UPDATES_LOG.md
+++ b/UPDATES_LOG.md
@@ -2,6 +2,10 @@
 
 This document provides a chronological record of gameplay-impacting changes merged into State Shift Strategy. Each entry should include the merge date and a brief, human-readable summary so future contributors can quickly understand how the game has evolved.
 
+## 2025-10-10 – Harden press archive imports
+- Normalize archived victory reports to ensure legendary deployments always load as arrays and avoid Player Hub crashes when old saves are opened.
+- Guard Player Hub archive and final edition readers against malformed legendary data so future saves remain resilient.
+
 ## 2025-10-09 – Reprioritize front page coverage
 - Teach the newspaper issue generator to spotlight captured states, major truth swings, and rotating highlights on the dispatch archive.
 - Keep hero articles in sync with the front-page package so combo main stories continue to render correctly.

--- a/src/components/game/FinalEditionLayout.tsx
+++ b/src/components/game/FinalEditionLayout.tsx
@@ -609,7 +609,7 @@ const FinalEditionLayout = ({ report }: FinalEditionLayoutProps) => {
       <NewspaperSection tone={tone} className="p-5">
         <h2 className={sectionHeadingClass}>After-Action Notes</h2>
         <div className={cn('mt-3 flex flex-wrap gap-3 text-xs', mutedBodyClass)}>
-          {report.legendaryUsed.length > 0 ? (
+          {Array.isArray(report.legendaryUsed) && report.legendaryUsed.length > 0 ? (
             <Badge variant="outline" className={cn(badgeClass, 'rounded-full px-3 py-0.5 text-[10px] tracking-[0.3em]')}>
               Legendary Deployments: {report.legendaryUsed.join(', ')}
             </Badge>

--- a/src/components/game/PressArchivePanel.tsx
+++ b/src/components/game/PressArchivePanel.tsx
@@ -58,6 +58,7 @@ const PressArchivePanel = ({ issues, onOpen, onDelete, className }: PressArchive
           <div className="space-y-3 pb-4">
             {issues.map(issue => {
               const { report } = issue;
+              const legendaryUsed = Array.isArray(report.legendaryUsed) ? report.legendaryUsed : [];
               const mvpName = report.mvp?.cardName ?? report.runnerUp?.cardName ?? 'Unsung Hero';
               const playerOutcome = getPlayerOutcomeLabel(report);
               const victoryLabel = getVictoryConditionLabel(report.victoryType);
@@ -98,7 +99,7 @@ const PressArchivePanel = ({ issues, onOpen, onDelete, className }: PressArchive
                         </div>
                         <div className="flex items-center gap-2 md:col-span-2">
                           <span className="font-mono text-xs uppercase tracking-[0.28em] text-emerald-200/70">Legendary</span>
-                          <span>{report.legendaryUsed.length > 0 ? report.legendaryUsed.join(', ') : 'None reported'}</span>
+                          <span>{legendaryUsed.length > 0 ? legendaryUsed.join(', ') : 'None reported'}</span>
                         </div>
                       </div>
                       <p className="text-xs font-mono uppercase tracking-[0.28em] text-emerald-200/60">{outcomeSummary}</p>

--- a/src/hooks/usePressArchive.ts
+++ b/src/hooks/usePressArchive.ts
@@ -54,12 +54,21 @@ export const usePressArchive = () => {
       }
       const normalized = parsed
         .filter(entry => entry && entry.report)
-        .map(entry => ({
-          ...entry,
-          id: entry.id ?? `edition-${entry.report.recordedAt}`,
-          title: entry.title ?? deriveTitle(entry.report),
-          savedAt: entry.savedAt ?? entry.report.recordedAt ?? Date.now(),
-        }))
+        .map(entry => {
+          const report = entry.report;
+          const normalizedReport = {
+            ...report,
+            legendaryUsed: Array.isArray(report.legendaryUsed) ? [...report.legendaryUsed] : [],
+          } as GameOverReport;
+
+          return {
+            ...entry,
+            report: normalizedReport,
+            id: entry.id ?? `edition-${normalizedReport.recordedAt}`,
+            title: entry.title ?? deriveTitle(normalizedReport),
+            savedAt: entry.savedAt ?? normalizedReport.recordedAt ?? Date.now(),
+          };
+        })
         .sort((a, b) => (b.savedAt ?? b.report.recordedAt ?? 0) - (a.savedAt ?? a.report.recordedAt ?? 0));
       setIssues(normalized);
     } catch (error) {


### PR DESCRIPTION
## Summary
- normalize archived press issues so `legendaryUsed` always persists as an array copy before saving back to storage
- harden Player Hub and final edition readers to tolerate missing or malformed legendary deployment data
- document the archive hardening in the gameplay updates log

## Testing
- npm run lint *(fails: existing repo lint violations unrelated to this change, e.g. widespread `any` usage and parser errors)*
- bun test --coverage --coverage-reporter=text

------
https://chatgpt.com/codex/tasks/task_e_68e2d4b4673c8320badb3d771fc5ce5f