### PR TITLE
Compose triple-card Extra Extra headlines

### DIFF
--- a/UPDATES_LOG.md
+++ b/UPDATES_LOG.md
@@ -11,6 +11,10 @@ This document provides a chronological record of gameplay-impacting changes merg
   thumbing through a classified suspect folder before launch.
 - Recolored actions and dossier cards to lean into the Paranoid Times manila-folder aesthetic while keeping mechanics unchanged.
 
+## 2025-10-07 – Compose triple-card Extra Extra headlines
+- Added a seeded triple-headline composer that braids the turn’s first three plays into a main story using combo rules, holiday buckets, and a generic fallback so every trigger prints a bespoke lead.
+- Hooked turn resolution and the MVP simulator into the new pools, preserving truth-delta math while logging the composed template or combo for debugging.
+
 ## 2025-10-06 – Restore card collection scroll rigging
 - Patched the broadsheet card collection overlay to import its shadcn scroll wrapper so the panel renders without tripping a `ScrollArea` reference error.
 - Verified the catalogue view no longer blanks out when the government archivists unroll their dossiers mid-session.

--- a/src/engine/news/__tests__/composeTriple.spec.ts
+++ b/src/engine/news/__tests__/composeTriple.spec.ts
@@ -1,0 +1,148 @@
+import { beforeAll, describe, expect, it } from 'vitest';
+
+import { composeTripleHeadline, type NewsCardLite } from '../composeTriple';
+import { initNewsPools } from '../newsPools';
+
+const createCard = (overrides: Partial<NewsCardLite> = {}): NewsCardLite => ({
+  id: 'CARD-001',
+  name: 'Placeholder Card',
+  faction: 'truth',
+  type: 'MEDIA',
+  tags: [],
+  ...overrides,
+});
+
+describe('composeTripleHeadline', () => {
+  beforeAll(async () => {
+    await initNewsPools();
+  });
+
+  it('uses the Elvis/UFO combo when tags match', () => {
+    const played: NewsCardLite[] = [
+      createCard({ id: 'TRUTH-801', name: 'Rhinestone Broadcast', tags: ['elvis'], type: 'MEDIA' }),
+      createCard({ id: 'TRUTH-802', name: 'Saucer Flyover', tags: ['ufo'], type: 'ZONE' }),
+      createCard({ id: 'TRUTH-803', name: 'Neon Witness', tags: [], type: 'ATTACK' }),
+    ];
+
+    const article = composeTripleHeadline(played, null, { seed: 42 });
+
+    expect(article).not.toBeNull();
+    expect(article?.comboId).toBe('cmb-elvis-ufo');
+    expect(article?.hed).toContain('ELVIS');
+    expect(article?.dek).toContain('control tower');
+  });
+
+  it('prefers combo headline for Bat Boy and Bigfoot summit', () => {
+    const played: NewsCardLite[] = [
+      createCard({ id: 'TRUTH-017', name: 'Bat Boy Stunt', tags: ['bat-boy'], type: 'MEDIA' }),
+      createCard({ id: 'TRUTH-120', name: 'Bigfoot Rally', tags: ['bigfoot'], type: 'ZONE' }),
+      createCard({ id: 'TRUTH-121', name: 'Coalition Snacks', tags: [], type: 'ATTACK' }),
+    ];
+
+    const article = composeTripleHeadline(played, null, { seed: 7 });
+
+    expect(article).not.toBeNull();
+    expect(article?.comboId).toBe('cmb-batboy-bigfoot-summit');
+    expect(article?.hed).toContain('BAT BOY & BIGFOOT HOLD SECRET SUMMIT');
+    expect(article?.tone).toBe('truth');
+  });
+
+  it('selects FOIA versus coverup combo when opponent cards match', () => {
+    const played: NewsCardLite[] = [
+      createCard({ id: 'TRUTH-039', name: 'FOIA Blitz', tags: ['coverup'], type: 'MEDIA' }),
+      createCard({ id: 'TRUTH-086', name: 'FOIA Lawsuit', tags: ['bureaucracy'], type: 'ATTACK' }),
+      createCard({ id: 'TRUTH-122', name: 'Sunshine Request', tags: [], type: 'ZONE' }),
+    ];
+    const opponent: NewsCardLite[] = [
+      createCard({
+        id: 'GOV-002',
+        name: 'Directorate Cover Story',
+        faction: 'government',
+        type: 'MEDIA',
+        tags: ['coverup', 'bureaucracy'],
+      }),
+    ];
+
+    const article = composeTripleHeadline(played, opponent, { seed: 13 });
+
+    expect(article).not.toBeNull();
+    expect(article?.comboId).toBe('cmb-foia-vs-coverup');
+    expect(article?.templateId).toBeUndefined();
+    expect(article?.tone).toBe('draw');
+    expect(article?.hed).toContain('FOIA BLITZ');
+  });
+
+  it('matches the zone chain template when all cards are zones', () => {
+    const played: NewsCardLite[] = [
+      createCard({ id: 'GOV-201', name: 'Perimeter Fence', faction: 'government', type: 'ZONE' }),
+      createCard({ id: 'GOV-202', name: 'Containment Grid', faction: 'government', type: 'ZONE' }),
+      createCard({ id: 'GOV-203', name: 'Lockdown Sweep', faction: 'government', type: 'ZONE' }),
+    ];
+
+    const article = composeTripleHeadline(played, null, { seed: 91 });
+
+    expect(article).not.toBeNull();
+    expect(article?.templateId).toBe('mix_all_gov:gov_triple_generic');
+    expect(article?.hed).toContain('OFFICIAL STORY');
+    expect(article?.tone).toBe('government');
+  });
+
+  it('uses the Halloween bucket when ghost tags dominate', () => {
+    const played: NewsCardLite[] = [
+      createCard({ id: 'TRUTH-301', name: 'Haunted Hotline', tags: ['ghost'], type: 'MEDIA' }),
+      createCard({ id: 'TRUTH-302', name: 'Graveyard Vigil', tags: ['haunted'], type: 'ZONE' }),
+      createCard({ id: 'TRUTH-303', name: 'Ectoplasm Sample', tags: [], type: 'ATTACK' }),
+    ];
+
+    const article = composeTripleHeadline(played, null, { seed: 5 });
+
+    expect(article).not.toBeNull();
+    expect(article?.templateId).toBe('theme_halloween_cluster:ghost_stack_combo');
+    expect(article?.hed).toContain('HAUNTED TRIPLE-HEADER');
+  });
+
+  it('produces a government triple template for all-government plays', () => {
+    const played: NewsCardLite[] = [
+      createCard({ id: 'GOV-401', name: 'Briefing Bulletin', faction: 'government', type: 'MEDIA' }),
+      createCard({ id: 'GOV-402', name: 'Containment Sweep', faction: 'government', type: 'ATTACK' }),
+      createCard({ id: 'GOV-403', name: 'Logistics Memo', faction: 'government', type: 'ZONE' }),
+    ];
+
+    const article = composeTripleHeadline(played, null, { seed: 27 });
+
+    expect(article).not.toBeNull();
+    expect(article?.templateId).toBe('mix_all_gov:gov_triple_generic');
+    expect(article?.tone).toBe('government');
+  });
+
+  it('falls back to the generic template when factions mix with no special tags', () => {
+    const played: NewsCardLite[] = [
+      createCard({ id: 'TRUTH-901', name: 'Obscure Lead', tags: ['oddity'], type: 'MEDIA' }),
+      createCard({ id: 'GOV-902', name: 'Containment Clarifier', faction: 'government', tags: ['clerical'], type: 'ATTACK' }),
+      createCard({ id: 'TRUTH-903', name: 'Late Night Call', tags: ['phone'], type: 'ZONE' }),
+    ];
+
+    const article = composeTripleHeadline(played, null, { seed: 3 });
+
+    expect(article).not.toBeNull();
+    expect(article?.templateId).toBe('generic:fallback_generic');
+    expect(article?.hed).toBeTruthy();
+  });
+
+  it('is deterministic for identical seeds and inputs', () => {
+    const played: NewsCardLite[] = [
+      createCard({ id: 'TRUTH-751', name: 'Signal Flare', tags: ['ghost'], type: 'MEDIA' }),
+      createCard({ id: 'TRUTH-752', name: 'Cemetery Watch', tags: ['haunted'], type: 'ZONE' }),
+      createCard({ id: 'TRUTH-753', name: 'Nocturne March', tags: [], type: 'ATTACK' }),
+    ];
+
+    const first = composeTripleHeadline(played, null, { seed: 123 });
+    const second = composeTripleHeadline(played, null, { seed: 123 });
+
+    expect(first).not.toBeNull();
+    expect(second).not.toBeNull();
+    expect(first?.hed).toBe(second?.hed);
+    expect(first?.dek).toBe(second?.dek);
+    expect(first?.bullets).toEqual(second?.bullets);
+  });
+});

--- a/src/engine/news/composeTriple.ts
+++ b/src/engine/news/composeTriple.ts
@@ -1,0 +1,542 @@
+import type { ArticleBlock as ExtraArticleBlock } from '@/news/headlineEngine';
+
+import {
+  getComboBankIfReady,
+  getTripleBankIfReady,
+  type ComboRule,
+  type TripleTemplateBank,
+  type TripleTemplateRule,
+} from './newsPools';
+
+export interface NewsCardLite {
+  id: string;
+  name: string;
+  faction: 'truth' | 'government';
+  type: 'MEDIA' | 'ATTACK' | 'ZONE' | string;
+  tags: string[];
+}
+
+interface ComposeContext {
+  played: NewsCardLite[];
+  opponent: NewsCardLite[];
+  bank: TripleTemplateBank;
+  rng: () => number;
+  mix: 'truth' | 'government' | 'mixed';
+}
+
+interface PlaceholderContext {
+  names: string[];
+  types: string[];
+  thirdType: string;
+  bank: TripleTemplateBank;
+  rng: () => number;
+}
+
+const MAX_NAME_LENGTH = 40;
+
+const shortenName = (name: string): string => {
+  const trimmed = name.trim();
+  if (trimmed.length <= MAX_NAME_LENGTH) {
+    return trimmed;
+  }
+  return `${trimmed.slice(0, MAX_NAME_LENGTH - 1).trimEnd()}…`;
+};
+
+const hashSeed = (input: string): number => {
+  let h = 1779033703 ^ input.length;
+  for (let i = 0; i < input.length; i += 1) {
+    h = Math.imul(h ^ input.charCodeAt(i), 3432918353);
+    h = (h << 13) | (h >>> 19);
+  }
+  h = Math.imul(h ^ (h >>> 16), 2246822507);
+  h = Math.imul(h ^ (h >>> 13), 3266489909);
+  h ^= h >>> 16;
+  return h >>> 0;
+};
+
+const mulberry32 = (seed: number): (() => number) => {
+  let a = seed >>> 0;
+  return () => {
+    a = (a + 0x6d2b79f5) | 0;
+    let t = Math.imul(a ^ (a >>> 15), 1 | a);
+    t ^= t + Math.imul(t ^ (t >>> 7), 61 | t);
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+};
+
+const pick = <T,>(pool: readonly T[], rng: () => number, fallback: T): T => {
+  if (!pool.length) {
+    return fallback;
+  }
+  const index = Math.floor(rng() * pool.length) % pool.length;
+  return pool[index] ?? fallback;
+};
+
+const cleanLines = (lines: string[]): string[] => {
+  const seen = new Set<string>();
+  const results: string[] = [];
+  for (const raw of lines) {
+    if (typeof raw !== 'string') {
+      continue;
+    }
+    const value = raw.replace(/\s+/g, ' ').trim();
+    if (!value || seen.has(value)) {
+      continue;
+    }
+    seen.add(value);
+    results.push(value);
+  }
+  return results;
+};
+
+const determineMix = (played: NewsCardLite[]): 'truth' | 'government' | 'mixed' => {
+  const truthOnly = played.every(card => card.faction === 'truth');
+  const governmentOnly = played.every(card => card.faction === 'government');
+  if (truthOnly) {
+    return 'truth';
+  }
+  if (governmentOnly) {
+    return 'government';
+  }
+  return 'mixed';
+};
+
+const determineTone = (
+  hint: 'truth' | 'government' | 'mixed' | undefined,
+  mix: 'truth' | 'government' | 'mixed',
+): ExtraArticleBlock['tone'] => {
+  if (hint === 'truth') {
+    return 'truth';
+  }
+  if (hint === 'government') {
+    return 'government';
+  }
+  if (hint === 'mixed') {
+    return 'draw';
+  }
+  if (mix === 'truth') {
+    return 'truth';
+  }
+  if (mix === 'government') {
+    return 'government';
+  }
+  return 'draw';
+};
+
+const dominantTypeLabel = (types: string[]): string => {
+  if (!types.length) {
+    return 'MEDIA';
+  }
+  const counts = new Map<string, number>();
+  for (const type of types) {
+    counts.set(type, (counts.get(type) ?? 0) + 1);
+  }
+  const [type] = Array.from(counts.entries()).sort((a, b) => b[1] - a[1])[0] ?? [];
+  return type ?? types[0] ?? 'MEDIA';
+};
+
+const buildPlaceholderContext = (
+  played: NewsCardLite[],
+  bank: TripleTemplateBank,
+  rng: () => number,
+): PlaceholderContext => {
+  const names = played.map(card => shortenName(card.name));
+  const types = played.map(card => card.type);
+  const typeCounts = new Map<string, number>();
+  for (const type of types) {
+    typeCounts.set(type, (typeCounts.get(type) ?? 0) + 1);
+  }
+  const rankedTypes = Array.from(typeCounts.entries()).sort((a, b) => b[1] - a[1]);
+  const dominantType = rankedTypes[0]?.[0] ?? (types[0] ?? 'MEDIA');
+  const thirdType = types[2] ?? dominantType;
+
+  return {
+    names,
+    types,
+    thirdType,
+    bank,
+    rng,
+  } satisfies PlaceholderContext;
+};
+
+const applyPlaceholders = (value: string, context: PlaceholderContext): string => {
+  if (!value) {
+    return '';
+  }
+  const { names, types, thirdType, bank, rng } = context;
+  const lexicon = bank.lexicon ?? {};
+  const fallbackLexiconEntry = (key: string): string => {
+    const pool = lexicon[key];
+    if (!Array.isArray(pool) || pool.length === 0) {
+      return key;
+    }
+    return pick(pool, rng, pool[0] ?? key);
+  };
+
+  return value.replace(/\{([A-Za-z0-9_]+)\}/g, (match, rawKey) => {
+    const key = String(rawKey ?? '').trim();
+    if (!key) {
+      return match;
+    }
+    if (key === 'N1') {
+      return names[0] ?? '';
+    }
+    if (key === 'N2') {
+      return names[1] ?? names[0] ?? '';
+    }
+    if (key === 'N3') {
+      return names[2] ?? names[1] ?? names[0] ?? '';
+    }
+    if (key === 'T1') {
+      return types[0] ?? dominantTypeLabel(types);
+    }
+    if (key === 'T2') {
+      return types[1] ?? dominantTypeLabel(types);
+    }
+    if (key === 'T3') {
+      return thirdType ?? dominantTypeLabel(types);
+    }
+    if (key === 'style') {
+      return bank.defaults.imageStyle;
+    }
+    const lower = key.toLowerCase();
+    if (lower in lexicon) {
+      return fallbackLexiconEntry(lower);
+    }
+    return match;
+  });
+};
+
+const renderFormat = (format: string, replacements: Record<string, string>): string => {
+  const substituted = format.replace(/\{([A-Z]+)\}/g, (match, rawKey) => {
+    const key = String(rawKey ?? '').trim();
+    if (!key) {
+      return '';
+    }
+    return replacements[key] ?? '';
+  });
+  return substituted
+    .replace(/\s+—\s*$/u, '')
+    .replace(/\s{2,}/g, ' ')
+    .replace(/\s+—\s+/g, ' — ')
+    .trim();
+};
+
+const limitBody = (lines: string[], max: number): string[] => lines.slice(0, Math.max(1, max));
+
+const collectMatchCount = (cards: NewsCardLite[], ids: Set<string>, tags: Set<string>): number => {
+  if (!ids.size && !tags.size) {
+    return 0;
+  }
+  const matched = new Set<string>();
+  for (const card of cards) {
+    if (ids.has(card.id)) {
+      matched.add(card.id);
+      continue;
+    }
+    for (const tag of card.tags) {
+      if (tags.has(tag)) {
+        matched.add(card.id);
+        break;
+      }
+    }
+  }
+  return matched.size;
+};
+
+const matchComboRule = (
+  rule: ComboRule,
+  played: NewsCardLite[],
+  opponent: NewsCardLite[],
+): boolean => {
+  const minCards = rule.when.minCards ?? 2;
+  const idSet = new Set(rule.when.anyIds ?? []);
+  const tagSet = new Set(rule.when.anyTags ?? []);
+  const matchCount = collectMatchCount(played, idSet, tagSet);
+  if (matchCount < minCards) {
+    return false;
+  }
+
+  if (rule.when.factions.length > 0) {
+    const allowed = new Set(rule.when.factions);
+    if (!played.every(card => allowed.has(card.faction))) {
+      return false;
+    }
+  }
+
+  if (rule.when.opponentIds.length > 0) {
+    const opponentSet = new Set(rule.when.opponentIds);
+    const hasMatch = opponent.some(card => opponentSet.has(card.id));
+    if (!hasMatch) {
+      return false;
+    }
+  }
+
+  if (rule.when.requiresStateEvent) {
+    return false;
+  }
+
+  return true;
+};
+
+const matchTemplateRule = (
+  rule: TripleTemplateRule,
+  context: ComposeContext,
+): boolean => {
+  const { played, opponent } = context;
+  const { match } = rule;
+  if (!match) {
+    return true;
+  }
+
+  if (match.tagsAny && match.tagsAny.length > 0) {
+    const tagSet = new Set(match.tagsAny);
+    const tagMatches = collectMatchCount(played, new Set(), tagSet);
+    const required = match.minCount ?? 1;
+    if (tagMatches < required) {
+      return false;
+    }
+  }
+
+  const allCards = [...played, ...opponent];
+  if (match.truthIdsAny && match.truthIdsAny.length > 0) {
+    const truthIds = new Set(match.truthIdsAny);
+    const hasTruth = allCards.some(card => card.faction === 'truth' && truthIds.has(card.id));
+    if (!hasTruth) {
+      return false;
+    }
+  }
+  if (match.govIdsAny && match.govIdsAny.length > 0) {
+    const govIds = new Set(match.govIdsAny);
+    const hasGov = allCards.some(card => card.faction === 'government' && govIds.has(card.id));
+    if (!hasGov) {
+      return false;
+    }
+  }
+  if (match.govTagsAny && match.govTagsAny.length > 0) {
+    const tagSet = new Set(match.govTagsAny);
+    const hasGovTag = allCards.some(card => {
+      if (card.faction !== 'government') {
+        return false;
+      }
+      return card.tags.some(tag => tagSet.has(tag));
+    });
+    if (!hasGovTag) {
+      return false;
+    }
+  }
+
+  if (match.types && match.types.length > 0) {
+    const expected = [...match.types];
+    const actual = played.map(card => card.type);
+    if (expected.length !== actual.length) {
+      return false;
+    }
+    const expectedSorted = [...expected].sort();
+    const actualSorted = [...actual].sort();
+    for (let i = 0; i < expectedSorted.length; i += 1) {
+      if (expectedSorted[i] !== actualSorted[i]) {
+        return false;
+      }
+    }
+  }
+
+  if (match.factions && match.factions.length > 0) {
+    if (match.factions.length !== played.length) {
+      return false;
+    }
+    for (let i = 0; i < match.factions.length; i += 1) {
+      if (match.factions[i] !== played[i]?.faction) {
+        return false;
+      }
+    }
+  }
+
+  if (match.typesAnyCount) {
+    const counts = new Map<string, number>();
+    for (const card of played) {
+      counts.set(card.type, (counts.get(card.type) ?? 0) + 1);
+    }
+    for (const [type, required] of Object.entries(match.typesAnyCount)) {
+      const value = counts.get(type) ?? 0;
+      if (value < required) {
+        return false;
+      }
+    }
+  }
+
+  return true;
+};
+
+const buildArticleFromCombo = (
+  rule: ComboRule,
+  context: ComposeContext,
+  placeholders: PlaceholderContext,
+): ExtraArticleBlock => {
+  const { bank, mix, rng } = context;
+  const tone = determineTone(resolveComboTone(rule), mix);
+  const kickerPoolKey = tone === 'truth' ? 'truth' : tone === 'government' ? 'government' : 'mixed';
+  const kicker = pick(bank.rendering.kickers[kickerPoolKey] ?? [], rng, 'EXTRA EXTRA');
+  const stinger = pick(bank.rendering.stingers ?? [], rng, 'SOURCE: “THIS IS FINE”');
+
+  const rawHeadline = applyPlaceholders(rule.headline, placeholders);
+  const rawSubhead = applyPlaceholders(rule.subhead ?? '', placeholders);
+  const body = limitBody(applyBodyPlaceholders(rule.body ?? [], placeholders), bank.defaults.maxBodyParas);
+  const imagePrompt = applyPlaceholders(rule.imagePrompt ?? '', placeholders);
+  const dek = rawSubhead;
+  const bullets = body;
+
+  return {
+    tone,
+    hed: rawHeadline,
+    dek,
+    bullets,
+    byline: rule.byline ?? bank.defaults.byline,
+    source: 'Source: Composite Wire',
+    body,
+    imagePrompt: imagePrompt || undefined,
+    kicker,
+    stinger,
+    comboId: rule.comboId,
+  } satisfies ExtraArticleBlock;
+};
+
+const resolveComboTone = (rule: ComboRule): 'truth' | 'government' | 'mixed' | undefined => {
+  const tags = rule.tags.map(tag => tag.toLowerCase());
+  if (tags.includes('truth-combo')) {
+    return 'truth';
+  }
+  if (tags.includes('government-combo')) {
+    return 'government';
+  }
+  if (tags.includes('truth-vs-gov')) {
+    return 'mixed';
+  }
+  return undefined;
+};
+
+const applyBodyPlaceholders = (body: string[], context: PlaceholderContext): string[] => {
+  return cleanLines(body.map(line => applyPlaceholders(line, context)));
+};
+
+const buildArticleFromTemplate = (
+  rule: TripleTemplateRule,
+  bucketId: string,
+  context: ComposeContext,
+  placeholders: PlaceholderContext,
+): ExtraArticleBlock => {
+  const { bank, mix, rng } = context;
+  const tone = determineTone(rule.factionHint, mix);
+  const toneKey = tone === 'truth' ? 'truth' : tone === 'government' ? 'government' : 'mixed';
+  const kicker = pick(bank.rendering.kickers[toneKey] ?? [], rng, 'EXTRA EXTRA');
+  const stinger = pick(bank.rendering.stingers ?? [], rng, 'UPSETTING TO PRINTERS');
+  const main = applyPlaceholders(rule.headline, placeholders);
+  const sub = applyPlaceholders(rule.subhead ?? '', placeholders);
+  const body = limitBody(applyBodyPlaceholders(rule.body ?? [], placeholders), bank.defaults.maxBodyParas);
+  const imagePrompt = applyPlaceholders(rule.imagePrompt ?? '', placeholders);
+
+  const hed = renderFormat(bank.rendering.headlineFormat, {
+    KICKER: kicker,
+    MAIN: main,
+    STINGER: stinger,
+  });
+  const dek = renderFormat(bank.rendering.subheadFormat, {
+    SUBA: sub,
+    SUBB: '',
+  });
+
+  return {
+    tone,
+    hed,
+    dek,
+    bullets: body,
+    byline: bank.defaults.byline,
+    source: 'Source: Composite Wire',
+    body,
+    imagePrompt: imagePrompt || undefined,
+    kicker,
+    stinger,
+    templateId: `${bucketId}:${rule.id}`,
+  } satisfies ExtraArticleBlock;
+};
+
+const selectComboMatch = (
+  combos: ComboRule[],
+  played: NewsCardLite[],
+  opponent: NewsCardLite[],
+): ComboRule | null => {
+  let firstMatch: ComboRule | null = null;
+  for (const combo of combos) {
+    if (!matchComboRule(combo, played, opponent)) {
+      continue;
+    }
+    if (!firstMatch) {
+      firstMatch = combo;
+    }
+    if (combo.exclusive) {
+      return combo;
+    }
+  }
+  return firstMatch;
+};
+
+const selectTemplateRule = (
+  bank: TripleTemplateBank,
+  context: ComposeContext,
+): { bucketId: string; rule: TripleTemplateRule } | null => {
+  const { priority, templates } = bank;
+  const buckets = priority.length ? priority : Object.keys(templates);
+  for (const bucketId of buckets) {
+    const rules = templates[bucketId];
+    if (!Array.isArray(rules) || !rules.length) {
+      continue;
+    }
+    for (const rule of rules) {
+      if (matchTemplateRule(rule, context)) {
+        return { bucketId, rule };
+      }
+    }
+  }
+  const genericRules = templates.generic ?? [];
+  if (genericRules.length) {
+    return { bucketId: 'generic', rule: genericRules[0]! };
+  }
+  return null;
+};
+
+export function composeTripleHeadline(
+  played: NewsCardLite[],
+  opponentPlayed: NewsCardLite[] | null,
+  opts?: { seed?: number },
+): ExtraArticleBlock | null {
+  if (!Array.isArray(played) || played.length !== 3) {
+    return null;
+  }
+
+  const bank = getTripleBankIfReady();
+  if (!bank) {
+    return null;
+  }
+
+  const combos = getComboBankIfReady();
+  const opponent = Array.isArray(opponentPlayed) ? opponentPlayed.slice(0, 3) : [];
+  const mix = determineMix(played);
+  const baseSeed = typeof opts?.seed === 'number' ? opts.seed : hashSeed(played.map(card => card.id).join('+'));
+  const rng = mulberry32(baseSeed);
+  const placeholders = buildPlaceholderContext(played, bank, rng);
+  const context: ComposeContext = { played, opponent, bank, rng, mix };
+
+  if (combos && combos.length > 0) {
+    const combo = selectComboMatch(combos, played, opponent);
+    if (combo) {
+      return buildArticleFromCombo(combo, context, placeholders);
+    }
+  }
+
+  const selected = selectTemplateRule(bank, context);
+  if (!selected) {
+    return null;
+  }
+
+  return buildArticleFromTemplate(selected.rule, selected.bucketId, context, placeholders);
+}

--- a/src/engine/news/newsPools.ts
+++ b/src/engine/news/newsPools.ts
@@ -1,0 +1,337 @@
+import { z } from 'zod';
+
+import perCardArticlesJson from './paranoid_times_card_articles_ALL.json' assert { type: 'json' };
+import comboBankJson from './story_combos.json' assert { type: 'json' };
+import tripleBankJson from './extra_extra_triple_bank.json' assert { type: 'json' };
+
+export type ArticleBlock = {
+  id: string;
+  tone: 'truth' | 'government';
+  tags: string[];
+  headline?: string;
+  subhead?: string;
+  byline?: string;
+  body?: string;
+  imagePrompt?: string;
+};
+
+export type ComboRule = {
+  comboId: string;
+  priority: number;
+  exclusive: boolean;
+  tags: string[];
+  when: {
+    minCards: number;
+    anyIds: string[];
+    anyTags: string[];
+    opponentIds: string[];
+    factions: Array<'truth' | 'government'>;
+    requiresStateEvent: boolean;
+  };
+  headline: string;
+  subhead: string;
+  byline: string;
+  body: string[];
+  imagePrompt?: string;
+};
+
+export type TripleTemplateMatch = {
+  tagsAny: string[];
+  minCount: number;
+  truthIdsAny: string[];
+  govIdsAny: string[];
+  govTagsAny: string[];
+  types: string[];
+  factions: Array<'truth' | 'government'>;
+  typesAnyCount: Record<string, number>;
+};
+
+export type TripleTemplateRule = {
+  id: string;
+  match: Partial<TripleTemplateMatch>;
+  headline: string;
+  subhead?: string;
+  imagePrompt?: string;
+  body: string[];
+  factionHint?: 'truth' | 'government' | 'mixed';
+};
+
+export type TripleTemplateBank = {
+  defaults: {
+    imageStyle: string;
+    maxBodyParas: number;
+    byline: string;
+  };
+  lexicon: Record<string, string[]>;
+  rendering: {
+    headlineFormat: string;
+    subheadFormat: string;
+    kickers: Record<'truth' | 'government' | 'mixed', string[]>;
+    stingers: string[];
+  };
+  priority: string[];
+  templates: Record<string, TripleTemplateRule[]>;
+};
+
+let cachedArticles: Map<string, ArticleBlock> | null = null;
+let cachedComboBank: ComboRule[] | null = null;
+let cachedTripleBank: TripleTemplateBank | null = null;
+
+const normaliseTag = (tag: string): string => tag.trim().toLowerCase().replace(/\s+/g, '-');
+
+const unique = <T,>(values: T[]): T[] => Array.from(new Set(values));
+
+const perCardArticleSchema = z.object({
+  schemaVersion: z.number().optional(),
+  articles: z
+    .array(
+      z.object({
+        id: z.string().min(1),
+        tone: z.string(),
+        tags: z.array(z.string()).default([]),
+        headline: z.string().optional(),
+        subhead: z.string().optional(),
+        byline: z.string().optional(),
+        body: z.string().optional(),
+        imagePrompt: z.string().optional(),
+      }),
+    )
+    .default([]),
+});
+
+const comboBankSchema = z.object({
+  schemaVersion: z.number().optional(),
+  combos: z
+    .array(
+      z.object({
+        comboId: z.string(),
+        priority: z.number().default(0),
+        exclusive: z.boolean().default(false),
+        tags: z.array(z.string()).default([]),
+        when: z
+          .object({
+            minCards: z.number().optional(),
+            anyIds: z.array(z.string()).optional(),
+            anyTags: z.array(z.string()).optional(),
+            opponentIds: z.array(z.string()).optional(),
+            factions: z.array(z.string()).optional(),
+            requiresStateEvent: z.boolean().optional(),
+          })
+          .default({}),
+        headline: z.string(),
+        subhead: z.string().default(''),
+        byline: z.string().default('By: Composite Desk'),
+        body: z.array(z.string()).default([]),
+        imagePrompt: z.string().optional(),
+      }),
+    )
+    .default([]),
+});
+
+const tripleBankSchema = z.object({
+  defaults: z.object({
+    imageStyle: z.string().default('grainy photo'),
+    maxBodyParas: z.number().default(3),
+    byline: z.string().default('By: Composite Desk'),
+  }),
+  lexicon: z.record(z.string(), z.array(z.string())),
+  rendering: z.object({
+    headline_format: z.string(),
+    subhead_format: z.string(),
+    kickers: z.object({
+      truth: z.array(z.string()).default([]),
+      government: z.array(z.string()).default([]),
+      mixed: z.array(z.string()).default([]),
+    }),
+    stingers: z.array(z.string()).default([]),
+  }),
+  priority: z.array(z.string()).default([]),
+  templates: z.record(
+    z.array(
+      z.object({
+        id: z.string(),
+        match: z
+          .object({
+            tagsAny: z.array(z.string()).optional(),
+            minCount: z.number().optional(),
+            truthIdsAny: z.array(z.string()).optional(),
+            govIdsAny: z.array(z.string()).optional(),
+            govTagsAny: z.array(z.string()).optional(),
+            types: z.array(z.string()).optional(),
+            factions: z.array(z.string()).optional(),
+            typesAnyCount: z.record(z.number()).optional(),
+          })
+          .default({}),
+        headline: z.string(),
+        subhead: z.string().optional(),
+        imagePrompt: z.string().optional(),
+        body: z.array(z.string()).default([]),
+        factionHint: z.string().optional(),
+      }),
+    ),
+  ),
+});
+
+export async function loadPerCardArticles(): Promise<Map<string, ArticleBlock>> {
+  if (cachedArticles) {
+    return cachedArticles;
+  }
+
+  const parsed = perCardArticleSchema.parse(perCardArticlesJson);
+  const map = new Map<string, ArticleBlock>();
+
+  for (const entry of parsed.articles) {
+    const tone = entry.tone.trim().toLowerCase();
+    if (tone !== 'truth' && tone !== 'gov' && tone !== 'government') {
+      continue;
+    }
+    const normalisedTags = unique(entry.tags.map(normaliseTag).filter(Boolean));
+    const record: ArticleBlock = {
+      id: entry.id,
+      tone: tone === 'truth' ? 'truth' : 'government',
+      tags: normalisedTags,
+      headline: entry.headline,
+      subhead: entry.subhead,
+      byline: entry.byline,
+      body: entry.body,
+      imagePrompt: entry.imagePrompt,
+    };
+    map.set(record.id, record);
+  }
+
+  cachedArticles = map;
+  return map;
+}
+
+export async function loadComboBank(): Promise<ComboRule[]> {
+  if (cachedComboBank) {
+    return cachedComboBank;
+  }
+
+  const parsed = comboBankSchema.parse(comboBankJson);
+
+  const combos: ComboRule[] = parsed.combos.map(combo => {
+    const tags = unique(combo.tags.map(normaliseTag).filter(Boolean));
+    const factions = (combo.when.factions ?? []).map(value => value.trim().toLowerCase()).filter(Boolean);
+    const normalizedFactions = factions.filter(
+      (value): value is 'truth' | 'government' => value === 'truth' || value === 'government',
+    );
+
+    const when: ComboRule['when'] = {
+      minCards: combo.when.minCards ?? 2,
+      anyIds: unique((combo.when.anyIds ?? []).map(id => id.trim()).filter(Boolean)),
+      anyTags: unique((combo.when.anyTags ?? []).map(normaliseTag).filter(Boolean)),
+      opponentIds: unique((combo.when.opponentIds ?? []).map(id => id.trim()).filter(Boolean)),
+      factions: normalizedFactions,
+      requiresStateEvent: Boolean(combo.when.requiresStateEvent),
+    };
+
+    return {
+      comboId: combo.comboId,
+      priority: combo.priority ?? 0,
+      exclusive: combo.exclusive ?? false,
+      tags,
+      when,
+      headline: combo.headline,
+      subhead: combo.subhead ?? '',
+      byline: combo.byline ?? 'By: Composite Desk',
+      body: combo.body ?? [],
+      imagePrompt: combo.imagePrompt,
+    } satisfies ComboRule;
+  });
+
+  combos.sort((a, b) => b.priority - a.priority);
+
+  cachedComboBank = combos;
+  return combos;
+}
+
+export async function loadTripleBank(): Promise<TripleTemplateBank> {
+  if (cachedTripleBank) {
+    return cachedTripleBank;
+  }
+
+  const parsed = tripleBankSchema.parse(tripleBankJson);
+
+  const templates: Record<string, TripleTemplateRule[]> = {};
+  for (const [bucketId, rules] of Object.entries(parsed.templates)) {
+    templates[bucketId] = rules.map(rule => {
+      const match: Partial<TripleTemplateMatch> = {};
+      if (rule.match.tagsAny) {
+        match.tagsAny = unique(rule.match.tagsAny.map(normaliseTag).filter(Boolean));
+      }
+      if (rule.match.minCount) {
+        match.minCount = rule.match.minCount;
+      }
+      if (rule.match.truthIdsAny) {
+        match.truthIdsAny = unique(rule.match.truthIdsAny.map(id => id.trim()).filter(Boolean));
+      }
+      if (rule.match.govIdsAny) {
+        match.govIdsAny = unique(rule.match.govIdsAny.map(id => id.trim()).filter(Boolean));
+      }
+      if (rule.match.govTagsAny) {
+        match.govTagsAny = unique(rule.match.govTagsAny.map(normaliseTag).filter(Boolean));
+      }
+      if (rule.match.types) {
+        match.types = rule.match.types.map(type => type.trim()).filter(Boolean);
+      }
+      if (rule.match.factions) {
+        const factions = rule.match.factions
+          .map(value => value.trim().toLowerCase())
+          .filter((value): value is 'truth' | 'government' => value === 'truth' || value === 'government');
+        if (factions.length === 3) {
+          match.factions = factions;
+        }
+      }
+      if (rule.match.typesAnyCount) {
+        match.typesAnyCount = {};
+        for (const [type, count] of Object.entries(rule.match.typesAnyCount)) {
+          if (typeof count === 'number' && Number.isFinite(count) && count > 0) {
+            match.typesAnyCount[type] = count;
+          }
+        }
+      }
+
+      return {
+        id: rule.id,
+        match,
+        headline: rule.headline,
+        subhead: rule.subhead,
+        imagePrompt: rule.imagePrompt,
+        body: rule.body,
+        factionHint:
+          rule.factionHint === 'truth' || rule.factionHint === 'government' || rule.factionHint === 'mixed'
+            ? rule.factionHint
+            : undefined,
+      } satisfies TripleTemplateRule;
+    });
+  }
+
+  const bank: TripleTemplateBank = {
+    defaults: {
+      imageStyle: parsed.defaults.imageStyle,
+      maxBodyParas: parsed.defaults.maxBodyParas,
+      byline: parsed.defaults.byline,
+    },
+    lexicon: parsed.lexicon,
+    rendering: {
+      headlineFormat: parsed.rendering.headline_format,
+      subheadFormat: parsed.rendering.subhead_format,
+      kickers: parsed.rendering.kickers,
+      stingers: parsed.rendering.stingers,
+    },
+    priority: parsed.priority,
+    templates,
+  } satisfies TripleTemplateBank;
+
+  cachedTripleBank = bank;
+  return bank;
+}
+
+export const getPerCardArticlesIfReady = (): Map<string, ArticleBlock> | null => cachedArticles;
+export const getComboBankIfReady = (): ComboRule[] | null => cachedComboBank;
+export const getTripleBankIfReady = (): TripleTemplateBank | null => cachedTripleBank;
+
+export async function initNewsPools(): Promise<void> {
+  await Promise.all([loadPerCardArticles(), loadComboBank(), loadTripleBank()]);
+}

--- a/src/hooks/useGameState.ts
+++ b/src/hooks/useGameState.ts
@@ -86,9 +86,11 @@ import {
 import { assignStateBonuses } from '@/game/stateBonuses';
 import { applyStateBonusAssignmentToState } from './stateBonusAssignment';
 import { clearNewsBuffer, getNewsTriplet, pushToNewsBuffer } from '@/state/game/roundNewsBuffer';
-import { summarize, generateExtraExtra, evaluateExtraExtra } from '@/news/headlineEngine';
+import { summarize, generateExtraExtra, evaluateExtraExtra, hashSeed } from '@/news/headlineEngine';
 import { loadNewsPools } from '@/news/newsPools';
-import type { ArticleBlock, TurnLog } from '@/news/headlineEngine';
+import type { ArticleBlock, TurnLog, PlayedLite } from '@/news/headlineEngine';
+import { composeTripleHeadline, type NewsCardLite } from '@/engine/news/composeTriple';
+import { getPerCardArticlesIfReady, initNewsPools } from '@/engine/news/newsPools';
 import type { GameOverReport } from '@/types/finalEdition';
 
 const omitClashKey = (key: string, value: unknown) => (key === 'clash' ? undefined : value);
@@ -306,7 +308,22 @@ const normalizeArticleBlock = (entry: unknown): ArticleBlock | null => {
         ? candidate.source
         : 'Source: Redacted';
 
-      return {
+      const normalizedBody = Array.isArray(candidate.body)
+        ? candidate.body
+            .filter((line): line is string => typeof line === 'string' && line.trim().length > 0)
+            .map(line => line.trim())
+        : [];
+      const imagePrompt = typeof candidate.imagePrompt === 'string' ? candidate.imagePrompt.trim() : '';
+      const kicker = typeof candidate.kicker === 'string' ? candidate.kicker.trim() : '';
+      const stinger = typeof candidate.stinger === 'string' ? candidate.stinger.trim() : '';
+      const templateId = typeof (candidate as { templateId?: unknown }).templateId === 'string'
+        ? (candidate as { templateId: string }).templateId
+        : undefined;
+      const comboId = typeof (candidate as { comboId?: unknown }).comboId === 'string'
+        ? (candidate as { comboId: string }).comboId
+        : undefined;
+
+      const normalized: ArticleBlock = {
         tone,
         hed,
         dek,
@@ -314,6 +331,27 @@ const normalizeArticleBlock = (entry: unknown): ArticleBlock | null => {
         byline,
         source,
       } satisfies ArticleBlock;
+
+      if (normalizedBody.length) {
+        normalized.body = normalizedBody;
+      }
+      if (imagePrompt) {
+        normalized.imagePrompt = imagePrompt;
+      }
+      if (kicker) {
+        normalized.kicker = kicker;
+      }
+      if (stinger) {
+        normalized.stinger = stinger;
+      }
+      if (templateId) {
+        normalized.templateId = templateId;
+      }
+      if (comboId) {
+        normalized.comboId = comboId;
+      }
+
+      return normalized;
     }
   }
 
@@ -407,6 +445,87 @@ const applyTurnNews = (prev: GameState, next: GameState, seedPrefix: string): Ga
     const focusLog: TurnLog = { ...turnLog, plays: evaluation.focusPlays };
     const focusTotals = summarize([focusLog]);
     const article = generateExtraExtra(`${seedPrefix}:${prev.round}:${prev.turn}`, [focusLog], focusTotals);
+
+    const perCardArticles = getPerCardArticlesIfReady();
+    if (perCardArticles) {
+      const collectFactionTrio = (plays: PlayedLite[], faction: 'truth' | 'government'): PlayedLite[] => {
+        const trio: PlayedLite[] = [];
+        for (const play of plays) {
+          if (play.faction !== faction) {
+            continue;
+          }
+          trio.push(play);
+          if (trio.length >= 3) {
+            break;
+          }
+        }
+        return trio;
+      };
+
+      const toNewsCard = (play: PlayedLite): NewsCardLite => {
+        const entry = perCardArticles.get(play.id);
+        return {
+          id: play.id,
+          name: play.name,
+          faction: play.faction,
+          type: play.type,
+          tags: entry?.tags ?? [],
+        } satisfies NewsCardLite;
+      };
+
+      const truthTrio = collectFactionTrio(buffer, 'truth');
+      const governmentTrio = collectFactionTrio(buffer, 'government');
+      const truthCards = truthTrio.length >= 3 ? truthTrio.slice(0, 3).map(toNewsCard) : [];
+      const governmentCards = governmentTrio.length >= 3 ? governmentTrio.slice(0, 3).map(toNewsCard) : [];
+
+      let focusCards: NewsCardLite[] | null = null;
+      let opponentCards: NewsCardLite[] = [];
+
+      if (evaluation.winningFaction === 'truth') {
+        focusCards = truthCards.length === 3 ? truthCards : null;
+        opponentCards = governmentCards;
+      } else if (evaluation.winningFaction === 'government') {
+        focusCards = governmentCards.length === 3 ? governmentCards : null;
+        opponentCards = truthCards;
+      } else {
+        if (truthCards.length === 3) {
+          focusCards = truthCards;
+          opponentCards = governmentCards;
+        } else if (governmentCards.length === 3) {
+          focusCards = governmentCards;
+          opponentCards = truthCards;
+        }
+      }
+
+      if ((!focusCards || focusCards.length !== 3) && evaluation.focusPlays.length >= 3) {
+        focusCards = evaluation.focusPlays.slice(0, 3).map(toNewsCard);
+      }
+
+      if (focusCards && focusCards.length === 3) {
+        const seed = hashSeed(`${seedPrefix}:${prev.round}:${prev.turn}:triple`);
+        const tripleArticle = composeTripleHeadline(focusCards, opponentCards, { seed });
+        if (tripleArticle) {
+          if (typeof console !== 'undefined' && typeof console.debug === 'function') {
+            const signature = focusCards.map(card => card.id).join(',');
+            const marker = tripleArticle.comboId ?? tripleArticle.templateId ?? 'template';
+            console.debug(`NEWS: triple-main ${signature} -> ${marker}`);
+          }
+          article.hed = tripleArticle.hed;
+          article.dek = tripleArticle.dek;
+          article.tone = tripleArticle.tone;
+          article.bullets = tripleArticle.bullets.length ? tripleArticle.bullets : article.bullets;
+          article.byline = tripleArticle.byline ?? article.byline;
+          article.source = tripleArticle.source ?? article.source;
+          article.body = tripleArticle.body && tripleArticle.body.length ? tripleArticle.body : undefined;
+          article.imagePrompt = tripleArticle.imagePrompt ?? article.imagePrompt;
+          article.kicker = tripleArticle.kicker ?? article.kicker;
+          article.stinger = tripleArticle.stinger ?? article.stinger;
+          article.templateId = tripleArticle.templateId ?? article.templateId;
+          article.comboId = tripleArticle.comboId ?? article.comboId;
+        }
+      }
+    }
+
     extraExtraFeed = [...extraExtraFeed, article];
 
     if (evaluation.truthDelta !== 0) {
@@ -2198,6 +2317,13 @@ export const useGameState = (aiDifficultyOverride?: AIDifficulty) => {
         return;
       }
       console.warn('Failed to preload news pools before turn resolution', error);
+    });
+
+    initNewsPools().catch(error => {
+      if (!isActive) {
+        return;
+      }
+      console.warn('Failed to preload triple headline pools before turn resolution', error);
     });
 
     return () => {

--- a/src/mvp/engine.ts
+++ b/src/mvp/engine.ts
@@ -5,8 +5,10 @@ import { applyComboRewards, evaluateCombos, getComboSettings, formatComboReward 
 import type { ComboEvaluation, ComboOptions, ComboSummary, TurnPlay } from '@/game/combo.types';
 import { getStateByAbbreviation, getStateById } from '@/data/usaStates';
 import { RelicEngine } from '@/expansions/tabloidRelics/RelicEngine';
-import { summarize, generateExtraExtra, evaluateExtraExtra } from '@/news/headlineEngine';
+import { summarize, generateExtraExtra, evaluateExtraExtra, hashSeed } from '@/news/headlineEngine';
 import type { PlayedLite, TurnLog } from '@/news/headlineEngine';
+import { composeTripleHeadline, type NewsCardLite } from '@/engine/news/composeTriple';
+import { getPerCardArticlesIfReady } from '@/engine/news/newsPools';
 import { cloneGameState } from './validator';
 import { auditGameState } from './gameStateAudit';
 import type { Card, EffectsATTACK, EffectsMEDIA, EffectsZONE, GameState, PlayerState } from './validator';
@@ -654,6 +656,87 @@ export function endTurn(
       const focusLog: TurnLog = { ...turnLogEntry, plays: evaluation.focusPlays };
       const focusTotals = summarize([focusLog]);
       const article = generateExtraExtra(`mvp:${currentId}:${turnNumber}`, [focusLog], focusTotals);
+
+      const perCardArticles = getPerCardArticlesIfReady();
+      if (perCardArticles) {
+        const collectFactionTrio = (plays: PlayedLite[], faction: 'truth' | 'government'): PlayedLite[] => {
+          const trio: PlayedLite[] = [];
+          for (const play of plays) {
+            if (play.faction !== faction) {
+              continue;
+            }
+            trio.push(play);
+            if (trio.length >= 3) {
+              break;
+            }
+          }
+          return trio;
+        };
+
+        const toNewsCard = (play: PlayedLite): NewsCardLite => {
+          const entry = perCardArticles.get(play.id);
+          return {
+            id: play.id,
+            name: play.name,
+            faction: play.faction,
+            type: play.type,
+            tags: entry?.tags ?? [],
+          } satisfies NewsCardLite;
+        };
+
+        const truthTrio = collectFactionTrio(bufferPlays, 'truth');
+        const governmentTrio = collectFactionTrio(bufferPlays, 'government');
+        const truthCards = truthTrio.length >= 3 ? truthTrio.slice(0, 3).map(toNewsCard) : [];
+        const governmentCards = governmentTrio.length >= 3 ? governmentTrio.slice(0, 3).map(toNewsCard) : [];
+
+        let focusCards: NewsCardLite[] | null = null;
+        let opponentCards: NewsCardLite[] = [];
+
+        if (evaluation.winningFaction === 'truth') {
+          focusCards = truthCards.length === 3 ? truthCards : null;
+          opponentCards = governmentCards;
+        } else if (evaluation.winningFaction === 'government') {
+          focusCards = governmentCards.length === 3 ? governmentCards : null;
+          opponentCards = truthCards;
+        } else {
+          if (truthCards.length === 3) {
+            focusCards = truthCards;
+            opponentCards = governmentCards;
+          } else if (governmentCards.length === 3) {
+            focusCards = governmentCards;
+            opponentCards = truthCards;
+          }
+        }
+
+        if ((!focusCards || focusCards.length !== 3) && evaluation.focusPlays.length >= 3) {
+          focusCards = evaluation.focusPlays.slice(0, 3).map(toNewsCard);
+        }
+
+        if (focusCards && focusCards.length === 3) {
+          const seed = hashSeed(`mvp:${currentId}:${turnNumber}:triple`);
+          const tripleArticle = composeTripleHeadline(focusCards, opponentCards, { seed });
+          if (tripleArticle) {
+            if (typeof console !== 'undefined' && typeof console.debug === 'function') {
+              const signature = focusCards.map(card => card.id).join(',');
+              const marker = tripleArticle.comboId ?? tripleArticle.templateId ?? 'template';
+              console.debug(`NEWS: triple-main ${signature} -> ${marker}`);
+            }
+            article.hed = tripleArticle.hed;
+            article.dek = tripleArticle.dek;
+            article.tone = tripleArticle.tone;
+            article.bullets = tripleArticle.bullets.length ? tripleArticle.bullets : article.bullets;
+            article.byline = tripleArticle.byline ?? article.byline;
+            article.source = tripleArticle.source ?? article.source;
+            article.body = tripleArticle.body && tripleArticle.body.length ? tripleArticle.body : undefined;
+            article.imagePrompt = tripleArticle.imagePrompt ?? article.imagePrompt;
+            article.kicker = tripleArticle.kicker ?? article.kicker;
+            article.stinger = tripleArticle.stinger ?? article.stinger;
+            article.templateId = tripleArticle.templateId ?? article.templateId;
+            article.comboId = tripleArticle.comboId ?? article.comboId;
+          }
+        }
+      }
+
       extraExtraFeed = [...extraExtraFeed, article];
 
       if (evaluation.truthDelta !== 0) {

--- a/src/news/headlineEngine.ts
+++ b/src/news/headlineEngine.ts
@@ -232,6 +232,12 @@ export interface ArticleBlock {
   bullets: string[];
   byline: string;
   source: string;
+  body?: string[];
+  imagePrompt?: string;
+  kicker?: string;
+  stinger?: string;
+  templateId?: string;
+  comboId?: string;
 }
 
 export interface FinalEdition {

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -80,6 +80,7 @@ import type { GameOverReport } from '@/types/finalEdition';
 import type { ArcProgressSummary } from '@/types/campaign';
 import { buildFinalEdition as buildNewsFinalEdition, type FinalEdition, type TurnLog } from '@/news/headlineEngine';
 import { loadNewsPools } from '@/news/newsPools';
+import { initNewsPools } from '@/engine/news/newsPools';
 import { toPlayedLite } from '@/hooks/aiHelpers';
 
 type ContextualEffectType = Parameters<typeof VisualEffectsCoordinator.triggerContextualEffect>[0];
@@ -1107,7 +1108,7 @@ const Index = () => {
 
     const prepareNewsPools = async () => {
       try {
-        await loadNewsPools();
+        await Promise.all([loadNewsPools(), initNewsPools()]);
         if (isMounted) {
           setAreNewsPoolsReady(true);
         }


### PR DESCRIPTION
## Summary
- add cached loaders for per-card articles, combo rules, and triple headline templates to support seeded composition
- implement the triple-card Extra Extra composer and integrate it into turn resolution in both the live loop and MVP simulator without touching truth-delta logic
- extend article metadata serialization, preload the new pools in the UI, and cover the composer with targeted Vitest specs while documenting the feature in the updates log

## Testing
- bun test src/engine/news/__tests__/composeTriple.spec.ts
- npm run lint *(fails: long-standing @typescript-eslint/no-explicit-any and hook dependency warnings)*
- bun test --coverage --coverage-reporter=text *(fails: pre-existing integration suites such as processAiActions and extraExtra mocks)*

------
https://chatgpt.com/codex/tasks/task_e_68e4ad8679508320a939498534ef87f0