### PR TITLE
Align truth delta signage with player faction

### DIFF
--- a/UPDATES_LOG.md
+++ b/UPDATES_LOG.md
@@ -2,6 +2,9 @@
 
 This document provides a chronological record of gameplay-impacting changes merged into State Shift Strategy. Each entry should include the merge date and a brief, human-readable summary so future contributors can quickly understand how the game has evolved.
 
+## 2025-11-04 – Align tooltip truth deltas with faction perspective
+- USA map tooltips now flip truth gain/loss signage for government players across hotspot history, active bonuses, and anomaly logs.
+
 ## 2025-11-03 – Reset map tooltip state during redraws
 - Clear pending tooltip timeouts and hovered state when the USA map SVG rebuilds so refreshed state data no longer leaves ghost tooltips hanging over the board.
 

--- a/src/components/game/EnhancedUSAMap.tsx
+++ b/src/components/game/EnhancedUSAMap.tsx
@@ -68,12 +68,24 @@ interface EnhancedUSAMapProps {
   playerFaction: 'truth' | 'government';
 }
 
+const formatTruthDeltaForFaction = (delta: number, playerFaction: 'truth' | 'government'): string => {
+  const perspectiveDelta = playerFaction === 'government' ? -delta : delta;
+
+  if (perspectiveDelta === 0) {
+    return '0';
+  }
+
+  const prefix = perspectiveDelta > 0 ? '+' : '';
+  return `${prefix}${perspectiveDelta}`;
+};
+
 export interface StateHotspotDetailsProps {
   hotspot?: EnhancedState['paranormalHotspot'];
   history?: StateParanormalHotspotSummary[];
+  playerFaction: 'truth' | 'government';
 }
 
-export const StateHotspotDetails: React.FC<StateHotspotDetailsProps> = ({ hotspot, history }) => {
+export const StateHotspotDetails: React.FC<StateHotspotDetailsProps> = ({ hotspot, history, playerFaction }) => {
   const entries = Array.isArray(history) ? history.slice(-5).reverse() : [];
   if (!hotspot && entries.length === 0) {
     return null;
@@ -128,7 +140,7 @@ export const StateHotspotDetails: React.FC<StateHotspotDetailsProps> = ({ hotspo
                   <div className="flex flex-wrap items-center gap-2">
                     {entry.truthDelta !== 0 && (
                       <span className="text-[10px] font-mono text-muted-foreground/80">
-                        Truth {entry.truthDelta > 0 ? '+' : ''}{entry.truthDelta}
+                        Truth {formatTruthDeltaForFaction(entry.truthDelta, playerFaction)}
                       </span>
                     )}
                     <span className="text-[10px] font-mono uppercase tracking-wide text-muted-foreground/70">
@@ -1001,12 +1013,12 @@ const EnhancedUSAMap: React.FC<EnhancedUSAMapProps> = ({
                     {stateInfo.activeStateBonus.summary}
                   </div>
                   <div className="grid grid-cols-2 gap-2 text-muted-foreground">
-                    {typeof stateInfo.activeStateBonus.truthDelta === 'number' && stateInfo.activeStateBonus.truthDelta !== 0 && (
-                      <span>
-                        Truth {stateInfo.activeStateBonus.truthDelta > 0 ? '+' : ''}
-                        {stateInfo.activeStateBonus.truthDelta}
-                      </span>
-                    )}
+                    {typeof stateInfo.activeStateBonus.truthDelta === 'number'
+                      && stateInfo.activeStateBonus.truthDelta !== 0 && (
+                        <span>
+                          Truth {formatTruthDeltaForFaction(stateInfo.activeStateBonus.truthDelta, playerFaction)}
+                        </span>
+                      )}
                     {typeof stateInfo.activeStateBonus.ipDelta === 'number' && stateInfo.activeStateBonus.ipDelta !== 0 && (
                       <span>
                         IP {stateInfo.activeStateBonus.ipDelta > 0 ? '+' : ''}
@@ -1060,7 +1072,7 @@ const EnhancedUSAMap: React.FC<EnhancedUSAMapProps> = ({
                       <div className="flex flex-wrap gap-2 pt-1 text-[11px] text-muted-foreground/90">
                         {typeof event.truthDelta === 'number' && event.truthDelta !== 0 && (
                           <span className="rounded border border-sky-500/40 px-2 py-0.5">
-                            Truth {event.truthDelta > 0 ? '+' : ''}{event.truthDelta}
+                            Truth {formatTruthDeltaForFaction(event.truthDelta, playerFaction)}
                           </span>
                         )}
                         {typeof event.ipDelta === 'number' && event.ipDelta !== 0 && (
@@ -1135,6 +1147,7 @@ const EnhancedUSAMap: React.FC<EnhancedUSAMapProps> = ({
             <StateHotspotDetails
               hotspot={stateInfo.paranormalHotspot}
               history={stateInfo.paranormalHotspotHistory}
+              playerFaction={playerFaction}
             />
           </div>
         </div>,

--- a/src/components/game/__tests__/StateHotspotDetails.test.tsx
+++ b/src/components/game/__tests__/StateHotspotDetails.test.tsx
@@ -25,7 +25,7 @@ const extractText = (node: unknown): string[] => {
 };
 
 describe('StateHotspotDetails', () => {
-  test('renders resolved hotspot history entries', () => {
+  test('renders resolved hotspot history entries for truth faction', () => {
     const renderer = create(
       <StateHotspotDetails
         hotspot={{
@@ -56,6 +56,7 @@ describe('StateHotspotDetails', () => {
             truthDelta: 8,
           },
         ]}
+        playerFaction="truth"
       />,
     );
 
@@ -64,8 +65,32 @@ describe('StateHotspotDetails', () => {
 
     expect(normalized).toContain('Resolved hotspots');
     expect(normalized).toContain('Desert Rift');
-    expect(normalized).toContain('Truth + 8');
+    expect(normalized).toContain('Truth +8');
     expect(normalized).toContain('Turn 6 · TRUTH');
+
+    renderer.unmount();
+  });
+
+  test('formats truth rewards from a government perspective as losses', () => {
+    const renderer = create(
+      <StateHotspotDetails
+        history={[
+          {
+            id: 'hotspot-active',
+            label: 'Desert Rift',
+            resolvedOnTurn: 6,
+            faction: 'truth',
+            truthDelta: 8,
+          },
+        ]}
+        playerFaction="government"
+      />,
+    );
+
+    const output = renderer.toJSON();
+    const normalized = extractText(output).join(' ').replace(/\s+/g, ' ').trim();
+
+    expect(normalized).toContain('Truth -8');
 
     renderer.unmount();
   });


### PR DESCRIPTION
## Summary
- add a perspective-aware truth delta formatter to EnhancedUSAMap and apply it to hotspot history, active bonuses, and anomaly tooltips
- pass the player faction into StateHotspotDetails and expand its tests to cover the government view
- log the tooltip signage update in UPDATES_LOG

## Testing
- npm run lint *(fails: existing lint violations throughout the repo)*
- bun test --coverage --coverage-reporter=text *(fails: existing MVP and AI regression suites)*

------
https://chatgpt.com/codex/tasks/task_e_68e51c9cf1e883209123f532cfc927a8