### PR TITLE
Integrate triple composer into Extra Extra workflow

### DIFF
--- a/__tests__/integration/extraExtra.test.ts
+++ b/__tests__/integration/extraExtra.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, mock } from 'bun:test';
+import * as actualFrontendNewsPools from '../../src/news/newsPools';
 import type { Card, GameState } from '../../src/mvp/validator';
 import type { TurnLog, PlayedLite } from '../../src/news/headlineEngine';
 
@@ -19,10 +20,35 @@ const stubPools = {
   weather: ['Calm Skies'],
 } as const;
 
-const getPoolsMock = mock.fn(() => stubPools);
-const getPoolsIfReadyMock = mock.fn(() => stubPools);
+const createMockFn = <Args extends unknown[], Return>(
+  implementation: (...args: Args) => Return,
+) => {
+  const fn = ((...args: Args) => {
+    fn.mock.calls.push(args);
+    return fn.mock.impl(...args);
+  }) as ((...args: Args) => Return) & {
+    mock: { calls: Args[]; impl: (...innerArgs: Args) => Return };
+    mockImplementation: (impl: (...innerArgs: Args) => Return) => void;
+    mockReset: () => void;
+  };
+
+  fn.mock = { calls: [] as Args[], impl: implementation };
+  fn.mockImplementation = (impl: (...innerArgs: Args) => Return) => {
+    fn.mock.impl = impl;
+  };
+  fn.mockReset = () => {
+    fn.mock.calls = [];
+    fn.mock.impl = implementation;
+  };
+
+  return fn;
+};
+
+const getPoolsMock = createMockFn(() => stubPools);
+const getPoolsIfReadyMock = createMockFn(() => stubPools);
 
 mock.module('@/news/newsPools', () => ({
+  ...actualFrontendNewsPools,
   getPools: getPoolsMock,
   getPoolsIfReady: getPoolsIfReadyMock,
 }));
@@ -117,11 +143,11 @@ describe('extra extra integration', () => {
       turn: state.turn,
       plays: state.turnBuffer,
     };
-    const evaluation = evaluateExtraExtra(state.turnBuffer);
+    const evaluation = evaluateExtraExtra(state.turnBuffer, { seed: 'mvp:P1:1' });
     expect(evaluation.trigger).toBe(true);
     const focusLog: TurnLog = { ...pendingLog, plays: evaluation.focusPlays };
     const totals = summarize([focusLog]);
-    const expectedArticle = generateExtraExtra('mvp:P1:1', [focusLog], totals);
+    const expectedArticle = generateExtraExtra('mvp:P1:1', [focusLog], totals, evaluation);
 
     const { state: endedState } = endTurn(state, []);
 
@@ -130,11 +156,15 @@ describe('extra extra integration', () => {
       'Turn 1 recap: Truth plays 3, Government plays 0',
     ]);
     expect(endedState.truth).toBe(53);
-    expect(endedState.extraExtraFeed[0]?.tone).toBe('truth');
+    expect(endedState.extraExtraFeed[0]?.tone).toBe(expectedArticle.tone);
   });
 
   it('falls back to a placeholder headline when pools are unavailable', async () => {
-    const warnMock = mock.method(console, 'warn');
+    const originalWarn = console.warn;
+    const warnings: unknown[][] = [];
+    console.warn = (...args: unknown[]) => {
+      warnings.push(args);
+    };
     getPoolsIfReadyMock.mockImplementation(() => null);
     getPoolsMock.mockImplementation(() => {
       throw new Error('getPools should not be called when pools are unavailable');
@@ -197,11 +227,11 @@ describe('extra extra integration', () => {
         turn: state.turn,
         plays: state.turnBuffer,
       };
-      const evaluation = evaluateExtraExtra(state.turnBuffer);
+      const evaluation = evaluateExtraExtra(state.turnBuffer, { seed: 'mvp:P1:1' });
       expect(evaluation.trigger).toBe(true);
       const focusLog: TurnLog = { ...pendingLog, plays: evaluation.focusPlays };
       const totals = summarize([focusLog]);
-      const expectedArticle = generateExtraExtra('mvp:P1:1', [focusLog], totals);
+      const expectedArticle = generateExtraExtra('mvp:P1:1', [focusLog], totals, evaluation);
 
       const { state: endedState } = endTurn(state, []);
 
@@ -211,9 +241,9 @@ describe('extra extra integration', () => {
         'Turn 1 recap: Truth plays 3, Government plays 0',
       ]);
       expect(endedState.truth).toBe(53);
-      expect(warnMock.mock.calls.length).toBeGreaterThan(0);
+      expect(warnings.length).toBeGreaterThan(0);
     } finally {
-      warnMock.mockRestore();
+      console.warn = originalWarn;
     }
   });
 
@@ -236,13 +266,13 @@ describe('extra extra integration', () => {
       plays,
     };
 
-    const evaluation = evaluateExtraExtra(plays);
+    const evaluation = evaluateExtraExtra(plays, { seed: 'mvp:P1:1' });
     expect(evaluation.trigger).toBe(true);
     expect(evaluation.winningFaction).toBe('government');
 
     const focusLog: TurnLog = { ...pendingLog, plays: evaluation.focusPlays };
     const totals = summarize([focusLog]);
-    const expectedArticle = generateExtraExtra('mvp:P1:1', [focusLog], totals);
+    const expectedArticle = generateExtraExtra('mvp:P1:1', [focusLog], totals, evaluation);
 
     const state: GameState = {
       turn: 1,
@@ -285,7 +315,7 @@ describe('extra extra integration', () => {
     const { state: endedState } = endTurn(state, []);
 
     expect(endedState.extraExtraFeed).toEqual([expectedArticle]);
-    expect(endedState.extraExtraFeed[0]?.tone).toBe('government');
+    expect(endedState.extraExtraFeed[0]?.tone).toBe(expectedArticle.tone);
     expect(endedState.truth).toBe(47);
     expect(endedState.headlineLog).toEqual([
       'Turn 1 recap: Truth plays 3, Government plays 3',

--- a/__tests__/news/headlineEngine.test.ts
+++ b/__tests__/news/headlineEngine.test.ts
@@ -1,4 +1,6 @@
 import { beforeEach, describe, expect, it, mock } from 'bun:test';
+import * as actualFrontendNewsPools from '../../src/news/newsPools';
+import * as actualEngineNewsPools from '../../src/engine/news/newsPools';
 import type { TurnLog, TurnTotals, PlayedLite } from '../../src/news/headlineEngine';
 
 const stubPools = {
@@ -18,12 +20,105 @@ const stubPools = {
   weather: ['Calm Skies'],
 } as const;
 
-const getPoolsMock = mock.fn(() => stubPools);
-const getPoolsIfReadyMock = mock.fn(() => stubPools);
+const createMockFn = <Args extends unknown[], Return>(
+  implementation: (...args: Args) => Return,
+) => {
+  const fn = ((...args: Args) => {
+    fn.mock.calls.push(args);
+    return fn.mock.impl(...args);
+  }) as ((...args: Args) => Return) & {
+    mock: { calls: Args[]; impl: (...innerArgs: Args) => Return };
+    mockImplementation: (impl: (...innerArgs: Args) => Return) => void;
+    mockReset: () => void;
+  };
+
+  fn.mock = { calls: [] as Args[], impl: implementation };
+  fn.mockImplementation = (impl: (...innerArgs: Args) => Return) => {
+    fn.mock.impl = impl;
+  };
+  fn.mockReset = () => {
+    fn.mock.calls = [];
+    fn.mock.impl = implementation;
+  };
+
+  return fn;
+};
+
+const getPoolsMock = createMockFn(() => stubPools);
+const getPoolsIfReadyMock = createMockFn(() => stubPools);
+
+const perCardArticles = new Map(
+  [
+    [
+      't1',
+      {
+        id: 't1',
+        tone: 'truth' as const,
+        tags: ['ghost'],
+        headline: 'Spectral Scoop',
+        subhead: 'Phantom radio callers jam the switchboard.',
+        byline: 'By: Phantom Desk',
+        body: 'Apparitions confirm the lead is extremely credible.',
+      },
+    ],
+    [
+      't2',
+      {
+        id: 't2',
+        tone: 'truth' as const,
+        tags: ['ufo'],
+        headline: 'Runway Lights Beckon',
+        subhead: 'Strobe-lit landing strips welcome midnight arrivals.',
+        byline: 'By: Hologram Bureau',
+        body: 'Hangars shuffle to make room for three chrome saucers.',
+      },
+    ],
+    [
+      't3',
+      {
+        id: 't3',
+        tone: 'truth' as const,
+        tags: ['coverup'],
+        headline: 'Archivists Blow the Gasket',
+        subhead: 'Dusty cabinets finally cough up the microfilm.',
+        byline: 'By: Records Desk',
+        body: 'Clerks report the files hummed ominously before opening.',
+      },
+    ],
+  ],
+);
+
+const getPerCardArticlesIfReadyMock = createMockFn(() => perCardArticles);
+
+const createTripleArticle = () => ({
+  tone: 'truth' as const,
+  hed: 'TRIPLE PLAY HITS FRONT PAGE',
+  dek: 'Composite deck weaves a unified broadcast.',
+  bullets: ['Operatives align their leads into a single flame.'],
+  byline: 'By: Composite Desk',
+  source: 'Source: News Vault',
+  body: ['Three signals sync inside the newsroom nerve center.'],
+  imagePrompt: 'Collaged news clippings swirling in red string',
+  kicker: 'EXTRA EXTRA',
+  stinger: 'Filed at 03:13',
+  comboId: 'combo-test',
+});
+
+const composeTripleHeadlineMock = createMockFn(() => createTripleArticle());
 
 mock.module('@/news/newsPools', () => ({
+  ...actualFrontendNewsPools,
   getPools: getPoolsMock,
   getPoolsIfReady: getPoolsIfReadyMock,
+}));
+
+mock.module('@/engine/news/newsPools', () => ({
+  ...actualEngineNewsPools,
+  getPerCardArticlesIfReady: getPerCardArticlesIfReadyMock,
+}));
+
+mock.module('@/engine/news/composeTriple', () => ({
+  composeTripleHeadline: composeTripleHeadlineMock,
 }));
 
 const loadEngine = () => import('../../src/news/headlineEngine');
@@ -33,6 +128,10 @@ beforeEach(() => {
   getPoolsIfReadyMock.mockReset();
   getPoolsMock.mockImplementation(() => stubPools);
   getPoolsIfReadyMock.mockImplementation(() => stubPools);
+  getPerCardArticlesIfReadyMock.mockReset();
+  getPerCardArticlesIfReadyMock.mockImplementation(() => perCardArticles);
+  composeTripleHeadlineMock.mockReset();
+  composeTripleHeadlineMock.mockImplementation(() => createTripleArticle());
 });
 
 describe('evaluateExtraExtra', () => {
@@ -83,6 +182,58 @@ describe('evaluateExtraExtra', () => {
     expect(outcome.winningFaction).toBe('draw');
     expect(outcome.truthDelta).toBe(0);
     expect(outcome.focusPlays).toHaveLength(6);
+  });
+
+  it('captures composed triple headline data for qualifying trio', async () => {
+    const { evaluateExtraExtra, generateExtraExtra, summarize } = await loadEngine();
+
+    const plays: PlayedLite[] = [
+      { id: 't1', name: 'Ghost Signal', type: 'MEDIA', faction: 'truth', truth: 4 },
+      { id: 't2', name: 'Saucer Scoop', type: 'ATTACK', faction: 'truth', truth: 2 },
+      { id: 't3', name: 'Archive Leak', type: 'ZONE', faction: 'truth', truth: 1 },
+    ];
+
+    const evaluation = evaluateExtraExtra(plays, { seed: 'unit-test' });
+
+    expect(composeTripleHeadlineMock.mock.calls.length).toBe(1);
+    expect(evaluation.composedMain?.hed).toBe('TRIPLE PLAY HITS FRONT PAGE');
+    expect(evaluation.composeSignature).toBe('t1,t2,t3');
+    expect(evaluation.winnerCards?.map(card => card.id)).toEqual(['t1', 't2', 't3']);
+
+    const focusLog: TurnLog = { round: 1, turn: 1, plays: evaluation.focusPlays };
+    const totals = summarize([focusLog]);
+    const article = generateExtraExtra('unit-test', [focusLog], totals, evaluation);
+
+    expect(article.hed).toBe('TRIPLE PLAY HITS FRONT PAGE');
+    expect(article.dek).toBe('Composite deck weaves a unified broadcast.');
+    expect(article.bullets).toEqual(['Operatives align their leads into a single flame.']);
+    expect(article.comboId).toBe('combo-test');
+  });
+
+  it('falls back to per-card dispatch headline when composer returns null', async () => {
+    composeTripleHeadlineMock.mockImplementation(() => null);
+
+    const { evaluateExtraExtra, generateExtraExtra, summarize } = await loadEngine();
+
+    const plays: PlayedLite[] = [
+      { id: 't1', name: 'Ghost Signal', type: 'MEDIA', faction: 'truth', truth: 4 },
+      { id: 't2', name: 'Saucer Scoop', type: 'ATTACK', faction: 'truth', truth: 2 },
+      { id: 't3', name: 'Archive Leak', type: 'ZONE', faction: 'truth', truth: 1 },
+    ];
+
+    const evaluation = evaluateExtraExtra(plays, { seed: 'fallback-test' });
+
+    expect(evaluation.composedMain).toBeNull();
+    expect(evaluation.dispatches.length).toBeGreaterThan(0);
+
+    const focusLog: TurnLog = { round: 1, turn: 1, plays: evaluation.focusPlays };
+    const totals = summarize([focusLog]);
+    const article = generateExtraExtra('fallback-test', [focusLog], totals, evaluation);
+
+    expect(article.hed).toBe('Spectral Scoop');
+    expect(article.dek).toBe('Phantom radio callers jam the switchboard.');
+    expect(article.byline).toBe('By: Phantom Desk');
+    expect(article.bullets.length).toBeGreaterThan(0);
   });
 });
 
@@ -302,7 +453,11 @@ describe('headlineEngine utilities', () => {
   });
 
   it('generateExtraExtra returns a placeholder article when pools are unavailable', async () => {
-    const warnMock = mock.method(console, 'warn');
+    const originalWarn = console.warn;
+    const warnings: unknown[][] = [];
+    console.warn = (...args: unknown[]) => {
+      warnings.push(args);
+    };
 
     getPoolsIfReadyMock.mockImplementation(() => null);
     getPoolsMock.mockImplementation(() => {
@@ -332,10 +487,10 @@ describe('headlineEngine utilities', () => {
       expect(article.byline).toMatch(/Standby Desk|Emergency Editor/);
       expect(article.source).toMatch(/Archive sync pending|Classified spool offline/);
       expect(article.bullets.length).toBeGreaterThan(0);
-      expect(warnMock).toHaveBeenCalled();
-      expect(String(warnMock.mock.calls[0]?.[0])).toContain('generateExtraExtra');
+      expect(warnings.length).toBeGreaterThan(0);
+      expect(String(warnings[0]?.[0])).toContain('generateExtraExtra');
     } finally {
-      warnMock.mockRestore();
+      console.warn = originalWarn;
     }
   });
 });

--- a/src/engine/news/composeTriple.ts
+++ b/src/engine/news/composeTriple.ts
@@ -1,5 +1,7 @@
 import type { ArticleBlock as ExtraArticleBlock } from '@/news/headlineEngine';
 
+export type ArticleBlock = ExtraArticleBlock;
+
 import {
   getComboBankIfReady,
   getTripleBankIfReady,

--- a/src/hooks/useGameState.ts
+++ b/src/hooks/useGameState.ts
@@ -86,11 +86,10 @@ import {
 import { assignStateBonuses } from '@/game/stateBonuses';
 import { applyStateBonusAssignmentToState } from './stateBonusAssignment';
 import { clearNewsBuffer, getNewsTriplet, pushToNewsBuffer } from '@/state/game/roundNewsBuffer';
-import { summarize, generateExtraExtra, evaluateExtraExtra, hashSeed } from '@/news/headlineEngine';
+import { summarize, generateExtraExtra, evaluateExtraExtra } from '@/news/headlineEngine';
 import { loadNewsPools } from '@/news/newsPools';
 import type { ArticleBlock, TurnLog, PlayedLite } from '@/news/headlineEngine';
-import { composeTripleHeadline, type NewsCardLite } from '@/engine/news/composeTriple';
-import { getPerCardArticlesIfReady, initNewsPools } from '@/engine/news/newsPools';
+import { initNewsPools } from '@/engine/news/newsPools';
 import type { GameOverReport } from '@/types/finalEdition';
 
 const omitClashKey = (key: string, value: unknown) => (key === 'clash' ? undefined : value);
@@ -439,92 +438,13 @@ const applyTurnNews = (prev: GameState, next: GameState, seedPrefix: string): Ga
   const headlineLog = [...next.headlineLog, summaryHeadline];
 
   let extraExtraFeed = next.extraExtraFeed;
-  const evaluation = evaluateExtraExtra(buffer);
+  const evaluationSeed = `${seedPrefix}:${prev.round}:${prev.turn}`;
+  const evaluation = evaluateExtraExtra(buffer, { seed: evaluationSeed });
 
   if (evaluation.trigger) {
     const focusLog: TurnLog = { ...turnLog, plays: evaluation.focusPlays };
     const focusTotals = summarize([focusLog]);
-    const article = generateExtraExtra(`${seedPrefix}:${prev.round}:${prev.turn}`, [focusLog], focusTotals);
-
-    const perCardArticles = getPerCardArticlesIfReady();
-    if (perCardArticles) {
-      const collectFactionTrio = (plays: PlayedLite[], faction: 'truth' | 'government'): PlayedLite[] => {
-        const trio: PlayedLite[] = [];
-        for (const play of plays) {
-          if (play.faction !== faction) {
-            continue;
-          }
-          trio.push(play);
-          if (trio.length >= 3) {
-            break;
-          }
-        }
-        return trio;
-      };
-
-      const toNewsCard = (play: PlayedLite): NewsCardLite => {
-        const entry = perCardArticles.get(play.id);
-        return {
-          id: play.id,
-          name: play.name,
-          faction: play.faction,
-          type: play.type,
-          tags: entry?.tags ?? [],
-        } satisfies NewsCardLite;
-      };
-
-      const truthTrio = collectFactionTrio(buffer, 'truth');
-      const governmentTrio = collectFactionTrio(buffer, 'government');
-      const truthCards = truthTrio.length >= 3 ? truthTrio.slice(0, 3).map(toNewsCard) : [];
-      const governmentCards = governmentTrio.length >= 3 ? governmentTrio.slice(0, 3).map(toNewsCard) : [];
-
-      let focusCards: NewsCardLite[] | null = null;
-      let opponentCards: NewsCardLite[] = [];
-
-      if (evaluation.winningFaction === 'truth') {
-        focusCards = truthCards.length === 3 ? truthCards : null;
-        opponentCards = governmentCards;
-      } else if (evaluation.winningFaction === 'government') {
-        focusCards = governmentCards.length === 3 ? governmentCards : null;
-        opponentCards = truthCards;
-      } else {
-        if (truthCards.length === 3) {
-          focusCards = truthCards;
-          opponentCards = governmentCards;
-        } else if (governmentCards.length === 3) {
-          focusCards = governmentCards;
-          opponentCards = truthCards;
-        }
-      }
-
-      if ((!focusCards || focusCards.length !== 3) && evaluation.focusPlays.length >= 3) {
-        focusCards = evaluation.focusPlays.slice(0, 3).map(toNewsCard);
-      }
-
-      if (focusCards && focusCards.length === 3) {
-        const seed = hashSeed(`${seedPrefix}:${prev.round}:${prev.turn}:triple`);
-        const tripleArticle = composeTripleHeadline(focusCards, opponentCards, { seed });
-        if (tripleArticle) {
-          if (typeof console !== 'undefined' && typeof console.debug === 'function') {
-            const signature = focusCards.map(card => card.id).join(',');
-            const marker = tripleArticle.comboId ?? tripleArticle.templateId ?? 'template';
-            console.debug(`NEWS: triple-main ${signature} -> ${marker}`);
-          }
-          article.hed = tripleArticle.hed;
-          article.dek = tripleArticle.dek;
-          article.tone = tripleArticle.tone;
-          article.bullets = tripleArticle.bullets.length ? tripleArticle.bullets : article.bullets;
-          article.byline = tripleArticle.byline ?? article.byline;
-          article.source = tripleArticle.source ?? article.source;
-          article.body = tripleArticle.body && tripleArticle.body.length ? tripleArticle.body : undefined;
-          article.imagePrompt = tripleArticle.imagePrompt ?? article.imagePrompt;
-          article.kicker = tripleArticle.kicker ?? article.kicker;
-          article.stinger = tripleArticle.stinger ?? article.stinger;
-          article.templateId = tripleArticle.templateId ?? article.templateId;
-          article.comboId = tripleArticle.comboId ?? article.comboId;
-        }
-      }
-    }
+    const article = generateExtraExtra(`${seedPrefix}:${prev.round}:${prev.turn}`, [focusLog], focusTotals, evaluation);
 
     extraExtraFeed = [...extraExtraFeed, article];
 

--- a/src/mvp/engine.ts
+++ b/src/mvp/engine.ts
@@ -5,10 +5,8 @@ import { applyComboRewards, evaluateCombos, getComboSettings, formatComboReward 
 import type { ComboEvaluation, ComboOptions, ComboSummary, TurnPlay } from '@/game/combo.types';
 import { getStateByAbbreviation, getStateById } from '@/data/usaStates';
 import { RelicEngine } from '@/expansions/tabloidRelics/RelicEngine';
-import { summarize, generateExtraExtra, evaluateExtraExtra, hashSeed } from '@/news/headlineEngine';
+import { summarize, generateExtraExtra, evaluateExtraExtra } from '@/news/headlineEngine';
 import type { PlayedLite, TurnLog } from '@/news/headlineEngine';
-import { composeTripleHeadline, type NewsCardLite } from '@/engine/news/composeTriple';
-import { getPerCardArticlesIfReady } from '@/engine/news/newsPools';
 import { cloneGameState } from './validator';
 import { auditGameState } from './gameStateAudit';
 import type { Card, EffectsATTACK, EffectsMEDIA, EffectsZONE, GameState, PlayerState } from './validator';
@@ -720,92 +718,13 @@ export function endTurn(
     const summaryHeadline = `Turn ${turnNumber} recap: Truth plays ${totals.truth.plays}, Government plays ${totals.government.plays}`;
     headlineLog = [...headlineLog, summaryHeadline];
 
-    const evaluation = evaluateExtraExtra(bufferPlays);
+    const evaluationSeed = `mvp:${currentId}:${turnNumber}`;
+    const evaluation = evaluateExtraExtra(bufferPlays, { seed: evaluationSeed });
 
     if (evaluation.trigger) {
       const focusLog: TurnLog = { ...turnLogEntry, plays: evaluation.focusPlays };
       const focusTotals = summarize([focusLog]);
-      const article = generateExtraExtra(`mvp:${currentId}:${turnNumber}`, [focusLog], focusTotals);
-
-      const perCardArticles = getPerCardArticlesIfReady();
-      if (perCardArticles) {
-        const collectFactionTrio = (plays: PlayedLite[], faction: 'truth' | 'government'): PlayedLite[] => {
-          const trio: PlayedLite[] = [];
-          for (const play of plays) {
-            if (play.faction !== faction) {
-              continue;
-            }
-            trio.push(play);
-            if (trio.length >= 3) {
-              break;
-            }
-          }
-          return trio;
-        };
-
-        const toNewsCard = (play: PlayedLite): NewsCardLite => {
-          const entry = perCardArticles.get(play.id);
-          return {
-            id: play.id,
-            name: play.name,
-            faction: play.faction,
-            type: play.type,
-            tags: entry?.tags ?? [],
-          } satisfies NewsCardLite;
-        };
-
-        const truthTrio = collectFactionTrio(bufferPlays, 'truth');
-        const governmentTrio = collectFactionTrio(bufferPlays, 'government');
-        const truthCards = truthTrio.length >= 3 ? truthTrio.slice(0, 3).map(toNewsCard) : [];
-        const governmentCards = governmentTrio.length >= 3 ? governmentTrio.slice(0, 3).map(toNewsCard) : [];
-
-        let focusCards: NewsCardLite[] | null = null;
-        let opponentCards: NewsCardLite[] = [];
-
-        if (evaluation.winningFaction === 'truth') {
-          focusCards = truthCards.length === 3 ? truthCards : null;
-          opponentCards = governmentCards;
-        } else if (evaluation.winningFaction === 'government') {
-          focusCards = governmentCards.length === 3 ? governmentCards : null;
-          opponentCards = truthCards;
-        } else {
-          if (truthCards.length === 3) {
-            focusCards = truthCards;
-            opponentCards = governmentCards;
-          } else if (governmentCards.length === 3) {
-            focusCards = governmentCards;
-            opponentCards = truthCards;
-          }
-        }
-
-        if ((!focusCards || focusCards.length !== 3) && evaluation.focusPlays.length >= 3) {
-          focusCards = evaluation.focusPlays.slice(0, 3).map(toNewsCard);
-        }
-
-        if (focusCards && focusCards.length === 3) {
-          const seed = hashSeed(`mvp:${currentId}:${turnNumber}:triple`);
-          const tripleArticle = composeTripleHeadline(focusCards, opponentCards, { seed });
-          if (tripleArticle) {
-            if (typeof console !== 'undefined' && typeof console.debug === 'function') {
-              const signature = focusCards.map(card => card.id).join(',');
-              const marker = tripleArticle.comboId ?? tripleArticle.templateId ?? 'template';
-              console.debug(`NEWS: triple-main ${signature} -> ${marker}`);
-            }
-            article.hed = tripleArticle.hed;
-            article.dek = tripleArticle.dek;
-            article.tone = tripleArticle.tone;
-            article.bullets = tripleArticle.bullets.length ? tripleArticle.bullets : article.bullets;
-            article.byline = tripleArticle.byline ?? article.byline;
-            article.source = tripleArticle.source ?? article.source;
-            article.body = tripleArticle.body && tripleArticle.body.length ? tripleArticle.body : undefined;
-            article.imagePrompt = tripleArticle.imagePrompt ?? article.imagePrompt;
-            article.kicker = tripleArticle.kicker ?? article.kicker;
-            article.stinger = tripleArticle.stinger ?? article.stinger;
-            article.templateId = tripleArticle.templateId ?? article.templateId;
-            article.comboId = tripleArticle.comboId ?? article.comboId;
-          }
-        }
-      }
+      const article = generateExtraExtra(`mvp:${currentId}:${turnNumber}`, [focusLog], focusTotals, evaluation);
 
       extraExtraFeed = [...extraExtraFeed, article];
 

--- a/src/mvp/validator.ts
+++ b/src/mvp/validator.ts
@@ -579,6 +579,12 @@ export function cloneGameState(state: GameState): GameState {
       bullets: [...article.bullets],
       byline: article.byline,
       source: article.source,
+      ...(article.body ? { body: [...article.body] } : {}),
+      ...(article.imagePrompt ? { imagePrompt: article.imagePrompt } : {}),
+      ...(article.kicker ? { kicker: article.kicker } : {}),
+      ...(article.stinger ? { stinger: article.stinger } : {}),
+      ...(article.templateId ? { templateId: article.templateId } : {}),
+      ...(article.comboId ? { comboId: article.comboId } : {}),
     })),
     turnBuffer: state.turnBuffer.map(play => ({ ...play })),
     turnPlays: state.turnPlays.map(play => ({

--- a/src/news/headlineEngine.ts
+++ b/src/news/headlineEngine.ts
@@ -1,3 +1,5 @@
+import { composeTripleHeadline, type ArticleBlock as TripleArticleBlock, type NewsCardLite } from '@/engine/news/composeTriple';
+import { getPerCardArticlesIfReady } from '@/engine/news/newsPools';
 import { getPools, getPoolsIfReady } from '@/news/newsPools';
 
 const FALLBACK_DEK_POOL = [
@@ -71,6 +73,12 @@ export interface ExtraExtraOutcome {
   winningFaction: 'truth' | 'government' | 'draw';
   focusPlays: PlayedLite[];
   truthDelta: number;
+  winnerCards: NewsCardLite[] | null;
+  opponentCards: NewsCardLite[] | null;
+  composedMain: TripleArticleBlock | null;
+  dispatches: ArticleBlock[];
+  composeSeed: number | null;
+  composeSignature: string | null;
 }
 
 const computePlayValue = (play: PlayedLite): number => {
@@ -160,7 +168,10 @@ const highestFactionValue = (plays: PlayedLite[]): number => {
   }, 0);
 };
 
-export const evaluateExtraExtra = (plays: PlayedLite[]): ExtraExtraOutcome => {
+export const evaluateExtraExtra = (
+  plays: PlayedLite[],
+  options?: { seed?: string | number },
+): ExtraExtraOutcome => {
   const truthTrio = collectFactionTrio(plays, 'truth');
   const governmentTrio = collectFactionTrio(plays, 'government');
 
@@ -173,56 +184,179 @@ export const evaluateExtraExtra = (plays: PlayedLite[]): ExtraExtraOutcome => {
       winningFaction: 'draw',
       focusPlays: [],
       truthDelta: 0,
+      winnerCards: null,
+      opponentCards: null,
+      composedMain: null,
+      dispatches: [],
+      composeSeed: null,
+      composeSignature: null,
     };
   }
 
-  if (truthQualifies && !governmentQualifies) {
+  const enrich = (base: {
+    trigger: boolean;
+    winningFaction: 'truth' | 'government' | 'draw';
+    focusPlays: PlayedLite[];
+    truthDelta: number;
+  }): ExtraExtraOutcome => {
+    if (!base.trigger) {
+      return {
+        ...base,
+        winnerCards: null,
+        opponentCards: null,
+        composedMain: null,
+        dispatches: [],
+        composeSeed: null,
+        composeSignature: null,
+      } satisfies ExtraExtraOutcome;
+    }
+
+    const perCardArticles = getPerCardArticlesIfReady();
+
+    const toNewsCard = (play: PlayedLite): NewsCardLite => {
+      const entry = perCardArticles?.get(play.id);
+      const tags = entry?.tags ?? [];
+      return {
+        id: play.id,
+        name: play.name,
+        faction: play.faction,
+        type: play.type,
+        tags: [...tags],
+      } satisfies NewsCardLite;
+    };
+
+    const toDispatchArticle = (play: PlayedLite): ArticleBlock | null => {
+      const entry = perCardArticles?.get(play.id);
+      const hed = entry?.headline?.trim();
+      if (!hed) {
+        return null;
+      }
+      const dek = entry?.subhead?.trim() ?? '';
+      const byline = entry?.byline?.trim() ?? 'By: Field Desk';
+      const bodyLines = typeof entry?.body === 'string'
+        ? entry!.body.split(/\n+/).map(line => line.trim()).filter(Boolean)
+        : [];
+      const article: ArticleBlock = {
+        tone: entry?.tone ?? play.faction,
+        hed,
+        dek,
+        bullets: [],
+        byline,
+        source: 'Source: Field Dispatch',
+      } satisfies ArticleBlock;
+      if (bodyLines.length) {
+        article.body = bodyLines;
+      }
+      if (entry?.imagePrompt) {
+        article.imagePrompt = entry.imagePrompt;
+      }
+      return article;
+    };
+
+    const truthCards = truthTrio.slice(0, 3).map(toNewsCard);
+    const governmentCards = governmentTrio.slice(0, 3).map(toNewsCard);
+    const truthHasTrio = truthCards.length === 3;
+    const governmentHasTrio = governmentCards.length === 3;
+
+    let winnerCards: NewsCardLite[] | null = null;
+    let opponentCards: NewsCardLite[] | null = null;
+
+    if (base.winningFaction === 'truth') {
+      winnerCards = truthHasTrio ? truthCards : null;
+      opponentCards = governmentHasTrio ? governmentCards : null;
+    } else if (base.winningFaction === 'government') {
+      winnerCards = governmentHasTrio ? governmentCards : null;
+      opponentCards = truthHasTrio ? truthCards : null;
+    } else {
+      if (truthHasTrio) {
+        winnerCards = truthCards;
+        opponentCards = governmentHasTrio ? governmentCards : null;
+      } else if (governmentHasTrio) {
+        winnerCards = governmentCards;
+        opponentCards = truthHasTrio ? truthCards : null;
+      }
+    }
+
+    if ((!winnerCards || winnerCards.length !== 3) && base.focusPlays.length >= 3) {
+      winnerCards = base.focusPlays.slice(0, 3).map(toNewsCard);
+    }
+
+    const composeSignature = winnerCards && winnerCards.length === 3
+      ? winnerCards.map(card => card.id).join(',')
+      : null;
+
+    let composeSeed: number | null = null;
+    let composedMain: TripleArticleBlock | null = null;
+
+    if (winnerCards && winnerCards.length === 3) {
+      const seedInput = options?.seed ?? composeSignature ?? '';
+      composeSeed = typeof seedInput === 'number' ? seedInput : hashSeed(String(seedInput));
+      const opponent = opponentCards && opponentCards.length ? opponentCards : null;
+      composedMain = composeTripleHeadline(winnerCards, opponent, { seed: composeSeed }) ?? null;
+    }
+
+    const dispatches = base.focusPlays
+      .map(toDispatchArticle)
+      .filter((article): article is ArticleBlock => article != null);
+
     return {
+      ...base,
+      winnerCards,
+      opponentCards,
+      composedMain,
+      dispatches,
+      composeSeed,
+      composeSignature,
+    } satisfies ExtraExtraOutcome;
+  };
+
+  if (truthQualifies && !governmentQualifies) {
+    return enrich({
       trigger: true,
       winningFaction: 'truth',
       focusPlays: truthTrio,
       truthDelta: 3,
-    };
+    });
   }
 
   if (!truthQualifies && governmentQualifies) {
-    return {
+    return enrich({
       trigger: true,
       winningFaction: 'government',
       focusPlays: governmentTrio,
       truthDelta: -3,
-    };
+    });
   }
 
   const truthValue = highestFactionValue(truthTrio);
   const governmentValue = highestFactionValue(governmentTrio);
 
   if (truthValue > governmentValue) {
-    return {
+    return enrich({
       trigger: true,
       winningFaction: 'truth',
       focusPlays: truthTrio,
       truthDelta: 3,
-    };
+    });
   }
 
   if (governmentValue > truthValue) {
-    return {
+    return enrich({
       trigger: true,
       winningFaction: 'government',
       focusPlays: governmentTrio,
       truthDelta: -3,
-    };
+    });
   }
 
   const focusPlays = collectDrawFocus(plays);
 
-  return {
+  return enrich({
     trigger: true,
     winningFaction: 'draw',
     focusPlays,
     truthDelta: 0,
-  };
+  });
 };
 
 export interface ArticleBlock {
@@ -628,11 +762,75 @@ export const generateExtraExtra = (
   seed: string,
   turns: TurnLog[],
   totalsArg?: TurnTotals,
+  evaluation?: ExtraExtraOutcome,
 ): ArticleBlock => {
   const totals = totalsArg ?? summarize(turns);
   const tone = dominantFromTotals(totals);
   const rng = mulberry32(hashSeed(`extra:${seed}`));
   const pools = getPoolsIfReady();
+
+  const applyComposedArticle = (article: ArticleBlock, composed: TripleArticleBlock): ArticleBlock => {
+    const next: ArticleBlock = {
+      ...article,
+      tone: composed.tone,
+      hed: composed.hed,
+      dek: composed.dek,
+      bullets: ensureBulletFallback([...composed.bullets], composed.tone),
+      byline: composed.byline ?? article.byline,
+      source: composed.source ?? article.source,
+    } satisfies ArticleBlock;
+
+    if (composed.body && composed.body.length) {
+      next.body = [...composed.body];
+    } else {
+      next.body = undefined;
+    }
+
+    if (composed.imagePrompt) {
+      next.imagePrompt = composed.imagePrompt;
+    } else if (article.imagePrompt) {
+      next.imagePrompt = article.imagePrompt;
+    }
+
+    if (composed.kicker) {
+      next.kicker = composed.kicker;
+    } else if (article.kicker) {
+      next.kicker = article.kicker;
+    }
+
+    if (composed.stinger) {
+      next.stinger = composed.stinger;
+    } else if (article.stinger) {
+      next.stinger = article.stinger;
+    }
+
+    if (composed.templateId) {
+      next.templateId = composed.templateId;
+    } else if (article.templateId) {
+      next.templateId = article.templateId;
+    }
+
+    if (composed.comboId) {
+      next.comboId = composed.comboId;
+    } else if (article.comboId) {
+      next.comboId = article.comboId;
+    }
+
+    return next;
+  };
+
+  const applyDispatchFallback = (fallback: ArticleBlock): ArticleBlock => {
+    const copy: ArticleBlock = {
+      ...fallback,
+      bullets: ensureBulletFallback([...fallback.bullets], fallback.tone),
+    } satisfies ArticleBlock;
+    if (fallback.body) {
+      copy.body = [...fallback.body];
+    }
+    return copy;
+  };
+
+  let article: ArticleBlock;
 
   if (!pools) {
     console.warn('generateExtraExtra: news pools not ready, using placeholder article.');
@@ -641,36 +839,56 @@ export const generateExtraExtra = (
     const byline = pick(FALLBACK_BYLINES, rng, FALLBACK_BYLINES[0]);
     const source = pick(FALLBACK_SOURCES, rng, FALLBACK_SOURCES[0]);
     const bullets = buildBullets(turns, totals, tone, rng);
-
-    return {
+    article = {
       tone,
       hed,
       dek,
       bullets,
       byline,
       source,
-    };
-  }
-  const dominantType = getDominantType(totals, tone);
-  const typeKey = dominantType === 'ATTACK' ? 'attack' : dominantType === 'MEDIA' ? 'media' : 'zone';
-  const subheadPool = [...pools.subheads.generic];
-  if (typeKey && pools.subheads[typeKey]) {
-    subheadPool.push(...pools.subheads[typeKey]);
-  }
-  const hed = buildHed(tone, totals, rng);
-  const dek = pick(subheadPool, rng, 'Sources refuse to elaborate.');
-  const byline = pick(pools.bylines, rng, 'By: Anonymous Insider');
-  const source = pick(pools.sources, rng, 'Source: Redacted');
-  const bullets = buildBullets(turns, totals, tone, rng);
+    } satisfies ArticleBlock;
+  } else {
+    const dominantType = getDominantType(totals, tone);
+    const typeKey = dominantType === 'ATTACK' ? 'attack' : dominantType === 'MEDIA' ? 'media' : 'zone';
+    const subheadPool = [...pools.subheads.generic];
+    if (typeKey && pools.subheads[typeKey]) {
+      subheadPool.push(...pools.subheads[typeKey]);
+    }
+    const hed = buildHed(tone, totals, rng);
+    const dek = pick(subheadPool, rng, 'Sources refuse to elaborate.');
+    const byline = pick(pools.bylines, rng, 'By: Anonymous Insider');
+    const source = pick(pools.sources, rng, 'Source: Redacted');
+    const bullets = buildBullets(turns, totals, tone, rng);
 
-  return {
-    tone,
-    hed,
-    dek,
-    bullets,
-    byline,
-    source,
-  };
+    article = {
+      tone,
+      hed,
+      dek,
+      bullets,
+      byline,
+      source,
+    } satisfies ArticleBlock;
+  }
+
+  if (pools && evaluation?.composedMain) {
+    article = applyComposedArticle(article, evaluation.composedMain);
+    if (typeof console !== 'undefined' && typeof console.debug === 'function') {
+      const signature = evaluation.composeSignature ?? 'n/a';
+      const marker = evaluation.composedMain.comboId ?? evaluation.composedMain.templateId ?? 'template';
+      console.debug(`NEWS: triple-main ${signature} -> ${marker}`);
+    }
+  } else if (pools && evaluation?.dispatches?.length) {
+    const fallback = evaluation.dispatches[0];
+    article = applyDispatchFallback(fallback);
+    if (typeof console !== 'undefined' && typeof console.info === 'function') {
+      const signature = evaluation.composeSignature ?? 'n/a';
+      console.info(`NEWS: triple-fallback ${signature} -> dispatch:${fallback.hed}`);
+    }
+  }
+
+  article.bullets = ensureBulletFallback(article.bullets, article.tone);
+
+  return article;
 };
 
 export const buildFinalEdition = (seed: string, turns: TurnLog[]): FinalEdition => {


### PR DESCRIPTION
## Summary
- extend the headline engine to derive triple-card story candidates, capture per-card dispatch fallbacks, and drive `generateExtraExtra` with composed headlines when pools are available. 【F:src/news/headlineEngine.ts†L171-L889】【F:src/engine/news/composeTriple.ts†L1-L11】
- update game state pipelines to pass deterministic seeds and reuse the enriched evaluation output when building Extra Extra editions. 【F:src/hooks/useGameState.ts†L424-L457】【F:src/mvp/engine.ts†L711-L737】
- ensure cloned game state retains new article metadata and add coverage for composer-driven stories and fallbacks. 【F:src/mvp/validator.ts†L561-L588】【F:__tests__/news/headlineEngine.test.ts†L23-L239】【F:__tests__/integration/extraExtra.test.ts†L20-L244】

## Testing
- npm run lint *(fails: repository contains pre-existing lint violations and parsing errors outside this change)*
- bun test --coverage --coverage-reporter=text *(fails: suite expects browser APIs like localStorage and other baseline issues outside this change)*

------
https://chatgpt.com/codex/tasks/task_e_68e4c04a72948320aaf9fa85723ca41a