### PR TITLE
Implement broadsheet player hub panels

### DIFF
--- a/UPDATES_LOG.md
+++ b/UPDATES_LOG.md
@@ -2,7 +2,11 @@
 
 This document provides a chronological record of gameplay-impacting changes merged into State Shift Strategy. Each entry should include the merge date and a brief, human-readable summary so future contributors can quickly understand how the game has evolved.
 
--## 2025-10-20 – Plot the Player Hub tabloid takeover
+## 2025-10-21 – Tabloidize the Player Hub intel desks
+- Finished broadsheet variants for tutorials, evidence, press archives, and the state intel board so every hub tab now reads like a Paranoid Times spread.
+- Unified archive filters, badges, and ticker data to match the new typewriter-and-ink styling while preserving existing default layouts.
+
+## 2025-10-20 – Plot the Player Hub tabloid takeover
 - Drafted a broadsheet-style blueprint for re-skinning the Player Hub so every tab reads like a leaked Paranoid Times edition, complete with masthead shell, kicker/dek templates, and tab-specific print treatments.
 - Outlined phased implementation tasks covering asset delivery, layout refactors, and atmospheric flourishes to guide art, frontend, audio, and QA contributors.
 

--- a/index.html
+++ b/index.html
@@ -9,7 +9,10 @@
 
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Anton:wght@400&family=Bebas+Neue:wght@400&display=swap" rel="stylesheet">
+    <link
+      href="https://fonts.googleapis.com/css2?family=Anton:wght@400&family=Bebas+Neue:wght@400&family=IBM+Plex+Mono:wght@400;500;600&family=Newsreader:opsz,wght@6..72,400;6..72,600;6..72,700&family=Oswald:wght@400;500;600&display=swap"
+      rel="stylesheet"
+    >
 
     <meta property="og:title" content="state-shift-strategy" />
     <meta property="og:description" content="Lovable Generated Project" />

--- a/src/components/game/AchievementPanel.tsx
+++ b/src/components/game/AchievementPanel.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect } from 'react';
+import clsx from 'clsx';
 import { Card } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
@@ -14,12 +15,14 @@ interface AchievementsSectionProps {
   onClose?: () => void;
   className?: string;
   showCloseButton?: boolean;
+  variant?: 'default' | 'broadsheet';
 }
 
 export const AchievementsSection = ({
   onClose,
   className,
   showCloseButton = false,
+  variant = 'default',
 }: AchievementsSectionProps) => {
   const [selectedAchievement, setSelectedAchievement] = useState<Achievement | null>(null);
   const [filter, setFilter] = useState<string>('all');
@@ -70,6 +73,19 @@ export const AchievementsSection = ({
         return 'border border-fuchsia-400/60 bg-fuchsia-500/15 text-fuchsia-200';
       default:
         return 'border border-slate-500/60 bg-slate-900/60 text-slate-300';
+    }
+  };
+
+  const getBroadsheetRarityTone = (rarity: string) => {
+    switch (rarity) {
+      case 'legendary':
+        return 'border-[#3c3a8f] bg-[#e3e0f7] text-[#25206a]';
+      case 'rare':
+        return 'border-[#1f5d82] bg-[#d3e5f2] text-[#123b53]';
+      case 'uncommon':
+        return 'border-[#2f6f3a] bg-[#d6edd9] text-[#1f4b24]';
+      default:
+        return 'border-[var(--broadsheet-rule)] bg-white text-[var(--broadsheet-muted)]';
     }
   };
 
@@ -128,6 +144,306 @@ export const AchievementsSection = ({
       resetProgress();
     }
   };
+  if (variant === 'broadsheet') {
+    const filterOptions: Array<{ key: string; label: string }> = [
+      { key: 'all', label: 'All' },
+      { key: 'victory', label: 'Victory' },
+      { key: 'mastery', label: 'Mastery' },
+      { key: 'discovery', label: 'Discovery' },
+      { key: 'challenge', label: 'Challenge' },
+      { key: 'social', label: 'Social' },
+      { key: 'collection', label: 'Collection' },
+    ];
+
+    return (
+      <div className={clsx('flex h-full flex-col gap-6 text-[var(--broadsheet-ink)]', className)}>
+        <header className="rounded-xl border border-[var(--broadsheet-rule)] bg-[rgba(255,255,255,0.9)] p-6 shadow-sm">
+          <div className="flex flex-wrap items-start justify-between gap-6">
+            <div className="space-y-3">
+              <p className="font-typewriter text-[11px] uppercase tracking-[0.42em] text-[var(--broadsheet-kicker)]">
+                Centerfold of Glory
+              </p>
+              <h2 className="font-broadsheetSans text-3xl uppercase tracking-[0.16em]">Agents of Record</h2>
+              <p className="max-w-2xl font-broadsheet text-[15px] leading-relaxed text-[var(--broadsheet-muted)]">
+                Mugshots, miracle stats, and sworn affidavits from field operatives the government insists do not exist.
+              </p>
+            </div>
+            <div className="grid min-w-[220px] grid-cols-2 gap-3 text-center">
+              <div className="rounded-lg border border-[var(--broadsheet-rule)] bg-white/90 p-3 shadow-sm">
+                <p className="font-typewriter text-[10px] uppercase tracking-[0.32em] text-[var(--broadsheet-muted)]">Unlocked</p>
+                <p className="font-broadsheetSans text-xl">{progress.unlocked}/{progress.total}</p>
+              </div>
+              <div className="rounded-lg border border-[var(--broadsheet-rule)] bg-white/90 p-3 shadow-sm">
+                <p className="font-typewriter text-[10px] uppercase tracking-[0.32em] text-[var(--broadsheet-muted)]">Points</p>
+                <p className="font-broadsheetSans text-xl">{progress.totalPoints}</p>
+              </div>
+              <div className="rounded-lg border border-[var(--broadsheet-rule)] bg-white/90 p-3 shadow-sm">
+                <p className="font-typewriter text-[10px] uppercase tracking-[0.32em] text-[var(--broadsheet-muted)]">Rank</p>
+                <p className="font-broadsheetSans text-xl">{progress.rank}</p>
+              </div>
+              <div className="rounded-lg border border-[var(--broadsheet-rule)] bg-white/90 p-3 shadow-sm">
+                <p className="font-typewriter text-[10px] uppercase tracking-[0.32em] text-[var(--broadsheet-muted)]">New Leads</p>
+                <p className="font-broadsheetSans text-xl">{newlyUnlocked.length}</p>
+              </div>
+            </div>
+          </div>
+          <div className="mt-5 flex flex-wrap items-center gap-2">
+            <Button
+              onClick={exportProgress}
+              variant="outline"
+              size="sm"
+              className="rounded-full border-[var(--broadsheet-rule)] bg-white/80 px-4 py-1 font-typewriter text-[11px] uppercase tracking-[0.32em] text-[var(--broadsheet-ink)] transition hover:border-[var(--broadsheet-accent)] hover:bg-white"
+            >
+              <Download size={14} className="mr-2" />
+              Export Ledger
+            </Button>
+            <Button
+              onClick={importProgress}
+              variant="outline"
+              size="sm"
+              className="rounded-full border-[var(--broadsheet-rule)] bg-white/80 px-4 py-1 font-typewriter text-[11px] uppercase tracking-[0.32em] text-[var(--broadsheet-ink)] transition hover:border-[var(--broadsheet-accent)] hover:bg-white"
+            >
+              <Upload size={14} className="mr-2" />
+              Import Proof
+            </Button>
+            <Button
+              onClick={handleResetProgress}
+              variant="outline"
+              size="sm"
+              className="rounded-full border-[#b7423f] bg-[#f6d4d1] px-4 py-1 font-typewriter text-[11px] uppercase tracking-[0.32em] text-[#5c1714] transition hover:bg-[#f2bdb8]"
+            >
+              <RotateCcw size={14} className="mr-2" />
+              Reset
+            </Button>
+          </div>
+        </header>
+
+        <div className="grid flex-1 gap-6 lg:grid-cols-[1.6fr,1fr]">
+          <section className="flex h-full flex-col rounded-xl border border-[var(--broadsheet-rule)] bg-[rgba(255,255,255,0.86)] p-5 shadow-sm">
+            <header className="flex flex-wrap items-center justify-between gap-3">
+              <h3 className="font-broadsheetSans text-xl uppercase tracking-[0.16em]">Achievement Ledger</h3>
+              <div className="flex flex-wrap gap-2">
+                {filterOptions.map(option => (
+                  <button
+                    key={option.key}
+                    type="button"
+                    onClick={() => setFilter(option.key)}
+                    className={clsx(
+                      'rounded-full border px-3 py-1 font-typewriter text-[11px] uppercase tracking-[0.28em] transition',
+                      filter === option.key
+                        ? 'border-[var(--broadsheet-accent)] bg-[var(--broadsheet-accent-soft)] text-[var(--broadsheet-ink)]'
+                        : 'border-[var(--broadsheet-rule)] text-[var(--broadsheet-muted)] hover:border-[var(--broadsheet-accent)] hover:text-[var(--broadsheet-ink)]',
+                    )}
+                  >
+                    {option.label}
+                  </button>
+                ))}
+              </div>
+            </header>
+
+            <ScrollArea className="mt-4 h-full pr-2">
+              <div className="space-y-6">
+                {filteredUnlocked.length > 0 && (
+                  <div>
+                    <p className="font-typewriter text-[10px] uppercase tracking-[0.38em] text-[var(--broadsheet-kicker)]">
+                      Filed Triumphs
+                    </p>
+                    <div className="mt-2 space-y-3">
+                      {filteredUnlocked.map(achievement => (
+                        <button
+                          key={achievement.id}
+                          type="button"
+                          onClick={() => setSelectedAchievement(achievement)}
+                          className={clsx(
+                            'w-full rounded-xl border border-[var(--broadsheet-rule)] bg-white/85 p-4 text-left transition',
+                            selectedAchievement?.id === achievement.id
+                              ? 'border-[var(--broadsheet-accent)] shadow-[0_16px_38px_rgba(0,0,0,0.12)]'
+                              : 'hover:border-[var(--broadsheet-accent)] hover:bg-white',
+                          )}
+                        >
+                          <div className="flex items-start gap-4">
+                            <div className="text-3xl text-[var(--broadsheet-accent)]">{achievement.icon}</div>
+                            <div className="flex-1 space-y-2">
+                              <div className="flex flex-wrap items-center gap-2">
+                                <h4 className="font-broadsheetSans text-lg uppercase tracking-[0.12em]">
+                                  {achievement.name}
+                                </h4>
+                                <span
+                                  className={clsx(
+                                    'rounded-full px-3 py-1 font-typewriter text-[10px] uppercase tracking-[0.28em]',
+                                    getBroadsheetRarityTone(achievement.rarity),
+                                  )}
+                                >
+                                  {achievement.rarity}
+                                </span>
+                                <span className="rounded-full border border-[var(--broadsheet-rule)] px-2 py-0.5 font-typewriter text-[10px] uppercase tracking-[0.32em] text-[var(--broadsheet-muted)]">
+                                  {achievement.points} pts
+                                </span>
+                              </div>
+                              <p className="font-broadsheet text-[15px] leading-relaxed text-[var(--broadsheet-muted)]">
+                                {achievement.description}
+                              </p>
+                              <div className="flex flex-wrap items-center gap-3 font-typewriter text-[10px] uppercase tracking-[0.32em] text-[var(--broadsheet-muted)]">
+                                <span>{achievement.category}</span>
+                                <span className="text-[#2f6f3a]">✓ Printed</span>
+                              </div>
+                            </div>
+                          </div>
+                        </button>
+                      ))}
+                    </div>
+                  </div>
+                )}
+
+                {filteredLocked.length > 0 && (
+                  <div>
+                    <p className="font-typewriter text-[10px] uppercase tracking-[0.38em] text-[var(--broadsheet-muted)]">
+                      Pending Investigations
+                    </p>
+                    <div className="mt-2 space-y-3">
+                      {filteredLocked.map(achievement => (
+                        <button
+                          key={achievement.id}
+                          type="button"
+                          onClick={() => setSelectedAchievement(achievement)}
+                          className={clsx(
+                            'w-full rounded-xl border border-dashed border-[var(--broadsheet-rule)] bg-white/70 p-4 text-left transition',
+                            selectedAchievement?.id === achievement.id
+                              ? 'border-[var(--broadsheet-accent)] shadow-[0_16px_38px_rgba(0,0,0,0.12)]'
+                              : 'hover:border-[var(--broadsheet-accent)] hover:bg-white/85',
+                          )}
+                        >
+                          <div className="flex items-start gap-4 opacity-80">
+                            <div className="text-3xl text-[var(--broadsheet-muted)]">{achievement.icon}</div>
+                            <div className="flex-1 space-y-2">
+                              <div className="flex flex-wrap items-center gap-2">
+                                <h4 className="font-broadsheetSans text-lg uppercase tracking-[0.12em]">
+                                  {achievement.name}
+                                </h4>
+                                <span
+                                  className={clsx(
+                                    'rounded-full px-3 py-1 font-typewriter text-[10px] uppercase tracking-[0.28em]',
+                                    getBroadsheetRarityTone(achievement.rarity),
+                                  )}
+                                >
+                                  {achievement.rarity}
+                                </span>
+                                <span className="rounded-full border border-[var(--broadsheet-rule)] px-2 py-0.5 font-typewriter text-[10px] uppercase tracking-[0.32em] text-[var(--broadsheet-muted)]">
+                                  {achievement.points} pts
+                                </span>
+                              </div>
+                              <p className="font-broadsheet text-[15px] leading-relaxed text-[var(--broadsheet-muted)]">
+                                {achievement.description}
+                              </p>
+                              <div className="font-typewriter text-[10px] uppercase tracking-[0.32em] text-[var(--broadsheet-muted)]">
+                                🔒 Evidence pending
+                              </div>
+                            </div>
+                          </div>
+                        </button>
+                      ))}
+                    </div>
+                  </div>
+                )}
+              </div>
+            </ScrollArea>
+          </section>
+
+          <aside className="flex h-full flex-col rounded-xl border border-[var(--broadsheet-rule)] bg-[rgba(255,255,255,0.86)] p-5 shadow-sm">
+            {selectedAchievement ? (
+              <div className="flex h-full flex-col gap-5">
+                <div className="space-y-2">
+                  <p className="font-typewriter text-[10px] uppercase tracking-[0.38em] text-[var(--broadsheet-kicker)]">
+                    Profile Dossier
+                  </p>
+                  <h3 className="font-broadsheetSans text-2xl uppercase tracking-[0.16em]">
+                    {selectedAchievement.name}
+                  </h3>
+                  <p className="font-broadsheet text-[15px] leading-relaxed text-[var(--broadsheet-muted)]">
+                    {selectedAchievement.description}
+                  </p>
+                </div>
+
+                <div className="space-y-3 rounded-lg border border-[var(--broadsheet-rule)] bg-white/90 p-4">
+                  <div className="flex items-center justify-between">
+                    <span className="font-typewriter text-[10px] uppercase tracking-[0.32em] text-[var(--broadsheet-muted)]">Category</span>
+                    <span className="font-typewriter text-[11px] uppercase tracking-[0.32em] text-[var(--broadsheet-ink)]">
+                      {selectedAchievement.category}
+                    </span>
+                  </div>
+                  <div className="flex items-center justify-between">
+                    <span className="font-typewriter text-[10px] uppercase tracking-[0.32em] text-[var(--broadsheet-muted)]">Rarity</span>
+                    <span className={clsx(
+                      'rounded-full px-3 py-1 font-typewriter text-[10px] uppercase tracking-[0.28em]',
+                      getBroadsheetRarityTone(selectedAchievement.rarity),
+                    )}>
+                      {selectedAchievement.rarity}
+                    </span>
+                  </div>
+                  <div className="flex items-center justify-between">
+                    <span className="font-typewriter text-[10px] uppercase tracking-[0.32em] text-[var(--broadsheet-muted)]">Points</span>
+                    <span className="font-broadsheetSans text-xl text-[var(--broadsheet-ink)]">
+                      {selectedAchievement.points}
+                    </span>
+                  </div>
+                  <div className="flex items-center justify-between">
+                    <span className="font-typewriter text-[10px] uppercase tracking-[0.32em] text-[var(--broadsheet-muted)]">Status</span>
+                    <span className="font-typewriter text-[11px] uppercase tracking-[0.32em] text-[#2f6f3a]">
+                      {unlockedAchievements.find(a => a.id === selectedAchievement.id) ? 'Filed' : 'Sealed'}
+                    </span>
+                  </div>
+                </div>
+
+                {selectedAchievement.requirements && (
+                  <div className="space-y-2">
+                    <p className="font-typewriter text-[10px] uppercase tracking-[0.38em] text-[var(--broadsheet-kicker)]">
+                      Requirements
+                    </p>
+                    <div className="space-y-2">
+                      {selectedAchievement.requirements.conditions.map((condition, index) => (
+                        <div
+                          key={index}
+                          className="rounded-lg border border-dashed border-[var(--broadsheet-rule)] bg-white/80 p-2 font-typewriter text-[11px] uppercase tracking-[0.3em] text-[var(--broadsheet-muted)]"
+                        >
+                          {condition.key.replace(/_/g, ' ')}: {condition.operator || '=='} {condition.value}
+                        </div>
+                      ))}
+                    </div>
+                  </div>
+                )}
+
+                {selectedAchievement.rewards && (
+                  <div className="space-y-2">
+                    <p className="font-typewriter text-[10px] uppercase tracking-[0.38em] text-[var(--broadsheet-kicker)]">
+                      Rewards
+                    </p>
+                    <div className="space-y-1 font-broadsheet text-[14px] leading-relaxed text-[var(--broadsheet-ink)]">
+                      {selectedAchievement.rewards.title && (
+                        <p>Honorific: {selectedAchievement.rewards.title}</p>
+                      )}
+                      {selectedAchievement.rewards.unlockTutorial && (
+                        <p>Unlocks correspondence: {selectedAchievement.rewards.unlockTutorial}</p>
+                      )}
+                      {selectedAchievement.rewards.unlockCard && (
+                        <p>Card Issued: {selectedAchievement.rewards.unlockCard}</p>
+                      )}
+                    </div>
+                  </div>
+                )}
+              </div>
+            ) : (
+              <div className="flex h-full flex-col items-center justify-center rounded-xl border border-dashed border-[var(--broadsheet-rule)] bg-white/80 p-6 text-center">
+                <p className="font-broadsheetSans text-xl uppercase tracking-[0.18em]">Select a headline to inspect the clippings.</p>
+                <p className="mt-2 font-broadsheet text-[15px] leading-relaxed text-[var(--broadsheet-muted)]">
+                  Choose an achievement from the ledger to open its dossier details.
+                </p>
+              </div>
+            )}
+          </aside>
+        </div>
+      </div>
+    );
+  }
 
   return (
     <div className={`flex h-full flex-col gap-5 text-slate-200 ${className ?? ''}`}>

--- a/src/components/game/CardCollection.tsx
+++ b/src/components/game/CardCollection.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useState } from 'react';
+import clsx from 'clsx';
 import { Dialog, DialogContent } from '@/components/ui/dialog';
 import { Badge } from '@/components/ui/badge';
 import { Input } from '@/components/ui/input';
@@ -15,12 +16,14 @@ interface CardCollectionContentProps {
   isActive?: boolean;
   onClose?: () => void;
   className?: string;
+  variant?: 'default' | 'broadsheet';
 }
 
 export const CardCollectionContent = ({
   isActive = true,
   onClose,
   className,
+  variant = 'default',
 }: CardCollectionContentProps) => {
   const { getDiscoveredCards, getCardStats, getCollectionStats } = useCardCollection();
   const [searchTerm, setSearchTerm] = useState('');
@@ -66,11 +69,61 @@ export const CardCollectionContent = ({
     }
   };
 
-  const CardItem = ({ card }: { card: GameCard }) => {
+  const CardItem = ({ card, variant }: { card: GameCard; variant: 'default' | 'broadsheet' }) => {
     const cardStats = getCardStats(card.id);
 
     const rawCardText = card.text ?? '';
     const cardDescription = rawCardText.trim().length > 0 ? rawCardText : 'No description available.';
+
+    if (variant === 'broadsheet') {
+      return (
+        <button
+          type="button"
+          onClick={() => setSelectedCard(card)}
+          className="w-full text-left"
+          aria-label={`View details for ${card.name}`}
+        >
+          <div
+            className="group relative overflow-hidden rounded-xl border border-[var(--broadsheet-rule)] bg-[rgba(255,255,255,0.88)] p-5 shadow-sm transition hover:border-[var(--broadsheet-accent)] hover:shadow-[0_16px_36px_rgba(0,0,0,0.12)]"
+          >
+            <div className="relative mb-3 flex flex-wrap items-start justify-between gap-3">
+              <div>
+                <p className="font-typewriter text-[10px] uppercase tracking-[0.32em] text-[var(--broadsheet-kicker)]">
+                  {normalizeCardType(card.type)}
+                </p>
+                <h3 className="font-broadsheetSans text-xl uppercase tracking-[0.14em]">{card.name}</h3>
+              </div>
+              <div className="flex flex-wrap gap-2">
+                <span
+                  className={clsx(
+                    'rounded-full px-3 py-1 font-typewriter text-[10px] uppercase tracking-[0.28em]',
+                    getBroadsheetRarityTone(card.rarity),
+                  )}
+                >
+                  {card.rarity}
+                </span>
+                <span className="rounded-full border border-[var(--broadsheet-rule)] px-3 py-1 font-typewriter text-[10px] uppercase tracking-[0.28em] text-[var(--broadsheet-muted)]">
+                  Cost {card.cost} IP
+                </span>
+              </div>
+            </div>
+
+            <p className="font-broadsheet text-[15px] leading-relaxed text-[var(--broadsheet-muted)]">{cardDescription}</p>
+
+            <div className="mt-4 flex flex-wrap items-center justify-between gap-3 font-typewriter text-[10px] uppercase tracking-[0.3em] text-[var(--broadsheet-muted)]">
+              <span>Played {cardStats.timesPlayed} times</span>
+              <span>{cardStats.winRate ? `${Math.round(cardStats.winRate * 100)}% win rate` : 'Win rate pending'}</span>
+            </div>
+
+            {(card.flavor ?? card.flavorGov ?? card.flavorTruth) && (
+              <div className="mt-4 rounded-lg border border-dashed border-[var(--broadsheet-rule)] bg-white/80 p-3 font-broadsheet text-[14px] italic text-[var(--broadsheet-ink)]">
+                "{card.flavor ?? card.flavorGov ?? card.flavorTruth}"
+              </div>
+            )}
+          </div>
+        </button>
+      );
+    }
 
     return (
       <button
@@ -109,6 +162,100 @@ export const CardCollectionContent = ({
       </button>
     );
   };
+  if (variant === 'broadsheet') {
+    return (
+      <div className={clsx('flex h-full flex-col gap-6 text-[var(--broadsheet-ink)]', className)}>
+        <header className="rounded-xl border border-[var(--broadsheet-rule)] bg-[rgba(255,255,255,0.9)] px-6 py-5 shadow-sm">
+          <div className="flex flex-wrap items-start justify-between gap-6">
+            <div className="space-y-3">
+              <p className="font-typewriter text-[11px] uppercase tracking-[0.42em] text-[var(--broadsheet-kicker)]">Collector Insert</p>
+              <h2 className="font-broadsheetSans text-3xl uppercase tracking-[0.16em]">Back-Page Archives</h2>
+              <p className="max-w-2xl font-broadsheet text-[15px] leading-relaxed text-[var(--broadsheet-muted)]">
+                Perforated card proofs, misaligned ink, and stat sheets smuggled out of the pressroom binder.
+              </p>
+            </div>
+            <div className="grid min-w-[240px] grid-cols-3 gap-3 text-center">
+              <div className="rounded-lg border border-[var(--broadsheet-rule)] bg-white/90 p-3 shadow-sm">
+                <p className="font-typewriter text-[10px] uppercase tracking-[0.3em] text-[var(--broadsheet-muted)]">Discovered</p>
+                <p className="font-broadsheetSans text-xl">{stats.discoveredCards}</p>
+              </div>
+              <div className="rounded-lg border border-[var(--broadsheet-rule)] bg-white/90 p-3 shadow-sm">
+                <p className="font-typewriter text-[10px] uppercase tracking-[0.3em] text-[var(--broadsheet-muted)]">Played</p>
+                <p className="font-broadsheetSans text-xl">{stats.totalPlays}</p>
+              </div>
+              <div className="rounded-lg border border-[var(--broadsheet-rule)] bg-white/90 p-3 shadow-sm">
+                <p className="font-typewriter text-[10px] uppercase tracking-[0.3em] text-[var(--broadsheet-muted)]">Complete</p>
+                <p className="font-broadsheetSans text-xl">{stats.completionPercentage}%</p>
+              </div>
+            </div>
+          </div>
+        </header>
+
+        <div className="flex flex-col gap-4 rounded-xl border border-[var(--broadsheet-rule)] bg-[rgba(255,255,255,0.86)] p-5 shadow-sm lg:flex-row">
+          <Input
+            placeholder="Search cards..."
+            value={searchTerm}
+            onChange={(e) => setSearchTerm(e.target.value)}
+            className="flex-1 rounded-lg border border-[var(--broadsheet-rule)] bg-white/90 px-4 py-2 font-broadsheet text-[15px] text-[var(--broadsheet-ink)] placeholder:text-[var(--broadsheet-muted)] focus:border-[var(--broadsheet-accent)] focus:ring-0"
+          />
+          <div className="flex flex-1 flex-wrap gap-2 sm:flex-none">
+            <Select value={filterType} onValueChange={setFilterType}>
+              <SelectTrigger className="min-w-[160px] rounded-lg border border-[var(--broadsheet-rule)] bg-white/90 px-4 py-2 font-typewriter text-[11px] uppercase tracking-[0.28em] text-[var(--broadsheet-ink)]">
+                <SelectValue placeholder="Type" />
+              </SelectTrigger>
+              <SelectContent className="border border-[var(--broadsheet-rule)] bg-[rgba(255,255,255,0.95)] text-[var(--broadsheet-ink)]">
+                <SelectItem value="all">All Types</SelectItem>
+                <SelectItem value="MEDIA">Media</SelectItem>
+                <SelectItem value="ZONE">Zone</SelectItem>
+                <SelectItem value="ATTACK">Attack</SelectItem>
+              </SelectContent>
+            </Select>
+            <Select value={filterRarity} onValueChange={setFilterRarity}>
+              <SelectTrigger className="min-w-[160px] rounded-lg border border-[var(--broadsheet-rule)] bg-white/90 px-4 py-2 font-typewriter text-[11px] uppercase tracking-[0.28em] text-[var(--broadsheet-ink)]">
+                <SelectValue placeholder="Rarity" />
+              </SelectTrigger>
+              <SelectContent className="border border-[var(--broadsheet-rule)] bg-[rgba(255,255,255,0.95)] text-[var(--broadsheet-ink)]">
+                <SelectItem value="all">All Rarities</SelectItem>
+                <SelectItem value="common">Common</SelectItem>
+                <SelectItem value="uncommon">Uncommon</SelectItem>
+                <SelectItem value="rare">Rare</SelectItem>
+                <SelectItem value="legendary">Legendary</SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
+        </div>
+
+        <div className="flex-1 overflow-hidden">
+          {filteredCards.length === 0 ? (
+            <div className="flex h-full items-center justify-center rounded-xl border border-dashed border-[var(--broadsheet-rule)] bg-white/70 text-center font-broadsheet text-[15px] text-[var(--broadsheet-muted)]">
+              {discoveredCards.length === 0
+                ? 'Start playing to discover cards!'
+                : 'No cards match your search criteria.'}
+            </div>
+          ) : (
+            <ScrollArea className="h-full pr-2">
+              <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+                {filteredCards.map(card => (
+                  <CardItem key={card.id} card={card} variant="broadsheet" />
+                ))}
+              </div>
+            </ScrollArea>
+          )}
+        </div>
+
+        {selectedCard && (
+          <CardDetailOverlay
+            card={selectedCard}
+            canAfford={false}
+            disabled
+            onClose={() => setSelectedCard(null)}
+            onPlayCard={() => setSelectedCard(null)}
+          />
+        )}
+      </div>
+    );
+  }
+
 
   return (
     <div className={`flex h-full flex-col gap-5 text-slate-200 ${className ?? ''}`}>
@@ -199,7 +346,7 @@ export const CardCollectionContent = ({
         ) : (
           <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
             {filteredCards.map(card => (
-              <CardItem key={card.id} card={card} />
+              <CardItem key={card.id} card={card} variant={variant} />
             ))}
           </div>
         )}

--- a/src/components/game/EvidenceArchivePanel.tsx
+++ b/src/components/game/EvidenceArchivePanel.tsx
@@ -12,6 +12,7 @@ interface EvidenceArchivePanelProps {
   onDelete: (id: string) => void;
   onClear?: () => void;
   className?: string;
+  variant?: 'default' | 'broadsheet';
 }
 
 const FILTER_ALL = 'all';
@@ -23,7 +24,7 @@ const formatTurnLabel = (turn: number, round: number): string => {
   return `Round ${round}, Turn ${turn}`;
 };
 
-const EvidenceArchivePanel = ({ entries, onDelete, onClear, className }: EvidenceArchivePanelProps) => {
+const EvidenceArchivePanel = ({ entries, onDelete, onClear, className, variant = 'default' }: EvidenceArchivePanelProps) => {
   const [stateFilter, setStateFilter] = useState<string>(FILTER_ALL);
   const [factionFilter, setFactionFilter] = useState<string>(FILTER_ALL);
   const [typeFilter, setTypeFilter] = useState<string>(FILTER_ALL);
@@ -59,16 +60,177 @@ const EvidenceArchivePanel = ({ entries, onDelete, onClear, className }: Evidenc
       return matchesState && matchesFaction && matchesType;
     });
 
+    const toOptionObjects = (entries: Array<[string, string]>) =>
+      entries
+        .filter(([value]) => Boolean(value))
+        .map(([value, label]) => ({ value, label }));
+
     return {
-      stateOptions: Array.from(states.entries()),
-      factionOptions: Array.from(factions.entries()),
-      typeOptions: Array.from(types.entries()),
+      stateOptions: [
+        { value: FILTER_ALL, label: 'All States' },
+        ...toOptionObjects(Array.from(states.entries()).sort((a, b) => a[1].localeCompare(b[1]))),
+      ],
+      factionOptions: [
+        { value: FILTER_ALL, label: 'All Factions' },
+        ...toOptionObjects(Array.from(factions.entries()).sort((a, b) => a[1].localeCompare(b[1]))),
+      ],
+      typeOptions: [
+        { value: FILTER_ALL, label: 'All Types' },
+        ...toOptionObjects(Array.from(types.entries()).sort((a, b) => a[1].localeCompare(b[1]))),
+      ],
       filteredEntries: filtered,
     };
   }, [entries, factionFilter, stateFilter, typeFilter]);
 
   const hasEntries = entries.length > 0;
   const hasFilteredResults = filteredEntries.length > 0;
+
+  const handleClearFilters = () => {
+    setStateFilter(FILTER_ALL);
+    setFactionFilter(FILTER_ALL);
+    setTypeFilter(FILTER_ALL);
+    onClear?.();
+  };
+
+  if (variant === 'broadsheet') {
+    return (
+      <div className={clsx('flex h-full flex-col gap-6 text-[var(--broadsheet-ink)]', className)}>
+        <header className="rounded-xl border border-[var(--broadsheet-rule)] bg-[rgba(255,255,255,0.9)] px-5 py-4 shadow-sm">
+          <div className="flex items-center justify-between">
+            <div>
+              <p className="font-typewriter text-[11px] uppercase tracking-[0.42em] text-[var(--broadsheet-kicker)]">Supplement A</p>
+              <h3 className="font-broadsheetSans text-2xl uppercase tracking-[0.16em]">Evidence Annex</h3>
+            </div>
+            <Layers className="h-6 w-6 text-[var(--broadsheet-accent)]" aria-hidden />
+          </div>
+        </header>
+
+        <div className="flex flex-col gap-3 rounded-xl border border-[var(--broadsheet-rule)] bg-[rgba(255,255,255,0.86)] p-4 shadow-sm md:flex-row">
+          <div className="grid flex-1 grid-cols-1 gap-3 sm:grid-cols-3">
+            <Select value={stateFilter} onValueChange={setStateFilter}>
+              <SelectTrigger className="rounded-lg border border-[var(--broadsheet-rule)] bg-white/90 px-4 py-2 font-typewriter text-[11px] uppercase tracking-[0.28em] text-[var(--broadsheet-ink)]">
+                <SelectValue placeholder="State" />
+              </SelectTrigger>
+              <SelectContent className="border border-[var(--broadsheet-rule)] bg-[rgba(255,255,255,0.95)] text-[var(--broadsheet-ink)]">
+                {stateOptions.map(option => (
+                  <SelectItem key={option.value} value={option.value}>
+                    {option.label}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+            <Select value={factionFilter} onValueChange={setFactionFilter}>
+              <SelectTrigger className="rounded-lg border border-[var(--broadsheet-rule)] bg-white/90 px-4 py-2 font-typewriter text-[11px] uppercase tracking-[0.28em] text-[var(--broadsheet-ink)]">
+                <SelectValue placeholder="Faction" />
+              </SelectTrigger>
+              <SelectContent className="border border-[var(--broadsheet-rule)] bg-[rgba(255,255,255,0.95)] text-[var(--broadsheet-ink)]">
+                {factionOptions.map(option => (
+                  <SelectItem key={option.value} value={option.value}>
+                    {option.label}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+            <Select value={typeFilter} onValueChange={setTypeFilter}>
+              <SelectTrigger className="rounded-lg border border-[var(--broadsheet-rule)] bg-white/90 px-4 py-2 font-typewriter text-[11px] uppercase tracking-[0.28em] text-[var(--broadsheet-ink)]">
+                <SelectValue placeholder="Type" />
+              </SelectTrigger>
+              <SelectContent className="border border-[var(--broadsheet-rule)] bg-[rgba(255,255,255,0.95)] text-[var(--broadsheet-ink)]">
+                {typeOptions.map(option => (
+                  <SelectItem key={option.value} value={option.value}>
+                    {option.label}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+          <Button
+            onClick={handleClearFilters}
+            variant="outline"
+            size="sm"
+            className="rounded-full border border-[var(--broadsheet-rule)] bg-white/85 px-4 py-1 font-typewriter text-[11px] uppercase tracking-[0.3em] text-[var(--broadsheet-ink)] hover:border-[var(--broadsheet-accent)]"
+          >
+            Clear Filters
+          </Button>
+        </div>
+
+        <div className="flex-1 overflow-hidden">
+          {filteredEntries.length === 0 ? (
+            <div className="flex h-full items-center justify-center rounded-xl border border-dashed border-[var(--broadsheet-rule)] bg-white/80 p-6 text-center font-broadsheet text-[15px] text-[var(--broadsheet-muted)]">
+              No evidence logged with current filters.
+            </div>
+          ) : (
+            <ScrollArea className="h-full pr-2">
+              <div className="space-y-3">
+                {filteredEntries.map(entry => (
+                  <article
+                    key={entry.id}
+                    className="rounded-xl border border-[var(--broadsheet-rule)] bg-[rgba(255,255,255,0.86)] p-4 shadow-sm transition hover:border-[var(--broadsheet-accent)] hover:shadow-[0_12px_30px_rgba(0,0,0,0.12)]"
+                  >
+                    <div className="flex flex-wrap items-start justify-between gap-3">
+                      <div>
+                        <p className="font-typewriter text-[10px] uppercase tracking-[0.32em] text-[var(--broadsheet-muted)]">
+                          {entry.stateName ?? entry.stateAbbreviation ?? entry.stateId ?? 'Unknown location'}
+                        </p>
+                        <h4 className="font-broadsheetSans text-lg uppercase tracking-[0.14em]">{entry.eventLabel}</h4>
+                      </div>
+                      <span className="rounded-full border border-[var(--broadsheet-rule)] px-3 py-1 font-typewriter text-[10px] uppercase tracking-[0.28em] text-[var(--broadsheet-muted)]">
+                        {formatTurnLabel(entry.triggeredOnTurn, entry.round)}
+                      </span>
+                    </div>
+
+                    <p className="mt-2 whitespace-pre-wrap font-broadsheet text-[15px] leading-relaxed text-[var(--broadsheet-muted)]">
+                      {entry.loreText}
+                    </p>
+
+                    {Array.isArray(entry.effectSummary) && entry.effectSummary.length > 0 && (
+                      <div className="mt-3 flex flex-wrap gap-2 font-typewriter text-[10px] uppercase tracking-[0.28em] text-[var(--broadsheet-muted)]">
+                        {entry.effectSummary.map(effect => (
+                          <span
+                            key={effect}
+                            className="rounded-full border border-[var(--broadsheet-rule)] bg-white/80 px-3 py-1"
+                          >
+                            {effect}
+                          </span>
+                        ))}
+                      </div>
+                    )}
+
+                    <div className="mt-3 flex flex-wrap items-center gap-3 font-typewriter text-[10px] uppercase tracking-[0.3em] text-[var(--broadsheet-muted)]">
+                      <span className="flex items-center gap-1">
+                        <Flag className="h-4 w-4 text-[var(--broadsheet-accent)]" />
+                        {entry.faction === 'truth'
+                          ? 'Truth Network'
+                          : entry.faction === 'government'
+                            ? 'Government'
+                            : 'Unknown faction'}
+                      </span>
+                      <span className="flex items-center gap-1">
+                        <MapPin className="h-4 w-4 text-[var(--broadsheet-accent)]" />
+                        {(entry.eventType ?? 'unknown').charAt(0).toUpperCase() + (entry.eventType ?? 'unknown').slice(1)}
+                      </span>
+                    </div>
+
+                    <div className="mt-3 flex flex-wrap items-center gap-3">
+                      <Button
+                        variant="ghost"
+                        size="sm"
+                        className="font-typewriter text-[11px] uppercase tracking-[0.3em] text-[var(--broadsheet-muted)] hover:text-[var(--broadsheet-accent)]"
+                        onClick={() => onDelete(entry.id)}
+                      >
+                        <Trash2 className="mr-1 h-4 w-4" aria-hidden />
+                        Remove
+                      </Button>
+                    </div>
+                  </article>
+                ))}
+              </div>
+            </ScrollArea>
+          )}
+        </div>
+      </div>
+    );
+  }
 
   return (
     <div className={clsx('flex h-full flex-col', className)}>
@@ -98,9 +260,9 @@ const EvidenceArchivePanel = ({ entries, onDelete, onClear, className }: Evidenc
                   </SelectTrigger>
                   <SelectContent>
                     <SelectItem value={FILTER_ALL}>All States</SelectItem>
-                    {stateOptions.map(([value, label]) => (
-                      <SelectItem key={value} value={value}>
-                        {label}
+                    {stateOptions.map(option => (
+                      <SelectItem key={option.value} value={option.value}>
+                        {option.label}
                       </SelectItem>
                     ))}
                   </SelectContent>
@@ -116,9 +278,9 @@ const EvidenceArchivePanel = ({ entries, onDelete, onClear, className }: Evidenc
                   </SelectTrigger>
                   <SelectContent>
                     <SelectItem value={FILTER_ALL}>All Factions</SelectItem>
-                    {factionOptions.map(([value, label]) => (
-                      <SelectItem key={value} value={value}>
-                        {label}
+                    {factionOptions.map(option => (
+                      <SelectItem key={option.value} value={option.value}>
+                        {option.label}
                       </SelectItem>
                     ))}
                   </SelectContent>
@@ -134,9 +296,9 @@ const EvidenceArchivePanel = ({ entries, onDelete, onClear, className }: Evidenc
                   </SelectTrigger>
                   <SelectContent>
                     <SelectItem value={FILTER_ALL}>All Types</SelectItem>
-                    {typeOptions.map(([value, label]) => (
-                      <SelectItem key={value} value={value}>
-                        {label}
+                    {typeOptions.map(option => (
+                      <SelectItem key={option.value} value={option.value}>
+                        {option.label}
                       </SelectItem>
                     ))}
                   </SelectContent>
@@ -149,10 +311,10 @@ const EvidenceArchivePanel = ({ entries, onDelete, onClear, className }: Evidenc
                   variant="ghost"
                   size="sm"
                   className="text-emerald-200/70 hover:text-emerald-100"
-                  onClick={onClear}
+                  onClick={handleClearFilters}
                 >
                   <Trash2 className="mr-1 h-4 w-4" aria-hidden />
-                  Clear Archive
+                  Clear Filters
                 </Button>
               </div>
             )}

--- a/src/components/game/PlayerHubOverlay.tsx
+++ b/src/components/game/PlayerHubOverlay.tsx
@@ -161,26 +161,17 @@ const PlayerHubOverlay = ({
     }
   }, []);
 
-  const agendaStatusTone: Record<AgendaMoment['status'], { badge: string; bullet: string }> = {
-    advance: {
-      badge: 'border-sky-500/60 bg-sky-500/10 text-sky-700 dark:text-sky-200',
-      bullet: 'border-sky-500 bg-sky-400',
-    },
-    setback: {
-      badge: 'border-rose-500/60 bg-rose-500/10 text-rose-700 dark:text-rose-200',
-      bullet: 'border-rose-500 bg-rose-400',
-    },
-    complete: {
-      badge: 'border-emerald-500/60 bg-emerald-500/10 text-emerald-700 dark:text-emerald-200',
-      bullet: 'border-emerald-500 bg-emerald-400',
-    },
+  const agendaStatusTone: Record<AgendaMoment['status'], string> = {
+    advance: 'border-[var(--broadsheet-accent)] bg-[var(--broadsheet-accent-soft)] text-[var(--broadsheet-ink)]',
+    setback: 'border-[#b7423f] bg-[#f5d4d1] text-[#5b1c15]',
+    complete: 'border-[#336f3a] bg-[#d1ead4] text-[#1f4b24]',
   };
 
   const agendaStatusLabel: Record<'all' | AgendaMoment['status'], string> = {
-    all: 'Alle',
-    advance: 'Fremdrift',
-    setback: 'Tilbakeslag',
-    complete: 'Fullført',
+    all: 'All',
+    advance: 'Advance',
+    setback: 'Setback',
+    complete: 'Complete',
   };
 
   const resolveMomentTimestamp = (timestamp: number | undefined): string => {
@@ -202,542 +193,412 @@ const PlayerHubOverlay = ({
     return `${month}/${day} ${hours}:${minutes}`;
   };
 
-  const difficultyTone: Record<AgendaDefinition['difficulty'], string> = {
-    easy: 'border-emerald-500/30 bg-emerald-500/15 text-emerald-600',
-    medium: 'border-amber-500/30 bg-amber-500/15 text-amber-700',
-    hard: 'border-rose-500/30 bg-rose-500/15 text-rose-600',
-    legendary: 'border-violet-500/30 bg-violet-500/15 text-violet-600',
+  const agendaDifficultyTone: Record<AgendaDefinition['difficulty'], string> = {
+    easy: 'border-[#336f3a] bg-[#d1ead4] text-[#1f4b24]',
+    medium: 'border-[#b1691b] bg-[#f6e2c5] text-[#633a09]',
+    hard: 'border-[#a12a3a] bg-[#f6cdd6] text-[#5c111d]',
+    legendary: 'border-[#3c3a8f] bg-[#dcd8f7] text-[#242064]',
   };
+
+  const dateline = useMemo(() => {
+    try {
+      return new Intl.DateTimeFormat(undefined, {
+        weekday: 'short',
+        month: 'short',
+        day: 'numeric',
+        year: 'numeric',
+      }).format(new Date());
+    } catch {
+      return new Date().toLocaleDateString();
+    }
+  }, []);
+
+  const volumeNumber = useMemo(
+    () => 208 + completedAgendaIds.length * 3 + (currentAgenda ? 1 : 0),
+    [completedAgendaIds.length, currentAgenda],
+  );
+
+  const tabDetails = useMemo(
+    (): Record<HubTab, { kicker: string; headline: string; dek: string; ticker: string; footer: string }> => ({
+      achievements: {
+        kicker: 'Scoop Filed',
+        headline: 'Centerfold of Glory',
+        dek: 'Hero mugshots, improbable stats, and “totally verified” testimonials.',
+        ticker: 'Hero desk updates every rotation. Suspicious applause recorded.',
+        footer: 'Send victory polaroids to the morgue editor before midnight.',
+      },
+      agendas: {
+        kicker: 'Classified Cables',
+        headline: 'Telegram Desk',
+        dek: 'Stamped envelopes leaking orders, setbacks, and whispered triumphs.',
+        ticker: 'Teleprinters jammed? Tap twice if the redaction lights flicker.',
+        footer: 'Agenda desk accepts bribes in microfilm or hand-labeled coffee tins.',
+      },
+      cards: {
+        kicker: 'Collector Insert',
+        headline: 'Back-Page Archives',
+        dek: 'Perforated card proofs with misaligned ink and contraband commentary.',
+        ticker: 'Rumor: new card run smuggled in cereal boxes, watch the aisles.',
+        footer: 'Clip-and-save corners so the archivist stops gnashing teeth.',
+      },
+      tutorials: {
+        kicker: 'Correspondence Course',
+        headline: 'Shadow Academy Lessons',
+        dek: 'Typewritten mailers teaching rookies to disappear and reappear in print.',
+        ticker: 'Night class enrollment up 23%. Faculty denies poltergeist assistance.',
+        footer: 'Return homework with coffee stains for accelerated grading.',
+      },
+      press: {
+        kicker: 'Newsstand Scoop',
+        headline: 'Leaked Editions',
+        dek: 'Stacked front pages liberated from shredders and “misplaced” trucks.',
+        ticker: 'Paperboys report third moonlight delivery in as many nights.',
+        footer: 'Tip the vendor in anomaly coupons for a bonus issue.',
+      },
+      evidence: {
+        kicker: 'Supplement A',
+        headline: 'Evidence Annex',
+        dek: 'Clippings, diagrams, and gum-stuck memos the officials call gossip.',
+        ticker: 'Evidence locker hum registered at 7.2 conspiracies per minute.',
+        footer: 'Keep pushpins recycled; the corkboard groans already.',
+      },
+      intel: {
+        kicker: 'Field Wires',
+        headline: 'Hotline Atlas',
+        dek: 'Live map of contested states, buzzing switchboards, and spectral sightings.',
+        ticker: 'Switchboard warns: crosswinds of truth spotted over flyover country.',
+        footer: 'Keep the hotline clear; ghosts insist on operator-assisted dialing.',
+      },
+    }),
+    [faction],
+  );
+
+  const stampLabel = faction === 'truth' ? 'Leaked Proof' : 'Cleared Copy';
+
+  const scribbleNote = useMemo(
+    () =>
+      faction === 'truth'
+        ? `Stashed this layout in the abandoned pressroom. ${completedAgendas.length} dossiers cracked so far — ink your alibis.`
+        : `Filed under “routine morale bulletin.” If ${completedAgendas.length} cases solved, remind interns to deny everything.`,
+    [faction, completedAgendas.length],
+  );
+
+  const tickerItems = useMemo(() => {
+    const items: string[] = [];
+    items.push(`Vol. ${volumeNumber.toString().padStart(3, '0')} // ${dateline}`);
+    items.push(tabDetails[activeTab].ticker);
+    const signalCount = (stateIntel?.recentEvents.length ?? 0) + intelArchive.length;
+    const agendaCount = completedAgendas.length + (currentAgenda ? 1 : 0);
+    items.push(`${signalCount} wires buzzing // ${agendaCount} dossiers live`);
+    return items;
+  }, [volumeNumber, dateline, tabDetails, activeTab, stateIntel?.recentEvents.length, intelArchive.length, completedAgendas.length, currentAgenda]);
 
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/80 p-4">
       <Card
         className={clsx(
-          'player-hub-card relative flex h-[90vh] w-full max-w-7xl flex-col overflow-hidden',
-          isTruth
-            ? 'player-hub-truth border border-amber-900/40 bg-[rgba(252,245,232,0.97)] text-stone-900 shadow-[0_35px_120px_rgba(124,45,18,0.25)]'
-            : 'player-hub-government border border-emerald-500/30 bg-slate-950/95 text-slate-100 shadow-[0_0_80px_rgba(16,185,129,0.25)]',
+          'player-hub-card player-hub-broadsheet relative flex h-[90vh] w-full max-w-7xl flex-col',
+          isTruth ? 'player-hub-truth' : 'player-hub-government',
         )}
       >
-        <div className="player-hub-background pointer-events-none absolute inset-0">
-          {isTruth ? (
-            <>
-              <div className="player-hub-truth__paper" />
-              <div className="player-hub-truth__grain" />
-              <div className="player-hub-truth__thread player-hub-truth__thread--one" />
-              <div className="player-hub-truth__thread player-hub-truth__thread--two" />
-              <div className="player-hub-truth__tape player-hub-truth__tape--one" />
-              <div className="player-hub-truth__tape player-hub-truth__tape--two" />
-            </>
-          ) : (
-            <>
-              <div className="absolute inset-0 bg-[radial-gradient(circle_at_top,_rgba(16,185,129,0.22),_transparent_55%)] opacity-60" />
-              <div className="absolute inset-0 bg-[radial-gradient(circle_at_bottom,_rgba(56,189,248,0.18),_transparent_60%)] opacity-50" />
-              <div
-                className="absolute inset-0 opacity-35 mix-blend-screen"
-                style={{ backgroundImage: 'linear-gradient(135deg, rgba(56,189,248,0.16), transparent 45%, rgba(16,185,129,0.12))' }}
-              />
-            </>
-          )}
+        <div className="player-hub-background">
+          <div className="broadsheet-paper" />
+          <div className="broadsheet-halftone" />
+          <div className="broadsheet-fibers" />
+          <div className="broadsheet-fold" />
+          <div className="broadsheet-margin-notes" />
         </div>
 
-        <div
-          className={clsx(
-            'player-hub-header relative border-b px-6 py-5 backdrop-blur',
-            isTruth
-              ? 'border-rose-900/40 bg-gradient-to-r from-amber-100 via-rose-50 to-amber-200/80 text-stone-900'
-              : 'border-emerald-500/20 bg-gradient-to-r from-emerald-900/40 via-slate-950 to-slate-950/90 text-emerald-100',
-          )}
-        >
-          <div className="flex flex-wrap items-start justify-between gap-6">
-            <div className="space-y-2">
-              <Badge
-                className={clsx(
-                  'player-hub-badge border font-mono text-[11px] uppercase tracking-[0.35em]',
-                  isTruth
-                    ? 'border-rose-800/60 bg-rose-100/90 text-rose-900 shadow-[0_6px_18px_rgba(124,45,18,0.18)]'
-                    : 'border-emerald-400/60 bg-emerald-500/15 text-emerald-200',
-                )}
-              >
-                Operator Uplink
-              </Badge>
-              <h2
-                className={clsx(
-                  'font-mono text-2xl font-semibold uppercase tracking-[0.2em]',
-                  isTruth ? 'text-rose-900 drop-shadow-[0_1px_0_rgba(255,255,255,0.65)]' : 'text-emerald-100',
-                )}
-              >
-                AGENT DOSSIER HUB
-              </h2>
-              <p
-                className={clsx(
-                  'max-w-2xl text-sm',
-                  isTruth ? 'text-stone-700' : 'text-emerald-100/70',
-                )}
-              >
-                Review your progress, browse unlocked cards, and continue your training across the network.
-              </p>
+        <div className="broadsheet-shell">
+          <header className="broadsheet-masthead">
+            <div className="broadsheet-masthead__logo">
+              <span>Paranoid Times Weekly</span>
+              <span>{faction === 'truth' ? 'Truth Underground Bureau' : 'Office of Official Narratives'}</span>
             </div>
+            <div className="broadsheet-masthead__edition">
+              <span>{dateline}</span>
+              <span>Volume {volumeNumber.toString().padStart(3, '0')}</span>
+              <span>Edition #{Math.max(pressIssues.length, 1).toString().padStart(2, '0')}</span>
+            </div>
+            <div className="broadsheet-masthead__price">3.50 or one classified lead</div>
             <Button
               onClick={onClose}
               variant="outline"
               size="sm"
-              className={clsx(
-                'player-hub-close-btn transition',
-                isTruth
-                  ? 'border-rose-800/40 bg-rose-100/70 text-rose-900 shadow-sm hover:bg-rose-200/80 hover:text-rose-900'
-                  : 'border-emerald-400/40 bg-emerald-500/10 text-emerald-200 hover:bg-emerald-500/20 hover:text-emerald-100',
-              )}
+              className="broadsheet-masthead__close rounded-full border-[1.5px] border-[var(--broadsheet-accent)] bg-white/80 px-4 py-1 font-typewriter text-[11px] uppercase tracking-[0.28em] text-[var(--broadsheet-accent)] shadow-sm transition hover:bg-white"
             >
-              <X size={16} className="mr-1" />
-              Close
+              <X size={14} className="mr-2" />
+              Close Archive
             </Button>
-          </div>
-        </div>
+          </header>
 
-        <Tabs
-          value={activeTab}
-          onValueChange={value => setActiveTab(value as HubTab)}
-          className="relative flex flex-1 flex-col overflow-hidden"
-        >
-          <div className="relative px-6 pt-6">
-            <TabsList
-              className={clsx(
-                'player-hub-tablist grid w-full grid-cols-7 gap-2 rounded-lg border p-1 backdrop-blur',
-                isTruth
-                  ? 'border-rose-900/40 bg-[rgba(255,255,255,0.86)] shadow-[inset_0_15px_40px_rgba(124,45,18,0.12)]'
-                  : 'border-emerald-500/20 bg-slate-900/70',
-              )}
-            >
-              <TabsTrigger
-                value="achievements"
-                className={clsx(
-                  'flex items-center justify-center gap-2 rounded-md border border-transparent px-3 py-2 text-[11px] font-semibold uppercase tracking-[0.32em] transition',
-                  isTruth
-                    ? 'text-stone-500 data-[state=active]:border-rose-900/60 data-[state=active]:bg-amber-100/90 data-[state=active]:text-rose-900 data-[state=active]:shadow-[inset_0_4px_18px_rgba(124,45,18,0.18)]'
-                    : 'text-slate-400 data-[state=active]:border-emerald-400/60 data-[state=active]:bg-emerald-500/15 data-[state=active]:text-emerald-200',
-                )}
-              >
-                <Trophy className="h-4 w-4" />
-                Achievements
-              </TabsTrigger>
-              <TabsTrigger
-                value="agendas"
-                className={clsx(
-                  'flex items-center justify-center gap-2 rounded-md border border-transparent px-3 py-2 text-[11px] font-semibold uppercase tracking-[0.32em] transition',
-                  isTruth
-                    ? 'text-stone-500 data-[state=active]:border-rose-900/60 data-[state=active]:bg-amber-100/90 data-[state=active]:text-rose-900 data-[state=active]:shadow-[inset_0_4px_18px_rgba(124,45,18,0.18)]'
-                    : 'text-slate-400 data-[state=active]:border-emerald-400/60 data-[state=active]:bg-emerald-500/15 data-[state=active]:text-emerald-200',
-                )}
-              >
-                <Target className="h-4 w-4" />
-                Agendas
-              </TabsTrigger>
-              <TabsTrigger
-                value="cards"
-                className={clsx(
-                  'flex items-center justify-center gap-2 rounded-md border border-transparent px-3 py-2 text-[11px] font-semibold uppercase tracking-[0.32em] transition',
-                  isTruth
-                    ? 'text-stone-500 data-[state=active]:border-rose-900/60 data-[state=active]:bg-amber-100/90 data-[state=active]:text-rose-900 data-[state=active]:shadow-[inset_0_4px_18px_rgba(124,45,18,0.18)]'
-                    : 'text-slate-400 data-[state=active]:border-emerald-400/60 data-[state=active]:bg-emerald-500/15 data-[state=active]:text-emerald-200',
-                )}
-              >
-                <Library className="h-4 w-4" />
-                Card Collection
-              </TabsTrigger>
-              <TabsTrigger
-                value="tutorials"
-                className={clsx(
-                  'flex items-center justify-center gap-2 rounded-md border border-transparent px-3 py-2 text-[11px] font-semibold uppercase tracking-[0.32em] transition',
-                  isTruth
-                    ? 'text-stone-500 data-[state=active]:border-rose-900/60 data-[state=active]:bg-amber-100/90 data-[state=active]:text-rose-900 data-[state=active]:shadow-[inset_0_4px_18px_rgba(124,45,18,0.18)]'
-                    : 'text-slate-400 data-[state=active]:border-emerald-400/60 data-[state=active]:bg-emerald-500/15 data-[state=active]:text-emerald-200',
-                )}
-              >
-                <GraduationCap className="h-4 w-4" />
-                Shadow Academy
-              </TabsTrigger>
-              <TabsTrigger
-                value="press"
-                className={clsx(
-                  'flex items-center justify-center gap-2 rounded-md border border-transparent px-3 py-2 text-[11px] font-semibold uppercase tracking-[0.32em] transition',
-                  isTruth
-                    ? 'text-stone-500 data-[state=active]:border-rose-900/60 data-[state=active]:bg-amber-100/90 data-[state=active]:text-rose-900 data-[state=active]:shadow-[inset_0_4px_18px_rgba(124,45,18,0.18)]'
-                    : 'text-slate-400 data-[state=active]:border-emerald-400/60 data-[state=active]:bg-emerald-500/15 data-[state=active]:text-emerald-200',
-                )}
-              >
-                <Newspaper className="h-4 w-4" />
-                Press Archive
-              </TabsTrigger>
-              <TabsTrigger
-                value="evidence"
-                className={clsx(
-                  'flex items-center justify-center gap-2 rounded-md border border-transparent px-3 py-2 text-[11px] font-semibold uppercase tracking-[0.32em] transition',
-                  isTruth
-                    ? 'text-stone-500 data-[state=active]:border-rose-900/60 data-[state=active]:bg-amber-100/90 data-[state=active]:text-rose-900 data-[state=active]:shadow-[inset_0_4px_18px_rgba(124,45,18,0.18)]'
-                    : 'text-slate-400 data-[state=active]:border-emerald-400/60 data-[state=active]:bg-emerald-500/15 data-[state=active]:text-emerald-200',
-                )}
-              >
-                <FileSearch2 className="h-4 w-4" />
-                Evidence
-              </TabsTrigger>
-              <TabsTrigger
-                value="intel"
-                className={clsx(
-                  'flex items-center justify-center gap-2 rounded-md border border-transparent px-3 py-2 text-[11px] font-semibold uppercase tracking-[0.32em] transition',
-                  isTruth
-                    ? 'text-stone-500 data-[state=active]:border-rose-900/60 data-[state=active]:bg-amber-100/90 data-[state=active]:text-rose-900 data-[state=active]:shadow-[inset_0_4px_18px_rgba(124,45,18,0.18)]'
-                    : 'text-slate-400 data-[state=active]:border-emerald-400/60 data-[state=active]:bg-emerald-500/15 data-[state=active]:text-emerald-200',
-                )}
-              >
-                <MapPin className="h-4 w-4" />
-                Field Intel
-              </TabsTrigger>
+          <Tabs
+            value={activeTab}
+            onValueChange={value => setActiveTab(value as HubTab)}
+            className="flex flex-1 flex-col"
+          >
+            <TabsList className="broadsheet-tablist">
+              {(Object.keys(tabDetails) as HubTab[]).map(tabKey => {
+                const detail = tabDetails[tabKey];
+                return (
+                  <TabsTrigger
+                    key={tabKey}
+                    value={tabKey}
+                    className="broadsheet-tab flex w-full flex-col items-start gap-1 tracking-[0.28em] data-[state=inactive]:opacity-85"
+                  >
+                    <span className="kicker">{detail.kicker}</span>
+                    <span>{detail.headline}</span>
+                    <span className="dek">{detail.dek}</span>
+                  </TabsTrigger>
+                );
+              })}
             </TabsList>
-          </div>
 
-          <div className="relative flex-1 overflow-hidden px-6 pb-6 pt-4">
-            <div
-              className={clsx(
-                'player-hub-panel relative flex h-full flex-col overflow-hidden rounded-2xl border',
-                isTruth
-                  ? 'border-rose-900/30 bg-[rgba(255,250,240,0.88)] shadow-[0_35px_80px_rgba(124,45,18,0.18)]'
-                  : 'border-emerald-500/25 bg-slate-950/80 shadow-[0_0_45px_rgba(16,185,129,0.15)]',
-              )}
-            >
-              <div className="pointer-events-none absolute inset-0 opacity-45">
-                {isTruth ? (
-                  <>
-                    <div className="absolute inset-0 bg-[radial-gradient(circle_at_top,_rgba(252,211,77,0.25),_transparent_60%)]" />
-                    <div className="absolute inset-0 bg-[linear-gradient(160deg,_rgba(244,114,182,0.18),_transparent_55%)]" />
-                  </>
-                ) : (
-                  <>
-                    <div className="absolute inset-0 bg-[radial-gradient(circle_at_top,_rgba(16,185,129,0.18),_transparent_55%)]" />
-                    <div className="absolute inset-0 bg-[linear-gradient(160deg,_rgba(56,189,248,0.12),_transparent_60%)]" />
-                  </>
-                )}
+            <div className="broadsheet-content">
+              <div className="broadsheet-stamp">{stampLabel}</div>
+              <div className="broadsheet-columns" aria-hidden />
+              <div className="broadsheet-content__ticker">
+                {tickerItems.map((item, index) => (
+                  <span key={`${item}-${index}`}>{item}</span>
+                ))}
               </div>
+              <div className="broadsheet-content__body">
+                <TabsContent
+                  value="achievements"
+                  className="relative h-full focus-visible:outline-none data-[state=inactive]:hidden"
+                >
+                  <AchievementsSection className="h-full" variant="broadsheet" />
+                </TabsContent>
 
-              <TabsContent value="achievements" className="relative h-full overflow-hidden p-6 focus-visible:outline-none">
-                <AchievementsSection className="h-full" />
-              </TabsContent>
-
-              <TabsContent value="agendas" className="relative h-full overflow-hidden p-6 focus-visible:outline-none">
-                <div className="flex h-full flex-col gap-4">
-                  {agendasEnabled ? (
-                    <>
-                      <Card
-                        className={clsx(
-                          'overflow-hidden border p-4 shadow-sm backdrop-blur',
-                          isTruth
-                            ? 'border-rose-900/30 bg-amber-50/80 text-stone-900'
-                            : 'border-emerald-500/25 bg-slate-900/80 text-emerald-50',
-                        )}
-                      >
-                        <div className="flex flex-wrap items-center justify-between gap-3">
-                          <div>
-                            <p className="text-[10px] font-semibold uppercase tracking-[0.32em] opacity-70">
-                              Active Agenda
-                            </p>
-                            <h3 className="text-lg font-bold uppercase tracking-[0.12em]">
-                              {currentAgenda?.title ?? 'No agenda assigned'}
-                            </h3>
-                          </div>
-                          {currentAgenda?.difficulty && (
-                            <Badge
-                              variant="outline"
-                              className={clsx(
-                                'border px-3 py-1 font-mono text-[10px] uppercase tracking-[0.32em]',
-                                difficultyTone[currentAgenda.difficulty],
-                              )}
-                            >
-                              {currentAgenda.difficulty}
-                            </Badge>
-                          )}
-                        </div>
-                        <div className="mt-4">
-                          {currentAgenda ? (
-                            <SecretAgendaCard agenda={currentAgenda} isPlayer={faction === 'truth'} />
-                          ) : (
-                            <div className="rounded border border-dashed border-current/40 bg-black/5 p-4 text-sm font-mono uppercase tracking-[0.2em] opacity-70">
-                              Awaiting assignment...
-                            </div>
-                          )}
-                        </div>
-                      </Card>
-
-                      <div className="flex-1 space-y-4 overflow-y-auto pr-1">
-                        {completedAgendas.length > 0 ? (
-                          <div className="grid gap-3 lg:grid-cols-2">
-                            {completedAgendas.map(agenda => (
-                              <Card
-                                key={agenda.id}
-                                className={clsx(
-                                  'h-full border p-4 transition hover:shadow-md',
-                                  isTruth
-                                    ? 'border-rose-900/30 bg-rose-50/80 text-stone-900'
-                                    : 'border-emerald-500/25 bg-slate-950/70 text-slate-100',
+                <TabsContent
+                  value="agendas"
+                  className="relative h-full focus-visible:outline-none data-[state=inactive]:hidden"
+                >
+                  <div className="flex h-full flex-col gap-6">
+                    {agendasEnabled ? (
+                      <>
+                        <div className="grid gap-6 lg:grid-cols-5">
+                          <div className="space-y-4 lg:col-span-3">
+                            <div className="rounded-xl border border-[var(--broadsheet-rule)] bg-[rgba(255,255,255,0.86)] p-5 shadow-sm">
+                              <div className="flex flex-wrap items-center justify-between gap-3">
+                                <div>
+                                  <p className="font-typewriter text-[10px] uppercase tracking-[0.42em] text-[var(--broadsheet-kicker)]">
+                                    Active Agenda Telegram
+                                  </p>
+                                  <h3 className="font-broadsheetSans text-2xl uppercase tracking-[0.18em]">
+                                    {currentAgenda?.title ?? 'Awaiting Assignment'}
+                                  </h3>
+                                </div>
+                                {currentAgenda?.difficulty && (
+                                  <Badge
+                                    variant="outline"
+                                    className={clsx(
+                                      'font-typewriter text-[11px] uppercase tracking-[0.38em]',
+                                      agendaDifficultyTone[currentAgenda.difficulty],
+                                    )}
+                                  >
+                                    {currentAgenda.difficulty}
+                                  </Badge>
                                 )}
-                              >
-                                <div className="flex flex-wrap items-center justify-between gap-2">
-                                  <div className="flex flex-wrap items-center gap-2">
-                                    <Badge variant="secondary" className="bg-green-500/20 text-green-900 dark:text-green-200">
-                                      Completed
-                                    </Badge>
-                                    <Badge
-                                      variant="outline"
+                              </div>
+                              <div className="mt-4 border-t border-dashed border-[var(--broadsheet-rule)] pt-4">
+                                {currentAgenda ? (
+                                  <SecretAgendaCard agenda={currentAgenda} isPlayer={faction === 'truth'} />
+                                ) : (
+                                  <div className="font-typewriter text-xs uppercase tracking-[0.32em] text-[var(--broadsheet-muted)]">
+                                    Bureaucrats misplaced the envelope again.
+                                  </div>
+                                )}
+                              </div>
+                            </div>
+                            <div className="rounded-xl border border-[var(--broadsheet-rule)] bg-[rgba(255,255,255,0.82)] p-5">
+                              <header className="mb-4 flex flex-wrap items-center justify-between gap-3">
+                                <div className="font-typewriter text-[11px] uppercase tracking-[0.38em] text-[var(--broadsheet-kicker)]">
+                                  Cable Log
+                                </div>
+                                <div className="flex flex-wrap items-center gap-2">
+                                  {(Object.keys(agendaStatusLabel) as Array<'all' | AgendaMoment['status']>).map(statusKey => (
+                                    <button
+                                      key={statusKey}
+                                      type="button"
+                                      onClick={() => setAgendaFilter(statusKey)}
                                       className={clsx(
-                                        'border px-2 py-0.5 font-mono text-[10px] uppercase tracking-[0.32em]',
-                                        difficultyTone[agenda.difficulty],
+                                        'rounded-full border px-3 py-1 text-[11px] font-typewriter uppercase tracking-[0.32em] transition',
+                                        agendaFilter === statusKey
+                                          ? 'border-[var(--broadsheet-accent)] bg-[var(--broadsheet-accent-soft)] text-[var(--broadsheet-ink)]'
+                                          : 'border-[var(--broadsheet-rule)] text-[var(--broadsheet-muted)] hover:bg-white/70',
                                       )}
                                     >
-                                      {agenda.difficulty}
-                                    </Badge>
-                                  </div>
-                                  <Badge variant="outline" className="text-[10px] uppercase tracking-[0.2em]">
-                                    {agenda.category}
-                                  </Badge>
+                                      {agendaStatusLabel[statusKey]}
+                                    </button>
+                                  ))}
                                 </div>
-                                <div className="mt-3 space-y-2">
-                                  <h4 className="text-base font-semibold uppercase tracking-[0.12em]">
-                                    {agenda.title}
-                                  </h4>
-                                  <p className="text-sm text-muted-foreground">
-                                    {agenda.description}
+                              </header>
+                              <div className="space-y-4 overflow-y-auto pr-1">
+                                {filteredAgendaHistory.length === 0 ? (
+                                  <p className="font-typewriter text-xs uppercase tracking-[0.3em] text-[var(--broadsheet-muted)]">
+                                    No cable traffic yet — suspiciously quiet.
                                   </p>
-                                  {agenda.issueTheme && (
-                                    <p className="text-[11px] font-mono uppercase tracking-[0.25em] text-muted-foreground/80">
-                                      Issue Focus: {agenda.issueTheme}
-                                    </p>
-                                  )}
-                                  {agenda.headline && (
-                                    <p className="text-xs italic text-muted-foreground/80">“{agenda.headline}”</p>
-                                  )}
-                                </div>
-                              </Card>
-                            ))}
-                          </div>
-                        ) : (
-                          <Card
-                            className={clsx(
-                              'border border-dashed p-6 text-center text-sm uppercase tracking-[0.28em]',
-                              isTruth
-                                ? 'border-rose-900/30 bg-rose-50/60 text-rose-900/70'
-                                : 'border-emerald-500/25 bg-slate-950/70 text-emerald-100/70',
-                            )}
-                          >
-                            No completed agendas logged yet.
-                          </Card>
-                        )}
-
-                        <Card
-                          className={clsx(
-                            'border p-4',
-                            isTruth
-                              ? 'border-rose-900/30 bg-rose-50/80 text-stone-900'
-                              : 'border-emerald-500/25 bg-slate-950/70 text-slate-100',
-                          )}
-                        >
-                          <div className="flex flex-wrap items-center justify-between gap-3">
-                            <div>
-                              <p className="text-[10px] font-semibold uppercase tracking-[0.32em] opacity-70">
-                                Agenda-Logg
-                              </p>
-                              <h3 className="text-lg font-bold uppercase tracking-[0.12em]">
-                                Historikk og signaler
-                              </h3>
-                            </div>
-                            <div className="flex flex-wrap gap-2">
-                              {(['all', 'advance', 'setback', 'complete'] as const).map(filterValue => (
-                                <button
-                                  key={filterValue}
-                                  type="button"
-                                  onClick={() => setAgendaFilter(filterValue)}
-                                  className={clsx(
-                                    'rounded-full border px-3 py-1 text-[10px] font-semibold uppercase tracking-[0.28em] transition',
-                                    agendaFilter === filterValue
-                                      ? isTruth
-                                        ? 'border-rose-900 bg-rose-200/40 text-rose-900 shadow-sm'
-                                        : 'border-emerald-400 bg-emerald-500/20 text-emerald-50 shadow-sm'
-                                      : isTruth
-                                        ? 'border-transparent bg-amber-100/40 text-rose-900/70 hover:border-rose-900/30 hover:bg-amber-100/60'
-                                        : 'border-transparent bg-slate-900/60 text-emerald-100/70 hover:border-emerald-500/30 hover:bg-slate-900/80',
-                                  )}
-                                >
-                                  {agendaStatusLabel[filterValue]}
-                                </button>
-                              ))}
-                            </div>
-                          </div>
-
-                          <div className="mt-4">
-                            {agendaHistory.length === 0 ? (
-                              <div
-                                className={clsx(
-                                  'rounded border border-dashed p-4 text-center text-xs uppercase tracking-[0.28em] opacity-70',
-                                  isTruth
-                                    ? 'border-rose-900/30 bg-amber-100/40 text-rose-900/70'
-                                    : 'border-emerald-500/25 bg-slate-950/60 text-emerald-100/70',
-                                )}
-                              >
-                                Ingen agenda-historikk registrert ennå.
-                              </div>
-                            ) : filteredAgendaHistory.length === 0 ? (
-                              <div
-                                className={clsx(
-                                  'rounded border border-dashed p-4 text-center text-xs uppercase tracking-[0.28em] opacity-70',
-                                  isTruth
-                                    ? 'border-rose-900/30 bg-amber-100/40 text-rose-900/70'
-                                    : 'border-emerald-500/25 bg-slate-950/60 text-emerald-100/70',
-                                )}
-                              >
-                                Ingen hendelser samsvarer med filteret.
-                              </div>
-                            ) : (
-                              <div className="relative">
-                                <div
-                                  className={clsx(
-                                    'absolute left-[0.65rem] top-2 bottom-2 w-px',
-                                    isTruth ? 'bg-rose-900/30' : 'bg-emerald-500/30',
-                                  )}
-                                />
-                                <div className="space-y-4">
-                                  {filteredAgendaHistory.map(moment => {
-                                    const progressLabel = `${moment.progress}/${moment.target}`;
-                                    const factionLabel =
-                                      moment.faction === 'truth' ? 'Truth Coalition' : 'Government Directorate';
-                                    const actorLabel = moment.actor === 'player' ? 'Operatives' : 'Opposition Network';
-                                    const tone = agendaStatusTone[moment.status];
-                                    const statusLabel =
-                                      moment.status === 'advance'
-                                        ? 'Fremdrift'
-                                        : moment.status === 'setback'
-                                        ? 'Tilbakeslag'
-                                        : 'Fullført';
-
-                                    return (
-                                      <div key={moment.id} className="relative pl-8">
+                                ) : (
+                                  filteredAgendaHistory.map(moment => (
+                                    <article
+                                      key={moment.id}
+                                      className="grid gap-3 rounded-lg border border-dashed border-[var(--broadsheet-rule)] bg-white/80 p-3 md:grid-cols-[180px,1fr]"
+                                    >
+                                      <div className="flex flex-col gap-2">
+                                        <span className="font-typewriter text-[11px] uppercase tracking-[0.32em] text-[var(--broadsheet-muted)]">
+                                          {resolveMomentTimestamp(moment.timestamp)}
+                                        </span>
+                                        <span className="font-typewriter text-[11px] uppercase tracking-[0.32em] text-[var(--broadsheet-muted)]">
+                                          Filed by {moment.actor ?? 'Unknown Bureau'}
+                                        </span>
                                         <span
                                           className={clsx(
-                                            'absolute left-0 top-3 h-3 w-3 -translate-x-1/2 transform rounded-full border-2 shadow-sm',
-                                            tone.bullet,
+                                            'inline-flex items-center justify-center rounded-full border px-3 py-1 text-[11px] font-typewriter uppercase tracking-[0.32em]',
+                                            agendaStatusTone[moment.status],
                                           )}
-                                        />
-                                        <div className="flex flex-wrap items-center gap-2 text-[10px] font-semibold uppercase tracking-[0.28em]">
-                                          <Badge variant="outline" className={clsx('px-2 py-0.5', tone.badge)}>
-                                            {statusLabel}
-                                          </Badge>
-                                          <Badge
-                                            variant="outline"
-                                            className={clsx(
-                                              'border px-2 py-0.5 font-mono text-[10px] uppercase tracking-[0.28em]',
-                                              isTruth
-                                                ? 'border-rose-900/30 bg-amber-50/80 text-rose-900'
-                                                : 'border-emerald-500/30 bg-slate-900/70 text-emerald-100',
-                                            )}
-                                          >
-                                            Stage: {moment.stageLabel}
-                                          </Badge>
-                                          <Badge
-                                            variant="outline"
-                                            className={clsx(
-                                              'border px-2 py-0.5 font-mono text-[10px] uppercase tracking-[0.28em]',
-                                              isTruth
-                                                ? 'border-rose-900/30 bg-amber-50/80 text-rose-900'
-                                                : 'border-emerald-500/30 bg-slate-900/70 text-emerald-100',
-                                            )}
-                                          >
-                                            Fremdrift {progressLabel}
-                                          </Badge>
-                                        </div>
-                                        <div className="mt-2 space-y-1">
-                                          <h4 className="text-sm font-semibold uppercase tracking-[0.12em]">
-                                            {moment.agendaTitle}
-                                          </h4>
-                                          {moment.stageDescription ? (
-                                            <p className="text-xs text-muted-foreground">
-                                              {moment.stageDescription}
-                                            </p>
-                                          ) : null}
-                                          <div className="text-[11px] font-mono uppercase tracking-[0.25em] text-muted-foreground/80">
-                                            Ansvarlig: {factionLabel} · {actorLabel}
-                                          </div>
-                                          <div className="text-[10px] uppercase tracking-[0.32em] text-muted-foreground/70">
-                                            {resolveMomentTimestamp(moment.recordedAt)}
-                                          </div>
-                                        </div>
+                                        >
+                                          {moment.status.toUpperCase()}
+                                        </span>
                                       </div>
-                                    );
-                                  })}
-                                </div>
+                                      <div className="space-y-2">
+                                        <h4 className="font-broadsheetSans text-lg uppercase tracking-[0.14em]">
+                                          {moment.title}
+                                        </h4>
+                                        <p className="font-broadsheet text-[15px] leading-relaxed text-[var(--broadsheet-ink)]">
+                                          {moment.description}
+                                        </p>
+                                        {moment.redaction && (
+                                          <p className="font-typewriter text-xs uppercase tracking-[0.32em] text-[var(--broadsheet-muted)]">
+                                            REDACTION NOTE: {moment.redaction}
+                                          </p>
+                                        )}
+                                      </div>
+                                    </article>
+                                  ))
+                                )}
+                              </div>
+                            </div>
+                          </div>
+                          <aside className="space-y-4 rounded-xl border border-[var(--broadsheet-rule)] bg-[rgba(255,255,255,0.82)] p-5">
+                            <h4 className="font-broadsheetSans text-xl uppercase tracking-[0.16em]">Completed Dossiers</h4>
+                            {completedAgendas.length === 0 ? (
+                              <p className="font-typewriter text-xs uppercase tracking-[0.3em] text-[var(--broadsheet-muted)]">
+                                Filing cabinet empty. That never happens.
+                              </p>
+                            ) : (
+                              <div className="space-y-3">
+                                {completedAgendas.map(agenda => (
+                                  <div
+                                    key={agenda.id}
+                                    className="rounded-lg border border-dashed border-[var(--broadsheet-rule)] bg-white/80 p-3"
+                                  >
+                                    <div className="flex flex-wrap items-center justify-between gap-2">
+                                      <span className="font-broadsheetSans text-sm uppercase tracking-[0.2em]">
+                                        {agenda.title}
+                                      </span>
+                                      <span className="font-typewriter text-[11px] uppercase tracking-[0.32em] text-[var(--broadsheet-muted)]">
+                                        {agenda.category}
+                                      </span>
+                                    </div>
+                                    <p className="mt-1 font-broadsheet text-sm leading-relaxed text-[var(--broadsheet-muted)]">
+                                      {agenda.description}
+                                    </p>
+                                    {agenda.headline && (
+                                      <p className="mt-2 font-broadsheet text-[13px] italic text-[var(--broadsheet-ink)]">
+                                        “{agenda.headline}”
+                                      </p>
+                                    )}
+                                  </div>
+                                ))}
                               </div>
                             )}
-                          </div>
-                        </Card>
+                          </aside>
+                        </div>
+                      </>
+                    ) : (
+                      <div className="flex flex-1 items-center justify-center rounded-xl border border-dashed border-[var(--broadsheet-rule)] bg-[rgba(255,255,255,0.7)] p-6 text-center font-typewriter text-xs uppercase tracking-[0.32em] text-[var(--broadsheet-muted)]">
+                        Agendas unlock later in the campaign. Keep the presses warm.
                       </div>
-                    </>
-                  ) : (
-                    <div className="flex h-full flex-col items-center justify-center gap-3 text-center text-sm text-muted-foreground">
-                      <Badge variant="outline" className="px-3 py-1 font-mono text-[10px] uppercase tracking-[0.3em]">
-                        System Offline
-                      </Badge>
-                      <p>Secret agendas are disabled for this campaign.</p>
-                    </div>
-                  )}
-                </div>
-              </TabsContent>
-
-              <TabsContent value="cards" className="relative h-full overflow-hidden p-6 focus-visible:outline-none">
-                <CardCollectionContent
-                  isActive={activeTab === 'cards'}
-                  className="h-full"
-                />
-              </TabsContent>
-
-              <TabsContent value="tutorials" className="relative h-full overflow-hidden p-6 focus-visible:outline-none">
-                <TutorialSection
-                  isActive={activeTab === 'tutorials'}
-                  onStartTutorial={onStartTutorial}
-                  onClose={onClose}
-                  className="h-full"
-                />
-              </TabsContent>
-
-              <TabsContent value="press" className="relative h-full overflow-hidden p-6 focus-visible:outline-none">
-                <PressArchivePanel
-                  issues={pressIssues}
-                  onOpen={onOpenEdition}
-                  onDelete={onDeleteEdition}
-                  className="h-full"
-                />
-              </TabsContent>
-              <TabsContent value="evidence" className="relative h-full overflow-hidden p-6 focus-visible:outline-none">
-                <EvidenceArchivePanel
-                  entries={intelArchive}
-                  onDelete={onDeleteIntel}
-                  onClear={onClearIntel}
-                  className="h-full"
-                />
-              </TabsContent>
-              <TabsContent value="intel" className="relative h-full overflow-hidden p-6 focus-visible:outline-none">
-                <div className="flex h-full flex-col gap-4 xl:grid xl:grid-cols-[minmax(0,1.05fr)_minmax(0,1fr)]">
-                  <PlayerHubMapView
-                    intel={stateIntel}
-                    faction={faction}
-                    className="h-full min-h-[320px]"
-                  />
-                  <div className="min-h-0 overflow-hidden">
-                    <StateIntelBoard intel={stateIntel} />
+                    )}
                   </div>
-                </div>
-              </TabsContent>
+                </TabsContent>
+
+                <TabsContent
+                  value="cards"
+                  className="relative h-full focus-visible:outline-none data-[state=inactive]:hidden"
+                >
+                  <CardCollectionContent className="h-full" isActive={activeTab === 'cards'} variant="broadsheet" />
+                </TabsContent>
+
+                <TabsContent
+                  value="tutorials"
+                  className="relative h-full focus-visible:outline-none data-[state=inactive]:hidden"
+                >
+                  <TutorialSection
+                    className="h-full"
+                    onClose={onClose}
+                    onStartTutorial={onStartTutorial}
+                    showCloseButton={false}
+                    isActive={activeTab === 'tutorials'}
+                    variant="broadsheet"
+                  />
+                </TabsContent>
+
+                <TabsContent
+                  value="press"
+                  className="relative h-full focus-visible:outline-none data-[state=inactive]:hidden"
+                >
+                  <PressArchivePanel
+                    className="h-full"
+                    issues={pressIssues}
+                    onOpen={onOpenEdition}
+                    onDelete={onDeleteEdition}
+                    variant="broadsheet"
+                  />
+                </TabsContent>
+
+                <TabsContent
+                  value="evidence"
+                  className="relative h-full focus-visible:outline-none data-[state=inactive]:hidden"
+                >
+                  <EvidenceArchivePanel
+                    className="h-full"
+                    entries={intelArchive}
+                    onDelete={onDeleteIntel}
+                    onClear={onClearIntel}
+                    variant="broadsheet"
+                  />
+                </TabsContent>
+
+                <TabsContent
+                  value="intel"
+                  className="relative h-full focus-visible:outline-none data-[state=inactive]:hidden"
+                >
+                  <div className="flex h-full flex-col gap-6 xl:grid xl:grid-cols-[1.1fr,0.9fr]">
+                    <div className="rounded-xl border border-[var(--broadsheet-rule)] bg-[rgba(255,255,255,0.86)] p-4 shadow-sm">
+                      <h3 className="mb-3 font-broadsheetSans text-xl uppercase tracking-[0.18em]">Nationwide Hotline</h3>
+                      <PlayerHubMapView intel={stateIntel} faction={faction} className="h-full min-h-[320px]" />
+                    </div>
+                    <div className="min-h-0 rounded-xl border border-[var(--broadsheet-rule)] bg-[rgba(255,255,255,0.82)] p-4">
+                      <StateIntelBoard intel={stateIntel} variant="broadsheet" />
+                    </div>
+                  </div>
+                </TabsContent>
+              </div>
             </div>
-          </div>
-        </Tabs>
+          </Tabs>
+
+          <footer className="broadsheet-footer-note">
+            <span>Paranoid Times Syndicate — {faction === 'truth' ? 'Leakers Welcome' : 'Censored for Your Safety'}</span>
+            <span>{activeTab === 'intel' ? 'Wire room humming — keep receivers calibrated.' : tabDetails[activeTab].footer}</span>
+          </footer>
+          <div className="broadsheet-chatter">{scribbleNote}</div>
+        </div>
       </Card>
     </div>
   );
 };
+
 
 export default PlayerHubOverlay;

--- a/src/components/game/PressArchivePanel.tsx
+++ b/src/components/game/PressArchivePanel.tsx
@@ -17,6 +17,7 @@ interface PressArchivePanelProps {
   onOpen: (issue: ArchivedEdition) => void;
   onDelete: (id: string) => void;
   className?: string;
+  variant?: 'default' | 'broadsheet';
 }
 
 const formatTimestamp = (timestamp: number): string => {
@@ -34,7 +35,112 @@ const formatTimestamp = (timestamp: number): string => {
   }
 };
 
-const PressArchivePanel = ({ issues, onOpen, onDelete, className }: PressArchivePanelProps) => {
+const PressArchivePanel = ({ issues, onOpen, onDelete, className, variant = 'default' }: PressArchivePanelProps) => {
+  if (variant === 'broadsheet') {
+    return (
+      <div className={clsx('flex h-full flex-col gap-4 text-[var(--broadsheet-ink)]', className)}>
+        <header className="rounded-xl border border-[var(--broadsheet-rule)] bg-[rgba(255,255,255,0.9)] px-5 py-4 shadow-sm">
+          <div className="flex items-center justify-between">
+            <div>
+              <p className="font-typewriter text-[11px] uppercase tracking-[0.42em] text-[var(--broadsheet-kicker)]">Newsstand Scoop</p>
+              <h3 className="font-broadsheetSans text-2xl uppercase tracking-[0.16em]">Leaked Editions</h3>
+            </div>
+            <Newspaper className="h-6 w-6 text-[var(--broadsheet-accent)]" aria-hidden />
+          </div>
+        </header>
+
+        {issues.length === 0 ? (
+          <div className="flex flex-1 flex-col items-center justify-center rounded-xl border border-dashed border-[var(--broadsheet-rule)] bg-white/80 p-6 text-center">
+            <Newspaper className="mb-3 h-10 w-10 text-[var(--broadsheet-muted)]" aria-hidden />
+            <h4 className="font-broadsheetSans text-lg uppercase tracking-[0.18em]">No editions archived</h4>
+            <p className="mt-2 font-broadsheet text-[15px] leading-relaxed text-[var(--broadsheet-muted)]">
+              Finish a match and mark “Archive to Player Hub” to file the front page here.
+            </p>
+          </div>
+        ) : (
+          <ScrollArea className="flex-1 pr-2">
+            <div className="space-y-3">
+              {issues.map(issue => {
+                const { report } = issue;
+                const legendaryUsed = Array.isArray(report.legendaryUsed) ? report.legendaryUsed : [];
+                const mvpName = report.mvp?.cardName ?? report.runnerUp?.cardName ?? 'Unsung Hero';
+                const playerOutcome = getPlayerOutcomeLabel(report);
+                const victoryLabel = getVictoryConditionLabel(report.victoryType);
+                const playerLabel = getFactionDisplayName(report.playerFaction);
+                const opponentLabel = getOppositionDisplayName(report.playerFaction);
+                const outcomeSummary = getOutcomeSummary(report);
+
+                return (
+                  <article
+                    key={issue.id}
+                    className="rounded-xl border border-[var(--broadsheet-rule)] bg-[rgba(255,255,255,0.86)] p-5 shadow-sm transition hover:border-[var(--broadsheet-accent)] hover:shadow-[0_16px_36px_rgba(0,0,0,0.12)]"
+                  >
+                    <div className="flex flex-wrap items-start justify-between gap-3">
+                      <div>
+                        <p className="font-typewriter text-[10px] uppercase tracking-[0.32em] text-[var(--broadsheet-muted)]">
+                          {formatTimestamp(issue.savedAt)}
+                        </p>
+                        <h4 className="font-broadsheetSans text-xl uppercase tracking-[0.14em]">{issue.title}</h4>
+                      </div>
+                      <span className="rounded-full border border-[var(--broadsheet-rule)] px-3 py-1 font-typewriter text-[10px] uppercase tracking-[0.28em] text-[var(--broadsheet-muted)]">
+                        {playerOutcome} · {victoryLabel}
+                      </span>
+                    </div>
+
+                    <div className="mt-3 grid gap-3 text-[15px] font-broadsheet text-[var(--broadsheet-muted)] md:grid-cols-2">
+                      <div className="flex items-center gap-2">
+                        <Clock className="h-4 w-4 text-[var(--broadsheet-accent)]" aria-hidden />
+                        <span>
+                          {report.rounds > 0 ? `${report.rounds} rounds` : 'Opening Gambit'} · Truth {Math.round(report.finalTruth)}%
+                        </span>
+                      </div>
+                      <div className="flex items-center gap-2">
+                        <Trophy className="h-4 w-4 text-[var(--broadsheet-accent)]" aria-hidden />
+                        <span>{mvpName}</span>
+                      </div>
+                      <div className="flex items-center gap-2">
+                        <Target className="h-4 w-4 text-[var(--broadsheet-accent)]" aria-hidden />
+                        <span>{playerLabel} {Math.round(report.ipPlayer)} · {opponentLabel} {Math.round(report.ipAI)}</span>
+                      </div>
+                      <div className="flex items-center gap-2">
+                        <Activity className="h-4 w-4 text-[var(--broadsheet-accent)]" aria-hidden />
+                        <span>{outcomeSummary}</span>
+                      </div>
+                    </div>
+
+                    <div className="mt-3 font-typewriter text-[10px] uppercase tracking-[0.3em] text-[var(--broadsheet-muted)]">
+                      Legendary: {legendaryUsed.length > 0 ? legendaryUsed.join(', ') : 'None reported'}
+                    </div>
+
+                    <div className="mt-4 flex flex-wrap items-center gap-3">
+                      <Button
+                        variant="outline"
+                        size="sm"
+                        className="rounded-full border border-[var(--broadsheet-accent)] bg-[var(--broadsheet-accent-soft)] px-4 py-1 font-typewriter text-[11px] uppercase tracking-[0.32em] text-[var(--broadsheet-ink)] hover:bg-white"
+                        onClick={() => onOpen(issue)}
+                      >
+                        Read Edition
+                      </Button>
+                      <Button
+                        variant="ghost"
+                        size="sm"
+                        className="font-typewriter text-[11px] uppercase tracking-[0.3em] text-[var(--broadsheet-muted)] hover:text-[var(--broadsheet-accent)]"
+                        onClick={() => onDelete(issue.id)}
+                      >
+                        <Trash2 className="mr-1 h-4 w-4" aria-hidden />
+                        Remove
+                      </Button>
+                    </div>
+                  </article>
+                );
+              })}
+            </div>
+          </ScrollArea>
+        )}
+      </div>
+    );
+  }
+
   return (
     <div className={clsx('flex h-full flex-col', className)}>
       <div className="relative mb-4 flex items-center justify-between rounded-lg border border-emerald-500/30 bg-emerald-500/10 px-4 py-3">

--- a/src/components/game/StateIntelBoard.tsx
+++ b/src/components/game/StateIntelBoard.tsx
@@ -1,13 +1,15 @@
 import { type CSSProperties } from 'react';
-import { AlertTriangle, Shield, Target, Activity } from 'lucide-react';
-import { Badge } from '@/components/ui/badge';
+import { AlertTriangle, Shield, Target, Activity, MapPin } from 'lucide-react';
+import clsx from 'clsx';
 import { ScrollArea } from '@/components/ui/scroll-area';
+import { Badge } from '@/components/ui/badge';
 import { cn } from '@/lib/utils';
 import styles from './StateIntelBoard.module.css';
 import type { PlayerStateIntel } from './PlayerHubOverlay';
 
 interface StateIntelBoardProps {
   intel?: PlayerStateIntel;
+  variant?: 'default' | 'broadsheet';
 }
 
 const ownerLabels: Record<PlayerStateIntel['states'][number]['owner'], string> = {
@@ -27,14 +29,221 @@ const factionBadgeStyles: Record<'truth' | 'government', string> = {
   government: 'bg-amber-500/20 text-amber-100 border border-amber-400/40',
 };
 
+const broadsheetOwnerBadge: Record<PlayerStateIntel['states'][number]['owner'], string> = {
+  player: 'border-[#336f3a] bg-[#d1ead4] text-[#1f4b24]',
+  ai: 'border-[#a12a3a] bg-[#f6cdd6] text-[#5c111d]',
+  neutral: 'border-[var(--broadsheet-rule)] bg-white/80 text-[var(--broadsheet-muted)]',
+};
+
+const broadsheetFactionBadge: Record<'truth' | 'government', string> = {
+  truth: 'border-[var(--broadsheet-accent)] bg-[var(--broadsheet-accent-soft)] text-[var(--broadsheet-ink)]',
+  government: 'border-[#b1691b] bg-[#f6e2c5] text-[#633a09]',
+};
+
 const rotations = [-2.8, -0.6, 1.6, -1.2, 2.4];
 const threadAngles = [-6, 3, -2, 4];
 
-const StateIntelBoard = ({ intel }: StateIntelBoardProps) => {
+const StateIntelBoard = ({ intel, variant = 'default' }: StateIntelBoardProps) => {
   const totals = intel?.totals ?? { player: 0, ai: 0, neutral: 0, contested: 0 };
-  const contestedStates = (intel?.states ?? []).filter(state => state.contested).slice(0, 5);
+  const contestedStates = (intel?.states ?? []).filter(state => state.contested);
+  const featuredContested = contestedStates.slice(0, 5);
   const recentEvents = intel?.recentEvents ?? [];
   const hasEvents = recentEvents.length > 0;
+
+  if (variant === 'broadsheet') {
+    return (
+      <div className="flex h-full flex-col gap-6 text-[var(--broadsheet-ink)]">
+        <header className="rounded-xl border border-[var(--broadsheet-rule)] bg-[rgba(255,255,255,0.9)] px-5 py-4 shadow-sm">
+          <div className="flex items-center justify-between">
+            <div>
+              <p className="font-typewriter text-[11px] uppercase tracking-[0.42em] text-[var(--broadsheet-kicker)]">Field Wires</p>
+              <h3 className="font-broadsheetSans text-2xl uppercase tracking-[0.16em]">Hotline Atlas</h3>
+            </div>
+            <Activity className="h-6 w-6 text-[var(--broadsheet-accent)]" aria-hidden />
+          </div>
+        </header>
+
+        <div className="grid flex-1 grid-cols-1 gap-6 lg:grid-cols-7">
+          <section className="flex flex-col gap-5 rounded-xl border border-[var(--broadsheet-rule)] bg-[rgba(255,255,255,0.86)] p-5 shadow-sm lg:col-span-2">
+            <div className="grid grid-cols-2 gap-3">
+              <div className="rounded-lg border border-[var(--broadsheet-rule)] bg-white/90 p-4 shadow-sm">
+                <p className="font-typewriter text-[10px] uppercase tracking-[0.32em] text-[var(--broadsheet-muted)]">Player Control</p>
+                <p className="font-broadsheetSans text-2xl text-[var(--broadsheet-ink)]">{totals.player}</p>
+                <p className="font-broadsheet text-[13px] text-[var(--broadsheet-muted)]">Strongholds</p>
+              </div>
+              <div className="rounded-lg border border-[var(--broadsheet-rule)] bg-white/90 p-4 shadow-sm">
+                <p className="font-typewriter text-[10px] uppercase tracking-[0.32em] text-[var(--broadsheet-muted)]">Opposition</p>
+                <p className="font-broadsheetSans text-2xl text-[var(--broadsheet-ink)]">{totals.ai}</p>
+                <p className="font-broadsheet text-[13px] text-[var(--broadsheet-muted)]">Occupied States</p>
+              </div>
+              <div className="rounded-lg border border-[var(--broadsheet-rule)] bg-white/90 p-4 shadow-sm">
+                <p className="font-typewriter text-[10px] uppercase tracking-[0.32em] text-[var(--broadsheet-muted)]">Neutral</p>
+                <p className="font-broadsheetSans text-2xl text-[var(--broadsheet-ink)]">{totals.neutral}</p>
+                <p className="font-broadsheet text-[13px] text-[var(--broadsheet-muted)]">In Flux</p>
+              </div>
+              <div className="rounded-lg border border-[var(--broadsheet-rule)] bg-white/90 p-4 shadow-sm">
+                <p className="font-typewriter text-[10px] uppercase tracking-[0.32em] text-[var(--broadsheet-muted)]">Contested</p>
+                <p className="font-broadsheetSans text-2xl text-[var(--broadsheet-ink)]">{totals.contested}</p>
+                <p className="font-broadsheet text-[13px] text-[var(--broadsheet-muted)]">Hot Zones</p>
+              </div>
+            </div>
+
+            <div className="rounded-lg border border-[var(--broadsheet-rule)] bg-white/90 p-4 font-typewriter text-[10px] uppercase tracking-[0.32em] text-[var(--broadsheet-muted)]">
+              <div className="flex items-center justify-between">
+                <span>Generated Turn</span>
+                <span className="font-broadsheetSans text-xl text-[var(--broadsheet-ink)]">{intel?.generatedAtTurn ?? '—'}</span>
+              </div>
+              <div className="mt-2 flex items-center justify-between">
+                <span>Round</span>
+                <span className="font-broadsheetSans text-xl text-[var(--broadsheet-ink)]">{intel?.round ?? '—'}</span>
+              </div>
+            </div>
+          </section>
+
+          <section className="flex flex-col gap-4 rounded-xl border border-[var(--broadsheet-rule)] bg-[rgba(255,255,255,0.86)] p-5 shadow-sm lg:col-span-2">
+            <header className="flex items-center justify-between">
+              <div>
+                <p className="font-typewriter text-[10px] uppercase tracking-[0.32em] text-[var(--broadsheet-muted)]">Hot Zones</p>
+                <h4 className="font-broadsheetSans text-xl uppercase tracking-[0.14em]">Active States</h4>
+              </div>
+              <Target className="h-5 w-5 text-[var(--broadsheet-accent)]" aria-hidden />
+            </header>
+
+            <div className="space-y-3">
+              {featuredContested.length > 0 ? (
+                featuredContested.map(state => (
+                  <div
+                    key={state.id}
+                    className="rounded-lg border border-[var(--broadsheet-rule)] bg-white/85 p-4 shadow-sm"
+                  >
+                    <div className="flex items-center justify-between">
+                      <div>
+                        <p className="font-typewriter text-[10px] uppercase tracking-[0.32em] text-[var(--broadsheet-muted)]">
+                          {state.abbreviation}
+                        </p>
+                        <h5 className="font-broadsheetSans text-lg uppercase tracking-[0.12em] text-[var(--broadsheet-ink)]">{state.name}</h5>
+                      </div>
+                      <span
+                        className={clsx(
+                          'rounded-full border px-3 py-1 font-typewriter text-[10px] uppercase tracking-[0.28em]',
+                          broadsheetOwnerBadge[state.owner],
+                        )}
+                      >
+                        {ownerLabels[state.owner]}
+                      </span>
+                    </div>
+
+                    <dl className="mt-3 grid grid-cols-2 gap-3 font-broadsheet text-[14px] text-[var(--broadsheet-muted)]">
+                      <div>
+                        <dt className="font-typewriter text-[10px] uppercase tracking-[0.28em] text-[var(--broadsheet-muted)]">Pressure</dt>
+                        <dd className="mt-1 flex items-center gap-2">
+                          <span className="text-[#a12a3a]">{state.pressureAi}</span>
+                          <span className="text-[var(--broadsheet-muted)]">vs</span>
+                          <span className="text-[#336f3a]">{state.pressurePlayer}</span>
+                        </dd>
+                      </div>
+                      <div>
+                        <dt className="font-typewriter text-[10px] uppercase tracking-[0.28em] text-[var(--broadsheet-muted)]">Defense</dt>
+                        <dd className="mt-1 text-[var(--broadsheet-ink)]">{state.defense}</dd>
+                      </div>
+                    </dl>
+                  </div>
+                ))
+              ) : (
+                <div className="flex flex-col items-center gap-2 rounded-lg border border-dashed border-[var(--broadsheet-rule)] bg-white/80 p-6 text-center">
+                  <Shield className="h-6 w-6 text-[var(--broadsheet-muted)]" aria-hidden />
+                  <p className="font-broadsheetSans text-sm uppercase tracking-[0.18em] text-[var(--broadsheet-muted)]">No contested states logged.</p>
+                </div>
+              )}
+            </div>
+          </section>
+
+          <section className="flex h-full flex-col rounded-xl border border-[var(--broadsheet-rule)] bg-[rgba(255,255,255,0.86)] p-5 shadow-sm lg:col-span-3">
+            <header className="flex items-center justify-between">
+              <div>
+                <p className="font-typewriter text-[10px] uppercase tracking-[0.32em] text-[var(--broadsheet-muted)]">Incident Board</p>
+                <h4 className="font-broadsheetSans text-xl uppercase tracking-[0.14em]">Field Reports</h4>
+              </div>
+              <AlertTriangle className="h-5 w-5 text-[var(--broadsheet-accent)]" aria-hidden />
+            </header>
+
+            <ScrollArea className="mt-4 flex-1 pr-3">
+              <div className="space-y-4">
+                {hasEvents ? (
+                  recentEvents.map((entry, index) => {
+                    const pressureDelta = (entry.pressurePlayer ?? 0) - (entry.pressureAi ?? 0);
+                    const pressureTone = pressureDelta > 0
+                      ? 'text-[#336f3a]'
+                      : pressureDelta < 0
+                        ? 'text-[#a12a3a]'
+                        : 'text-[var(--broadsheet-muted)]';
+
+                    return (
+                      <article
+                        key={`${entry.stateId}-${entry.event.eventId}-${index}`}
+                        className="rounded-lg border border-[var(--broadsheet-rule)] bg-white/85 p-4 shadow-sm"
+                      >
+                        <div className="flex flex-wrap items-start justify-between gap-3">
+                          <div>
+                            <p className="font-typewriter text-[10px] uppercase tracking-[0.32em] text-[var(--broadsheet-muted)]">
+                              Turn {entry.event.triggeredOnTurn} · Round {intel?.round ?? '—'}
+                            </p>
+                            <h5 className="font-broadsheetSans text-xl uppercase tracking-[0.14em] text-[var(--broadsheet-ink)]">
+                              {entry.event.label}
+                            </h5>
+                          </div>
+                          <span
+                            className={clsx(
+                              'rounded-full border px-3 py-1 font-typewriter text-[10px] uppercase tracking-[0.28em]',
+                              broadsheetFactionBadge[entry.event.faction],
+                            )}
+                          >
+                            {entry.event.faction === 'truth' ? 'Truth Ops' : 'Government Ops'}
+                          </span>
+                        </div>
+
+                        {entry.event.description && (
+                          <p className="mt-3 font-broadsheet text-[15px] leading-relaxed text-[var(--broadsheet-muted)]">
+                            {entry.event.description}
+                          </p>
+                        )}
+
+                        {Array.isArray(entry.event.effectSummary) && entry.event.effectSummary.length > 0 && (
+                          <ul className="mt-3 list-disc space-y-1 pl-5 font-broadsheet text-[14px] text-[var(--broadsheet-muted)]">
+                            {entry.event.effectSummary.map((summary, idx) => (
+                              <li key={idx}>{summary}</li>
+                            ))}
+                          </ul>
+                        )}
+
+                        <footer className="mt-4 flex flex-wrap items-center justify-between gap-3 font-typewriter text-[10px] uppercase tracking-[0.3em] text-[var(--broadsheet-muted)]">
+                          <span className="flex items-center gap-2">
+                            <MapPin className="h-4 w-4 text-[var(--broadsheet-accent)]" aria-hidden />
+                            {entry.stateName ?? entry.abbreviation ?? entry.stateId}
+                          </span>
+                          <span className={clsx('flex items-center gap-2', pressureTone)}>
+                            <span>Defense {entry.defense ?? '—'}</span>
+                            <span>Pressure Δ {pressureDelta > 0 ? `+${pressureDelta}` : pressureDelta}</span>
+                          </span>
+                        </footer>
+                      </article>
+                    );
+                  })
+                ) : (
+                  <div className="flex flex-col items-center gap-2 rounded-lg border border-dashed border-[var(--broadsheet-rule)] bg-white/80 p-6 text-center">
+                    <p className="font-broadsheetSans text-sm uppercase tracking-[0.18em] text-[var(--broadsheet-muted)]">No field events recorded yet.</p>
+                    <p className="font-broadsheet text-[14px] leading-relaxed text-[var(--broadsheet-muted)]">
+                      Run operations to generate intel—dispatches will pin here once intercepted.
+                    </p>
+                  </div>
+                )}
+              </div>
+            </ScrollArea>
+          </section>
+        </div>
+      </div>
+    );
+  }
 
   return (
     <div className={styles.board}>
@@ -79,8 +288,8 @@ const StateIntelBoard = ({ intel }: StateIntelBoardProps) => {
           <span>Active Hot Zones</span>
         </header>
         <div className={styles.contestedList}>
-          {contestedStates.length > 0 ? (
-            contestedStates.map(state => (
+          {featuredContested.length > 0 ? (
+            featuredContested.map(state => (
               <div key={state.id} className={styles.contestedCard}>
                 <span className={styles.tape} aria-hidden />
                 <div className="flex items-center justify-between">

--- a/src/components/game/TutorialOverlay.tsx
+++ b/src/components/game/TutorialOverlay.tsx
@@ -1,8 +1,10 @@
 import { useState, useEffect } from 'react';
+import clsx from 'clsx';
 import { Card } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
 import { Progress } from '@/components/ui/progress';
+import { ScrollArea } from '@/components/ui/scroll-area';
 import { X, Play, BookOpen, Award } from 'lucide-react';
 import { TutorialManager, TUTORIAL_SEQUENCES, type TutorialSequence } from '@/data/tutorialSystem';
 import { useToast } from '@/hooks/use-toast';
@@ -13,6 +15,7 @@ interface TutorialSectionProps {
   className?: string;
   showCloseButton?: boolean;
   isActive?: boolean;
+  variant?: 'default' | 'broadsheet';
 }
 
 export const TutorialSection = ({
@@ -21,6 +24,7 @@ export const TutorialSection = ({
   className,
   showCloseButton = false,
   isActive = true,
+  variant = 'default',
 }: TutorialSectionProps) => {
   const [tutorialManager] = useState(() => new TutorialManager());
   const [selectedSequence, setSelectedSequence] = useState<TutorialSequence | null>(null);
@@ -78,6 +82,183 @@ export const TutorialSection = ({
     if (stepCount <= 10) return 'Intermediate';
     return 'Advanced';
   };
+  if (variant === 'broadsheet') {
+    const statusStyles: Record<'completed' | 'available' | 'locked', string> = {
+      completed: 'border-[#336f3a] bg-[#d1ead4] text-[#1f4b24]',
+      available: 'border-[var(--broadsheet-accent)] bg-[var(--broadsheet-accent-soft)] text-[var(--broadsheet-ink)]',
+      locked: 'border-[var(--broadsheet-rule)] bg-white/70 text-[var(--broadsheet-muted)]',
+    };
+
+    const difficultyStyles: Record<'Basic' | 'Intermediate' | 'Advanced', string> = {
+      Basic: 'border-[#2f6f3a] bg-[#d6edd9] text-[#1f4b24]',
+      Intermediate: 'border-[#b1691b] bg-[#f6e2c5] text-[#633a09]',
+      Advanced: 'border-[#a12a3a] bg-[#f6cdd6] text-[#5c111d]',
+    };
+
+    return (
+      <div className={clsx('flex h-full flex-col gap-6 text-[var(--broadsheet-ink)]', className)}>
+        <header className="rounded-xl border border-[var(--broadsheet-rule)] bg-[rgba(255,255,255,0.9)] px-6 py-5 shadow-sm">
+          <div className="flex flex-wrap items-start justify-between gap-6">
+            <div className="space-y-3">
+              <p className="font-typewriter text-[11px] uppercase tracking-[0.42em] text-[var(--broadsheet-kicker)]">Correspondence Course</p>
+              <h2 className="font-broadsheetSans text-3xl uppercase tracking-[0.16em]">Shadow Academy Lessons</h2>
+              <p className="max-w-2xl font-broadsheet text-[15px] leading-relaxed text-[var(--broadsheet-muted)]">
+                Typewritten mailers for operatives too suspicious to attend class in daylight.
+              </p>
+            </div>
+            <div className="grid min-w-[220px] grid-cols-2 gap-3 text-center">
+              <div className="rounded-lg border border-[var(--broadsheet-rule)] bg-white/90 p-3 shadow-sm">
+                <p className="font-typewriter text-[10px] uppercase tracking-[0.3em] text-[var(--broadsheet-muted)]">Sequences</p>
+                <p className="font-broadsheetSans text-xl">{availableSequences.length}</p>
+              </div>
+              <div className="rounded-lg border border-[var(--broadsheet-rule)] bg-white/90 p-3 shadow-sm">
+                <p className="font-typewriter text-[10px] uppercase tracking-[0.3em] text-[var(--broadsheet-muted)]">Completion</p>
+                <p className="font-broadsheetSans text-xl">{stats.completionRate}%</p>
+              </div>
+            </div>
+          </div>
+        </header>
+
+        <div className="grid flex-1 gap-6 lg:grid-cols-[1.6fr,1fr]">
+          <section className="flex h-full flex-col rounded-xl border border-[var(--broadsheet-rule)] bg-[rgba(255,255,255,0.86)] p-5 shadow-sm">
+            <header className="mb-4 flex flex-wrap items-center justify-between gap-3">
+              <h3 className="font-broadsheetSans text-xl uppercase tracking-[0.16em]">Lesson Ledger</h3>
+              <div className="flex items-center gap-4 font-typewriter text-[10px] uppercase tracking-[0.32em] text-[var(--broadsheet-muted)]">
+                <span>Completion {stats.completionRate}%</span>
+                <Progress value={stats.completionRate} className="h-2 w-32 rounded-full bg-[rgba(0,0,0,0.08)]" />
+              </div>
+            </header>
+
+            <ScrollArea className="flex-1 pr-2">
+              <div className="space-y-3">
+                {TUTORIAL_SEQUENCES.map(sequence => {
+                  const sequenceStatus = getSequenceStatus(sequence);
+                  const difficultyText = getDifficultyText(sequence);
+                  const isSelected = selectedSequence?.id === sequence.id;
+                  const statusClass = statusStyles[sequenceStatus.status as 'completed' | 'available' | 'locked'];
+
+                  return (
+                    <div
+                      key={sequence.id}
+                      className={clsx(
+                        'rounded-xl border px-4 py-3 transition',
+                        statusClass,
+                        isSelected && 'shadow-[0_16px_36px_rgba(0,0,0,0.12)]',
+                        sequenceStatus.status !== 'locked' && 'cursor-pointer',
+                      )}
+                      onClick={() => {
+                        if (sequenceStatus.status !== 'locked') {
+                          setSelectedSequence(sequence);
+                        }
+                      }}
+                    >
+                      <div className="flex flex-wrap items-center justify-between gap-3">
+                        <div>
+                          <p className="font-typewriter text-[10px] uppercase tracking-[0.3em] text-[var(--broadsheet-muted)]">
+                            Lesson {sequence.id.toUpperCase()}
+                          </p>
+                          <h4 className="font-broadsheetSans text-lg uppercase tracking-[0.14em]">{sequence.name}</h4>
+                        </div>
+                        <div className="flex flex-wrap items-center gap-2">
+                          <span className={clsx('rounded-full px-3 py-1 font-typewriter text-[10px] uppercase tracking-[0.28em]', statusClass)}>
+                            {sequenceStatus.status === 'completed'
+                              ? 'Completed'
+                              : sequenceStatus.status === 'available'
+                                ? 'Available'
+                                : 'Locked'}
+                          </span>
+                          <span className={clsx('rounded-full border px-3 py-1 font-typewriter text-[10px] uppercase tracking-[0.28em]', difficultyStyles[difficultyText])}>
+                            {difficultyText}
+                          </span>
+                        </div>
+                      </div>
+                      <p className="mt-2 font-broadsheet text-[14px] leading-relaxed text-[var(--broadsheet-muted)]">
+                        {sequence.description}
+                      </p>
+                      <div className="mt-2 flex flex-wrap items-center gap-3 font-typewriter text-[10px] uppercase tracking-[0.3em] text-[var(--broadsheet-muted)]">
+                        <span>{sequence.steps.length} steps</span>
+                        {sequence.prerequisites && <span>Requires: {sequence.prerequisites.join(', ')}</span>}
+                      </div>
+                    </div>
+                  );
+                })}
+              </div>
+            </ScrollArea>
+          </section>
+
+          <aside className="flex h-full flex-col rounded-xl border border-[var(--broadsheet-rule)] bg-[rgba(255,255,255,0.86)] p-5 shadow-sm">
+            {selectedSequence ? (
+              <div className="flex h-full flex-col gap-5">
+                <div className="space-y-2">
+                  <p className="font-typewriter text-[10px] uppercase tracking-[0.38em] text-[var(--broadsheet-kicker)]">Course Brief</p>
+                  <h3 className="font-broadsheetSans text-2xl uppercase tracking-[0.16em]">{selectedSequence.name}</h3>
+                  <p className="font-broadsheet text-[15px] leading-relaxed text-[var(--broadsheet-muted)]">
+                    {selectedSequence.description}
+                  </p>
+                </div>
+
+                <div className="space-y-3 rounded-lg border border-[var(--broadsheet-rule)] bg-white/90 p-4">
+                  <div className="flex items-center justify-between font-typewriter text-[10px] uppercase tracking-[0.32em] text-[var(--broadsheet-muted)]">
+                    <span>Steps</span>
+                    <span className="font-broadsheetSans text-xl text-[var(--broadsheet-ink)]">{selectedSequence.steps.length}</span>
+                  </div>
+                  <div className="flex items-center justify-between font-typewriter text-[10px] uppercase tracking-[0.32em] text-[var(--broadsheet-muted)]">
+                    <span>Difficulty</span>
+                    <span className={clsx('rounded-full border px-3 py-1 font-typewriter text-[10px] uppercase tracking-[0.28em]', difficultyStyles[getDifficultyText(selectedSequence)])}>
+                      {getDifficultyText(selectedSequence)}
+                    </span>
+                  </div>
+                  <div className="flex items-center justify-between font-typewriter text-[10px] uppercase tracking-[0.32em] text-[var(--broadsheet-muted)]">
+                    <span>Status</span>
+                    <span className={clsx('rounded-full border px-3 py-1 font-typewriter text-[10px] uppercase tracking-[0.28em]', statusStyles[getSequenceStatus(selectedSequence).status as 'completed' | 'available' | 'locked'])}>
+                      {getSequenceStatus(selectedSequence).status.toUpperCase()}
+                    </span>
+                  </div>
+                </div>
+
+                <div className="space-y-2 font-typewriter text-[11px] uppercase tracking-[0.3em] text-[var(--broadsheet-muted)]">
+                  {selectedSequence.prerequisites?.length ? (
+                    <p>Prerequisites: {selectedSequence.prerequisites.join(', ')}</p>
+                  ) : (
+                    <p>No prerequisites logged.</p>
+                  )}
+                </div>
+
+                <div className="mt-auto flex flex-wrap items-center gap-3">
+                  <Button
+                    onClick={() => handleStartTutorial(selectedSequence.id)}
+                    disabled={getSequenceStatus(selectedSequence).status !== 'available'}
+                    className="rounded-full border border-[var(--broadsheet-accent)] bg-[var(--broadsheet-accent-soft)] px-5 py-2 font-typewriter text-[11px] uppercase tracking-[0.32em] text-[var(--broadsheet-ink)] transition hover:bg-white"
+                  >
+                    <Play size={14} className="mr-2" />
+                    Begin Lesson
+                  </Button>
+                  {showCloseButton && onClose && (
+                    <Button
+                      onClick={onClose}
+                      variant="outline"
+                      size="sm"
+                      className="rounded-full border border-[var(--broadsheet-rule)] bg-white/80 px-4 py-1 font-typewriter text-[11px] uppercase tracking-[0.28em] text-[var(--broadsheet-ink)] hover:border-[var(--broadsheet-accent)]"
+                    >
+                      Close
+                    </Button>
+                  )}
+                </div>
+              </div>
+            ) : (
+              <div className="flex h-full flex-col items-center justify-center rounded-xl border border-dashed border-[var(--broadsheet-rule)] bg-white/80 p-6 text-center">
+                <p className="font-broadsheetSans text-xl uppercase tracking-[0.18em]">Select a syllabus to inspect the lesson plan.</p>
+                <p className="mt-2 font-broadsheet text-[15px] leading-relaxed text-[var(--broadsheet-muted)]">
+                  Choose a course from the ledger to review its steps and start the correspondence.
+                </p>
+              </div>
+            )}
+          </aside>
+        </div>
+      </div>
+    );
+  }
+
 
   return (
     <div className={`flex h-full flex-col gap-5 text-slate-200 ${className ?? ''}`}>

--- a/src/styles/playerHub.css
+++ b/src/styles/playerHub.css
@@ -1,163 +1,493 @@
 .player-hub-card {
   position: relative;
+  overflow: hidden;
+  border-radius: 1.5rem;
+}
+
+.player-hub-broadsheet {
+  --broadsheet-paper: #f6f0de;
+  --broadsheet-paper-deep: #efe4c6;
+  --broadsheet-paper-edge: #d9ccb0;
+  --broadsheet-ink: #1f1914;
+  --broadsheet-muted: #5f5347;
+  --broadsheet-kicker: #8a7763;
+  --broadsheet-grid-line: rgba(86, 69, 48, 0.18);
+  --broadsheet-halftone: rgba(60, 45, 25, 0.15);
+  --broadsheet-shadow: rgba(43, 35, 28, 0.35);
+  --broadsheet-underline: rgba(43, 35, 28, 0.55);
+  --broadsheet-highlight: rgba(246, 209, 132, 0.55);
+  --broadsheet-stamp: #b33a58;
+  --broadsheet-rule: rgba(45, 32, 23, 0.35);
+  --broadsheet-ticker: rgba(45, 32, 23, 0.16);
+  color: var(--broadsheet-ink);
+}
+
+.player-hub-broadsheet.player-hub-truth {
+  --broadsheet-accent: #981b3d;
+  --broadsheet-accent-soft: rgba(152, 27, 61, 0.18);
+  --broadsheet-banner: rgba(152, 27, 61, 0.12);
+  --broadsheet-stamp: #bc2449;
+}
+
+.player-hub-broadsheet.player-hub-government {
+  --broadsheet-accent: #0f4f6c;
+  --broadsheet-accent-soft: rgba(15, 79, 108, 0.18);
+  --broadsheet-banner: rgba(15, 79, 108, 0.1);
+  --broadsheet-stamp: #17698c;
 }
 
 .player-hub-card .player-hub-background {
   pointer-events: none;
+  position: absolute;
+  inset: 0;
 }
 
-.player-hub-truth {
-  --player-hub-truth-paper: linear-gradient(135deg, rgba(255, 247, 231, 0.95), rgba(245, 228, 200, 0.85));
-  --player-hub-truth-paper-secondary: repeating-linear-gradient(
-    0deg,
-    rgba(255, 255, 255, 0.05) 0px,
-    rgba(255, 255, 255, 0.05) 4px,
-    rgba(233, 216, 166, 0.08) 4px,
-    rgba(233, 216, 166, 0.08) 8px
-  );
-  --player-hub-truth-fiber: repeating-linear-gradient(
-    115deg,
-    rgba(255, 255, 255, 0.15) 0px,
-    rgba(255, 255, 255, 0.15) 8px,
-    rgba(230, 214, 175, 0.12) 8px,
-    rgba(230, 214, 175, 0.12) 18px
-  );
-  --player-hub-truth-noise: url('data:image/svg+xml,%3Csvg xmlns="http://www.w3.org/2000/svg" width="120" height="120" viewBox="0 0 120 120"%3E%3Cg fill="none" fill-opacity="0.2"%3E%3Ccircle fill="%23d97706" cx="6" cy="6" r="1"/%3E%3Ccircle fill="%23facc15" cx="50" cy="30" r="1"/%3E%3Ccircle fill="%23f59e0b" cx="24" cy="84" r="1"/%3E%3Ccircle fill="%23ef4444" cx="90" cy="20" r="1"/%3E%3Ccircle fill="%23dc2626" cx="70" cy="100" r="1"/%3E%3Ccircle fill="%23f97316" cx="110" cy="60" r="1"/%3E%3C/g%3E%3C/svg%3E');
-}
-
-.player-hub-truth .player-hub-background > * {
+.player-hub-broadsheet .broadsheet-paper,
+.player-hub-broadsheet .broadsheet-halftone,
+.player-hub-broadsheet .broadsheet-fold,
+.player-hub-broadsheet .broadsheet-fibers,
+.player-hub-broadsheet .broadsheet-margin-notes {
+  position: absolute;
+  inset: 0;
   pointer-events: none;
 }
 
-.player-hub-truth .player-hub-truth__paper {
-  position: absolute;
-  inset: 0;
-  background-image: var(--player-hub-truth-paper), var(--player-hub-truth-paper-secondary), var(--player-hub-truth-fiber);
-  background-blend-mode: multiply;
-  filter: saturate(1.02) contrast(1.05);
+.player-hub-broadsheet .broadsheet-paper {
+  background:
+    linear-gradient(180deg, rgba(255, 255, 255, 0.8) 0%, rgba(238, 227, 200, 0.9) 65%, rgba(215, 198, 168, 0.95) 100%),
+    var(--broadsheet-paper);
+  filter: contrast(1.02) saturate(1.03);
 }
 
-.player-hub-truth .player-hub-truth__grain {
-  position: absolute;
-  inset: 0;
-  background-image: var(--player-hub-truth-noise);
-  background-size: 120px 120px;
-  opacity: 0.28;
+.player-hub-broadsheet .broadsheet-halftone {
+  opacity: 0.35;
+  background-image: radial-gradient(circle at 0 0, rgba(0, 0, 0, 0.08) 0.5px, transparent 0.5px);
+  background-size: 4px 4px;
   mix-blend-mode: multiply;
 }
 
-.player-hub-truth .player-hub-truth__thread {
+.player-hub-broadsheet .broadsheet-fold {
+  background:
+    linear-gradient(135deg, rgba(255, 255, 255, 0) 55%, rgba(255, 255, 255, 0.7) 60%, rgba(0, 0, 0, 0) 70%),
+    radial-gradient(circle at 12% 18%, rgba(255, 255, 255, 0.35), rgba(0, 0, 0, 0) 60%),
+    radial-gradient(circle at 88% 65%, rgba(0, 0, 0, 0.12), rgba(0, 0, 0, 0) 55%);
+  mix-blend-mode: soft-light;
+  opacity: 0.45;
+}
+
+.player-hub-broadsheet .broadsheet-fibers {
+  background-image:
+    repeating-linear-gradient(115deg, rgba(255, 255, 255, 0.12) 0px, rgba(255, 255, 255, 0.12) 14px, rgba(210, 190, 160, 0.08) 14px, rgba(210, 190, 160, 0.08) 28px),
+    repeating-linear-gradient(-135deg, rgba(0, 0, 0, 0.05) 0px, rgba(0, 0, 0, 0.05) 10px, rgba(255, 255, 255, 0.07) 10px, rgba(255, 255, 255, 0.07) 20px);
+  mix-blend-mode: multiply;
+  opacity: 0.42;
+}
+
+.player-hub-broadsheet .broadsheet-margin-notes {
+  background-image:
+    repeating-linear-gradient(0deg, transparent 0px, transparent 20px, rgba(177, 136, 90, 0.22) 20px, rgba(177, 136, 90, 0.22) 21px),
+    repeating-linear-gradient(90deg, transparent 0px, transparent 36px, rgba(177, 136, 90, 0.2) 36px, rgba(177, 136, 90, 0.2) 37px);
+  opacity: 0.18;
+}
+
+.player-hub-broadsheet .broadsheet-shell {
+  position: relative;
+  z-index: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+  min-height: 100%;
+  padding: 1.75rem 1.75rem 2.25rem;
+  background: linear-gradient(180deg, rgba(255, 255, 255, 0.65) 0%, rgba(255, 248, 231, 0.75) 55%, rgba(249, 239, 214, 0.95) 100%);
+  box-shadow: 0 35px 60px var(--broadsheet-shadow);
+}
+
+.player-hub-broadsheet .broadsheet-shell::before,
+.player-hub-broadsheet .broadsheet-shell::after {
+  content: "";
   position: absolute;
-  height: 3px;
-  border-radius: 999px;
-  background: linear-gradient(90deg, rgba(127, 29, 29, 0.75) 0%, rgba(220, 38, 38, 0.85) 45%, rgba(127, 29, 29, 0.75) 100%);
-  box-shadow: 0 0 14px rgba(185, 28, 28, 0.35);
-  opacity: 0.8;
+  inset: 0;
+  pointer-events: none;
+  border-radius: 1.5rem;
 }
 
-.player-hub-truth .player-hub-truth__thread::before,
-.player-hub-truth .player-hub-truth__thread::after {
-  content: '';
+.player-hub-broadsheet .broadsheet-shell::before {
+  border: 1px solid rgba(0, 0, 0, 0.04);
+  mix-blend-mode: multiply;
+}
+
+.player-hub-broadsheet .broadsheet-shell::after {
+  border: 8px solid rgba(0, 0, 0, 0.04);
+  mask: linear-gradient(#000 0 0) content-box, linear-gradient(#000 0 0);
+  mask-composite: exclude;
+  padding: 12px;
+  opacity: 0.5;
+}
+
+.player-hub-broadsheet .broadsheet-masthead {
+  display: grid;
+  grid-template-columns: repeat(12, minmax(0, 1fr));
+  align-items: center;
+  gap: 1.25rem;
+  border-bottom: 3px solid var(--broadsheet-rule);
+  padding-bottom: 1.25rem;
+  position: relative;
+}
+
+.player-hub-broadsheet .broadsheet-masthead::after {
+  content: "PARANOID TIMES";
   position: absolute;
-  width: 12px;
-  height: 12px;
-  border-radius: 50%;
-  background: radial-gradient(circle at 30% 30%, rgba(248, 113, 113, 0.85), rgba(127, 29, 29, 0.95));
-  border: 2px solid rgba(127, 29, 29, 0.6);
-  box-shadow: 0 4px 10px rgba(127, 29, 29, 0.4);
+  inset-inline: 0;
+  bottom: -1.2rem;
+  font-family: "Oswald", "Bebas Neue", sans-serif;
+  font-size: 13px;
+  letter-spacing: 0.6em;
+  text-align: center;
+  color: rgba(45, 32, 23, 0.32);
+  pointer-events: none;
 }
 
-.player-hub-truth .player-hub-truth__thread::before {
-  left: -4px;
-  top: -5px;
+.player-hub-broadsheet .broadsheet-masthead__logo {
+  grid-column: span 4 / span 4;
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  text-transform: uppercase;
 }
 
-.player-hub-truth .player-hub-truth__thread::after {
-  right: -4px;
-  top: -5px;
+.player-hub-broadsheet .broadsheet-masthead__logo > span:first-child {
+  font-family: "Oswald", "Bebas Neue", sans-serif;
+  font-size: clamp(1.6rem, 2.8vw, 2.25rem);
+  letter-spacing: 0.28em;
+  color: var(--broadsheet-accent);
+  text-shadow: 1px 1px 0 rgba(255, 255, 255, 0.75);
 }
 
-.player-hub-truth .player-hub-truth__thread--one {
-  top: 18%;
-  left: 6%;
-  width: 78%;
-  transform: rotate(-5deg);
-}
-
-.player-hub-truth .player-hub-truth__thread--two {
-  bottom: 24%;
-  right: 5%;
-  width: 72%;
-  transform: rotate(8deg);
-}
-
-.player-hub-truth .player-hub-truth__tape {
-  position: absolute;
-  width: 160px;
-  height: 48px;
-  border-radius: 6px;
-  background: linear-gradient(135deg, rgba(255, 243, 205, 0.9) 0%, rgba(255, 223, 148, 0.9) 50%, rgba(249, 210, 118, 0.85) 100%);
-  box-shadow: 0 18px 26px rgba(120, 53, 15, 0.22);
-  opacity: 0.78;
-  filter: saturate(1.1);
-}
-
-.player-hub-truth .player-hub-truth__tape::before {
-  content: '';
-  position: absolute;
-  inset: 10px 12px;
-  border-radius: 4px;
-  background: repeating-linear-gradient(
-    90deg,
-    rgba(255, 255, 255, 0.55) 0,
-    rgba(255, 255, 255, 0.55) 12px,
-    rgba(253, 230, 138, 0.4) 12px,
-    rgba(253, 230, 138, 0.4) 24px
-  );
-  opacity: 0.55;
-}
-
-.player-hub-truth .player-hub-truth__tape--one {
-  top: 18px;
-  left: 50%;
-  transform: translateX(-50%) rotate(-6deg);
-}
-
-.player-hub-truth .player-hub-truth__tape--two {
-  bottom: 26px;
-  right: 60px;
-  width: 130px;
-  transform: rotate(7deg);
-}
-
-.player-hub-truth .player-hub-tablist {
-  box-shadow: inset 0 20px 40px rgba(124, 45, 18, 0.08);
-}
-
-.player-hub-truth .player-hub-panel {
-  backdrop-filter: blur(6px);
-}
-
-.player-hub-truth .player-hub-header {
-  backdrop-filter: blur(8px);
-}
-
-.player-hub-truth .player-hub-badge {
+.player-hub-broadsheet .broadsheet-masthead__logo > span:last-child {
+  font-family: "IBM Plex Mono", ui-monospace, SFMono-Regular, monospace;
+  font-size: 0.75rem;
   letter-spacing: 0.32em;
+  color: var(--broadsheet-muted);
 }
 
-.player-hub-truth .player-hub-close-btn {
-  font-weight: 600;
+.player-hub-broadsheet .broadsheet-masthead__edition {
+  grid-column: span 5 / span 5;
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  text-transform: uppercase;
+  font-family: "IBM Plex Mono", ui-monospace, SFMono-Regular, monospace;
+  color: var(--broadsheet-muted);
+  letter-spacing: 0.28em;
+}
+
+.player-hub-broadsheet .broadsheet-masthead__price {
+  grid-column: span 3 / span 3;
+  justify-self: end;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-family: "IBM Plex Mono", ui-monospace, SFMono-Regular, monospace;
+  text-transform: uppercase;
+  font-size: 0.72rem;
+  letter-spacing: 0.28em;
+  color: var(--broadsheet-accent);
+}
+
+.player-hub-broadsheet .broadsheet-masthead__price::before {
+  content: "₮";
+  display: inline-flex;
+  width: 2.25rem;
+  height: 2.25rem;
+  align-items: center;
+  justify-content: center;
+  border: 2px solid var(--broadsheet-accent);
+  border-radius: 50%;
+  font-family: "Oswald", "Bebas Neue", sans-serif;
+  font-size: 1.15rem;
+  letter-spacing: normal;
+}
+
+.player-hub-broadsheet .broadsheet-masthead__close {
+  position: absolute;
+  right: 0;
+  top: -0.75rem;
+  transform: translateY(-100%);
+}
+
+.player-hub-broadsheet .broadsheet-tablist {
+  background: linear-gradient(180deg, rgba(255, 255, 255, 0.9) 0%, rgba(253, 241, 211, 0.85) 100%);
+  border: 2px solid var(--broadsheet-rule);
+  border-radius: 0.75rem;
+  box-shadow: inset 0 -8px 18px rgba(0, 0, 0, 0.08);
+  display: grid;
+  gap: 0.5rem;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  padding: 0.75rem;
+  position: relative;
+}
+
+.player-hub-broadsheet .broadsheet-tablist::before {
+  content: "LATE EDITION";
+  position: absolute;
+  top: -1.1rem;
+  left: 1rem;
+  padding: 0.15rem 0.6rem;
+  border: 1px solid var(--broadsheet-accent);
+  background: var(--broadsheet-banner);
+  color: var(--broadsheet-accent);
+  font-family: "IBM Plex Mono", ui-monospace, SFMono-Regular, monospace;
+  font-size: 0.68rem;
+  letter-spacing: 0.28em;
+}
+
+.player-hub-broadsheet .broadsheet-tablist .broadsheet-tab {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  padding: 0.85rem 1rem;
+  border: 1px solid transparent;
+  border-radius: 0.65rem;
+  text-align: left;
+  text-transform: uppercase;
+  font-family: "Oswald", "Bebas Neue", sans-serif;
+  letter-spacing: 0.22em;
+  font-size: 0.88rem;
+  line-height: 1.2;
+  color: var(--broadsheet-muted);
+  transition: all 0.2s ease;
+  background: rgba(255, 255, 255, 0.72);
+}
+
+.player-hub-broadsheet .broadsheet-tablist .broadsheet-tab .kicker {
+  font-family: "IBM Plex Mono", ui-monospace, SFMono-Regular, monospace;
+  font-size: 0.58rem;
+  letter-spacing: 0.42em;
+  color: var(--broadsheet-kicker);
+}
+
+.player-hub-broadsheet .broadsheet-tablist .broadsheet-tab .dek {
+  font-family: "Newsreader", "Iowan Old Style", "Palatino", serif;
+  text-transform: none;
+  letter-spacing: 0.02em;
+  font-size: 0.7rem;
+  line-height: 1.35;
+  color: rgba(43, 32, 23, 0.72);
+}
+
+.player-hub-broadsheet .broadsheet-tablist .broadsheet-tab::after {
+  content: "";
+  position: absolute;
+  inset: -1px;
+  border-radius: inherit;
+  border: 1px dashed transparent;
+  opacity: 0;
+  transition: opacity 0.2s ease;
+}
+
+.player-hub-broadsheet .broadsheet-tablist .broadsheet-tab[data-state="active"] {
+  border-color: var(--broadsheet-accent);
+  color: var(--broadsheet-ink);
+  background: linear-gradient(180deg, rgba(255, 255, 255, 0.95) 0%, rgba(255, 244, 216, 0.95) 100%);
+  box-shadow: inset 0 0 0 2px rgba(255, 255, 255, 0.7), 0 10px 24px rgba(0, 0, 0, 0.12);
+}
+
+.player-hub-broadsheet .broadsheet-tablist .broadsheet-tab[data-state="active"]::after {
+  border-color: var(--broadsheet-accent);
+  opacity: 1;
+}
+
+.player-hub-broadsheet .broadsheet-tablist .broadsheet-tab:hover {
+  border-color: rgba(43, 32, 23, 0.45);
+  color: var(--broadsheet-ink);
+  transform: translateY(-1px);
+  box-shadow: inset 0 0 0 2px rgba(255, 255, 255, 0.6);
+}
+
+.player-hub-broadsheet .broadsheet-content {
+  position: relative;
+  flex: 1 1 auto;
+  display: flex;
+  flex-direction: column;
+  margin-top: 0.75rem;
+  border: 2px solid var(--broadsheet-rule);
+  border-radius: 1rem;
+  background: linear-gradient(180deg, rgba(255, 255, 255, 0.85) 0%, rgba(252, 242, 214, 0.92) 100%);
+  box-shadow: inset 0 0 0 1px rgba(0, 0, 0, 0.04);
+  overflow: hidden;
+}
+
+.player-hub-broadsheet .broadsheet-content::before {
+  content: "";
+  position: absolute;
+  inset-inline: 0;
+  top: 0;
+  height: 3.25rem;
+  background: linear-gradient(180deg, rgba(255, 250, 238, 0.9) 0%, rgba(255, 244, 219, 0.75) 100%);
+  border-bottom: 1px solid var(--broadsheet-rule);
+  box-shadow: inset 0 -1px 0 rgba(255, 255, 255, 0.55);
+  pointer-events: none;
+}
+
+.player-hub-broadsheet .broadsheet-content__ticker {
+  position: relative;
+  z-index: 1;
+  display: flex;
+  align-items: center;
+  gap: 1.5rem;
+  padding: 0.75rem 1.5rem;
+  font-family: "IBM Plex Mono", ui-monospace, SFMono-Regular, monospace;
+  font-size: 0.72rem;
+  text-transform: uppercase;
+  letter-spacing: 0.32em;
+  color: rgba(43, 32, 23, 0.65);
+}
+
+.player-hub-broadsheet .broadsheet-content__ticker span::before {
+  content: "✱";
+  margin-right: 0.5rem;
+  color: var(--broadsheet-accent);
+}
+
+.player-hub-broadsheet .broadsheet-content__body {
+  position: relative;
+  z-index: 1;
+  flex: 1 1 auto;
+  padding: 2.5rem 1.75rem 1.75rem;
+}
+
+.player-hub-broadsheet .broadsheet-stamp {
+  position: absolute;
+  right: 2rem;
+  top: 2rem;
+  padding: 0.4rem 1.25rem;
+  border: 2px solid var(--broadsheet-stamp);
+  color: var(--broadsheet-stamp);
+  font-family: "Oswald", "Bebas Neue", sans-serif;
+  font-size: 0.78rem;
+  letter-spacing: 0.36em;
+  text-transform: uppercase;
+  transform: rotate(-6deg);
+  box-shadow: 0 8px 20px rgba(0, 0, 0, 0.18);
+  background: rgba(255, 255, 255, 0.85);
+}
+
+.player-hub-broadsheet .broadsheet-columns {
+  position: absolute;
+  inset: 1.5rem;
+  border-left: 1px solid var(--broadsheet-grid-line);
+  border-right: 1px solid var(--broadsheet-grid-line);
+  pointer-events: none;
+  opacity: 0.5;
+}
+
+.player-hub-broadsheet .broadsheet-columns::before,
+.player-hub-broadsheet .broadsheet-columns::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  border-left: 1px solid var(--broadsheet-grid-line);
+  border-right: 1px solid var(--broadsheet-grid-line);
+  transform: translateX(-33.333%);
+}
+
+.player-hub-broadsheet .broadsheet-columns::after {
+  transform: translateX(33.333%);
+}
+
+.player-hub-broadsheet .broadsheet-footer-note {
+  margin-top: 1.25rem;
+  border-top: 1px solid var(--broadsheet-rule);
+  padding-top: 1rem;
+  font-family: "IBM Plex Mono", ui-monospace, SFMono-Regular, monospace;
+  font-size: 0.72rem;
+  letter-spacing: 0.26em;
+  text-transform: uppercase;
+  color: rgba(43, 32, 23, 0.55);
+  display: flex;
+  justify-content: space-between;
+  flex-wrap: wrap;
+  gap: 1rem;
+}
+
+.player-hub-broadsheet .broadsheet-footer-note span::before {
+  content: "⇢";
+  margin-right: 0.5rem;
+}
+
+.player-hub-broadsheet .broadsheet-chatter {
+  position: absolute;
+  left: 1.75rem;
+  bottom: 1.5rem;
+  font-family: "Newsreader", "Iowan Old Style", "Palatino", serif;
+  font-size: 0.78rem;
+  letter-spacing: 0.05em;
+  max-width: 24rem;
+  color: rgba(43, 32, 23, 0.65);
+  transform: rotate(-1deg);
+}
+
+.player-hub-broadsheet .broadsheet-chatter::before {
+  content: "(handwritten note)";
+  display: block;
+  font-family: "IBM Plex Mono", ui-monospace, SFMono-Regular, monospace;
+  font-size: 0.58rem;
+  letter-spacing: 0.32em;
+  text-transform: uppercase;
+  color: rgba(43, 32, 23, 0.45);
+  margin-bottom: 0.25rem;
+}
+
+@media (max-width: 1280px) {
+  .player-hub-broadsheet .broadsheet-masthead {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .player-hub-broadsheet .broadsheet-masthead__logo {
+    grid-column: span 2 / span 2;
+  }
+
+  .player-hub-broadsheet .broadsheet-masthead__edition {
+    grid-column: span 2 / span 2;
+  }
+
+  .player-hub-broadsheet .broadsheet-masthead__price {
+    grid-column: span 2 / span 2;
+    justify-self: start;
+  }
 }
 
 @media (max-width: 1024px) {
-  .player-hub-truth .player-hub-truth__thread--one,
-  .player-hub-truth .player-hub-truth__thread--two {
+  .player-hub-broadsheet .broadsheet-shell {
+    padding: 1.5rem;
+  }
+
+  .player-hub-broadsheet .broadsheet-content__body {
+    padding: 2rem 1.25rem 1.5rem;
+  }
+
+  .player-hub-broadsheet .broadsheet-columns {
+    display: none;
+  }
+}
+
+@media (max-width: 768px) {
+  .player-hub-broadsheet .broadsheet-tablist {
+    grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+  }
+
+  .player-hub-broadsheet .broadsheet-content::before {
+    height: 3rem;
+  }
+
+  .player-hub-broadsheet .broadsheet-stamp {
     display: none;
   }
 
-  .player-hub-truth .player-hub-truth__tape--one,
-  .player-hub-truth .player-hub-truth__tape--two {
-    opacity: 0.6;
+  .player-hub-broadsheet .broadsheet-chatter {
+    position: static;
+    transform: none;
+    margin-top: 1rem;
   }
 }

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -100,6 +100,9 @@ export default {
       fontFamily: {
         headline: ["Anton", "Bebas Neue", "system-ui", "sans-serif"],
         tabloid: ["Bebas Neue", "Anton", "system-ui", "sans-serif"],
+        broadsheet: ["Newsreader", "Iowan Old Style", "Palatino", "serif"],
+        broadsheetSans: ["Oswald", "Bebas Neue", "system-ui", "sans-serif"],
+        typewriter: ["IBM Plex Mono", "ui-monospace", "SFMono-Regular", "monospace"],
       },
       boxShadow: {
         tabloid: "0 6px 24px var(--pt-shadow)",


### PR DESCRIPTION
## Summary
- finalize the broadsheet Evidence Annex with unified filters, enriched entry cards, and reusable reset handling
- rebuild the state intel board's broadsheet branch with masthead stats, contested state rollups, and scrolling field reports
- log the hub tabloidization milestone in the updates log

## Testing
- npm run lint *(fails: repository has existing lint violations)*
- bun test --coverage --coverage-reporter=text *(fails: existing test suite issues and mocked dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68e4086fdf108320a02d5aebcb659741