### PR TITLE
Gracefully handle unloaded news pools

### DIFF
--- a/UPDATES_LOG.md
+++ b/UPDATES_LOG.md
@@ -2,6 +2,10 @@
 
 This document provides a chronological record of gameplay-impacting changes merged into State Shift Strategy. Each entry should include the merge date and a brief, human-readable summary so future contributors can quickly understand how the game has evolved.
 
+## 2025-10-13 – Stabilize AI triple-play headlines
+- Allow the Extra! Extra! generator and final edition builder to emit deterministic `[WIRE DELAY]` placeholders when news pools are still loading.
+- Kick off news pool loading from the game state hook and add regression coverage so three-card turns no longer crash while assets hydrate.
+
 ## 2025-10-12 – Harden press archive persistence
 - Switch the press archive hook to the safe storage helpers so localStorage errors no longer crash the hub.
 - Add regression coverage that verifies the archive stays empty when storage access fails.

--- a/__tests__/integration/extraExtra.test.ts
+++ b/__tests__/integration/extraExtra.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, mock } from 'bun:test';
+import { beforeEach, describe, expect, it, mock } from 'bun:test';
 import type { Card, GameState } from '../../src/mvp/validator';
 import type { TurnLog } from '../../src/news/headlineEngine';
 
@@ -19,8 +19,12 @@ const stubPools = {
   weather: ['Calm Skies'],
 } as const;
 
+const getPoolsMock = mock.fn(() => stubPools);
+const getPoolsIfReadyMock = mock.fn(() => stubPools);
+
 mock.module('@/news/newsPools', () => ({
-  getPools: () => stubPools,
+  getPools: getPoolsMock,
+  getPoolsIfReady: getPoolsIfReadyMock,
 }));
 
 mock.module('@/engine/applyEffects-mvp', () => ({
@@ -36,6 +40,13 @@ mock.module('@/game/comboEngine', () => ({
 
 const loadMvpEngine = () => import('../../src/mvp/engine');
 const loadHeadlineEngine = () => import('../../src/news/headlineEngine');
+
+beforeEach(() => {
+  getPoolsMock.mockReset();
+  getPoolsIfReadyMock.mockReset();
+  getPoolsMock.mockImplementation(() => stubPools);
+  getPoolsIfReadyMock.mockImplementation(() => stubPools);
+});
 
 const createCard = (id: string): Card => ({
   id,
@@ -111,5 +122,81 @@ describe('extra extra integration', () => {
     expect(endedState.headlineLog).toEqual([
       'Turn 1 recap: Truth plays 3, Government plays 0',
     ]);
+  });
+
+  it('falls back to a placeholder headline when pools are unavailable', async () => {
+    const warnMock = mock.method(console, 'warn');
+    getPoolsIfReadyMock.mockImplementation(() => null);
+    getPoolsMock.mockImplementation(() => {
+      throw new Error('getPools should not be called when pools are unavailable');
+    });
+
+    try {
+      const { playCard, endTurn } = await loadMvpEngine();
+      const { summarize, generateExtraExtra } = await loadHeadlineEngine();
+
+      const cards = [createCard('delta'), createCard('echo'), createCard('foxtrot')];
+
+      let state: GameState = {
+        turn: 1,
+        currentPlayer: 'P1',
+        truth: 50,
+        players: {
+          P1: {
+            id: 'P1',
+            faction: 'truth',
+            deck: [],
+            hand: [...cards],
+            discard: [],
+            ip: 0,
+            states: [],
+          },
+          P2: {
+            id: 'P2',
+            faction: 'government',
+            deck: [],
+            hand: [],
+            discard: [],
+            ip: 0,
+            states: [],
+          },
+        },
+        pressureByState: {},
+        stateDefense: {},
+        playsThisTurn: 0,
+        turnPlays: [],
+        log: [],
+        headlineLog: [],
+        extraExtraFeed: [],
+        turnBuffer: [],
+        winner: null,
+        victoryType: null,
+        finalEdition: null,
+        tabloidRelicsRuntime: null,
+      };
+
+      for (const card of cards) {
+        state = playCard(state, card.id);
+      }
+
+      const pendingLog: TurnLog = {
+        round: state.turn,
+        turn: state.turn,
+        plays: state.turnBuffer,
+      };
+      const totals = summarize([pendingLog]);
+      const expectedArticle = generateExtraExtra('mvp:P1:1', [pendingLog], totals);
+
+      const { state: endedState } = endTurn(state, []);
+
+      expect(endedState.extraExtraFeed).toEqual([expectedArticle]);
+      expect(endedState.extraExtraFeed[0]?.hed).toContain('[WIRE DELAY]');
+      expect(endedState.headlineLog).toEqual([
+        'Turn 1 recap: Truth plays 3, Government plays 0',
+      ]);
+      expect(warnMock.mock.calls.length).toBeGreaterThan(0);
+    } finally {
+      warnMock.mockRestore();
+    }
   });
 });

--- a/__tests__/news/headlineEngine.test.ts
+++ b/__tests__/news/headlineEngine.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, mock } from 'bun:test';
+import { beforeEach, describe, expect, it, mock } from 'bun:test';
 import type { TurnLog, TurnTotals } from '../../src/news/headlineEngine';
 
 const stubPools = {
@@ -18,11 +18,22 @@ const stubPools = {
   weather: ['Calm Skies'],
 } as const;
 
+const getPoolsMock = mock.fn(() => stubPools);
+const getPoolsIfReadyMock = mock.fn(() => stubPools);
+
 mock.module('@/news/newsPools', () => ({
-  getPools: () => stubPools,
+  getPools: getPoolsMock,
+  getPoolsIfReady: getPoolsIfReadyMock,
 }));
 
 const loadEngine = () => import('../../src/news/headlineEngine');
+
+beforeEach(() => {
+  getPoolsMock.mockReset();
+  getPoolsIfReadyMock.mockReset();
+  getPoolsMock.mockImplementation(() => stubPools);
+  getPoolsIfReadyMock.mockImplementation(() => stubPools);
+});
 
 describe('headlineEngine utilities', () => {
   it('summarize aggregates faction totals and ignores invalid values', async () => {
@@ -237,5 +248,43 @@ describe('headlineEngine utilities', () => {
       source: 'Source',
     });
     expect(first.bullets.length).toBeGreaterThan(0);
+  });
+
+  it('generateExtraExtra returns a placeholder article when pools are unavailable', async () => {
+    const warnMock = mock.method(console, 'warn');
+
+    getPoolsIfReadyMock.mockImplementation(() => null);
+    getPoolsMock.mockImplementation(() => {
+      throw new Error('getPools should not be invoked when pools are unavailable');
+    });
+
+    try {
+      const { generateExtraExtra, summarize } = await loadEngine();
+      const turns: TurnLog[] = [
+        {
+          round: 1,
+          turn: 1,
+          plays: [
+            { id: 'a', name: 'Truth Play', type: 'MEDIA', faction: 'truth', truth: 2 },
+            { id: 'b', name: 'Gov Play', type: 'ATTACK', faction: 'government', damage: 1 },
+            { id: 'c', name: 'Truth Followup', type: 'ZONE', faction: 'truth', captures: 1 },
+          ],
+        },
+      ];
+
+      const totals = summarize(turns);
+      const article = generateExtraExtra('seed:fallback', turns, totals);
+
+      expect(article.tone).toBe('truth');
+      expect(article.hed).toContain('[WIRE DELAY]');
+      expect(article.dek).toMatch(/Archive uplink pending|Wire desk files a placeholder/);
+      expect(article.byline).toMatch(/Standby Desk|Emergency Editor/);
+      expect(article.source).toMatch(/Archive sync pending|Classified spool offline/);
+      expect(article.bullets.length).toBeGreaterThan(0);
+      expect(warnMock).toHaveBeenCalled();
+      expect(String(warnMock.mock.calls[0]?.[0])).toContain('generateExtraExtra');
+    } finally {
+      warnMock.mockRestore();
+    }
   });
 });

--- a/docs/TECHNICAL_README.md
+++ b/docs/TECHNICAL_README.md
@@ -126,6 +126,11 @@ Front-page assembly exposes extra telemetry during local development. Set `VITE_
 `npm run dev` to enable console logs from the Tabloid newspaper render. The flag is ignored in production builds and defaults to
 disabled, preventing debug chatter in shipped bundles. The console output summarizes the selected template, shared tags across the
 compiled articles, and the verb pools chosen for each card, matching the `GeneratedStory.debug` payload.
+
+### News pool loading
+
+- `useGameState` now primes `loadNewsPools()` as soon as the hook mounts so the reducer has the cached mastheads, verbs, and ads ready before the first AI turn resolves.
+- `generateExtraExtra` and `buildFinalEdition` tolerate an empty cache by pulling from deterministic `[WIRE DELAY]` placeholder copy until `getPoolsIfReady()` returns real data. Both helpers emit a console warning whenever the fallback path runs so QA can spot asset fetch regressions quickly.
 | *(Attempted)* `state-capture` | Synergy activations attempt to play this hyphenated key (note: the manifest only exposes `stateCapture`). |
 | QA / settings hooks | In-game options expose a test button for the click SFX, and developer QA controls can audition any registered key. |
 | Manifest reference | Complete list of bundled SFX keys and file mappings lives in the manifest. |

--- a/src/hooks/useGameState.ts
+++ b/src/hooks/useGameState.ts
@@ -85,6 +85,7 @@ import { assignStateBonuses } from '@/game/stateBonuses';
 import { applyStateBonusAssignmentToState } from './stateBonusAssignment';
 import { clearNewsBuffer, getNewsTriplet, pushToNewsBuffer } from '@/state/game/roundNewsBuffer';
 import { summarize, generateExtraExtra } from '@/news/headlineEngine';
+import { loadNewsPools } from '@/news/newsPools';
 import type { ArticleBlock, TurnLog } from '@/news/headlineEngine';
 import type { GameOverReport } from '@/types/finalEdition';
 
@@ -2014,6 +2015,21 @@ export const useGameState = (aiDifficultyOverride?: AIDifficulty) => {
   const achievements = useAchievements();
   const [hotspotDirector] = useState(() => new HotspotDirector());
   const { triggerStateEvent, resetStateEvents } = useStateEvents();
+
+  useEffect(() => {
+    let isActive = true;
+
+    loadNewsPools().catch(error => {
+      if (!isActive) {
+        return;
+      }
+      console.warn('Failed to preload news pools before turn resolution', error);
+    });
+
+    return () => {
+      isActive = false;
+    };
+  }, []);
 
   const triggerCapturedStateEvents = useCallback(
     (resolution: CardPlayResolution | undefined, nextState: GameState): GameEvent[] => {

--- a/src/news/headlineEngine.ts
+++ b/src/news/headlineEngine.ts
@@ -1,4 +1,35 @@
-import { getPools } from '@/news/newsPools';
+import { getPools, getPoolsIfReady } from '@/news/newsPools';
+
+const FALLBACK_DEK_POOL = [
+  'Archive uplink pending. Full briefing to follow shortly.',
+  'Wire desk files a placeholder while the reels warm up.',
+];
+
+const FALLBACK_BYLINES = [
+  'By: Standby Desk',
+  'By: Emergency Editor',
+];
+
+const FALLBACK_SOURCES = [
+  'Source: Archive sync pending.',
+  'Source: Classified spool offline.',
+];
+
+const FALLBACK_MASTHEADS = [
+  'Paranoid Press — Wire Delay Edition',
+  'The Interim Ledger',
+];
+
+const FALLBACK_WEATHER = [
+  'Weather withheld pending clearance.',
+  'Forecast delayed until archives respond.',
+];
+
+const FALLBACK_ADS = [
+  'Placeholder classified: Archives reconnecting shortly.',
+  'Advertisement suspended pending copy approval.',
+  'Wire notice: Refresh for full classifieds.',
+];
 
 export type CardType = 'ATTACK' | 'MEDIA' | 'ZONE';
 
@@ -179,6 +210,43 @@ const ensureBulletFallback = (bullets: string[], tone: ArticleBlock['tone']): st
 const formatNumber = (value: number): string => {
   const rounded = Math.round(value * 10) / 10;
   return Number.isInteger(rounded) ? String(rounded) : rounded.toFixed(1);
+};
+
+const buildFallbackHed = (tone: ArticleBlock['tone'], totals: TurnTotals): string => {
+  const truthTotals = totals.truth;
+  const govTotals = totals.government;
+  const combined: FactionTotals = {
+    plays: truthTotals.plays + govTotals.plays,
+    attack: truthTotals.attack + govTotals.attack,
+    media: truthTotals.media + govTotals.media,
+    zone: truthTotals.zone + govTotals.zone,
+    truth: truthTotals.truth + govTotals.truth,
+    ip: truthTotals.ip + govTotals.ip,
+    captures: truthTotals.captures + govTotals.captures,
+    damage: truthTotals.damage + govTotals.damage,
+  };
+
+  const focus = tone === 'truth' ? truthTotals : tone === 'government' ? govTotals : combined;
+  const subject = tone === 'truth' ? 'TRUTH WIRE' : tone === 'government' ? 'GOVERNMENT BULLETIN' : 'TABLOID DESK';
+
+  const highlight = (() => {
+    if (focus.captures > 0) {
+      const label = focus.captures === 1 ? 'capture' : 'captures';
+      return `${formatNumber(focus.captures)} ${label}`.toUpperCase();
+    }
+    if (focus.truth > 0) {
+      return `TRUTH +${formatNumber(focus.truth)}%`;
+    }
+    if (focus.ip > 0) {
+      return `IP +${formatNumber(focus.ip)}`;
+    }
+    if (focus.plays > 0) {
+      return `${formatNumber(focus.plays)} PLAYS LOGGED`;
+    }
+    return 'NO MAJOR SHIFTS';
+  })();
+
+  return `[WIRE DELAY] ${subject} NOTES ${highlight}`;
 };
 
 export const summarize = (turns: TurnLog[]): TurnTotals => {
@@ -399,7 +467,25 @@ export const generateExtraExtra = (
   const totals = totalsArg ?? summarize(turns);
   const tone = dominantFromTotals(totals);
   const rng = mulberry32(hashSeed(`extra:${seed}`));
-  const pools = getPools();
+  const pools = getPoolsIfReady();
+
+  if (!pools) {
+    console.warn('generateExtraExtra: news pools not ready, using placeholder article.');
+    const hed = buildFallbackHed(tone, totals);
+    const dek = pick(FALLBACK_DEK_POOL, rng, FALLBACK_DEK_POOL[0]);
+    const byline = pick(FALLBACK_BYLINES, rng, FALLBACK_BYLINES[0]);
+    const source = pick(FALLBACK_SOURCES, rng, FALLBACK_SOURCES[0]);
+    const bullets = buildBullets(turns, totals, tone, rng);
+
+    return {
+      tone,
+      hed,
+      dek,
+      bullets,
+      byline,
+      source,
+    };
+  }
   const dominantType = getDominantType(totals, tone);
   const typeKey = dominantType === 'ATTACK' ? 'attack' : dominantType === 'MEDIA' ? 'media' : 'zone';
   const subheadPool = [...pools.subheads.generic];
@@ -426,7 +512,26 @@ export const buildFinalEdition = (seed: string, turns: TurnLog[]): FinalEdition 
   const totals = summarize(turns);
   const dominantFaction = dominantFromTotals(totals);
   const rng = mulberry32(hashSeed(`edition:${seed}`));
-  const pools = getPools();
+  const pools = getPoolsIfReady();
+
+  if (!pools) {
+    console.warn('buildFinalEdition: news pools not ready, using placeholder edition.');
+    const masthead = pick(FALLBACK_MASTHEADS, rng, FALLBACK_MASTHEADS[0]);
+    const weather = pick(FALLBACK_WEATHER, rng, FALLBACK_WEATHER[0]);
+    const ads = pickMany(FALLBACK_ADS, Math.min(3, FALLBACK_ADS.length), rng);
+    const article = generateExtraExtra(seed, turns, totals);
+
+    return {
+      seed,
+      masthead,
+      weather,
+      ads,
+      totals,
+      dominantFaction,
+      article,
+    };
+  }
+
   const masthead = pick(pools.mastheads, rng, 'Paranoid Press');
   const weather = pick(pools.weather, rng, 'Forecast withheld pending clearance.');
   const ads = pickMany(pools.ads, 3, rng);

--- a/src/news/newsPools.ts
+++ b/src/news/newsPools.ts
@@ -130,3 +130,7 @@ export const getPools = (): NewsPools => {
   }
   return cachedPools;
 };
+
+export const getPoolsIfReady = (): NewsPools | null => cachedPools ?? null;
+
+export const areNewsPoolsReady = (): boolean => cachedPools != null;


### PR DESCRIPTION
## Summary
- add deterministic placeholder headlines/editions when the news pools have not hydrated yet
- preload the news pools during game bootstrap and expose a safe getter for consumers
- expand headline integration/unit tests plus documentation and update log for the new lazy-loading flow

## Testing
- npm run lint *(fails: repository has existing lint errors about `any` usage and parser limits)*
- bun test --coverage --coverage-reporter=text *(fails: existing AI planner regression tests fail on current branch)*

------
https://chatgpt.com/codex/tasks/task_e_68e35dd1418c8320a153546bd33cfe44