### PR TITLE
Guard editor effect descriptions against missing configs

### DIFF
--- a/UPDATES_LOG.md
+++ b/UPDATES_LOG.md
@@ -2,6 +2,10 @@
 
 This document provides a chronological record of gameplay-impacting changes merged into State Shift Strategy. Each entry should include the merge date and a brief, human-readable summary so future contributors can quickly understand how the game has evolved.
 
+## 2025-10-31 – Guard editor effect descriptions
+- Hardened the editor effect descriptor so dossiers without optional blocks no longer crash when summarizing start cards on the index page.
+- Synced the expansion wrapper to pass through nullable configs, ensuring runtime callers never dereference missing effect data.
+
 ## 2025-10-30 – Fix desk editor summary crash
 - Updated the campaign HUD’s editor summary to read bonuses, tradeoffs, and modifiers from the dossier configs so the start-card descriptors always receive a valid effect block.
 - Surfaced modifier bullet points and preferred dossier quotes to keep the popover copy consistent after the data model shift.

--- a/src/expansions/editors/EditorsEngine.ts
+++ b/src/expansions/editors/EditorsEngine.ts
@@ -125,4 +125,6 @@ export const gatherEditorPlayCardAdjustments = (
   };
 };
 
-export const describeEditorEffect = (effect: EditorEffectConfig): string[] => describeEffectConfig(effect);
+export const describeEditorEffect = (
+  effect?: EditorEffectConfig | null,
+): string[] => describeEffectConfig(effect ?? null);

--- a/src/game/editors.ts
+++ b/src/game/editors.ts
@@ -203,8 +203,14 @@ const describeStartDiscardChance = (value: number): string => {
   return `Start of turn: ${percent}% discard 1 random card`;
 };
 
-export const describeEditorEffectConfig = (config: EditorEffectConfig): string[] => {
+export const describeEditorEffectConfig = (
+  config?: EditorEffectConfig | null,
+): string[] => {
   const descriptions: string[] = [];
+
+  if (!config) {
+    return descriptions;
+  }
 
   if (Array.isArray(config.startCards) && config.startCards.length > 0) {
     descriptions.push(describeStartCards(config.startCards));
@@ -277,5 +283,6 @@ export const forEachEditorEffect = (
   }
 };
 
-export const describeEditorEffect = (config: EditorEffectConfig): string[] =>
-  describeEditorEffectConfig(config);
+export const describeEditorEffect = (
+  config?: EditorEffectConfig | null,
+): string[] => describeEditorEffectConfig(config);


### PR DESCRIPTION
## Summary
- allow editor effect description helpers to accept null configs without crashing start-card summaries
- update the expansion wrapper and change log to reflect the safer effect description behavior

## Testing
- `npm run lint` *(fails: repository contains pre-existing lint errors unrelated to this change)*
- `bun test --coverage --coverage-reporter=text` *(fails: pre-existing integration and composeTripleHeadline tests rely on browser APIs and card pools)*

------
https://chatgpt.com/codex/tasks/task_e_68e5063f3e788320a67dd6f24d508170