### PR TITLE
Add red-to-blue progress indicator gradient

### DIFF
--- a/UPDATES_LOG.md
+++ b/UPDATES_LOG.md
@@ -2,6 +2,10 @@
 
 This document provides a chronological record of gameplay-impacting changes merged into State Shift Strategy. Each entry should include the merge date and a brief, human-readable summary so future contributors can quickly understand how the game has evolved.
 
+## 2025-11-02 – Hue-shift the Truth Index feedback
+- Progress bars now shift from red at 0% to deep indigo at 100%, clamping undefined inputs to the midpoint so every overlay broadcasts a clear heat reading.
+- Tabloid Truth Index wrappers lean on a translucent white track to keep the new gradient legible against the broadsheet texture, with documentation for designers in the technical overview.
+
 ## 2025-11-01 – Mirror relic truth polarity by host faction
 - Tabloid relic truth pulses now invert for government-controlled hosts while preserving clamp guards.
 - Added round-start logging for the signed truth delta along with regression coverage for faction parity.

--- a/docs/TECHNICAL_README.md
+++ b/docs/TECHNICAL_README.md
@@ -102,6 +102,12 @@ The table below keeps designers out of TypeScript while they balance the weights
 | Contextual help | Optional strategy suggestions surface as neutral toasts styled like UI hints. |
 | Legacy UI overlays | Truth/IP deltas and combo events use lightweight HUD toasts wired through global helpers triggered during attack/truth resolution. |
 
+### Truth Index gradient reference
+
+- The shared `Progress` component now maps its indicator hue from red (0%) through indigo-blue (100%), clamping undefined or out-of-range values to a neutral 50% midpoint to avoid washed-out tracks.
+- Designers should expect the Truth Index bar in Tabloid spreads to start warm when conspiracies spiral out of control and cool toward deep blue as the coalition wins back credibility; other progress bars inherit the same interpolation without extra wiring.
+- When composing new layouts around the Truth Index, leave a light or translucent track background (`bg-white/40` in the newspaper) so the gradient remains legible over print textures.
+
 ### Sound effects
 
 | SFX key(s) | Where it plays |

--- a/src/components/game/TabloidNewspaperV2.tsx
+++ b/src/components/game/TabloidNewspaperV2.tsx
@@ -1045,7 +1045,7 @@ const TabloidNewspaperV2 = ({
               <div className="flex items-center gap-3">
                 <span className="font-semibold uppercase tracking-wide">Truth Index</span>
                 <div className="w-36">
-                  <Progress value={truthProgress} className="h-2" />
+                  <Progress value={truthProgress} className="h-2 bg-white/40" />
                 </div>
                 <span className="font-mono text-xs">{truthProgress}%</span>
                 {truthDeltaLabel ? (

--- a/src/components/ui/progress.tsx
+++ b/src/components/ui/progress.tsx
@@ -3,21 +3,43 @@ import * as ProgressPrimitive from "@radix-ui/react-progress";
 
 import { cn } from "@/lib/utils";
 
+const clampProgressValue = (input: number | undefined): number => {
+  if (typeof input !== "number" || !Number.isFinite(input)) {
+    return 50;
+  }
+
+  return Math.min(100, Math.max(0, input));
+};
+
+const interpolateHue = (value: number): number => {
+  // 0 → 0° (red), 100 → 220° (blue-leaning indigo) for an intuitive cold/hot blend.
+  return Math.round((value / 100) * 220);
+};
+
 const Progress = React.forwardRef<
   React.ElementRef<typeof ProgressPrimitive.Root>,
   React.ComponentPropsWithoutRef<typeof ProgressPrimitive.Root>
->(({ className, value, ...props }, ref) => (
-  <ProgressPrimitive.Root
-    ref={ref}
-    className={cn("relative h-4 w-full overflow-hidden rounded-full bg-secondary", className)}
-    {...props}
-  >
-    <ProgressPrimitive.Indicator
-      className="h-full w-full flex-1 bg-primary transition-all"
-      style={{ transform: `translateX(-${100 - (value || 0)}%)` }}
-    />
-  </ProgressPrimitive.Root>
-));
+>(({ className, value, ...props }, ref) => {
+  const clampedValue = clampProgressValue(value);
+  const hue = interpolateHue(clampedValue);
+
+  return (
+    <ProgressPrimitive.Root
+      ref={ref}
+      value={clampedValue}
+      className={cn("relative h-4 w-full overflow-hidden rounded-full bg-secondary", className)}
+      {...props}
+    >
+      <ProgressPrimitive.Indicator
+        className="h-full w-full flex-1 transition-all"
+        style={{
+          transform: `translateX(-${100 - clampedValue}%)`,
+          backgroundColor: `hsl(${hue} 85% 55%)`,
+        }}
+      />
+    </ProgressPrimitive.Root>
+  );
+});
 Progress.displayName = ProgressPrimitive.Root.displayName;
 
 export { Progress };


### PR DESCRIPTION
## Summary
- derive the shared Progress indicator hue from clamped values with a midpoint fallback
- adjust the Tabloid Truth Index track and document the red-to-blue gradient expectations for designers
- record the gradient shift in the gameplay updates log

## Testing
- npm run lint *(fails: existing lint debt around widespread `any` usage and parser recursion)*
- bun test --coverage --coverage-reporter=text *(fails: existing failing scenarios in AI planning, combo rewards, and composeTriple suites)*

------
https://chatgpt.com/codex/tasks/task_e_68e51797794083209bde2aaa64d468b1