### PR TITLE
Implement faction showdown logic for Extra Extra bulletins

### DIFF
--- a/UPDATES_LOG.md
+++ b/UPDATES_LOG.md
@@ -2,6 +2,10 @@
 
 This document provides a chronological record of gameplay-impacting changes merged into State Shift Strategy. Each entry should include the merge date and a brief, human-readable summary so future contributors can quickly understand how the game has evolved.
 
+## 2025-10-18 – Rig extra extra showdowns
+- End-of-turn bulletins now spotlight the faction with the strongest triple-play, granting a faction-sensitive ±3% Truth swing and crowning their cards as the Extra Extra main story.
+- Added deterministic tiebreakers and regression coverage so rival triple-plays resolve cleanly even when both sides flood the presses.
+
 ## 2025-10-17 – Sync real-world weather with tabloids
 - Replaced the start screen weather badge with live, conspiratorial forecasts sourced from the player's location (with caching for repeat visits).
 - Routed the end-of-turn newspaper weather column through the same live feed so evening editions echo the player's local conditions.

--- a/__tests__/integration/extraExtra.test.ts
+++ b/__tests__/integration/extraExtra.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it, mock } from 'bun:test';
 import type { Card, GameState } from '../../src/mvp/validator';
-import type { TurnLog } from '../../src/news/headlineEngine';
+import type { TurnLog, PlayedLite } from '../../src/news/headlineEngine';
 
 const stubPools = {
   mastheads: ['Test Masthead'],
@@ -48,23 +48,27 @@ beforeEach(() => {
   getPoolsIfReadyMock.mockImplementation(() => stubPools);
 });
 
-const createCard = (id: string): Card => ({
+const createCard = (id: string, faction: 'truth' | 'government', truthDelta: number): Card => ({
   id,
   name: `Card ${id}`,
   type: 'MEDIA',
-  faction: 'truth',
+  faction,
   rarity: 'common',
   cost: 0,
   text: '',
-  effects: { truthDelta: 2 },
+  effects: { truthDelta },
 });
 
 describe('extra extra integration', () => {
   it('appends a headline + subhead after three plays in a turn', async () => {
     const { playCard, endTurn } = await loadMvpEngine();
-    const { summarize, generateExtraExtra } = await loadHeadlineEngine();
+    const { summarize, generateExtraExtra, evaluateExtraExtra } = await loadHeadlineEngine();
 
-    const cards = [createCard('alpha'), createCard('bravo'), createCard('charlie')];
+    const cards = [
+      createCard('alpha', 'truth', 2),
+      createCard('bravo', 'truth', 2),
+      createCard('charlie', 'truth', 2),
+    ];
 
     let state: GameState = {
       turn: 1,
@@ -113,8 +117,11 @@ describe('extra extra integration', () => {
       turn: state.turn,
       plays: state.turnBuffer,
     };
-    const totals = summarize([pendingLog]);
-    const expectedArticle = generateExtraExtra('mvp:P1:1', [pendingLog], totals);
+    const evaluation = evaluateExtraExtra(state.turnBuffer);
+    expect(evaluation.trigger).toBe(true);
+    const focusLog: TurnLog = { ...pendingLog, plays: evaluation.focusPlays };
+    const totals = summarize([focusLog]);
+    const expectedArticle = generateExtraExtra('mvp:P1:1', [focusLog], totals);
 
     const { state: endedState } = endTurn(state, []);
 
@@ -122,6 +129,8 @@ describe('extra extra integration', () => {
     expect(endedState.headlineLog).toEqual([
       'Turn 1 recap: Truth plays 3, Government plays 0',
     ]);
+    expect(endedState.truth).toBe(53);
+    expect(endedState.extraExtraFeed[0]?.tone).toBe('truth');
   });
 
   it('falls back to a placeholder headline when pools are unavailable', async () => {
@@ -133,9 +142,13 @@ describe('extra extra integration', () => {
 
     try {
       const { playCard, endTurn } = await loadMvpEngine();
-      const { summarize, generateExtraExtra } = await loadHeadlineEngine();
+      const { summarize, generateExtraExtra, evaluateExtraExtra } = await loadHeadlineEngine();
 
-      const cards = [createCard('delta'), createCard('echo'), createCard('foxtrot')];
+      const cards = [
+        createCard('delta', 'truth', 2),
+        createCard('echo', 'truth', 2),
+        createCard('foxtrot', 'truth', 2),
+      ];
 
       let state: GameState = {
         turn: 1,
@@ -184,8 +197,11 @@ describe('extra extra integration', () => {
         turn: state.turn,
         plays: state.turnBuffer,
       };
-      const totals = summarize([pendingLog]);
-      const expectedArticle = generateExtraExtra('mvp:P1:1', [pendingLog], totals);
+      const evaluation = evaluateExtraExtra(state.turnBuffer);
+      expect(evaluation.trigger).toBe(true);
+      const focusLog: TurnLog = { ...pendingLog, plays: evaluation.focusPlays };
+      const totals = summarize([focusLog]);
+      const expectedArticle = generateExtraExtra('mvp:P1:1', [focusLog], totals);
 
       const { state: endedState } = endTurn(state, []);
 
@@ -194,9 +210,85 @@ describe('extra extra integration', () => {
       expect(endedState.headlineLog).toEqual([
         'Turn 1 recap: Truth plays 3, Government plays 0',
       ]);
+      expect(endedState.truth).toBe(53);
       expect(warnMock.mock.calls.length).toBeGreaterThan(0);
     } finally {
       warnMock.mockRestore();
     }
+  });
+
+  it('awards extra extra to the faction with the highest-value triple play', async () => {
+    const { endTurn } = await loadMvpEngine();
+    const { summarize, generateExtraExtra, evaluateExtraExtra } = await loadHeadlineEngine();
+
+    const plays: PlayedLite[] = [
+      { id: 't1', name: 'Truth Pulse', type: 'MEDIA', faction: 'truth', truth: 2 },
+      { id: 'g1', name: 'Gov Silence', type: 'MEDIA', faction: 'government', truth: -4 },
+      { id: 't2', name: 'Truth Echo', type: 'MEDIA', faction: 'truth', truth: 1 },
+      { id: 'g2', name: 'Gov Clampdown', type: 'MEDIA', faction: 'government', truth: -3 },
+      { id: 't3', name: 'Truth Finale', type: 'MEDIA', faction: 'truth', truth: 3 },
+      { id: 'g3', name: 'Gov Sweep', type: 'MEDIA', faction: 'government', truth: -5 },
+    ];
+
+    const pendingLog: TurnLog = {
+      round: 1,
+      turn: 1,
+      plays,
+    };
+
+    const evaluation = evaluateExtraExtra(plays);
+    expect(evaluation.trigger).toBe(true);
+    expect(evaluation.winningFaction).toBe('government');
+
+    const focusLog: TurnLog = { ...pendingLog, plays: evaluation.focusPlays };
+    const totals = summarize([focusLog]);
+    const expectedArticle = generateExtraExtra('mvp:P1:1', [focusLog], totals);
+
+    const state: GameState = {
+      turn: 1,
+      currentPlayer: 'P1',
+      truth: 50,
+      players: {
+        P1: {
+          id: 'P1',
+          faction: 'truth',
+          deck: [],
+          hand: [],
+          discard: [],
+          ip: 0,
+          states: [],
+        },
+        P2: {
+          id: 'P2',
+          faction: 'government',
+          deck: [],
+          hand: [],
+          discard: [],
+          ip: 0,
+          states: [],
+        },
+      },
+      pressureByState: {},
+      stateDefense: {},
+      playsThisTurn: 0,
+      turnPlays: [],
+      log: [],
+      headlineLog: [],
+      extraExtraFeed: [],
+      turnBuffer: plays,
+      winner: null,
+      victoryType: null,
+      finalEdition: null,
+      tabloidRelicsRuntime: null,
+    };
+
+    const { state: endedState } = endTurn(state, []);
+
+    expect(endedState.extraExtraFeed).toEqual([expectedArticle]);
+    expect(endedState.extraExtraFeed[0]?.tone).toBe('government');
+    expect(endedState.truth).toBe(47);
+    expect(endedState.headlineLog).toEqual([
+      'Turn 1 recap: Truth plays 3, Government plays 3',
+    ]);
   });
 });

--- a/__tests__/news/headlineEngine.test.ts
+++ b/__tests__/news/headlineEngine.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, mock } from 'bun:test';
-import type { TurnLog, TurnTotals } from '../../src/news/headlineEngine';
+import type { TurnLog, TurnTotals, PlayedLite } from '../../src/news/headlineEngine';
 
 const stubPools = {
   mastheads: ['Test Masthead'],
@@ -33,6 +33,57 @@ beforeEach(() => {
   getPoolsIfReadyMock.mockReset();
   getPoolsMock.mockImplementation(() => stubPools);
   getPoolsIfReadyMock.mockImplementation(() => stubPools);
+});
+
+describe('evaluateExtraExtra', () => {
+  it('returns no trigger when neither faction plays three cards', async () => {
+    const { evaluateExtraExtra } = await loadEngine();
+
+    const outcome = evaluateExtraExtra([]);
+
+    expect(outcome.trigger).toBe(false);
+    expect(outcome.truthDelta).toBe(0);
+    expect(outcome.focusPlays).toEqual([]);
+  });
+
+  it('declares truth winner when only truth reaches three plays', async () => {
+    const { evaluateExtraExtra } = await loadEngine();
+
+    const plays: PlayedLite[] = [
+      { id: 't1', name: 'Truth Broadcast', type: 'MEDIA', faction: 'truth', truth: 2 },
+      { id: 't2', name: 'Truth Broadcast 2', type: 'MEDIA', faction: 'truth', truth: 1 },
+      { id: 't3', name: 'Truth Broadcast 3', type: 'MEDIA', faction: 'truth', truth: 4 },
+      { id: 'g1', name: 'Gov Teaser', type: 'MEDIA', faction: 'government', truth: -1 },
+    ];
+
+    const outcome = evaluateExtraExtra(plays);
+
+    expect(outcome.trigger).toBe(true);
+    expect(outcome.winningFaction).toBe('truth');
+    expect(outcome.truthDelta).toBe(3);
+    expect(outcome.focusPlays).toHaveLength(3);
+    expect(outcome.focusPlays.every(play => play.faction === 'truth')).toBe(true);
+  });
+
+  it('breaks ties with a draw when top card values match', async () => {
+    const { evaluateExtraExtra } = await loadEngine();
+
+    const plays: PlayedLite[] = [
+      { id: 't1', name: 'Truth Wave', type: 'MEDIA', faction: 'truth', truth: 3 },
+      { id: 't2', name: 'Truth Echo', type: 'MEDIA', faction: 'truth', truth: 1 },
+      { id: 't3', name: 'Truth Finale', type: 'MEDIA', faction: 'truth', truth: 2 },
+      { id: 'g1', name: 'Gov Silence', type: 'MEDIA', faction: 'government', truth: -3 },
+      { id: 'g2', name: 'Gov Clamp', type: 'MEDIA', faction: 'government', truth: -2 },
+      { id: 'g3', name: 'Gov Sweep', type: 'MEDIA', faction: 'government', truth: -1 },
+    ];
+
+    const outcome = evaluateExtraExtra(plays);
+
+    expect(outcome.trigger).toBe(true);
+    expect(outcome.winningFaction).toBe('draw');
+    expect(outcome.truthDelta).toBe(0);
+    expect(outcome.focusPlays).toHaveLength(6);
+  });
 });
 
 describe('headlineEngine utilities', () => {

--- a/src/hooks/useGameState.ts
+++ b/src/hooks/useGameState.ts
@@ -84,7 +84,7 @@ import {
 import { assignStateBonuses } from '@/game/stateBonuses';
 import { applyStateBonusAssignmentToState } from './stateBonusAssignment';
 import { clearNewsBuffer, getNewsTriplet, pushToNewsBuffer } from '@/state/game/roundNewsBuffer';
-import { summarize, generateExtraExtra } from '@/news/headlineEngine';
+import { summarize, generateExtraExtra, evaluateExtraExtra } from '@/news/headlineEngine';
 import { loadNewsPools } from '@/news/newsPools';
 import type { ArticleBlock, TurnLog } from '@/news/headlineEngine';
 import type { GameOverReport } from '@/types/finalEdition';
@@ -238,9 +238,20 @@ const applyTurnNews = (prev: GameState, next: GameState, seedPrefix: string): Ga
   const headlineLog = [...next.headlineLog, summaryHeadline];
 
   let extraExtraFeed = next.extraExtraFeed;
-  if (buffer.length >= 3) {
-    const article = generateExtraExtra(`${seedPrefix}:${prev.round}:${prev.turn}`, [turnLog], totals);
+  const evaluation = evaluateExtraExtra(buffer);
+
+  if (evaluation.trigger) {
+    const focusLog: TurnLog = { ...turnLog, plays: evaluation.focusPlays };
+    const focusTotals = summarize([focusLog]);
+    const article = generateExtraExtra(`${seedPrefix}:${prev.round}:${prev.turn}`, [focusLog], focusTotals);
     extraExtraFeed = [...extraExtraFeed, article];
+
+    if (evaluation.truthDelta !== 0) {
+      const truthOwner = next.players.P1.faction === 'truth' ? 'P1' : 'P2';
+      const governmentOwner = next.players.P1.faction === 'government' ? 'P1' : 'P2';
+      const actor = evaluation.winningFaction === 'truth' ? truthOwner : governmentOwner;
+      applyTruthDelta(next, evaluation.truthDelta, actor);
+    }
   }
 
   return {

--- a/src/mvp/engine.ts
+++ b/src/mvp/engine.ts
@@ -5,12 +5,13 @@ import { applyComboRewards, evaluateCombos, getComboSettings, formatComboReward 
 import type { ComboEvaluation, ComboOptions, ComboSummary, TurnPlay } from '@/game/combo.types';
 import { getStateByAbbreviation, getStateById } from '@/data/usaStates';
 import { RelicEngine } from '@/expansions/tabloidRelics/RelicEngine';
-import { summarize, generateExtraExtra } from '@/news/headlineEngine';
+import { summarize, generateExtraExtra, evaluateExtraExtra } from '@/news/headlineEngine';
 import type { PlayedLite, TurnLog } from '@/news/headlineEngine';
 import { cloneGameState } from './validator';
 import { auditGameState } from './gameStateAudit';
 import type { Card, EffectsATTACK, EffectsMEDIA, EffectsZONE, GameState, PlayerState } from './validator';
 import type { MediaResolutionOptions } from './media';
+import { applyTruthDelta } from '@/utils/truth';
 
 const otherPlayer = (id: PlayerId): PlayerId => (id === 'P1' ? 'P2' : 'P1');
 
@@ -647,9 +648,20 @@ export function endTurn(
     const summaryHeadline = `Turn ${turnNumber} recap: Truth plays ${totals.truth.plays}, Government plays ${totals.government.plays}`;
     headlineLog = [...headlineLog, summaryHeadline];
 
-    if (bufferPlays.length >= 3) {
-      const article = generateExtraExtra(`mvp:${currentId}:${turnNumber}`, [turnLogEntry], totals);
+    const evaluation = evaluateExtraExtra(bufferPlays);
+
+    if (evaluation.trigger) {
+      const focusLog: TurnLog = { ...turnLogEntry, plays: evaluation.focusPlays };
+      const focusTotals = summarize([focusLog]);
+      const article = generateExtraExtra(`mvp:${currentId}:${turnNumber}`, [focusLog], focusTotals);
       extraExtraFeed = [...extraExtraFeed, article];
+
+      if (evaluation.truthDelta !== 0) {
+        const truthOwner = cloned.players.P1.faction === 'truth' ? 'P1' : 'P2';
+        const governmentOwner = cloned.players.P1.faction === 'government' ? 'P1' : 'P2';
+        const actor = evaluation.winningFaction === 'truth' ? truthOwner : governmentOwner;
+        applyTruthDelta(logEnhancedState, evaluation.truthDelta, actor);
+      }
     }
   }
 

--- a/src/news/headlineEngine.ts
+++ b/src/news/headlineEngine.ts
@@ -66,6 +66,165 @@ export interface TurnLog {
   plays: PlayedLite[];
 }
 
+export interface ExtraExtraOutcome {
+  trigger: boolean;
+  winningFaction: 'truth' | 'government' | 'draw';
+  focusPlays: PlayedLite[];
+  truthDelta: number;
+}
+
+const computePlayValue = (play: PlayedLite): number => {
+  if (!play) {
+    return 0;
+  }
+
+  const values: number[] = [];
+
+  if (typeof play.truth === 'number' && Number.isFinite(play.truth)) {
+    values.push(Math.abs(play.truth));
+  }
+
+  if (typeof play.ip === 'number' && Number.isFinite(play.ip)) {
+    values.push(Math.abs(play.ip));
+  }
+
+  if (typeof play.captures === 'number' && Number.isFinite(play.captures)) {
+    values.push(Math.abs(play.captures) * 2);
+  }
+
+  if (typeof play.damage === 'number' && Number.isFinite(play.damage)) {
+    values.push(Math.abs(play.damage));
+  }
+
+  if (!values.length) {
+    return 0;
+  }
+
+  return Math.max(...values);
+};
+
+const collectFactionTrio = (
+  plays: PlayedLite[],
+  faction: 'truth' | 'government',
+): PlayedLite[] => {
+  const result: PlayedLite[] = [];
+
+  for (const play of plays) {
+    if (play.faction !== faction) {
+      continue;
+    }
+
+    result.push(play);
+
+    if (result.length >= 3) {
+      break;
+    }
+  }
+
+  return result;
+};
+
+const collectDrawFocus = (plays: PlayedLite[]): PlayedLite[] => {
+  const result: PlayedLite[] = [];
+  let truthCount = 0;
+  let governmentCount = 0;
+
+  for (const play of plays) {
+    if (play.faction === 'truth' && truthCount < 3) {
+      result.push(play);
+      truthCount += 1;
+      continue;
+    }
+
+    if (play.faction === 'government' && governmentCount < 3) {
+      result.push(play);
+      governmentCount += 1;
+    }
+
+    if (truthCount >= 3 && governmentCount >= 3) {
+      break;
+    }
+  }
+
+  return result;
+};
+
+const highestFactionValue = (plays: PlayedLite[]): number => {
+  if (!plays.length) {
+    return 0;
+  }
+
+  return plays.reduce((max, play) => {
+    const value = computePlayValue(play);
+    return value > max ? value : max;
+  }, 0);
+};
+
+export const evaluateExtraExtra = (plays: PlayedLite[]): ExtraExtraOutcome => {
+  const truthTrio = collectFactionTrio(plays, 'truth');
+  const governmentTrio = collectFactionTrio(plays, 'government');
+
+  const truthQualifies = truthTrio.length >= 3;
+  const governmentQualifies = governmentTrio.length >= 3;
+
+  if (!truthQualifies && !governmentQualifies) {
+    return {
+      trigger: false,
+      winningFaction: 'draw',
+      focusPlays: [],
+      truthDelta: 0,
+    };
+  }
+
+  if (truthQualifies && !governmentQualifies) {
+    return {
+      trigger: true,
+      winningFaction: 'truth',
+      focusPlays: truthTrio,
+      truthDelta: 3,
+    };
+  }
+
+  if (!truthQualifies && governmentQualifies) {
+    return {
+      trigger: true,
+      winningFaction: 'government',
+      focusPlays: governmentTrio,
+      truthDelta: -3,
+    };
+  }
+
+  const truthValue = highestFactionValue(truthTrio);
+  const governmentValue = highestFactionValue(governmentTrio);
+
+  if (truthValue > governmentValue) {
+    return {
+      trigger: true,
+      winningFaction: 'truth',
+      focusPlays: truthTrio,
+      truthDelta: 3,
+    };
+  }
+
+  if (governmentValue > truthValue) {
+    return {
+      trigger: true,
+      winningFaction: 'government',
+      focusPlays: governmentTrio,
+      truthDelta: -3,
+    };
+  }
+
+  const focusPlays = collectDrawFocus(plays);
+
+  return {
+    trigger: true,
+    winningFaction: 'draw',
+    focusPlays,
+    truthDelta: 0,
+  };
+};
+
 export interface ArticleBlock {
   tone: 'truth' | 'government' | 'draw';
   hed: string;


### PR DESCRIPTION
## Summary
- add an Extra Extra evaluator that determines the winning faction, focus plays, and Truth swing for triple-play turns
- update the game state hook and MVP engine to spotlight the winning faction's plays in end-of-turn bulletins and award a ±3% Truth adjustment
- expand integration and unit tests plus the updates log to cover faction showdowns and tie handling

## Testing
- npm run lint
- bun test --coverage --coverage-reporter=text


------
https://chatgpt.com/codex/tasks/task_e_68e3dd0335508320ab648a0ee31635ac