### PR TITLE
Document Extra Extra system in player guide

### DIFF
--- a/UPDATES_LOG.md
+++ b/UPDATES_LOG.md
@@ -15,6 +15,10 @@ This document provides a chronological record of gameplay-impacting changes merg
 - Patched the broadsheet card collection overlay to import its shadcn scroll wrapper so the panel renders without tripping a `ScrollArea` reference error.
 - Verified the catalogue view no longer blanks out when the government archivists unroll their dossiers mid-session.
 
+## 2025-10-07 – Document Extra Extra win logic for players
+- Expanded the How to Play briefing with a rundown of the Extra Extra showdown rules so operatives know how triple-card turns award Truth swings and headlines.
+- Highlighted how the newsroom calculates winners, resolves ties, and pushes the Truth meter to keep players watching the paper between turns.
+
 ## 2025-10-06 – Rewire AI difficulties and editor bias
 - Replaced the retired TOP_SECRET_PLUS tier with the new INSANE difficulty, updating presets, UI labels, and save normalization so the option flows stay coherent.
 - Routed each editor profile’s combo and income bias scalars into the enhanced strategist and planner, letting targeting, income forecasts, and combo scoring honor newsroom tuning.

--- a/public/how-to-play-mvp.md
+++ b/public/how-to-play-mvp.md
@@ -55,6 +55,15 @@ Campaign storylines will occasionally override the random tabloids at the end of
 - **Paranormal Hotspots** temporarily raise a state’s defense while promising a Truth swing to whichever faction resolves the anomaly first. When a hotspot appears you’ll see a flying UFO skim the affected state and leave a green glow around it, plus you’ll hear the UFO bulletin sting so you can react even while scanning other panels. If you’ve enabled reduced-motion mode, the UFO flashes in place without sweeping across the map, but the glow still locks on—and the sting still plays—so you can track the target. Drop pressure there immediately or sabotage your opponent’s attempt—the glow clears the moment someone resolves the anomaly.
 - **Combo Engine** rewards coordinated turns with bonus IP, Truth swings, or additional card draws. Review combo summaries in the newspaper and adjust your play order to trigger the effects you need.
 
+### Extra Extra System
+The Extra Extra desk reviews every turn’s action log to decide whether to run a headline feature. It only fires once either faction actually plays three cards during the Action Phase; if both sides stall at two or fewer, the newsroom shreds the draft and moves on.
+
+1. **Trigger Check** – The `evaluateExtraExtra` routine sweeps the turn buffer after each Action Phase and looks for three-card runs by either faction. If only one side hits the threshold, their column automatically runs and they claim the issue.
+2. **Winner Calculation** – When both factions reach three cards, the editor compares the single strongest play from each trio. Truth/IP swings, direct damage, and captures all count, with captures weighted double. Highest impact wins the headline; ties produce a draw and no Truth shift.
+3. **Truth Adjustment** – A winning faction pushes the campaign’s Truth meter three points toward its ideology (+3 for Truth Seekers, –3 for Government). Draws leave Truth untouched, but still archive the featured plays in the paper’s clipping log.
+
+When the system triggers, it publishes a focused article listing the three decisive cards, updates the turn headline, and drops the recap into the feed so you can track how each faction is shaping the wider narrative.
+
 ## Tactical Tips
 - Spend early turns establishing IP-positive states before committing expensive legendary plays.
 - Use MEDIA to push Truth toward your victory thresholds while denying the opponent their extremes.


### PR DESCRIPTION
## Summary
- document how the Extra Extra triple-card showdown triggers and resolves inside the How to Play briefing
- record the documentation update in the gameplay updates log

## Testing
- `npm run lint` *(fails: existing lint violations across unrelated files)*
- `bun test --coverage --coverage-reporter=text` *(fails: existing Bun test suite errors such as missing mock.fn in headlineEngine.test)*

------
https://chatgpt.com/codex/tasks/task_e_68e4ab144fc48320b72bf225eeda6eca