### PR TITLE
Fix zone pressure audit regression and harden broadsheet rarity helper

### DIFF
--- a/UPDATES_LOG.md
+++ b/UPDATES_LOG.md
@@ -17,6 +17,10 @@ This document provides a chronological record of gameplay-impacting changes merg
   thumbing through a classified suspect folder before launch.
 - Recolored actions and dossier cards to lean into the Paranoid Times manila-folder aesthetic while keeping mechanics unchanged.
 
+## 2025-10-07 – Safeguard zone pressure audits
+- Stop ZONE cards from stacking pressure on states the acting player already controls so game-state audits no longer trip controlled-state invariants.
+- Harden the broadsheet rarity helper with normalized inputs and a global fallback to silence missing-function errors in archive views.
+
 ## 2025-10-07 – Compose triple-card Extra Extra headlines
 - Added a seeded triple-headline composer that braids the turn’s first three plays into a main story using combo rules, holiday buckets, and a generic fallback so every trigger prints a bespoke lead.
 - Hooked turn resolution and the MVP simulator into the new pools, preserving truth-delta math while logging the composed template or combo for debugging.

--- a/src/engine/applyEffects-mvp.ts
+++ b/src/engine/applyEffects-mvp.ts
@@ -100,6 +100,19 @@ function applyZoneEffect(
 ) {
   const opponent = otherPlayer(owner);
   const currentPressure = state.pressureByState[targetStateId] ?? { P1: 0, P2: 0 };
+  const ownerControlsState = state.players[owner]?.states.includes(targetStateId);
+
+  if (ownerControlsState) {
+    if ((currentPressure[owner] ?? 0) !== 0) {
+      state.pressureByState = {
+        ...state.pressureByState,
+        [targetStateId]: { ...currentPressure, [owner]: 0 },
+      } satisfies GameState['pressureByState'];
+    }
+    state.log.push(`${owner} reinforces ${targetStateId} but already controls it—pressure remains at 0.`);
+    return;
+  }
+
   const updatedOwnerPressure = (currentPressure[owner] ?? 0) + effects.pressureDelta;
 
   let pressureByState: GameState['pressureByState'] = {

--- a/src/mvp/__tests__/engine.editors.test.ts
+++ b/src/mvp/__tests__/engine.editors.test.ts
@@ -188,4 +188,29 @@ describe('editor runtime modifiers', () => {
     expect(state.pressureByState.CA.P1).toBe(2);
     expect(state.log.some(entry => entry.includes('Bat Boy Jr.'))).toBe(true);
   });
+
+  it('ignores additional pressure on already controlled states', () => {
+    const zoneCard = createCard({
+      id: 'zone-2',
+      name: 'Friendly Patrol',
+      type: 'ZONE',
+      cost: 1,
+      effects: { pressureDelta: 3 },
+      target: { scope: 'state', count: 1 },
+    });
+    const state = createState({
+      players: {
+        P1: {
+          states: ['CA'],
+        },
+      },
+      pressureByState: { CA: { P1: 0, P2: 0 } },
+      stateDefense: { CA: 4 },
+    });
+
+    applyEffectsMvp(state, 'P1', zoneCard, 'CA');
+
+    expect(state.pressureByState.CA.P1).toBe(0);
+    expect(state.log[state.log.length - 1]).toContain('already controls it');
+  });
 });

--- a/src/utils/broadsheet.ts
+++ b/src/utils/broadsheet.ts
@@ -1,14 +1,22 @@
 export type BroadsheetRarity = 'common' | 'uncommon' | 'rare' | 'legendary';
 
-export const getBroadsheetRarityTone = (rarity: string) => {
-  switch (rarity as BroadsheetRarity) {
-    case 'legendary':
-      return 'border-[#3c3a8f] bg-[#e3e0f7] text-[#25206a]';
-    case 'rare':
-      return 'border-[#1f5d82] bg-[#d3e5f2] text-[#123b53]';
-    case 'uncommon':
-      return 'border-[#2f6f3a] bg-[#d6edd9] text-[#1f4b24]';
-    default:
-      return 'border-[var(--broadsheet-rule)] bg-white text-[var(--broadsheet-muted)]';
-  }
+const RARITY_CLASS_MAP: Record<BroadsheetRarity | 'default', string> = {
+  legendary: 'border-[#3c3a8f] bg-[#e3e0f7] text-[#25206a]',
+  rare: 'border-[#1f5d82] bg-[#d3e5f2] text-[#123b53]',
+  uncommon: 'border-[#2f6f3a] bg-[#d6edd9] text-[#1f4b24]',
+  common: 'border-[var(--broadsheet-rule)] bg-white text-[var(--broadsheet-muted)]',
+  default: 'border-[var(--broadsheet-rule)] bg-white text-[var(--broadsheet-muted)]',
 };
+
+export const getBroadsheetRarityTone = (rarity: string): string => {
+  const key = rarity?.toLowerCase() as BroadsheetRarity | undefined;
+  return RARITY_CLASS_MAP[key ?? 'default'] ?? RARITY_CLASS_MAP.default;
+};
+
+const globalScope = typeof globalThis === 'object' && globalThis ? (globalThis as Record<string, unknown>) : null;
+
+if (globalScope && typeof globalScope.getBroadsheetRarityTone !== 'function') {
+  globalScope.getBroadsheetRarityTone = getBroadsheetRarityTone;
+}
+
+export const broadsheetRarityClassMap = RARITY_CLASS_MAP;


### PR DESCRIPTION
## Summary
- prevent zone effects from stacking pressure on states the acting player already controls and record a reinforcement log entry
- normalize the broadsheet rarity tone helper, expose its class map, and mirror the function on the global scope to avoid missing references
- add regression coverage for the new zone guard and document the change in the update log

## Testing
- npm run lint *(fails: repository currently has pre-existing lint errors, including many any-typed values and a parsing failure in paranormalSfx.ts)*
- bun test --coverage --coverage-reporter=text *(fails: test suite expects browser globals like localStorage and a mock.fn helper that are unavailable in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e4bb30ad2c83209e040de4e86fca08