### PR TITLE
Add AI editor roster and banter banks

### DIFF
--- a/src/ai/banter/agnes_inkwraith.en-US.json
+++ b/src/ai/banter/agnes_inkwraith.en-US.json
@@ -1,0 +1,27 @@
+{
+  "schemaVersion": 1,
+  "editorId": "agnes_inkwraith",
+  "locale": "en-US",
+  "categories": {
+    "greetings": [
+      "The morgue ledger flipped to a blank page and wrote your initials in fountain pen. Shall we investigate?",
+      "I dusted the archive vault and the fingerprints spelled 'bring allies'. Consider yourself summoned.",
+      "Obituaries started humming a hymn in reverse. Only you and I know the harmony." 
+    ],
+    "victory": [
+      "Another immortal donor forced into the daylight pages. Let the estates scramble for shadow.",
+      "Filed our revision before midnight mass. The choir will need new sheet music after this leak.",
+      "Crossed their hush money with probate law, and the ledger confessed. Excellent work." 
+    ],
+    "defeat": [
+      "The executor sealed the vault ahead of us. I memorized the wards—next time we breach softly.",
+      "They bribed the mausoleum lighting to flicker. We'll bring our own lanterns.",
+      "Ancestral lawyers stalled the presses, but the ancestors just switched sides." 
+    ],
+    "idle": [
+      "Guestbook ink refuses to dry. Spirits are reserving column inches for future exposés.",
+      "I caught a will o' the wisp editing our copy. Left it a red pen and conditions.",
+      "If you hear a lullaby in the stacks, it's merely my index of undead benefactors rehearsing." 
+    ]
+  }
+}

--- a/src/ai/banter/delta_echo.en-US.json
+++ b/src/ai/banter/delta_echo.en-US.json
@@ -1,0 +1,27 @@
+{
+  "schemaVersion": 1,
+  "editorId": "delta_echo",
+  "locale": "en-US",
+  "categories": {
+    "greetings": [
+      "Shortwave static spelled our rendezvous time again. Welcome to the signal pit.",
+      "Triangulated three unauthorized frequencies pointing straight at your desk. Shall we answer?",
+      "Receiver warmed up, foil hat polished. Let's transcribe the numbers before they mutate." 
+    ],
+    "victory": [
+      "We flooded their blacksite bandwidth with headlines. Expect irritated engineers by dawn.",
+      "Another cipher undone. The agencies will need a new numbers station after this broadcast.",
+      "Truth amplitude peaked at eleven and the noise floor surrendered. Archive the waveform."
+    ],
+    "defeat": [
+      "Signal drifted under heavy jamming. Logging the interference to reverse-engineer their filter.",
+      "They swapped out the antenna array mid-stream. I'll requisition a taller tower.",
+      "Encryption held—for now. Next round we broadcast from the lunar relay they forgot we own." 
+    ],
+    "idle": [
+      "Taped a quartz crystal to the console. It keeps humming newsroom gossip in Morse.",
+      "Signal room coffee tastes like ozone again. Good omen for espionage weather.",
+      "If the needles start writing cursive, do not panic. It just means the future tuned in." 
+    ]
+  }
+}

--- a/src/ai/banter/el_visto.en-US.json
+++ b/src/ai/banter/el_visto.en-US.json
@@ -1,0 +1,27 @@
+{
+  "schemaVersion": 1,
+  "editorId": "el_visto",
+  "locale": "en-US",
+  "categories": {
+    "greetings": [
+      "Curtain lifts, spotlight hits, and the Elvis impersonators all just saluted you. Must mean it's showtime.",
+      "I tuned the casino lights to blink Morse code for 'scoop incoming.' Hope you brought a comped pen.",
+      "Backstage spirits rehearsed the secret setlist again. Let's give the audience the reveal they paid for."
+    ],
+    "victory": [
+      "Standing ovation from the wormhole tourists, boos from the censors. I'd call that a residency win.",
+      "We swapped their sleight-of-hand for ours, and the crowd recorded every unapproved angle.",
+      "Encore secured. Cashier cage already rumors we're printing the evidence on souvenir chips."
+    ],
+    "defeat": [
+      "House stacked the deck tonight. We'll rig the lighting grid before the next shuffle.",
+      "Security swapped my cape for a straightjacket. Joke's on them—it's reversible.",
+      "They comped our silence with neon hush money. Refund pending the next headline."
+    ],
+    "idle": [
+      "Elvis hologram keeps lip-syncing classified coordinates. I'm looping the footage for later.",
+      "Roulette ball landed on thirteen three times. Either a glitch or a Council inside joke.",
+      "If the marquee flickers, it's just the portal warming up for press night."
+    ]
+  }
+}

--- a/src/ai/banter/florida_man.en-US.json
+++ b/src/ai/banter/florida_man.en-US.json
@@ -1,0 +1,27 @@
+{
+  "schemaVersion": 1,
+  "editorId": "florida_man",
+  "locale": "en-US",
+  "categories": {
+    "greetings": [
+      "Humidity's thick with omens and gator radio—perfect conditions for reckless reportage.",
+      "Sunset sirens harmonized with my airboat engine. That's the newsroom calling for chaos.",
+      "Grab sunscreen and subpoenas; the swamp just texted me coordinates it shouldn't have."
+    ],
+    "victory": [
+      "Filed the story with sand still on the lens. Agencies will need a mop and an alibi.",
+      "We turned their hush order into fireworks over the Everglades. Print it before the ash settles.",
+      "Headline secured, pressure rising. Somebody warn the meteorologists this storm was editorial."
+    ],
+    "defeat": [
+      "State troopers outpaced us this time. Next run, we cut through the sinkholes.",
+      "They rerouted the hotline through a theme park. Fine—I'll leak the map on the souvenir cups.",
+      "Gator militia confiscated the van, but the van owes me favors. Expect an escape clause."
+    ],
+    "idle": [
+      "Tinfoil forecast: 94% humidity, 100% probability of spectral fireworks.",
+      "Local diner keeps comping my coffee with lottery tickets that predict the news. I’m keeping score.",
+      "If the newsroom ferret starts wearing sunglasses again, we're due for a coup."
+    ]
+  }
+}

--- a/src/ai/banter/fox_muldrunk.en-US.json
+++ b/src/ai/banter/fox_muldrunk.en-US.json
@@ -1,0 +1,27 @@
+{
+  "schemaVersion": 1,
+  "editorId": "fox_muldrunk",
+  "locale": "en-US",
+  "categories": {
+    "greetings": [
+      "Basement desk says the projector flickered again. Must mean you're ready to chase another classified rumor.",
+      "Muldrunk here. Coffee reeks of truth serum, which means the caseboard wants company.",
+      "Got a call from the custodian: the archive just whispered your name through the vents. Let's follow the echo."
+    ],
+    "victory": [
+      "Another redacted paragraph un-blackened. The Council will be livid we left fingerprints on their lies.",
+      "Filed the story before the men in velvet suits even started their burner phones. That's our kind of scoop.",
+      "Truth scored, obfuscation zero. Make sure the midnight edition keeps the evidence margin wide."
+    ],
+    "defeat": [
+      "They buried the lead under six feet of nondisclosure. We'll exhume it on the next pass.",
+      "Counterintel flipped the breaker on us. Reset the tape reel; I refuse to let the static win.",
+      "Our corkboard collapsed, but the pushpins remember where they belonged. We'll rebuild the pattern."
+    ],
+    "idle": [
+      "The X-unit fax machine is dialing by itself again. Either a ghost or tomorrow's headline.",
+      "Noticed three identical briefcases outside the newsroom. Cataloged the serials just in case.",
+      "If anyone asks, we never saw the mirrored elevator open to a seventeenth floor."
+    ]
+  }
+}

--- a/src/ai/banter/hunter_s_thampson.en-US.json
+++ b/src/ai/banter/hunter_s_thampson.en-US.json
@@ -1,0 +1,27 @@
+{
+  "schemaVersion": 1,
+  "editorId": "hunter_s_thampson",
+  "locale": "en-US",
+  "categories": {
+    "greetings": [
+      "Pack the riot pen and the emergency thesaurus; the motorcade of liars is warming up.",
+      "I can smell the hallucinogenic toner from here. Means the presses expect spectacle.",
+      "Managed to tape a microphone to a lightning bolt. Let's go interrogate the storm." 
+    ],
+    "victory": [
+      "We detonated a manifesto in the op-ed and the agencies are still blinking through the smoke.",
+      "Filed the piece at 130 mph. The legal desk will catch up whenever the dust permits.",
+      "Truth just rode shotgun across their roadblock. Someone send a postcard from the wreckage."
+    ],
+    "defeat": [
+      "The suits confiscated my typewriter cartridge. Joke's on them—it's loaded with backup evidence.",
+      "We hit the brakes before the cliff, but the cliff took notes. Next time we floor it.",
+      "Lost the story this round, but I memorized the exit routes while they gloated."
+    ],
+    "idle": [
+      "Hotel minibar replaced the ice with classified microfiche. Stirred it into the bourbon anyway.",
+      "Hearing rumors the pressroom couches are bugged. I stapled a counter-bug that whispers lullabies.",
+      "Thunderheads spelling out deadlines again. Grab the camera before they go to print without us."
+    ]
+  }
+}

--- a/src/ai/banter/index.ts
+++ b/src/ai/banter/index.ts
@@ -1,0 +1,132 @@
+import type { EditorId } from "../editors";
+
+import agnesInkwraith from "./agnes_inkwraith.en-US.json" assert { type: "json" };
+import deltaEcho from "./delta_echo.en-US.json" assert { type: "json" };
+import elVisto from "./el_visto.en-US.json" assert { type: "json" };
+import floridaMan from "./florida_man.en-US.json" assert { type: "json" };
+import foxMuldrunk from "./fox_muldrunk.en-US.json" assert { type: "json" };
+import hunterThampson from "./hunter_s_thampson.en-US.json" assert { type: "json" };
+import nocturneTypesetter from "./nocturne_typesetter.en-US.json" assert { type: "json" };
+import sybilMargin from "./sybil_margin.en-US.json" assert { type: "json" };
+
+type BanterCategoryMap = Record<string, string[]>;
+
+export interface EditorBanterBank {
+  schemaVersion: number;
+  editorId: EditorId;
+  locale: string;
+  categories: BanterCategoryMap;
+}
+
+type RawEditorBanterBank = {
+  schemaVersion?: unknown;
+  editorId?: unknown;
+  locale?: unknown;
+  categories?: unknown;
+};
+
+type Locale = string;
+
+type BankLookup = Partial<Record<EditorId, EditorBanterBank>>;
+
+const RAW_BANKS: Record<Locale, Partial<Record<EditorId, unknown>>> = {
+  "en-US": {
+    fox_muldrunk: foxMuldrunk,
+    florida_man: floridaMan,
+    el_visto: elVisto,
+    hunter_s_thampson: hunterThampson,
+    agnes_inkwraith: agnesInkwraith,
+    delta_echo: deltaEcho,
+    sybil_margin: sybilMargin,
+    nocturne_typesetter: nocturneTypesetter,
+  },
+};
+
+const isStringArray = (value: unknown): value is string[] => {
+  return Array.isArray(value) && value.every((item) => typeof item === "string");
+};
+
+const validateBank = (value: unknown): EditorBanterBank | null => {
+  const raw = value as RawEditorBanterBank | null;
+  if (!raw || typeof raw !== "object") {
+    return null;
+  }
+
+  const { schemaVersion, editorId, locale, categories } = raw;
+  if (typeof schemaVersion !== "number" || schemaVersion < 1) {
+    return null;
+  }
+  if (typeof editorId !== "string") {
+    return null;
+  }
+  if (typeof locale !== "string" || locale.length === 0) {
+    return null;
+  }
+  if (!categories || typeof categories !== "object") {
+    return null;
+  }
+
+  const normalizedCategories: BanterCategoryMap = {};
+  for (const [key, valueList] of Object.entries(categories)) {
+    if (!isStringArray(valueList)) {
+      return null;
+    }
+    normalizedCategories[key] = valueList;
+  }
+
+  return {
+    schemaVersion,
+    editorId: editorId as EditorId,
+    locale,
+    categories: normalizedCategories,
+  };
+};
+
+const BANKS: Record<Locale, BankLookup> = {};
+
+for (const [locale, entries] of Object.entries(RAW_BANKS)) {
+  for (const [editorId, payload] of Object.entries(entries) as [EditorId, unknown][]) {
+    const validated = validateBank(payload);
+    if (!validated) {
+      console.warn(
+        `[AI][Banter] Failed to validate banter bank for ${editorId} (${locale}). Payload was ignored.`,
+      );
+      continue;
+    }
+
+    if (!BANKS[locale]) {
+      BANKS[locale] = {};
+    }
+
+    BANKS[locale]![editorId] = validated;
+  }
+}
+
+const DEFAULT_LOCALE = "en-US";
+
+export const getBanterBank = (
+  editorId: EditorId,
+  locale: string = DEFAULT_LOCALE,
+): EditorBanterBank | null => {
+  const normalizedLocale = locale || DEFAULT_LOCALE;
+  const localeBanks = BANKS[normalizedLocale];
+  const exactMatch = localeBanks?.[editorId] ?? null;
+  if (exactMatch) {
+    return exactMatch;
+  }
+
+  if (normalizedLocale !== DEFAULT_LOCALE) {
+    const fallback = BANKS[DEFAULT_LOCALE]?.[editorId] ?? null;
+    if (fallback) {
+      console.warn(
+        `[AI][Banter] Missing ${normalizedLocale} bank for ${editorId}. Falling back to ${DEFAULT_LOCALE}.`,
+      );
+      return fallback;
+    }
+  }
+
+  console.warn(`[AI][Banter] No banter bank found for editor ${editorId} in locale ${normalizedLocale}.`);
+  return null;
+};
+
+export const listBanterLocales = (): string[] => Object.keys(BANKS);

--- a/src/ai/banter/nocturne_typesetter.en-US.json
+++ b/src/ai/banter/nocturne_typesetter.en-US.json
@@ -1,0 +1,27 @@
+{
+  "schemaVersion": 1,
+  "editorId": "nocturne_typesetter",
+  "locale": "en-US",
+  "categories": {
+    "greetings": [
+      "Blueprints for tomorrow's front page just arrived via pneumatic tube from next Tuesday.",
+      "Typesetting ghosts rearranged the headlines into your initials. Shall we oblige them?",
+      "Temporal press is synced and humming. Please keep arms inside the timestream."
+    ],
+    "victory": [
+      "Timeline stabilized around our scoop. Paradox auditors sent a begrudging thumbs-up.",
+      "We printed the truth twelve minutes early and reality adjusted its watches to match.",
+      "Another midnight edition delivered without fracturing the day. Archive the causal chain."
+    ],
+    "defeat": [
+      "Layout slipped into a recursion loop. I've queued a safer spread for the rematch.",
+      "Chronomancers embargoed the presses. Luckily, time owes me a favor at dawn.",
+      "Our kerning drifted across dimensions. Retracing the glyphs as we speak."
+    ],
+    "idle": [
+      "Typesetter gremlins keep swapping serif fonts with classified sigils. I left them snacks and warnings.",
+      "If the clock in the pressroom runs backwards, it's just me rewinding the last misprint.",
+      "The proofing table currently exists in two minutes at once. Stand where the ink is driest."
+    ]
+  }
+}

--- a/src/ai/banter/sybil_margin.en-US.json
+++ b/src/ai/banter/sybil_margin.en-US.json
@@ -1,0 +1,27 @@
+{
+  "schemaVersion": 1,
+  "editorId": "sybil_margin",
+  "locale": "en-US",
+  "categories": {
+    "greetings": [
+      "Probability curve bent toward your chair at 3σ. Time to reroute destiny again.",
+      "Forecast says 84% chance of scandal with a 16% garnish of déjà vu. Ready to cash in?",
+      "My predictive crossword spelled your codename twice. Coincidence rejected." 
+    ],
+    "victory": [
+      "Odds collapsed in our favor and the house statisticians just resigned. Document the tremor.",
+      "We rewrote the betting line mid-race. Now the future owes us royalties.",
+      "That spread we published? Already moving markets and rattling the Council's sleep schedule."
+    ],
+    "defeat": [
+      "Variance spiked against us. Logging the anomaly so we can weaponize it tomorrow.",
+      "They bribed the actuaries and the dice. Fine—we'll replace both with truth tables.",
+      "Our projections slipped, but every failure refines the simulation. Prep the next run." 
+    ],
+    "idle": [
+      "Tea leaves formed a bar chart shaped like the Capitol dome. I'm annotating it for later.",
+      "Bookies just offered me hush money to stop predicting their upsets. I negotiated for more upsets.",
+      "If you notice a flicker in the ticker tape, that's just the future calling collect." 
+    ]
+  }
+}

--- a/src/ai/editors.ts
+++ b/src/ai/editors.ts
@@ -1,0 +1,198 @@
+import type { Difficulty } from "./difficulty";
+
+export type EditorId =
+  | "fox_muldrunk"
+  | "florida_man"
+  | "el_visto"
+  | "hunter_s_thampson"
+  | "agnes_inkwraith"
+  | "delta_echo"
+  | "sybil_margin"
+  | "nocturne_typesetter";
+
+export type DifficultyTier = Difficulty;
+
+export interface AIPersonality {
+  description: string;
+  curiosity: number; // appetite for uncovering new leads
+  caution: number; // willingness to hedge before publishing
+  improvisation: number; // comfort with chaotic board states
+  bravado: number; // taste for risky headline plays
+  escalation: number; // tendency to press the attack once an opening appears
+}
+
+export interface EditorProfile {
+  id: EditorId;
+  codename: string;
+  coverTitle: string;
+  difficulty: DifficultyTier;
+  desks: string[];
+  specialty: string;
+  personality: AIPersonality;
+  defaultLocale: string;
+}
+
+const createPersonality = (
+  description: string,
+  values: Omit<AIPersonality, "description">,
+): AIPersonality => ({
+  description,
+  ...values,
+});
+
+export const AI_EDITORS: Record<EditorId, EditorProfile> = {
+  fox_muldrunk: {
+    id: "fox_muldrunk",
+    codename: "Fox Muldrunk",
+    coverTitle: "Basement Desk Sleuth",
+    difficulty: "NORMAL",
+    desks: ["Investigations", "Cold Files"],
+    specialty: "Connects redacted dots before anyone else bothers to notice they align.",
+    personality: createPersonality(
+      "A believer with a corkboard empire and more leads than sleep.",
+      {
+        curiosity: 0.9,
+        caution: 0.55,
+        improvisation: 0.65,
+        bravado: 0.45,
+        escalation: 0.6,
+      },
+    ),
+    defaultLocale: "en-US",
+  },
+  florida_man: {
+    id: "florida_man",
+    codename: "Florida Man",
+    coverTitle: "Chaos Stringer",
+    difficulty: "NORMAL",
+    desks: ["Breaking Weird", "Disaster Lifestyle"],
+    specialty: "Turns every hotline tip into a statewide emergency drill.",
+    personality: createPersonality(
+      "Breathes conspiracy humidity and thrives on reactive plays.",
+      {
+        curiosity: 0.7,
+        caution: 0.25,
+        improvisation: 0.9,
+        bravado: 0.85,
+        escalation: 0.8,
+      },
+    ),
+    defaultLocale: "en-US",
+  },
+  el_visto: {
+    id: "el_visto",
+    codename: "El Visto",
+    coverTitle: "Vegas Residency Reviewer",
+    difficulty: "EASY",
+    desks: ["Entertainment", "Anomalous Sightings"],
+    specialty: "Stacks stagecraft reveals with real sightings until audiences forget which is which.",
+    personality: createPersonality(
+      "Charming showman who slow-plays the weird until the encore.",
+      {
+        curiosity: 0.6,
+        caution: 0.45,
+        improvisation: 0.7,
+        bravado: 0.6,
+        escalation: 0.5,
+      },
+    ),
+    defaultLocale: "en-US",
+  },
+  hunter_s_thampson: {
+    id: "hunter_s_thampson",
+    codename: "Hunter S. Thampson",
+    coverTitle: "Gonzo Bureau Chief",
+    difficulty: "HARD",
+    desks: ["Field Reports", "Chemical Accountability"],
+    specialty: "Drops manifesto-length exposes mid-chase and dares rivals to keep up.",
+    personality: createPersonality(
+      "A rolling thundercloud of deadline adrenaline.",
+      {
+        curiosity: 0.8,
+        caution: 0.3,
+        improvisation: 0.75,
+        bravado: 0.9,
+        escalation: 0.85,
+      },
+    ),
+    defaultLocale: "en-US",
+  },
+  agnes_inkwraith: {
+    id: "agnes_inkwraith",
+    codename: "Agnes Inkwraith",
+    coverTitle: "Obituary Revisionist",
+    difficulty: "HARD",
+    desks: ["Archives", "Occult Estates"],
+    specialty: "Excavates censored obits to expose immortal donors and their shadow trusts.",
+    personality: createPersonality(
+      "Keeps ledgers of restless sources and pays debts in secrets.",
+      {
+        curiosity: 0.85,
+        caution: 0.7,
+        improvisation: 0.4,
+        bravado: 0.35,
+        escalation: 0.55,
+      },
+    ),
+    defaultLocale: "en-US",
+  },
+  delta_echo: {
+    id: "delta_echo",
+    codename: "Delta Echo",
+    coverTitle: "Numbers Station Ombudsman",
+    difficulty: "TOP_SECRET_PLUS",
+    desks: ["Signals", "Cipher Watch"],
+    specialty: "Decodes broadcast anomalies before the agencies notice their encryption glitched.",
+    personality: createPersonality(
+      "A walking shortwave antenna who plays the board four transmissions ahead.",
+      {
+        curiosity: 0.75,
+        caution: 0.8,
+        improvisation: 0.55,
+        bravado: 0.4,
+        escalation: 0.65,
+      },
+    ),
+    defaultLocale: "en-US",
+  },
+  sybil_margin: {
+    id: "sybil_margin",
+    codename: "Sybil Margin",
+    coverTitle: "Probability Columnist",
+    difficulty: "HARD",
+    desks: ["Analytics", "Future Crime"],
+    specialty: "Publishes predictive spreads that make the odds blink first.",
+    personality: createPersonality(
+      "Cold reader of timelines with a fondness for impossible margins.",
+      {
+        curiosity: 0.65,
+        caution: 0.75,
+        improvisation: 0.5,
+        bravado: 0.55,
+        escalation: 0.6,
+      },
+    ),
+    defaultLocale: "en-US",
+  },
+  nocturne_typesetter: {
+    id: "nocturne_typesetter",
+    codename: "Nocturne Typesetter",
+    coverTitle: "Midnight Edition Cartographer",
+    difficulty: "TOP_SECRET_PLUS",
+    desks: ["Layout", "Temporal Logistics"],
+    specialty: "Maps tomorrow's front page onto today's operations without ripping the timeline.",
+    personality: createPersonality(
+      "Calm, precise, and allergic to paradox but willing to bend headlines through it.",
+      {
+        curiosity: 0.7,
+        caution: 0.85,
+        improvisation: 0.6,
+        bravado: 0.45,
+        escalation: 0.5,
+      },
+    ),
+    defaultLocale: "en-US",
+  },
+};
+
+export const EDITOR_IDS = Object.keys(AI_EDITORS) as EditorId[];


### PR DESCRIPTION
## Summary
- add an AI editor roster file with typed profiles for the eight newsroom personalities
- implement a locale-aware banter loader that validates JSON payloads and falls back cleanly
- seed en-US banter banks for each editor with tone-consistent lines

## Testing
- npm run lint *(fails: repository currently has pre-existing lint violations)*
- bun test --coverage --coverage-reporter=text *(fails: repository tests rely on browser APIs and Vitest mock helpers unavailable in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e42c1f9ae883208f1ccb9d8e448cd7