### PR TITLE
Handle undefined editor effect configs safely

### DIFF
--- a/__tests__/game/editors.test.ts
+++ b/__tests__/game/editors.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from 'bun:test';
+import { describeEditorEffect } from '../../src/game/editors';
+
+describe('describeEditorEffect', () => {
+  it('returns an empty list for undefined input', () => {
+    expect(describeEditorEffect(undefined)).toEqual([]);
+  });
+
+  it('returns an empty list for null input', () => {
+    expect(describeEditorEffect(null)).toEqual([]);
+  });
+});

--- a/src/game/editors.ts
+++ b/src/game/editors.ts
@@ -208,16 +208,15 @@ export const describeEditorEffectConfig = (
 ): string[] => {
   const descriptions: string[] = [];
 
-  if (!config) {
-    return descriptions;
-  }
+  const safeConfig: EditorEffectConfig = config ?? {};
 
-  if (Array.isArray(config.startCards) && config.startCards.length > 0) {
-    descriptions.push(describeStartCards(config.startCards));
+  const { startCards } = safeConfig;
+  if (Array.isArray(startCards) && startCards.length > 0) {
+    descriptions.push(describeStartCards(startCards));
   }
 
   for (const key of NUMERIC_EFFECT_KEYS) {
-    const value = config[key];
+    const value = safeConfig?.[key];
     if (typeof value !== 'number' || value === 0) {
       continue;
     }


### PR DESCRIPTION
## Summary
- guard `describeEditorEffectConfig` against missing configuration objects before reading effect properties
- normalize start card and numeric effect lookups to avoid runtime errors when configs are absent
- add regression tests that ensure `describeEditorEffect` returns an empty list for null and undefined inputs

## Testing
- npm run lint *(fails: existing repository lint errors unrelated to this change)*
- NO_COLOR=1 bun test --coverage --coverage-reporter=text *(fails: existing repository test failures unrelated to this change)*

------
https://chatgpt.com/codex/tasks/task_e_68e51435db848320bdb317c33b24e5d9