### PR TITLE
Reset map tooltip state when rebuilding SVG

### DIFF
--- a/UPDATES_LOG.md
+++ b/UPDATES_LOG.md
@@ -2,6 +2,9 @@
 
 This document provides a chronological record of gameplay-impacting changes merged into State Shift Strategy. Each entry should include the merge date and a brief, human-readable summary so future contributors can quickly understand how the game has evolved.
 
+## 2025-11-03 – Reset map tooltip state during redraws
+- Clear pending tooltip timeouts and hovered state when the USA map SVG rebuilds so refreshed state data no longer leaves ghost tooltips hanging over the board.
+
 ## 2025-11-02 – Hue-shift the Truth Index feedback
 - Progress bars now shift from red at 0% to deep indigo at 100%, clamping undefined inputs to the midpoint so every overlay broadcasts a clear heat reading.
 - Tabloid Truth Index wrappers lean on a translucent white track to keep the new gradient legible against the broadsheet texture, with documentation for designers in the technical overview.

--- a/src/components/game/EnhancedUSAMap.tsx
+++ b/src/components/game/EnhancedUSAMap.tsx
@@ -326,7 +326,12 @@ const EnhancedUSAMap: React.FC<EnhancedUSAMapProps> = ({
 
     const path = geoPath(projection);
 
-    // Clear previous content
+    // Clear previous content and reset tooltip state before rebuilding the SVG
+    if (tooltipStableRef.current.timeout) {
+      clearTimeout(tooltipStableRef.current.timeout);
+      tooltipStableRef.current.timeout = null;
+    }
+    setHoveredState(null);
     svg.innerHTML = '';
 
     // Create groups for different layers
@@ -843,6 +848,10 @@ const EnhancedUSAMap: React.FC<EnhancedUSAMapProps> = ({
       svg.removeEventListener('pointerleave', handlePointerLeave);
       contestedAnimationTimeoutsRef.current.forEach(timeoutId => window.clearTimeout(timeoutId));
       contestedAnimationTimeoutsRef.current = [];
+      if (tooltipStableRef.current.timeout) {
+        clearTimeout(tooltipStableRef.current.timeout);
+        tooltipStableRef.current.timeout = null;
+      }
     };
 
   }, [


### PR DESCRIPTION
## Summary
- clear pending tooltip timeouts and hovered state when rebuilding the USA map SVG so refreshes cannot leave ghost tooltips active
- null out tooltip timeout refs during cleanup and log the change in the project update log

## Testing
- npm run lint *(fails: existing repository lint violations unrelated to this change)*
- bun test --coverage --coverage-reporter=text *(fails: pre-existing test failures around localStorage mocks, combo engines, and MVP income calculations)*

------
https://chatgpt.com/codex/tasks/task_e_68e51b05ad7483209e81291d6cac1ab4