### PR TITLE
Guard press archive storage against localStorage failures

### DIFF
--- a/UPDATES_LOG.md
+++ b/UPDATES_LOG.md
@@ -2,6 +2,10 @@
 
 This document provides a chronological record of gameplay-impacting changes merged into State Shift Strategy. Each entry should include the merge date and a brief, human-readable summary so future contributors can quickly understand how the game has evolved.
 
+## 2025-10-12 – Harden press archive persistence
+- Switch the press archive hook to the safe storage helpers so localStorage errors no longer crash the hub.
+- Add regression coverage that verifies the archive stays empty when storage access fails.
+
 ## 2025-10-11 – Stabilize AI turn wrap-up
 - Keep the AI turn progress flag active until the scheduled hand-off completes so the planner no longer loops.
 - Add regression coverage to confirm control returns to the player after the wrap-up timeout resolves.

--- a/src/hooks/__tests__/usePressArchive.test.ts
+++ b/src/hooks/__tests__/usePressArchive.test.ts
@@ -1,0 +1,146 @@
+import { afterEach, beforeEach, describe, expect, it, mock } from 'bun:test';
+import React from 'react';
+import TestRenderer, { act } from 'react-test-renderer';
+import type { ReactTestRenderer } from 'react-test-renderer';
+import { Window as HappyWindow } from 'happy-dom';
+
+import { usePressArchive } from '../usePressArchive';
+
+type MutableGlobal = typeof globalThis & {
+  window?: Window & typeof globalThis;
+  document?: Document;
+  navigator?: Navigator;
+  HTMLElement?: typeof HTMLElement;
+  CustomEvent?: typeof CustomEvent;
+  Event?: typeof Event;
+};
+
+type HookResult<T> = {
+  current: T | undefined;
+};
+
+const getMutableGlobal = (): MutableGlobal => globalThis as MutableGlobal;
+
+let originalWindow: (Window & typeof globalThis) | undefined;
+let originalDocument: Document | undefined;
+let originalNavigator: Navigator | undefined;
+let originalHTMLElement: typeof HTMLElement | undefined;
+let originalCustomEvent: typeof CustomEvent | undefined;
+let originalEvent: typeof Event | undefined;
+let originalConsoleWarn: typeof console.warn;
+
+const renderHook = async <T,>(callback: () => T) => {
+  const result: HookResult<T> = { current: undefined };
+
+  const TestComponent = () => {
+    result.current = callback();
+    return null;
+  };
+
+  let renderer: ReactTestRenderer;
+
+  await act(async () => {
+    renderer = TestRenderer.create(React.createElement(TestComponent));
+  });
+
+  return {
+    result: result as { current: T },
+    unmount: () => renderer.unmount(),
+  };
+};
+
+beforeEach(() => {
+  const globalRef = getMutableGlobal();
+  originalWindow = globalRef.window;
+  originalDocument = globalRef.document;
+  originalNavigator = globalRef.navigator;
+  originalHTMLElement = globalRef.HTMLElement;
+  originalCustomEvent = globalRef.CustomEvent;
+  originalEvent = globalRef.Event;
+  originalConsoleWarn = console.warn;
+
+  const happyWindow = new HappyWindow();
+  globalRef.window = happyWindow as unknown as Window & typeof globalThis;
+  globalRef.document = happyWindow.document;
+  globalRef.navigator = happyWindow.navigator;
+  globalRef.HTMLElement = happyWindow.HTMLElement;
+  globalRef.CustomEvent = happyWindow.CustomEvent;
+  globalRef.Event = happyWindow.Event;
+});
+
+afterEach(() => {
+  const globalRef = getMutableGlobal();
+  if (originalWindow) {
+    globalRef.window = originalWindow;
+  } else {
+    delete globalRef.window;
+  }
+
+  if (originalDocument) {
+    globalRef.document = originalDocument;
+  } else {
+    delete globalRef.document;
+  }
+
+  if (originalNavigator) {
+    globalRef.navigator = originalNavigator;
+  } else {
+    delete globalRef.navigator;
+  }
+
+  if (originalHTMLElement) {
+    globalRef.HTMLElement = originalHTMLElement;
+  } else {
+    delete globalRef.HTMLElement;
+  }
+
+  if (originalCustomEvent) {
+    globalRef.CustomEvent = originalCustomEvent;
+  } else {
+    delete globalRef.CustomEvent;
+  }
+
+  if (originalEvent) {
+    globalRef.Event = originalEvent;
+  } else {
+    delete globalRef.Event;
+  }
+
+  console.warn = originalConsoleWarn;
+});
+
+describe('usePressArchive', () => {
+  it('returns an empty archive when localStorage throws', async () => {
+    const warn = mock(() => {});
+    console.warn = warn;
+
+    const failingStorage = {
+      getItem: () => {
+        throw new Error('blocked');
+      },
+      setItem: () => {
+        throw new Error('blocked');
+      },
+      removeItem: () => {
+        throw new Error('blocked');
+      },
+      clear: () => {
+        /* noop */
+      },
+      key: () => null,
+      length: 0,
+    } as unknown as Storage;
+
+    const globalRef = getMutableGlobal();
+    Object.defineProperty(globalRef.window!, 'localStorage', {
+      configurable: true,
+      value: failingStorage,
+    });
+
+    const { result } = await renderHook(() => usePressArchive());
+
+    expect(result.current.issues).toEqual([]);
+    expect(result.current.agendaMoments).toEqual([]);
+    expect(warn.mock.calls.length).toBeGreaterThan(0);
+  });
+});

--- a/src/hooks/usePressArchive.ts
+++ b/src/hooks/usePressArchive.ts
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useState } from 'react';
 import type { GameOverReport } from '@/types/finalEdition';
 import { getFactionDisplayName, getVictoryConditionLabel } from '@/utils/finalEdition';
+import { safeGetLocalStorageItem, safeSetLocalStorageItem } from '@/utils/storage';
 
 export interface ArchivedEdition {
   id: string;
@@ -44,7 +45,7 @@ export const usePressArchive = () => {
 
   useEffect(() => {
     try {
-      const stored = localStorage.getItem(STORAGE_KEY);
+      const stored = safeGetLocalStorageItem(STORAGE_KEY, { logger: console });
       if (!stored) {
         return;
       }
@@ -79,7 +80,10 @@ export const usePressArchive = () => {
   useEffect(() => {
     try {
       const payload = JSON.stringify(issues);
-      localStorage.setItem(STORAGE_KEY, payload);
+      const didPersist = safeSetLocalStorageItem(STORAGE_KEY, payload, { logger: console });
+      if (!didPersist) {
+        console.warn('Failed to persist press archive');
+      }
     } catch (error) {
       console.warn('Failed to persist press archive', error);
     }


### PR DESCRIPTION
## Summary
- switch the press archive hook to the shared safe localStorage helpers so read/write failures are handled gracefully
- add a focused regression test that exercises the hook when localStorage throws and ensures an empty archive is returned
- document the resilience fix in the updates log

## Testing
- `npm run lint` *(fails: repository currently has numerous pre-existing lint errors unrelated to this change)*
- `bun test --coverage --coverage-reporter=text`


------
https://chatgpt.com/codex/tasks/task_e_68e2e0d867908320a0dc781be4d82213