### PR TITLE
Add truth polarity tests for core systems

### DIFF
--- a/src/expansions/tabloidRelics/__tests__/RelicEngine.truthSymmetry.spec.ts
+++ b/src/expansions/tabloidRelics/__tests__/RelicEngine.truthSymmetry.spec.ts
@@ -1,0 +1,62 @@
+import { beforeEach, describe, expect, it } from 'bun:test';
+
+import { RelicEngine } from '../RelicEngine';
+import type { RelicHostState, TabloidRelicRuntimeState } from '../RelicTypes';
+import { hydrateExpansionFeatures } from '@/data/expansions/features';
+
+const createRuntime = (): TabloidRelicRuntimeState => ({
+  entries: [
+    {
+      uid: 'truth-beacon',
+      ruleId: 'truth-beacon',
+      label: 'Truth Beacon',
+      rarity: 'rare',
+      summary: 'Broadcasts a truth charge every round.',
+      duration: 3,
+      remaining: 3,
+      status: 'queued',
+      triggeredOnRound: 1,
+      effects: { truthPerRound: 3 },
+    },
+    {
+      uid: 'shadow-pylon',
+      ruleId: 'shadow-pylon',
+      label: 'Shadow Pylon',
+      rarity: 'uncommon',
+      summary: 'Secondary relic used to confirm mirrored totals.',
+      duration: 2,
+      remaining: 2,
+      status: 'queued',
+      triggeredOnRound: 2,
+      effects: { truthPerRound: 2 },
+    },
+  ],
+  lastIssueRound: 2,
+  selectionHistory: [],
+});
+
+const createHostState = (faction: 'truth' | 'government'): RelicHostState => ({
+  faction,
+  truth: 42,
+  ip: 8,
+  aiIP: 2,
+  round: 5,
+  turn: 10,
+  tabloidRelicsRuntime: createRuntime(),
+});
+
+beforeEach(() => {
+  hydrateExpansionFeatures({ editors: false, tabloidRelics: true });
+});
+
+describe('RelicEngine.applyRoundStart relic upkeep polarity', () => {
+  it('grants mirrored truth swings for opposing factions', () => {
+    const truthResult = RelicEngine.applyRoundStart({ state: createHostState('truth') });
+    const governmentResult = RelicEngine.applyRoundStart({ state: createHostState('government') });
+
+    expect(truthResult.truthDelta).toBe(5);
+    expect(governmentResult.truthDelta).toBe(-5);
+    expect(truthResult.truth).toBe(47);
+    expect(governmentResult.truth).toBe(37);
+  });
+});

--- a/src/game/__tests__/truthParityMechanics.spec.ts
+++ b/src/game/__tests__/truthParityMechanics.spec.ts
@@ -1,0 +1,141 @@
+import { beforeEach, describe, expect, it, mock } from 'bun:test';
+
+mock.module('@/data/stateThemedPools', () => ({
+  resolvePoolForState: () => ({
+    bonuses: [
+      {
+        id: 'truth-signal',
+        label: 'Truth Signal',
+        summary: 'Amplifies local whistleblowers.',
+        headline: 'Whistleblowers Flood the Phone Lines',
+        subhead: 'Anonymous tips overwhelm censors.',
+        icon: '📡',
+        weight: 1,
+        effect: { truthDelta: 4, ipDelta: 0, pressureDelta: 0 },
+      },
+    ],
+    events: [],
+  }),
+}));
+
+mock.module('@/data/eventDatabase', () => ({
+  DEFAULT_EVENT_TRIGGER_CHANCE: 0,
+}));
+
+import { applyComboRewards } from '../comboEngine';
+import { assignStateBonuses } from '../stateBonuses';
+import type { ComboEvaluation } from '../combo.types';
+import type { GameState } from '@/mvp/validator';
+
+const createBaseState = (faction: 'truth' | 'government'): GameState => ({
+  turn: 3,
+  currentPlayer: 'P1',
+  truth: 50,
+  players: {
+    P1: {
+      id: 'P1',
+      faction,
+      deck: [],
+      hand: [],
+      discard: [],
+      ip: 10,
+      states: ['NY'],
+    },
+    P2: {
+      id: 'P2',
+      faction: faction === 'truth' ? 'government' : 'truth',
+      deck: [],
+      hand: [],
+      discard: [],
+      ip: 10,
+      states: ['CA'],
+    },
+  },
+  pressureByState: {},
+  stateDefense: {},
+  playsThisTurn: 0,
+  turnPlays: [],
+  log: [],
+  headlineLog: [],
+  extraExtraFeed: [],
+  turnBuffer: [],
+  winner: null,
+  victoryType: null,
+});
+
+describe('comboEngine.applyComboRewards truth mirror enforcement', () => {
+  let evaluation: ComboEvaluation;
+
+  beforeEach(() => {
+    evaluation = {
+      results: [
+        {
+          definition: {
+            id: 'mirror-messaging',
+            name: 'Mirror Messaging',
+            description: 'Truth/IP reward combo used for parity testing.',
+            category: 'sequence',
+            priority: 1,
+            trigger: { kind: 'sequence', sequence: ['MEDIA'] },
+            reward: { truth: 3 },
+          },
+          reward: { truth: 3 },
+          appliedReward: { truth: 3 },
+          details: { matchedPlays: [] },
+        },
+      ],
+      totalReward: { truth: 3 },
+      logs: ['Mirror Messaging Truth +3'],
+    } satisfies ComboEvaluation;
+  });
+
+  it('raises global truth when the truth faction triggers a combo', () => {
+    const state = createBaseState('truth');
+
+    applyComboRewards(state, 'P1', evaluation);
+
+    expect(state.truth).toBe(53);
+    expect(state.log.at(-1)).toContain('Truth manipulation');
+  });
+
+  it('penalizes truth equally for government combo beneficiaries', () => {
+    const state = createBaseState('government');
+
+    applyComboRewards(state, 'P1', evaluation);
+
+    expect(state.truth).toBe(47);
+    expect(state.log.at(-1)).toContain('Truth manipulation');
+  });
+});
+
+describe('assignStateBonuses faction polarity guardrail', () => {
+  const sharedStates = [
+    { id: 'ny', abbreviation: 'NY', name: 'New York', owner: 'player' as const },
+  ];
+
+  it('awards positive truth to truth-aligned territories', () => {
+    const result = assignStateBonuses({
+      states: sharedStates,
+      baseSeed: 123,
+      round: 4,
+      playerFaction: 'truth',
+      eventChance: 0,
+    });
+
+    expect(result.playerTruthDelta).toBe(4);
+    expect(result.aiTruthDelta).toBe(0);
+  });
+
+  it('mirrors the assignment for government-controlled players', () => {
+    const result = assignStateBonuses({
+      states: sharedStates,
+      baseSeed: 123,
+      round: 4,
+      playerFaction: 'government',
+      eventChance: 0,
+    });
+
+    expect(result.playerTruthDelta).toBe(-4);
+    expect(result.aiTruthDelta).toBe(0);
+  });
+});

--- a/src/mvp/__tests__/mediaTruthDelta.polarity.spec.ts
+++ b/src/mvp/__tests__/mediaTruthDelta.polarity.spec.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'bun:test';
+
+import { computeMediaTruthDelta_MVP } from '../media';
+import type { Card } from '../validator';
+
+describe('computeMediaTruthDelta_MVP media polarity safeguards', () => {
+  const mediaCard: Pick<Card, 'id' | 'type' | 'effects'> = {
+    id: 'media-spin-lab',
+    type: 'MEDIA',
+    effects: { truthDelta: 5 },
+  };
+
+  it('boosts truth for truth-faction broadcasters', () => {
+    const delta = computeMediaTruthDelta_MVP({ faction: 'truth' }, mediaCard);
+
+    expect(delta).toBe(5);
+  });
+
+  it('mirrors the magnitude for government propagandists', () => {
+    const delta = computeMediaTruthDelta_MVP({ faction: 'government' }, mediaCard);
+
+    expect(delta).toBe(-5);
+  });
+});

--- a/src/systems/__tests__/paranormalHotspotTruthPolarity.spec.ts
+++ b/src/systems/__tests__/paranormalHotspotTruthPolarity.spec.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it, mock } from 'bun:test';
+
+mock.module('@/data/hotspots.catalog.json', () => ({
+  default: { hotspots: [] },
+}));
+
+mock.module('@/data/hotspots.config.json', () => ({
+  default: {
+    resolution: {
+      truthRewards: {
+        defaults: { base: 6, min: -10, max: 10 },
+      },
+    },
+  },
+}));
+
+mock.module('@/data/cryptids.homestate.json', () => ({
+  default: {},
+}));
+
+mock.module('@/data/usaStates', () => ({
+  USA_STATES: [],
+}));
+
+mock.module('@/data/expansions/state', () => ({
+  getEnabledExpansionIdsSnapshot: () => [],
+}));
+
+import { resolveHotspot as resolveParanormalHotspot } from '../paranormalHotspots';
+
+describe('resolveParanormalHotspot mirrored truth rewards', () => {
+  it('returns equal and opposite truth deltas for opposing factions', () => {
+    const baseline = resolveParanormalHotspot('OR', 'truth', {
+      fallbackTruthReward: 6,
+      enabledExpansions: [],
+    });
+    const opposition = resolveParanormalHotspot('OR', 'government', {
+      fallbackTruthReward: 6,
+      enabledExpansions: [],
+    });
+
+    expect(baseline.truthDelta).toBe(6);
+    expect(opposition.truthDelta).toBe(-6);
+    expect(Math.abs(baseline.truthDelta)).toBe(Math.abs(opposition.truthDelta));
+  });
+});


### PR DESCRIPTION
## Summary
- add MVP media resolution regression test to confirm truth/government sign mirroring
- cover combo rewards and state bonus assignment with mocked pools to ensure mirrored truth deltas
- verify paranormal hotspot resolution and relic engine upkeep preserve factional truth symmetry under dummy configs

## Testing
- npm run lint *(fails: legacy lint debt in repository)*
- bun test src/mvp/__tests__/mediaTruthDelta.polarity.spec.ts
- bun test src/game/__tests__/truthParityMechanics.spec.ts
- bun test src/systems/__tests__/paranormalHotspotTruthPolarity.spec.ts
- bun test src/expansions/tabloidRelics/__tests__/RelicEngine.truthSymmetry.spec.ts

------
https://chatgpt.com/codex/tasks/task_e_68e50fb9b3c083208abf62ff0eccb269