### PR TITLE
Fix Extra Extra truth adjustments when MVP metadata missing

### DIFF
--- a/UPDATES_LOG.md
+++ b/UPDATES_LOG.md
@@ -54,6 +54,10 @@ This document provides a chronological record of gameplay-impacting changes merg
 - Route the live agenda moment feed into the Player Hub overlay and surface a chronological timeline of stages and outcomes.
 - Add status filters, timeline styling, and empty-state messaging to help players review agenda advances, setbacks, and completions at a glance.
 
+## 2025-10-06 – Stabilize Extra Extra truth swings
+- Ensure the Extra Extra truth adjustment looks at the active UI factions when legacy MVP player data is missing so post-turn articles no longer crash.
+- Fall back to the player's faction to decide which side gains or loses truth when bulletins trigger without engine player metadata.
+
 ## 2025-10-06 – Harden turn newspaper handoff
 - Sanitize end-of-turn played card logs before printing so corrupted save data no longer crashes the Resolve-phase newspaper reveal.
 - Add regression coverage that verifies malformed records are ignored while valid cards still headline the post-turn bulletin.

--- a/src/hooks/useGameState.ts
+++ b/src/hooks/useGameState.ts
@@ -29,7 +29,7 @@ import { getStartingHandSize, type DrawMode, type CardDrawState } from '@/data/c
 import { useAchievements } from '@/contexts/AchievementContext';
 import { resolveCardMVP, type CardPlayResolution, type CardHotspotResolution } from '@/systems/cardResolution';
 import { useStateEvents } from '@/hooks/useStateEvents';
-import { applyTruthDelta } from '@/utils/truth';
+import { applyTruthDelta, type TruthActorId } from '@/utils/truth';
 import type { Difficulty } from '@/ai';
 import { getDifficulty } from '@/state/settings';
 import { featureFlags } from '@/state/featureFlags';
@@ -221,6 +221,42 @@ const emitEditorToastMessages = (messages: string[]): void => {
   }
 };
 
+type LegacyPlayerSnapshot = {
+  faction?: 'truth' | 'government';
+};
+
+const resolveFactionOwner = (
+  state: GameState,
+  faction: 'truth' | 'government',
+): TruthActorId => {
+  const legacyPlayers = (state as GameState & {
+    players?: Record<string, LegacyPlayerSnapshot | undefined>;
+  }).players;
+
+  if (legacyPlayers) {
+    for (const [id, player] of Object.entries(legacyPlayers)) {
+      if (!player || player.faction !== faction) {
+        continue;
+      }
+
+      if (id === 'P1' || id === 'P2') {
+        return id;
+      }
+
+      if (id === 'human' || id === 'ai' || id === 'player') {
+        return id;
+      }
+    }
+  }
+
+  const playerIsTruth = state.faction === 'truth';
+  if (faction === 'truth') {
+    return playerIsTruth ? 'human' : 'ai';
+  }
+
+  return playerIsTruth ? 'ai' : 'human';
+};
+
 const applyTurnNews = (prev: GameState, next: GameState, seedPrefix: string): GameState => {
   const buffer = prev.turnBuffer ?? [];
   if (buffer.length === 0) {
@@ -247,8 +283,8 @@ const applyTurnNews = (prev: GameState, next: GameState, seedPrefix: string): Ga
     extraExtraFeed = [...extraExtraFeed, article];
 
     if (evaluation.truthDelta !== 0) {
-      const truthOwner = next.players.P1.faction === 'truth' ? 'P1' : 'P2';
-      const governmentOwner = next.players.P1.faction === 'government' ? 'P1' : 'P2';
+      const truthOwner = resolveFactionOwner(next, 'truth');
+      const governmentOwner = resolveFactionOwner(next, 'government');
       const actor = evaluation.winningFaction === 'truth' ? truthOwner : governmentOwner;
       applyTruthDelta(next, evaluation.truthDelta, actor);
     }


### PR DESCRIPTION
## Summary
- guard the Extra Extra truth adjustment logic against game states that no longer expose MVP-style player records
- fall back to the human vs AI faction ownership when only the modern UI game state is available so truth swings resolve safely
- document the regression fix in the updates log

## Testing
- npm run lint *(fails: repository-wide lint suite currently errors out on pre-existing parsing/type issues outside this change)*
- bun test --coverage --coverage-reporter=text *(fails: existing CardCollectionContent suite expects browser localStorage and aborts)*

------
https://chatgpt.com/codex/tasks/task_e_68e3ed2b643c8320a8efd1114713e4ef