### PR TITLE
Sanitize relic runtime cloning to prevent round crashes

### DIFF
--- a/UPDATES_LOG.md
+++ b/UPDATES_LOG.md
@@ -2,6 +2,9 @@
 
 This document provides a chronological record of gameplay-impacting changes merged into State Shift Strategy. Each entry should include the merge date and a brief, human-readable summary so future contributors can quickly understand how the game has evolved.
 
+## 2025-10-19 – Harden relic runtime rehydration
+- Sanitize tabloid relic runtime data before applying round effects so corrupted saves or old runtime payloads no longer crash when a new round starts.
+
 ## 2025-10-18 – Rig extra extra showdowns
 - End-of-turn bulletins now spotlight the faction with the strongest triple-play, granting a faction-sensitive ±3% Truth swing and crowning their cards as the Extra Extra main story.
 - Added deterministic tiebreakers and regression coverage so rival triple-plays resolve cleanly even when both sides flood the presses.

--- a/__tests__/expansions/tabloidRelics/RelicEngine.test.ts
+++ b/__tests__/expansions/tabloidRelics/RelicEngine.test.ts
@@ -4,6 +4,7 @@ import { hydrateExpansionFeatures } from '@/data/expansions/features';
 import type { CardPlayRecord } from '@/hooks/gameStateTypes';
 import type {
   RelicIssueSnapshot,
+  RelicRoundStartPayload,
   TabloidRelicRuntimeState,
 } from '@/expansions/tabloidRelics/RelicTypes';
 
@@ -183,5 +184,34 @@ describe('RelicEngine.ingestIssue rotation', () => {
       'red_string_reactor',
       'black_budget_briefing',
     ]);
+  });
+
+  it('sanitizes malformed runtime data when applying round start', async () => {
+    const { RelicEngine } = await loadRelicEngine();
+
+    const corruptedState = {
+      faction: 'truth' as const,
+      truth: 45,
+      ip: 12,
+      aiIP: 18,
+      round: 3,
+      turn: 3,
+      editorId: null,
+      editorDef: null,
+      tabloidRelicsRuntime: {
+        entries: { bogus: true },
+        lastIssueRound: '2',
+        lastUpdatedTurn: '2',
+        selectionHistory: ['pressroom_lockdown', 123, null],
+      } as unknown,
+    } satisfies RelicRoundStartPayload['state'];
+
+    const result = RelicEngine.applyRoundStart({ state: corruptedState });
+
+    expect(result.runtime).toBeNull();
+    expect(result.truth).toBe(corruptedState.truth);
+    expect(result.ip).toBe(corruptedState.ip);
+    expect(result.aiIp).toBe(corruptedState.aiIP);
+    expect(result.logEntries).toEqual([]);
   });
 });

--- a/docs/relic-runtime-hardening-plan.md
+++ b/docs/relic-runtime-hardening-plan.md
@@ -1,0 +1,18 @@
+# Tabloid Relic Runtime Hardening Plan
+
+## Root cause recap
+- Existing saves or malformed runtime payloads could lack a valid `entries` array.
+- The round start hook blindly cloned `runtime.entries`, triggering a crash when the data was not an array.
+- The failure surfaced consistently at the start of round three when the runtime was first processed after being deserialized.
+
+## Immediate mitigation
+1. Sanitize `cloneRuntime` to treat non-object, non-array, or partially populated structures as empty.
+2. Normalize selection history and numeric counters while discarding invalid members.
+3. Ensure `RelicEngine.applyRoundStart` gracefully returns `null` runtime when sanitized data yields no active entries.
+
+## Follow-up tasks
+- [ ] Extend save/load rehydration to validate `tabloidRelicsRuntime` at the point of persistence to prevent future corruption.
+- [ ] Add telemetry for discarded runtime entries so QA can spot recurring malformed payloads.
+- [ ] Cover the ingest path with fixtures representing older save formats to guarantee forward compatibility.
+- [ ] Build a regression test that loads a mocked legacy save blob and steps through three rounds without throwing.
+- [ ] Document the runtime schema in `docs/TECHNICAL_README.md` to help tool authors avoid emitting malformed data.

--- a/src/expansions/tabloidRelics/RelicEngine.ts
+++ b/src/expansions/tabloidRelics/RelicEngine.ts
@@ -105,14 +105,35 @@ const pickCandidateWithRotation = (
 const cloneRuntime = (
   runtime: TabloidRelicRuntimeState | null | undefined,
 ): TabloidRelicRuntimeState | null => {
-  if (!runtime) {
+  if (!runtime || typeof runtime !== 'object') {
     return { entries: [], lastIssueRound: 0, selectionHistory: [] };
   }
+
+  const entriesSource = Array.isArray(runtime.entries) ? runtime.entries : [];
+  const entries = entriesSource
+    .filter(entry => entry && typeof entry === 'object' && typeof (entry as { ruleId?: unknown }).ruleId === 'string')
+    .map(entry => ({ ...entry }));
+
+  const lastIssueRound = typeof runtime.lastIssueRound === 'number' && Number.isFinite(runtime.lastIssueRound)
+    ? runtime.lastIssueRound
+    : 0;
+  const lastUpdatedTurn = typeof runtime.lastUpdatedTurn === 'number' && Number.isFinite(runtime.lastUpdatedTurn)
+    ? runtime.lastUpdatedTurn
+    : undefined;
+  const selectionHistorySource = Array.isArray(runtime.selectionHistory) ? runtime.selectionHistory : [];
+  const selectionHistory = selectionHistorySource
+    .map(historyId => (typeof historyId === 'string' ? historyId : null))
+    .filter((historyId): historyId is string => Boolean(historyId));
+
+  if (entries.length === 0 && selectionHistory.length === 0) {
+    return { entries: [], lastIssueRound: 0, selectionHistory: [] };
+  }
+
   return {
-    entries: runtime.entries.map(entry => ({ ...entry })),
-    lastIssueRound: runtime.lastIssueRound,
-    lastUpdatedTurn: runtime.lastUpdatedTurn,
-    selectionHistory: [...(runtime.selectionHistory ?? [])],
+    entries,
+    lastIssueRound,
+    lastUpdatedTurn,
+    selectionHistory,
   };
 };
 


### PR DESCRIPTION
## Summary
- sanitize tabloid relic runtime cloning so malformed save data no longer crashes the game when a new round begins
- add regression coverage ensuring RelicEngine.applyRoundStart tolerates corrupted runtime payloads
- document the mitigation in the updates log and outline follow-up hardening tasks for relic runtime rehydration

## Testing
- bun test __tests__/expansions/tabloidRelics/RelicEngine.test.ts
- npm run lint *(fails: existing eslint configuration reports hundreds of pre-existing issues in unrelated files)*
- bun test --coverage --coverage-reporter=text *(fails: integration suite relies on mock.fn which is unavailable under Bun's test runner)*

------
https://chatgpt.com/codex/tasks/task_e_68e3ec06c0788320a3d149a7f7e479b4