### PR TITLE
Separate archive clearing from filter reset in EvidenceArchivePanel

### DIFF
--- a/UPDATES_LOG.md
+++ b/UPDATES_LOG.md
@@ -2,6 +2,10 @@
 
 This document provides a chronological record of gameplay-impacting changes merged into State Shift Strategy. Each entry should include the merge date and a brief, human-readable summary so future contributors can quickly understand how the game has evolved.
 
+## 2025-10-22 – Safeguard the evidence archive controls
+- Split the evidence archive filter reset from the full archive wipe so players only delete entries when they deliberately hit the new clear-archive control.
+- Styled the destructive action as a red-alert button in both classic and broadsheet layouts to telegraph its impact.
+
 ## 2025-10-06 – Float the discard toggle on card overlays
 - Removed the orange queue discard button and replaced it with a floating trash icon anchored to the card edge for quicker access.
 - Highlight the icon when a discard is queued so players see the state directly on the card art.

--- a/src/components/game/EvidenceArchivePanel.tsx
+++ b/src/components/game/EvidenceArchivePanel.tsx
@@ -1,6 +1,6 @@
 import { useMemo, useState } from 'react';
 import clsx from 'clsx';
-import { Archive, Filter, Flag, Layers, MapPin, Trash2 } from 'lucide-react';
+import { Archive, Filter, Flag, Layers, MapPin, RotateCcw, Trash2 } from 'lucide-react';
 import { Card } from '@/components/ui/card';
 import { ScrollArea } from '@/components/ui/scroll-area';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
@@ -85,10 +85,13 @@ const EvidenceArchivePanel = ({ entries, onDelete, onClear, className, variant =
   const hasEntries = entries.length > 0;
   const hasFilteredResults = filteredEntries.length > 0;
 
-  const handleClearFilters = () => {
+  const handleResetFilters = () => {
     setStateFilter(FILTER_ALL);
     setFactionFilter(FILTER_ALL);
     setTypeFilter(FILTER_ALL);
+  };
+
+  const handleClearArchive = () => {
     onClear?.();
   };
 
@@ -144,14 +147,28 @@ const EvidenceArchivePanel = ({ entries, onDelete, onClear, className, variant =
               </SelectContent>
             </Select>
           </div>
-          <Button
-            onClick={handleClearFilters}
-            variant="outline"
-            size="sm"
-            className="rounded-full border border-[var(--broadsheet-rule)] bg-white/85 px-4 py-1 font-typewriter text-[11px] uppercase tracking-[0.3em] text-[var(--broadsheet-ink)] hover:border-[var(--broadsheet-accent)]"
-          >
-            Clear Filters
-          </Button>
+          <div className="flex items-center justify-end gap-2">
+            <Button
+              onClick={handleResetFilters}
+              variant="outline"
+              size="sm"
+              className="rounded-full border border-[var(--broadsheet-rule)] bg-white/85 px-4 py-1 font-typewriter text-[11px] uppercase tracking-[0.3em] text-[var(--broadsheet-ink)] hover:border-[var(--broadsheet-accent)]"
+            >
+              <RotateCcw className="mr-2 h-4 w-4" aria-hidden />
+              Reset Filters
+            </Button>
+            {onClear && (
+              <Button
+                onClick={handleClearArchive}
+                variant="outline"
+                size="sm"
+                className="rounded-full border border-red-600/60 bg-[rgba(248,113,113,0.2)] px-4 py-1 font-typewriter text-[11px] uppercase tracking-[0.3em] text-red-900 hover:border-red-600 hover:bg-[rgba(239,68,68,0.25)]"
+              >
+                <Trash2 className="mr-2 h-4 w-4" aria-hidden />
+                Clear Archive
+              </Button>
+            )}
+          </div>
         </div>
 
         <div className="flex-1 overflow-hidden">
@@ -305,19 +322,28 @@ const EvidenceArchivePanel = ({ entries, onDelete, onClear, className, variant =
                 </Select>
               </div>
             </div>
-            {onClear && (
-              <div className="mt-4 flex justify-end">
+            <div className="mt-4 flex flex-wrap justify-end gap-2">
+              <Button
+                variant="ghost"
+                size="sm"
+                className="text-emerald-200/70 hover:text-emerald-100"
+                onClick={handleResetFilters}
+              >
+                <RotateCcw className="mr-1 h-4 w-4" aria-hidden />
+                Reset Filters
+              </Button>
+              {onClear && (
                 <Button
-                  variant="ghost"
+                  variant="destructive"
                   size="sm"
-                  className="text-emerald-200/70 hover:text-emerald-100"
-                  onClick={handleClearFilters}
+                  className="bg-red-700/80 text-red-50 hover:bg-red-700"
+                  onClick={handleClearArchive}
                 >
                   <Trash2 className="mr-1 h-4 w-4" aria-hidden />
-                  Clear Filters
+                  Clear Archive
                 </Button>
-              </div>
-            )}
+              )}
+            </div>
           </Card>
 
           {hasFilteredResults ? (


### PR DESCRIPTION
## Summary
- decouple the evidence archive filter reset from the destructive archive wipe and add explicit controls in both default and broadsheet layouts
- highlight the new clear-archive action with warning styling and keep a dedicated reset filters affordance
- record the UX safeguard in the updates log

## Testing
- npm run lint *(fails: existing repository lint violations)*
- bun test --coverage --coverage-reporter=text *(fails: existing repository test failures)*

------
https://chatgpt.com/codex/tasks/task_e_68e41ad3978c83208c926c35fe5003f2