### PR TITLE
Guard editor start card aggregation

### DIFF
--- a/UPDATES_LOG.md
+++ b/UPDATES_LOG.md
@@ -2,6 +2,10 @@
 
 This document provides a chronological record of gameplay-impacting changes merged into State Shift Strategy. Each entry should include the merge date and a brief, human-readable summary so future contributors can quickly understand how the game has evolved.
 
+## 2025-10-27 – Harden editor start-card dossiers
+- Guarded the editor effect merger so dossiers without explicit start-card arrays no longer crash the run phase when ops flip
+  between classified profiles.
+
 ## 2025-10-26 – Wire Desk Editors into MVP runtime
 - Replaced the temporary editor roster with faction-specific dossiers in `src/data/editors.json`, updated the selector UI to
   filter by faction, surface quotes and tradeoffs, and persist the chosen editor via the hardened storage helpers.

--- a/src/game/editors.ts
+++ b/src/game/editors.ts
@@ -111,9 +111,12 @@ const mergeEffectConfig = (
     return target;
   }
 
+  const startCards = Array.isArray(target?.startCards) ? target.startCards : [];
+
   const next: EditorAggregatedEffects = {
+    ...EMPTY_EFFECTS,
     ...target,
-    startCards: target.startCards,
+    startCards,
   };
 
   for (const key of NUMERIC_EFFECT_KEYS) {


### PR DESCRIPTION
## Summary
- ensure editor effect aggregation always seeds `startCards` with an array so dossiers lacking the field cannot crash downstream consumers
- log the safeguard in the project updates ledger

## Testing
- `npm run lint` *(fails: existing lint violations unrelated to this change)*
- `bun test --coverage --coverage-reporter=text` *(fails: existing tests relying on Vitest's `mock.fn` helper)*

------
https://chatgpt.com/codex/tasks/task_e_68e4c712a21c83208feb386fd5528d24