### PR TITLE
Guard newspaper issues against malformed card logs

### DIFF
--- a/UPDATES_LOG.md
+++ b/UPDATES_LOG.md
@@ -54,6 +54,10 @@ This document provides a chronological record of gameplay-impacting changes merg
 - Route the live agenda moment feed into the Player Hub overlay and surface a chronological timeline of stages and outcomes.
 - Add status filters, timeline styling, and empty-state messaging to help players review agenda advances, setbacks, and completions at a glance.
 
+## 2025-10-06 – Harden turn newspaper handoff
+- Sanitize end-of-turn played card logs before printing so corrupted save data no longer crashes the Resolve-phase newspaper reveal.
+- Add regression coverage that verifies malformed records are ignored while valid cards still headline the post-turn bulletin.
+
 ## 2025-10-06 – Surface agenda history in player hub
 - Add an agendas tab to the Player Hub that highlights the current secret agenda when enabled.
 - Surface completed agendas with descriptions, issue themes, and difficulty badges for quick review.

--- a/src/engine/newspaper/IssueGenerator.ts
+++ b/src/engine/newspaper/IssueGenerator.ts
@@ -116,6 +116,9 @@ const shuffle = <T,>(input: T[]): T[] => {
   return arr;
 };
 
+const isNonEmptyString = (value: unknown): value is string =>
+  typeof value === 'string' && value.trim().length > 0;
+
 const formatTruthDeltaLabel = (value: number | undefined | null): string | null => {
   if (typeof value !== 'number' || Number.isNaN(value) || value === 0) {
     return null;
@@ -161,6 +164,47 @@ const normalizeCardType = (value: Card['type']): PlayedCardMeta['type'] | null =
 const normalizeFaction = (value: Card['faction']): PlayedCardMeta['faction'] => {
   const upper = String(value ?? '').toUpperCase();
   return upper.includes('GOV') ? 'GOV' : 'TRUTH';
+};
+
+const isCardShaped = (card: Card | null | undefined): card is Card => {
+  if (!card || typeof card !== 'object') {
+    return false;
+  }
+  const candidate = card as Record<string, unknown>;
+  return (
+    isNonEmptyString(candidate.id) &&
+    isNonEmptyString(candidate.name) &&
+    isNonEmptyString(candidate.type) &&
+    isNonEmptyString(candidate.faction)
+  );
+};
+
+const sanitizePlayedCards = (entries: PlayedCardInput[]): PlayedCardInput[] => {
+  if (!entries.length) {
+    return entries;
+  }
+
+  const valid: PlayedCardInput[] = [];
+  let skipped = 0;
+
+  for (const entry of entries) {
+    const rawCard = entry.card ?? null;
+    if (!isCardShaped(rawCard)) {
+      skipped += 1;
+      continue;
+    }
+    valid.push({ ...entry, card: rawCard });
+  }
+
+  if (skipped > 0 && typeof console !== 'undefined' && typeof console.warn === 'function') {
+    console.warn(
+      '[Newspaper] Ignored',
+      skipped,
+      skipped === 1 ? 'malformed played card while building the issue.' : 'malformed played cards while building the issue.',
+    );
+  }
+
+  return valid;
 };
 
 const resolveStateName = (input?: string | null): string | null => {
@@ -356,8 +400,10 @@ export async function generateIssue(input: IssueGeneratorInput): Promise<Narrati
     articleBank = null;
   }
 
-  const playerCards = input.playedCards.filter(entry => entry.player === 'human');
-  const opponentCards = input.playedCards.filter(entry => entry.player === 'ai');
+  const sanitizedPlayedCards = sanitizePlayedCards(input.playedCards);
+
+  const playerCards = sanitizedPlayedCards.filter(entry => entry.player === 'human');
+  const opponentCards = sanitizedPlayedCards.filter(entry => entry.player === 'ai');
 
   const heroCard = chooseHeroCard(playerCards);
 

--- a/src/engine/newspaper/__tests__/IssueGenerator.safety.test.ts
+++ b/src/engine/newspaper/__tests__/IssueGenerator.safety.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it, mock } from 'bun:test';
+
+import { generateIssue } from '../IssueGenerator';
+import type { NewspaperData } from '@/lib/newspaperData';
+import type { Card } from '@/types';
+
+const minimalDataset: NewspaperData = {
+  mastheads: ['The Paranoid Times'],
+  ads: ['Classified ads temporarily unavailable.'],
+  subheads: {
+    generic: ['Officials refuse to comment.'],
+    attack: ['Officials refuse to comment.'],
+    media: ['Officials refuse to comment.'],
+    zone: ['Officials refuse to comment.'],
+  },
+  bylines: ['By: Anonymous Insider'],
+  sources: ['Source: Redacted'],
+  conspiracyCorner: ['All rumors currently sealed in vault storage.'],
+  weather: ['Forecast withheld pending clearance.'],
+  attackVerbs: ['EXPOSED'],
+  mediaVerbs: ['GOES VIRAL'],
+  zoneVerbs: ['SURGE'],
+  stamps: {
+    breaking: ['BREAKING'],
+    classified: ['CLASSIFIED'],
+  },
+};
+
+mock.module('@/engine/newspaper/CardLexicon', () => ({
+  loadCardLexicon: async () => ({}),
+}));
+
+mock.module('@/engine/news/articleBank', () => ({
+  loadArticleBank: async () => ({
+    getById: () => null,
+    hasArticles: () => false,
+  }),
+}));
+
+describe('IssueGenerator safety guards', () => {
+  it('skips malformed played card records when composing an issue', async () => {
+    const originalWarn = console.warn;
+    const warnCalls: unknown[][] = [];
+    console.warn = (...args: unknown[]) => {
+      warnCalls.push(args);
+    };
+
+    const validCard: Card = {
+      id: 'valid-card',
+      name: 'Valid Signal',
+      type: 'ATTACK',
+      faction: 'truth',
+      text: 'Do something dramatic.',
+      rarity: 'common',
+      cost: 1,
+    } as Card;
+
+    const issue = await generateIssue({
+      dataset: minimalDataset,
+      playedCards: [
+        {
+          // Simulate a corrupted save entry missing the card payload.
+          card: null as unknown as Card,
+          player: 'human',
+          truthDelta: 4,
+          capturedStates: ['NV'],
+        },
+        {
+          card: validCard,
+          player: 'human',
+          truthDelta: 6,
+          capturedStates: ['NM'],
+        },
+      ],
+    });
+
+    expect(issue.hero?.cardId).toBe('valid-card');
+    expect(issue.generatedStory.cards.map(card => card.id)).toEqual(['valid-card']);
+
+    expect(warnCalls.length).toBeGreaterThan(0);
+    console.warn = originalWarn;
+  });
+});


### PR DESCRIPTION
## Summary
- sanitize played card snapshots before generating end-of-turn newspaper issues and warn when malformed entries are skipped
- add a regression test that exercises the sanitizer against a corrupted save record while keeping valid cards on the front page
- document the hardened Resolve-phase newspaper handoff in the updates log

## Testing
- npm run lint *(fails: repository has pre-existing lint violations)*
- bun test --coverage --coverage-reporter=text *(fails: repository has pre-existing test failures in integration suites)*

------
https://chatgpt.com/codex/tasks/task_e_68e3e324bc948320b12b9862a7447d40