### PR TITLE
Invert tabloid relic truth pulses for government hosts

### DIFF
--- a/UPDATES_LOG.md
+++ b/UPDATES_LOG.md
@@ -2,6 +2,10 @@
 
 This document provides a chronological record of gameplay-impacting changes merged into State Shift Strategy. Each entry should include the merge date and a brief, human-readable summary so future contributors can quickly understand how the game has evolved.
 
+## 2025-11-01 – Mirror relic truth polarity by host faction
+- Tabloid relic truth pulses now invert for government-controlled hosts while preserving clamp guards.
+- Added round-start logging for the signed truth delta along with regression coverage for faction parity.
+
 ## 2025-10-31 – Guard editor effect descriptions
 - Hardened the editor effect descriptor so dossiers without optional blocks no longer crash when summarizing start cards on the index page.
 - Synced the expansion wrapper to pass through nullable configs, ensuring runtime callers never dereference missing effect data.

--- a/src/expansions/tabloidRelics/RelicEngine.ts
+++ b/src/expansions/tabloidRelics/RelicEngine.ts
@@ -32,6 +32,23 @@ const clampNumber = (value: number, min: number, max: number): number => {
   return value;
 };
 
+const formatSignedDelta = (value: number): string => {
+  if (value > 0) {
+    return `+${value}`;
+  }
+  if (value < 0) {
+    return `${value}`;
+  }
+  return '0';
+};
+
+const truthEffectSummaryNeeded = (rawDelta: number, netDelta: number): boolean => {
+  if (rawDelta !== 0) {
+    return true;
+  }
+  return netDelta !== 0;
+};
+
 const toPositiveInteger = (value: unknown, fallback: number): number => {
   const numeric = typeof value === 'number' && Number.isFinite(value) ? value : fallback;
   return Math.max(0, Math.trunc(numeric));
@@ -360,8 +377,9 @@ export const RelicEngine = {
     let aiClampMin: number | undefined;
     let aiClampMax: number | undefined;
 
+    const truthPolarity = state.faction === 'government' ? -1 : 1;
+
     for (const entry of runtime.entries) {
-      const status = entry.status === 'queued' ? 'active' : entry.status;
       const remaining = entry.status === 'queued' ? entry.remaining : entry.remaining - 1;
       const nextEntry: TabloidRelicRuntimeEntry = {
         ...entry,
@@ -369,13 +387,17 @@ export const RelicEngine = {
         remaining,
       };
 
+      const truthEffect = entry.effects.truthPerRound ?? 0;
+      const signedTruthEffect = truthEffect ? truthEffect * truthPolarity : 0;
+      const truthEffectSummary = truthEffect ? ` (Truth ${formatSignedDelta(signedTruthEffect)})` : '';
+
       if (entry.status === 'queued') {
-        logEntries.push(`Tabloid Relic activates: ${entry.label}`);
+        logEntries.push(`Tabloid Relic activates: ${entry.label}${truthEffectSummary}`);
       }
 
       if (nextEntry.remaining >= 0) {
-        if (entry.effects.truthPerRound) {
-          truthDelta += entry.effects.truthPerRound;
+        if (truthEffect) {
+          truthDelta += signedTruthEffect;
         }
         if (entry.effects.ipPerRound) {
           ipDelta += entry.effects.ipPerRound;
@@ -449,9 +471,18 @@ export const RelicEngine = {
     const resolvedAiClampMin = aiClampMin ?? 0;
     const resolvedAiClampMax = aiClampMax ?? Number.POSITIVE_INFINITY;
 
-    const nextTruth = clampNumber(state.truth + truthDelta, resolvedTruthClampMin, resolvedTruthClampMax);
+    const unclampedTruth = state.truth + truthDelta;
+    const nextTruth = clampNumber(unclampedTruth, resolvedTruthClampMin, resolvedTruthClampMax);
     const nextIp = clampNumber(state.ip + ipDelta, resolvedIpClampMin, resolvedIpClampMax);
     const nextAiIp = clampNumber(state.aiIP + aiIpDelta, resolvedAiClampMin, resolvedAiClampMax);
+
+    const reportedTruthDelta = nextTruth - state.truth;
+    if (truthEffectSummaryNeeded(truthDelta, reportedTruthDelta)) {
+      const clampNote = reportedTruthDelta !== truthDelta
+        ? ` (from ${formatSignedDelta(truthDelta)})`
+        : '';
+      logEntries.push(`Tabloid Relics net truth delta: ${formatSignedDelta(reportedTruthDelta)}${clampNote}`);
+    }
 
     return {
       runtime: nextRuntime,

--- a/src/expansions/tabloidRelics/__tests__/RelicEngine.truthParity.spec.ts
+++ b/src/expansions/tabloidRelics/__tests__/RelicEngine.truthParity.spec.ts
@@ -1,0 +1,62 @@
+import { beforeEach, describe, expect, it } from 'bun:test';
+
+import { RelicEngine } from '../RelicEngine';
+import type { RelicHostState, TabloidRelicRuntimeState } from '../RelicTypes';
+import { hydrateExpansionFeatures } from '@/data/expansions/features';
+
+const createRuntime = (): TabloidRelicRuntimeState => ({
+  entries: [
+    {
+      uid: 'truth-beacon',
+      ruleId: 'truth-beacon',
+      label: 'Truth Beacon',
+      rarity: 'rare',
+      summary: 'Test relic ensuring truth alignment.',
+      duration: 3,
+      remaining: 3,
+      status: 'queued',
+      triggeredOnRound: 1,
+      effects: { truthPerRound: 4 },
+    },
+  ],
+  lastIssueRound: 1,
+  selectionHistory: [],
+});
+
+const createHostState = (faction: 'truth' | 'government'): RelicHostState => ({
+  faction,
+  truth: 50,
+  ip: 12,
+  aiIP: 3,
+  round: 4,
+  turn: 8,
+  tabloidRelicsRuntime: createRuntime(),
+});
+
+beforeEach(() => {
+  hydrateExpansionFeatures({ editors: false, tabloidRelics: true });
+});
+
+describe('RelicEngine.applyRoundStart truth polarity', () => {
+  it('awards positive truth for truth faction hosts', () => {
+    const state = createHostState('truth');
+
+    const result = RelicEngine.applyRoundStart({ state });
+
+    expect(result.truth).toBe(54);
+    expect(result.truthDelta).toBe(4);
+    expect(result.logEntries.some(entry => entry.includes('Truth +4'))).toBe(true);
+    expect(result.logEntries.some(entry => entry.includes('net truth delta: +4'))).toBe(true);
+  });
+
+  it('applies an equal-magnitude penalty for government faction hosts', () => {
+    const state = createHostState('government');
+
+    const result = RelicEngine.applyRoundStart({ state });
+
+    expect(result.truth).toBe(46);
+    expect(result.truthDelta).toBe(-4);
+    expect(result.logEntries.some(entry => entry.includes('Truth -4'))).toBe(true);
+    expect(result.logEntries.some(entry => entry.includes('net truth delta: -4'))).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- flip tabloid relic truth-per-round effects based on the host faction so government runs incur the mirrored loss while preserving clamps and signed logs
- append a net truth delta round log with formatted +/- values alongside the existing activation messaging
- add a regression test covering truth/government parity and document the gameplay change in the updates log

## Testing
- npm run lint *(fails: existing repo lint violations unrelated to this change)*
- bun test --coverage --coverage-reporter=text *(fails: pre-existing integration and coverage suite issues)*
- bun test src/expansions/tabloidRelics/__tests__/RelicEngine.truthParity.spec.ts


------
https://chatgpt.com/codex/tasks/task_e_68e50bb280288320a042c2c1f92d7d53