### PR TITLE
Adjust played cards dock scaling and palette

### DIFF
--- a/UPDATES_LOG.md
+++ b/UPDATES_LOG.md
@@ -2,6 +2,10 @@
 
 This document provides a chronological record of gameplay-impacting changes merged into State Shift Strategy. Each entry should include the merge date and a brief, human-readable summary so future contributors can quickly understand how the game has evolved.
 
+## 2025-11-05 – Right-size board minis and retone played dock
+- Board mini card frames now render at 45% scale to keep played-card layouts breathing and prevent clipping.
+- Opponent slots lean into a blue halftone while the player stack stays red, with section headers picking up matching tones.
+
 ## 2025-11-04 – Align tooltip truth deltas with faction perspective
 - USA map tooltips now flip truth gain/loss signage for government players across hotspot history, active bonuses, and anomaly logs.
 

--- a/src/components/game/PlayedCardsDock.tsx
+++ b/src/components/game/PlayedCardsDock.tsx
@@ -29,18 +29,34 @@ const CardsInPlayCard = ({ card, onInspect }: { card: GameCard; onInspect?: (car
 interface SectionProps {
   title: string;
   toneClass: string;
+  headerToneClass?: string;
   cards: CardPlayRecord[];
   emptyMessage: string;
   ariaLabel: string;
   onInspectCard?: (card: GameCard) => void;
 }
 
-const PlayedCardsSection: React.FC<SectionProps> = ({ title, toneClass, cards, emptyMessage, ariaLabel, onInspectCard }) => (
+const PlayedCardsSection: React.FC<SectionProps> = ({
+  title,
+  toneClass,
+  headerToneClass,
+  cards,
+  emptyMessage,
+  ariaLabel,
+  onInspectCard,
+}) => (
   <section
     aria-label={ariaLabel}
     className={cn('rounded-md p-3 text-black', toneClass)}
   >
-    <h4 className="mb-2 text-[12px] font-extrabold uppercase tracking-[0.2em] text-black/70">{title}</h4>
+    <h4
+      className={cn(
+        'mb-2 text-[12px] font-extrabold uppercase tracking-[0.2em]',
+        headerToneClass ?? 'text-black/70',
+      )}
+    >
+      {title}
+    </h4>
     {cards.length > 0 ? (
       <div className="grid grid-cols-3 gap-2 place-items-start">
         {cards.map((entry, index) => (
@@ -74,7 +90,8 @@ const PlayedCardsDock: React.FC<PlayedCardsDockProps> = ({ playedCards, onInspec
           ariaLabel="Opponent Cards"
           cards={aiCards}
           emptyMessage="Opponent has no cards in play."
-          toneClass="bg-[image:var(--halftone-red)] bg-[length:8px_8px] bg-repeat bg-red-50/40"
+          toneClass="bg-[image:var(--halftone-blue)] bg-[length:8px_8px] bg-repeat bg-blue-50/40"
+          headerToneClass="text-blue-900/80"
           onInspectCard={onInspectCard}
         />
         <PlayedCardsSection
@@ -82,7 +99,8 @@ const PlayedCardsDock: React.FC<PlayedCardsDockProps> = ({ playedCards, onInspec
           ariaLabel="Your Cards"
           cards={humanCards}
           emptyMessage="No cards deployed this turn."
-          toneClass="bg-[image:var(--halftone-blue)] bg-[length:8px_8px] bg-repeat bg-blue-50/40"
+          toneClass="bg-[image:var(--halftone-red)] bg-[length:8px_8px] bg-repeat bg-red-50/40"
+          headerToneClass="text-red-900/80"
           onInspectCard={onInspectCard}
         />
       </div>

--- a/src/components/game/cards/BaseCard.tsx
+++ b/src/components/game/cards/BaseCard.tsx
@@ -18,7 +18,7 @@ export type CardFrameSize = 'modal' | 'boardMini' | 'handMini';
 
 const SIZE_TO_SCALE: Record<CardFrameSize, number> = {
   modal: 1,
-  boardMini: 0.56,
+  boardMini: 0.45,
   handMini: 0.78,
 };
 

--- a/src/ui/CardFrame.tsx
+++ b/src/ui/CardFrame.tsx
@@ -5,9 +5,9 @@ type Props = { children: React.ReactNode; size?: Size };
 
 export default function CardFrame({ children, size = "modal" }: Props) {
   // FINJUSTÉR SKALA HER:
-  // - boardMini: senket til 0.56 for å unngå scroll i "Cards in Play"
+  // - boardMini: senket til 0.45 for bedre luft i "Cards in Play"
   // - handMini: beholdt 0.78 (god lesbarhet i Your Hand)
-  const scale = size === "modal" ? 1 : size === "boardMini" ? 0.56 : 0.78;
+  const scale = size === "modal" ? 1 : size === "boardMini" ? 0.45 : 0.78;
 
   // Basemål MÅ matche fullkortets outer size (inkl. border)
   const BASE_W = 320;


### PR DESCRIPTION
## Summary
- shrink board mini card rendering to 45% so played-card layouts have more breathing room
- keep CardFrame scaling logic in sync with the new board mini size
- swap the played cards dock halftone colors so the opponent row is blue and the player row is red, tinting headers to match
- document the change in the updates log

## Testing
- npm run lint *(fails: existing lint debt throughout the repo, see log for details)*

------
https://chatgpt.com/codex/tasks/task_e_68e522a0450c8320bde45b89c04a7eba