### PR TITLE
Deliver lore onboarding docs and tone tooling

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,6 +2,29 @@
 
 This guidance applies to the entire repository. If any directory later introduces its own `AGENTS.md`, those nested instructions take precedence for their scope. At present, no subdirectories provide additional rules.
 
+## Storytone, humor, and world-lore integration
+- The project leans on the "Paranoid Times" alternate-history vibe. When you create narrative assets (copy, quests, cards, etc.), weave in conspiratorial whimsy rather than slapstick. Think "shadowy cabal memos" and "smirking time-travel dossiers."
+- Pepper in sly humor, but keep it diegetic—jokes should feel like they belong to the universe's paranoid insiders.
+- Reference the living world lore document (`'Humor Template  – Paranoid Times.md'`) before writing new flavor text so tone stays consistent.
+- When inventing new factions, artifacts, or historical twists, leave breadcrumbs for future expansions (e.g., mention rumors, redacted files).
+
+## Copy and template usage
+- Reuse established narrative/copy templates stored in `/docs` and the repository root before drafting new structures. Only diverge when the story demands it, and document why in commit messages or PR notes.
+- Keep new templates in `/docs/templates`. If you need a fresh template, include a README snippet describing when to use it.
+- Maintain a catalog entry in `components.json` whenever a new UI element is introduced so designers can track available building blocks.
+
+## Content quality checklist
+- Card or quest content should answer: "What paranoia lever does this pull?" Capture that in a one-line intent note inside the file or PR.
+- Cross-check against `paranoid_times_card_articles_ALL.json` to avoid duplicating core plot points.
+- Verify entries reference at least one piece of in-universe technology, rumor, or organization to keep the lore web dense.
+
+## Suggested backlog tasks
+1. Draft a "World Lore Quickstart" page summarizing the top five conspiracies every new writer must know.
+2. Build a reusable card narrative template that highlights "Setup → Twist → Redacted Footnote."
+3. Add automated lint rules that flag non-diegetic humor keywords (e.g., "banana peel") to maintain tone.
+4. Create a style guide for naming temporal anomalies, including examples and banned clichés.
+5. Prototype a script that cross-links lore references between cards and design docs for easier continuity checks.
+
 ## Technology stack
 - Vite-powered React application written in TypeScript with Tailwind CSS and shadcn/ui components.
 - State management and data fetching rely on React Query and standard React patterns.

--- a/UPDATES_LOG.md
+++ b/UPDATES_LOG.md
@@ -2,6 +2,10 @@
 
 This document provides a chronological record of gameplay-impacting changes merged into State Shift Strategy. Each entry should include the merge date and a brief, human-readable summary so future contributors can quickly understand how the game has evolved.
 
+## 2025-10-15 – Align lore ops with conspiratorial canon
+- Publish a Paranoid Times world lore quickstart, card template, and anomaly naming guide to harmonize future writing sprints.
+- Enforce tone-safe lint rules and introduce a lore cross-linking prototype so non-diegetic jokes and continuity gaps surface fast.
+
 ## 2025-10-14 – Restore paranormal sighting flavor pools
 - Reintroduce missing tagline templates for synergy, broadcast, cryptid, and hotspot events so sightings no longer crash.
 - Wire templates into the index page with a resilient filler to keep paranormal notifications descriptive.

--- a/docs/templates/README.md
+++ b/docs/templates/README.md
@@ -1,0 +1,10 @@
+# Template Catalog
+
+This directory houses narrative scaffolds approved for Paranoid Times content. Each entry includes a quick brief on when to deploy it so story teams stay aligned.
+
+## Available Templates
+
+### `card-setup-twist-footnote-template.md`
+- **Use when:** Drafting card copy that must arc from premise to paradox within a single page.
+- **Highlights:** Guides writers through `Setup → Twist → Redacted Footnote`, keeps paranoia intent explicit, and embeds continuity hooks for future cross-links.
+- **Related lore anchors:** Bureau of Recursive Revisions memos, Hollow Signal chants, MERCURY-LILAC residue, and Archivist auction ledgers.

--- a/docs/templates/card-setup-twist-footnote-template.md
+++ b/docs/templates/card-setup-twist-footnote-template.md
@@ -1,0 +1,23 @@
+# Card Narrative Template – Setup → Twist → Redacted Footnote
+
+> **When to use:** Apply this template when drafting new Paranoid Times card copy that must escalate quickly from premise to paradox while leaving a trail of in-universe breadcrumbs. Ideal for Truth deck articles, agenda reveals, and anomaly encounter briefs.
+
+## Setup
+- **Intent pulse:** _(What paranoia lever are you pulling?)_
+- **Inciting detail:** _(Give the reader one diegetic clue: a dossier stamp, a code phrase from the Choir, or a MERCURY-LILAC launch residue.)_
+- **Immediate stakes:** _(Why does the conspiracy care right now? Mention factions, timers, or collectors bidding on absence.)_
+
+## Twist
+- **Contradictory evidence:** _(What makes the setup buckle? Lean on time-synced ledgers, recycled déjà vu, or rogue archivists.)_
+- **Escalation beat:** _(Show the fallout: crossfaded radio chants, clockwork negotiators, or violet contrails tracing backwards.)_
+- **Player-facing prompt:** _(Offer a choice, a rumor to chase, or a consequence to pre-empt.)_
+
+## Redacted Footnote
+- **Classification tag:** `[[REDACTED CLASS-{alpha|beta|gamma}]]`
+- **Suppressed intel:** _(Two sentences or less. Hint at a deeper file, cite a pneumatic memo, or attach a negative-space invoice number.)_
+- **Continuity hook:** _(Name another document, card, or anomaly guide entry that this footnote cross-references.)_
+
+### Usage Notes
+- Mirror language from the **World Lore Quickstart** conspiracies to reinforce tonal cohesion.
+- Keep humor diegetic: let the joke be that the Archivists auctioned off sarcasm licenses rather than referencing slapstick props.
+- Save a copy of each filled template in your feature branch `docs/templates/filled/` folder for future audits.

--- a/docs/temporal-anomaly-naming-style-guide.md
+++ b/docs/temporal-anomaly-naming-style-guide.md
@@ -1,0 +1,33 @@
+# Temporal Anomaly Naming Style Guide
+
+Keep anomaly labels punchy, ominous, and rooted in Paranoid Times vernacular. Every name should hint at cause, effect, and bureaucratic fallout in ten syllables or less.
+
+## Core Principles
+1. **Blend timestamp with mood.** Pair precise chronology with unsettling descriptors (e.g., "07:13 Reverberation Ledger").
+2. **Honor in-universe departments.** Cite who discovered or sanctioned the anomaly: Bureau of Recursive Revisions, Clockwork Mutual Aid Society actuaries, etc.
+3. **Signal containment status.** Append suffixes like `Hold`, `Loop`, or `Quarantine` to telegraph whether the timeline is stable, repeating, or leaking.
+4. **Encode hints, not spoilers.** Use ciphers, docket numbers, or Hollow Signal call signs that reward obsessive readers without breaking diegesis.
+5. **Leave breadcrumbs for expansion.** Reference cross-files or negative-space invoices that future writers can escalate.
+
+## Approved Patterns
+- `HH:MM {Adjective} {Noun} {Status}` → `19:42 Liminal Dock Quarantine`
+- `{Agency Acronym}-{Artifact}-{Effect}` → `BRR-Ledger-Backflow`
+- `Seasonal Codename + Contrail` → `Equinox Violet Contrail`
+- `Choir Call Sign + Phenomenon` → `Signal Kilo-13 Afterimage`
+
+## Examples
+- **Clockwork Mutual Aid Society:** `CMS-Pension-Slipstream Hold`
+- **Hollow Signal:** `Signal Delta-77 Feedback Loop`
+- **Project MERCURY-LILAC:** `MERC-LILAC Violet Drift Quarantine`
+- **Archivists of Negative Space:** `ANS-Blank Invoice Echo`
+
+## Banned Clichés
+- Slapstick phrases ("banana split", "whoopee cushion")
+- Generic sci-fi filler ("Temporal Thingy", "Space-Time Wobble")
+- Pop culture wink-outs ("Multiverse 2: Electric Boogaloo")
+- Time puns that break tension ("Clock-a-doodle-doo", "Back to the Future Lite")
+
+## Continuity Hooks
+- Log anomaly IDs in the card brief and cross-reference with `docs/world-lore-quickstart.md` conspiracies.
+- When an anomaly touches multiple factions, assign each a variant of the base name (e.g., `CMS-Pension-Slipstream Hold` vs. `Truth Broadcast Slipstream Hold`).
+- Archive decommissioned names in `docs/anomaly-ledger/` (create if absent) for future callbacks.

--- a/docs/world-lore-quickstart.md
+++ b/docs/world-lore-quickstart.md
@@ -1,0 +1,33 @@
+# Paranoid Times World Lore Quickstart
+
+Welcome to the whisper network. Before you draft a single card headline or timeline memo, calibrate your paranoia with these five cornerstone conspiracies. Treat them as the backbone of every smirk, redacted cite, and late-night broadcast.
+
+## 1. The Bureau of Recursive Revisions
+- **Cover story:** A harmless archival department that "preserves" timelines.
+- **Reality leak:** They edit history as casually as memos, then ship revisions through pneumatic tubes that arrive yesterday.
+- **Writer's cue:** Seed documents with stamped revision codes, ghost edits, and smug clerks who know how your scene ends.
+
+## 2. Choir of the Hollow Signal
+- **Cover story:** A volunteer amateur radio guild maintaining shortwave nostalgia.
+- **Reality leak:** Their harmonized numbers stations tune humanity to alternate probability tracks.
+- **Writer's cue:** Let static choruses foreshadow plot turns; embed ciphers that characters almost notice.
+
+## 3. The Clockwork Mutual Aid Society
+- **Cover story:** A friendly community watch trading clock repair tips.
+- **Reality leak:** They swap chrono-futures, hedge timelines like assets, and quote interest rates denominated in yesterdays.
+- **Writer's cue:** Drop overheard negotiations about rescheduled sunrises, collateralized déjà vu, and actuarial charts for paradox exposure.
+
+## 4. Project MERCURY-LILAC
+- **Cover story:** A defunct aerospace study tucked into dusty government ledgers.
+- **Reality leak:** The rockets launched sideways into liminal airspace, seeding violet contrails that magnetize memories.
+- **Writer's cue:** Invoke violet smears on artifacts, astronauts who speak in mirrored tenses, and ground crews still chasing drifting launch pads.
+
+## 5. The Archivists of Negative Space
+- **Cover story:** An art collective cataloging minimalism.
+- **Reality leak:** They warehouse events that never happened, renting gaps in reality to the highest bidder.
+- **Writer's cue:** Reference auctions of unused Tuesdays, contracts to forget wars, and galleries where silhouettes hold press conferences.
+
+### How to deploy this quickstart
+- Anchor every new narrative beat to at least one conspiracy above.
+- Cross-thread conspiracies often; the Hollow Signal might hum MERCURY-LILAC telemetry, and the Archivists sell that silence.
+- Leave breadcrumbs for future teams: stamped docket numbers, scrambled songlists, or negative-space invoices hinting at deeper files.

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -21,6 +21,24 @@ export default tseslint.config(
       ...reactHooks.configs.recommended.rules,
       "react-refresh/only-export-components": ["warn", { allowConstantExport: true }],
       "@typescript-eslint/no-unused-vars": "off",
+      "no-restricted-syntax": [
+        "error",
+        {
+          selector: "Literal[value=/\\bbanana peel\\b/i]",
+          message:
+            "Non-diegetic humor keyword \"banana peel\" detected. Swap in an in-universe gag sanctioned by Paranoid Times canon.",
+        },
+        {
+          selector: "Literal[value=/\\bclown car\\b/i]",
+          message:
+            "Non-diegetic humor keyword \"clown car\" detected. Channel conspiratorial wit instead of slapstick props.",
+        },
+        {
+          selector: "Literal[value=/\\brubber chicken\\b/i]",
+          message:
+            "Non-diegetic humor keyword \"rubber chicken\" detected. Keep jokes rooted in the Paranoid Times mythos.",
+        },
+      ],
     },
   },
 );

--- a/tools/cross-link-lore.mjs
+++ b/tools/cross-link-lore.mjs
@@ -1,0 +1,152 @@
+#!/usr/bin/env node
+import { readFile, readdir } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const repoRoot = path.resolve(__dirname, "..");
+
+const CARD_DATA_PATH = path.join(repoRoot, "paranoid_times_card_articles_ALL.json");
+const DOCS_DIRS = [path.join(repoRoot, "docs")];
+const DOCS_FILES = [
+  path.join(repoRoot, "DESIGN_DOC_MVP.md"),
+  path.join(repoRoot, "README.md"),
+  path.join(repoRoot, "README-core-recovery.md"),
+  path.join(repoRoot, "TRUTH_MECHANICS_AUDIT.md"),
+  path.join(repoRoot, "Humor Template  – Paranoid Times.md"),
+];
+const MARKDOWN_EXTENSIONS = new Set([".md", ".MD"]);
+
+const NON_DIEGETIC_KEYWORDS = ["banana peel", "clown car", "rubber chicken"];
+
+function escapeRegExp(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+async function readJson(filePath) {
+  const raw = await readFile(filePath, "utf8");
+  return JSON.parse(raw);
+}
+
+async function gatherMarkdownFiles(dir) {
+  try {
+    const entries = await readdir(dir, { withFileTypes: true });
+    const files = await Promise.all(
+      entries.map(async (entry) => {
+        const resolved = path.join(dir, entry.name);
+        if (entry.isDirectory()) {
+          return gatherMarkdownFiles(resolved);
+        }
+        const ext = path.extname(entry.name);
+        if (MARKDOWN_EXTENSIONS.has(ext)) {
+          return [resolved];
+        }
+        return [];
+      }),
+    );
+    return files.flat();
+  } catch (error) {
+    if (error.code === "ENOENT") {
+      return [];
+    }
+    throw error;
+  }
+}
+
+async function loadDesignDocs() {
+  const files = new Set();
+  for (const dir of DOCS_DIRS) {
+    const found = await gatherMarkdownFiles(dir);
+    for (const file of found) {
+      files.add(file);
+    }
+  }
+  for (const file of DOCS_FILES) {
+    try {
+      await readFile(file, "utf8");
+      files.add(file);
+    } catch (error) {
+      if (error.code !== "ENOENT") {
+        throw error;
+      }
+    }
+  }
+  return [...files];
+}
+
+function buildKeywordSet(article) {
+  const base = new Set();
+  if (article.faction) {
+    base.add(String(article.faction).toLowerCase());
+  }
+  if (Array.isArray(article.tags)) {
+    for (const tag of article.tags) {
+      base.add(String(tag).toLowerCase());
+    }
+  }
+  if (article.headline) {
+    const words = String(article.headline)
+      .toLowerCase()
+      .match(/[a-z0-9]+/g);
+    if (words) {
+      for (const word of words) {
+        if (word.length >= 5) {
+          base.add(word);
+        }
+      }
+    }
+  }
+  for (const keyword of NON_DIEGETIC_KEYWORDS) {
+    base.delete(keyword);
+  }
+  return base;
+}
+
+async function main() {
+  const cardData = await readJson(CARD_DATA_PATH);
+  const designDocs = await loadDesignDocs();
+
+  const loreIndex = new Map();
+
+  for (const article of cardData.articles ?? []) {
+    const keywords = buildKeywordSet(article);
+    for (const keyword of keywords) {
+      if (!loreIndex.has(keyword)) {
+        loreIndex.set(keyword, { cards: new Set(), docs: new Set() });
+      }
+      loreIndex.get(keyword).cards.add(article.id);
+    }
+  }
+
+  for (const docPath of designDocs) {
+    const content = (await readFile(docPath, "utf8")).toLowerCase();
+    for (const [keyword, entry] of loreIndex.entries()) {
+      const pattern = new RegExp(`\\b${escapeRegExp(keyword)}\\b`, "i");
+      if (pattern.test(content)) {
+        entry.docs.add(path.relative(repoRoot, docPath));
+      }
+    }
+  }
+
+  const results = [];
+  for (const [keyword, entry] of loreIndex.entries()) {
+    if (entry.docs.size === 0) {
+      continue;
+    }
+    results.push({
+      keyword,
+      cards: [...entry.cards].sort(),
+      docs: [...entry.docs].sort(),
+    });
+  }
+
+  results.sort((a, b) => a.keyword.localeCompare(b.keyword));
+
+  console.log(JSON.stringify({ generated: new Date().toISOString(), results }, null, 2));
+}
+
+main().catch((error) => {
+  console.error("Failed to cross-link lore references:", error);
+  process.exitCode = 1;
+});


### PR DESCRIPTION
## Summary
- add a world lore quickstart plus anomaly naming guidance to orient new writers
- introduce a reusable Setup → Twist → Redacted Footnote card template and catalog entry
- enforce lint checks for non-diegetic humor keywords and prototype a lore cross-linking script
- record the lore operations update in the repository changelog

## Testing
- `npm run lint` *(fails: existing lint errors in legacy files)*
- `bun test --coverage --coverage-reporter=text` *(fails: existing test suite and coverage failures)*

------
https://chatgpt.com/codex/tasks/task_e_68e36ece5dfc83208f16cc5269ee8f2b