### PR TITLE
Refactor weighted distribution to use injected expansion data

### DIFF
--- a/src/data/expansions/state.ts
+++ b/src/data/expansions/state.ts
@@ -43,6 +43,10 @@ const getManifestIdSet = () => new Set(EXPANSION_MANIFEST.map(pack => pack.id));
 const notify = () => {
   const snapshotCards = getExpansionCardsSnapshot();
   const snapshotIds = getEnabledExpansionIdsSnapshot();
+  weightedDistribution.setExpansionContext({
+    enabledExpansionIds: snapshotIds,
+    expansionCards: snapshotCards,
+  });
   for (const listener of listeners) {
     try {
       listener({ ids: snapshotIds, cards: snapshotCards });
@@ -187,9 +191,15 @@ export const initializeExpansions = async (): Promise<void> => {
   );
 
   rebuildEnabledMap();
-  const storedDistribution = loadDistributionSettingsFromStorage();
+  const enabledSnapshot = getEnabledExpansionIdsSnapshot();
+  const storedDistribution = loadDistributionSettingsFromStorage(enabledSnapshot);
   const distributionSettings =
-    storedDistribution ?? sanitizeDistributionSettings(DEFAULT_DISTRIBUTION_SETTINGS);
-  weightedDistribution.updateSettings(distributionSettings);
+    storedDistribution ??
+    sanitizeDistributionSettings(DEFAULT_DISTRIBUTION_SETTINGS, enabledSnapshot);
+  weightedDistribution.setExpansionContext({
+    enabledExpansionIds: enabledSnapshot,
+    expansionCards: getExpansionCardsSnapshot(),
+  });
+  weightedDistribution.updateSettings(distributionSettings, enabledSnapshot);
   await ensureCardsLoaded();
 };

--- a/src/data/weightedCardDistribution.ts
+++ b/src/data/weightedCardDistribution.ts
@@ -1,10 +1,6 @@
 import type { GameCard } from '@/rules/mvp';
 import { ensureMvpCosts, getCoreCards, isMvpCard } from './cardDatabase';
 import { EXPANSION_MANIFEST } from './expansions';
-import {
-  getEnabledExpansionIdsSnapshot,
-  getExpansionCardsSnapshot,
-} from './expansions/state';
 
 export const DISTRIBUTION_STORAGE_KEY = 'shadowgov-distribution-settings';
 
@@ -184,11 +180,22 @@ export const DEFAULT_DISTRIBUTION_SETTINGS: DistributionSettings = {
   earlySeedCount: 4
 };
 
+export interface DistributionExpansionContext {
+  enabledExpansionIds: string[];
+  expansionCards: GameCard[];
+}
+
+const DEFAULT_EXPANSION_CONTEXT: DistributionExpansionContext = {
+  enabledExpansionIds: [],
+  expansionCards: [],
+};
+
 export const sanitizeDistributionSettings = (
-  incoming?: Partial<DistributionSettings>,
+  incoming: Partial<DistributionSettings> | undefined,
+  enabledExpansionIds: string[] = DEFAULT_EXPANSION_CONTEXT.enabledExpansionIds,
 ): DistributionSettings => {
   const base = incoming ?? {};
-  const enabledExpansions = getEnabledExpansionIdsSnapshot();
+  const enabledExpansions = enabledExpansionIds;
   const hasEnabledExpansions = enabledExpansions.length > 0;
 
   const requestedMode = base.mode ?? DEFAULT_DISTRIBUTION_SETTINGS.mode;
@@ -234,7 +241,9 @@ export const sanitizeDistributionSettings = (
   };
 };
 
-export const loadDistributionSettingsFromStorage = (): DistributionSettings | null => {
+export const loadDistributionSettingsFromStorage = (
+  enabledExpansionIds: string[] = DEFAULT_EXPANSION_CONTEXT.enabledExpansionIds,
+): DistributionSettings | null => {
   const storage = getStorage();
   if (!storage) {
     return null;
@@ -247,7 +256,7 @@ export const loadDistributionSettingsFromStorage = (): DistributionSettings | nu
     }
 
     const parsed = JSON.parse(saved) as DistributionSettings;
-    return sanitizeDistributionSettings(parsed);
+    return sanitizeDistributionSettings(parsed, enabledExpansionIds);
   } catch (error) {
     console.error('Failed to load distribution settings:', error);
     return null;
@@ -256,8 +265,9 @@ export const loadDistributionSettingsFromStorage = (): DistributionSettings | nu
 
 export const persistDistributionSettings = (
   settings: DistributionSettings,
+  enabledExpansionIds: string[] = DEFAULT_EXPANSION_CONTEXT.enabledExpansionIds,
 ): DistributionSettings => {
-  const sanitized = sanitizeDistributionSettings(settings);
+  const sanitized = sanitizeDistributionSettings(settings, enabledExpansionIds);
   const storage = getStorage();
   if (!storage) {
     return sanitized;
@@ -282,7 +292,17 @@ interface CardSet {
 
 class WeightedCardDistribution {
   private settings: DistributionSettings = { ...DEFAULT_DISTRIBUTION_SETTINGS };
-  
+  private expansionContext: DistributionExpansionContext = {
+    ...DEFAULT_EXPANSION_CONTEXT,
+  };
+
+  setExpansionContext(context: DistributionExpansionContext): void {
+    this.expansionContext = {
+      enabledExpansionIds: [...context.enabledExpansionIds],
+      expansionCards: context.expansionCards.map(card => ({ ...card })),
+    };
+  }
+
   // Get available card sets (core only in MVP)
   private getAvailableCardSets(): CardSet[] {
     const sets: CardSet[] = [
@@ -294,7 +314,7 @@ class WeightedCardDistribution {
       },
     ];
 
-    const expansionCards = getExpansionCardsSnapshot();
+    const expansionCards = this.expansionContext.expansionCards;
     if (expansionCards.length === 0) {
       return sets;
     }
@@ -309,7 +329,7 @@ class WeightedCardDistribution {
       cardsByExpansion.get(extId)!.push(card);
     }
 
-    const enabledIds = getEnabledExpansionIdsSnapshot();
+    const enabledIds = this.expansionContext.enabledExpansionIds;
 
     for (const expansionId of enabledIds) {
       const cards = cardsByExpansion.get(expansionId);
@@ -613,8 +633,15 @@ class WeightedCardDistribution {
   }
 
   // Configuration methods
-  updateSettings(newSettings: Partial<DistributionSettings>): void {
-    this.settings = sanitizeDistributionSettings({ ...this.settings, ...newSettings });
+  updateSettings(
+    newSettings: Partial<DistributionSettings>,
+    enabledExpansionIds?: string[],
+  ): void {
+    const ids = enabledExpansionIds ?? this.expansionContext.enabledExpansionIds;
+    this.settings = sanitizeDistributionSettings(
+      { ...this.settings, ...newSettings },
+      ids,
+    );
   }
 
   getSettings(): DistributionSettings {

--- a/src/hooks/useDistributionSettings.ts
+++ b/src/hooks/useDistributionSettings.ts
@@ -11,21 +11,27 @@ import {
 import { getEnabledExpansionIdsSnapshot } from '@/data/expansions/state';
 
 export const useDistributionSettings = () => {
+  const getEnabledExpansions = () => getEnabledExpansionIdsSnapshot();
+  const initialEnabled = getEnabledExpansions();
   const [settings, setSettings] = useState<DistributionSettings>(
-    sanitizeDistributionSettings(DEFAULT_DISTRIBUTION_SETTINGS),
+    sanitizeDistributionSettings(DEFAULT_DISTRIBUTION_SETTINGS, initialEnabled),
   );
   const [isLoading, setIsLoading] = useState(true);
 
   useEffect(() => {
     const loadSettings = () => {
       try {
-        const saved = loadDistributionSettingsFromStorage();
+        const enabledIds = getEnabledExpansions();
+        const saved = loadDistributionSettingsFromStorage(enabledIds);
         if (saved) {
           setSettings(saved);
-          weightedDistribution.updateSettings(saved);
+          weightedDistribution.updateSettings(saved, enabledIds);
         } else {
-          const defaults = sanitizeDistributionSettings(DEFAULT_DISTRIBUTION_SETTINGS);
-          weightedDistribution.updateSettings(defaults);
+          const defaults = sanitizeDistributionSettings(
+            DEFAULT_DISTRIBUTION_SETTINGS,
+            enabledIds,
+          );
+          weightedDistribution.updateSettings(defaults, enabledIds);
         }
       } finally {
         setIsLoading(false);
@@ -37,20 +43,23 @@ export const useDistributionSettings = () => {
 
   useEffect(() => {
     if (!isLoading) {
-      const sanitized = persistDistributionSettings(settings);
-      weightedDistribution.updateSettings(sanitized);
+      const enabledIds = getEnabledExpansions();
+      const sanitized = persistDistributionSettings(settings, enabledIds);
+      weightedDistribution.updateSettings(sanitized, enabledIds);
     }
   }, [settings, isLoading]);
 
   const setMode = (targetMode: DistributionMode) => {
-    const enabledExpansions = getEnabledExpansionIdsSnapshot();
+    const enabledExpansions = getEnabledExpansions();
     const resolvedMode = enabledExpansions.length > 0 ? targetMode : 'core-only';
 
-    setSettings(prev => sanitizeDistributionSettings({ ...prev, mode: resolvedMode }));
+    setSettings(prev =>
+      sanitizeDistributionSettings({ ...prev, mode: resolvedMode }, enabledExpansions),
+    );
   };
 
   const setSetWeight = (setId: string, weight: number) => {
-    const enabledExpansions = getEnabledExpansionIdsSnapshot();
+    const enabledExpansions = getEnabledExpansions();
     if (setId !== 'core' && !enabledExpansions.includes(setId)) {
       return;
     }
@@ -62,7 +71,7 @@ export const useDistributionSettings = () => {
           ...prev.setWeights,
           [setId]: weight,
         },
-      }),
+      }, enabledExpansions),
     );
   };
 
@@ -101,7 +110,11 @@ export const useDistributionSettings = () => {
   };
 
   const resetToDefaults = () => {
-    const defaults = sanitizeDistributionSettings(DEFAULT_DISTRIBUTION_SETTINGS);
+    const enabledExpansions = getEnabledExpansions();
+    const defaults = sanitizeDistributionSettings(
+      DEFAULT_DISTRIBUTION_SETTINGS,
+      enabledExpansions,
+    );
     setSettings(defaults);
   };
 


### PR DESCRIPTION
## Summary
- inject the enabled expansion context into weighted distribution helpers instead of reading expansion state singletons
- forward expansion snapshots from the expansion initialization flow and distribution settings hook to keep weights in sync
- update the weighted distribution singleton to accept externally supplied expansion cards and ids

## Testing
- npm run lint *(fails: repository currently has existing lint violations unrelated to this change)*
- bun test --coverage --coverage-reporter=text *(fails: existing test failures and environment limitations around localStorage)*

------
https://chatgpt.com/codex/tasks/task_e_68e369c5c6488320905523cca2dd1727