### PR TITLE
Fix editor start card aggregation crash

### DIFF
--- a/UPDATES_LOG.md
+++ b/UPDATES_LOG.md
@@ -2,6 +2,10 @@
 
 This document provides a chronological record of gameplay-impacting changes merged into State Shift Strategy. Each entry should include the merge date and a brief, human-readable summary so future contributors can quickly understand how the game has evolved.
 
+## 2025-10-28 – Stabilize editor start-card dossiers
+- Patched the editor effect aggregation and setup adjustments to tolerate dossiers missing `startCards`, preventing crash loops
+  when launching a run with minimalist government handlers.
+
 ## 2025-10-27 – Harden editor start-card dossiers
 - Guarded the editor effect merger so dossiers without explicit start-card arrays no longer crash the run phase when ops flip
   between classified profiles.

--- a/src/expansions/editors/EditorsEngine.ts
+++ b/src/expansions/editors/EditorsEngine.ts
@@ -62,10 +62,13 @@ export const gatherEditorSetupAdjustments = (
   editor: EditorDefinition | null | undefined,
 ): EditorSetupAdjustments => {
   const aggregated = getEditorAggregatedEffects(editor ?? undefined);
+  const startCards = Array.isArray(aggregated?.startCards)
+    ? aggregated.startCards
+    : [];
   return {
     ipDelta: aggregated.startIpDelta,
     deckSizeDelta: aggregated.deckSizeDelta,
-    addCardIds: [...new Set(aggregated.startCards)],
+    addCardIds: [...new Set(startCards)],
   };
 };
 

--- a/src/game/editors.ts
+++ b/src/game/editors.ts
@@ -148,9 +148,10 @@ export const getEditorAggregatedEffects = (
     mergeEffectConfig(mergeEffectConfig({ ...EMPTY_EFFECTS }, editor.bonuses), editor.tradeoffs),
     editor.modifiers,
   );
+  const startCards = Array.isArray(merged.startCards) ? merged.startCards : [];
   return {
     ...merged,
-    startCards: Array.from(new Set(merged.startCards)),
+    startCards: Array.from(new Set(startCards)),
   };
 };
 


### PR DESCRIPTION
## Summary
- ensure editor aggregated effects fall back to an empty start-card list when dossiers omit the field
- guard the editor setup adjustment helper before deduplicating start cards
- log the stabilization in the project update log

## Testing
- npm run lint *(fails: pre-existing lint violations across unrelated files)*
- bun test --coverage --coverage-reporter=text *(fails: pre-existing AI planning and headline composition test failures)*

------
https://chatgpt.com/codex/tasks/task_e_68e4cbd96dc08320b380d4a540762bc8