### PR TITLE
Add gameplay loop guardrails to agent guidelines

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,6 +30,12 @@ This guidance applies to the entire repository. If any directory later introduce
 - State management and data fetching rely on React Query and standard React patterns.
 - See [`docs/TECHNICAL_README.md`](docs/TECHNICAL_README.md) for detailed architecture and engineering conventions.
 
+## Gameplay loop guardrails
+- Core loop beats follow **Investigate → Uncover Contradiction → Escalate Paranoia → Resolve (or Repress)**.
+- Every new mechanic or quest step should slot into one of those beats; call out which beat it serves in docs and commits.
+- Protect the player fantasy of "unraveling an official lie"—fail states should hint at deeper secrets rather than simple retries.
+- Keep escalation moments interactive (choices, resource spends) so the player feels they *author* the conspiracy reveal.
+
 ## Mandatory checks before sending changes
 - `npm run lint`
 - `bun test --coverage --coverage-reporter=text`


### PR DESCRIPTION
## Summary
- add a gameplay loop guardrails section to AGENTS.md to capture the core investigate-to-resolve cadence
- document expectations for how new mechanics and fail states should reinforce the conspiracy-unraveling fantasy

## Testing
- `npm run lint` *(fails: existing lint violations across src/ components and utils)*
- `bun test --coverage --coverage-reporter=text` *(fails: existing test failures in processAiActions suite and missing mock.fn in headlineEngine tests)*

------
https://chatgpt.com/codex/tasks/task_e_68e3b4b5ac3c8320a179b4b7c373f289