### PR TITLE
Make newsroom desk hand layout responsive

### DIFF
--- a/UPDATES_LOG.md
+++ b/UPDATES_LOG.md
@@ -59,6 +59,10 @@ This document provides a chronological record of gameplay-impacting changes merg
   thumbing through a classified suspect folder before launch.
 - Recolored actions and dossier cards to lean into the Paranoid Times manila-folder aesthetic while keeping mechanics unchanged.
 
+## 2025-10-07 – Stabilize newsroom desk hand columns
+- Rebuilt the newsroom hand grid with an auto-fit template so extra track columns only render when there is horizontal space.
+- Let card buttons flex to `w-full` with `min-w-0` so dropping assets on the desk no longer widens the panel during play.
+
 ## 2025-10-07 – Safeguard zone pressure audits
 - Stop ZONE cards from stacking pressure on states the acting player already controls so game-state audits no longer trip controlled-state invariants.
 - Harden the broadsheet rarity helper with normalized inputs and a global fallback to silence missing-function errors in archive views.

--- a/src/components/game/EnhancedGameHand.tsx
+++ b/src/components/game/EnhancedGameHand.tsx
@@ -123,7 +123,7 @@ const EnhancedGameHand: React.FC<EnhancedGameHandProps> = ({
       ref={handRef}
       onPointerLeave={() => onCardHover?.(null)}
     >
-      <div className="grid w-full grid-cols-3 gap-3 justify-items-start items-start content-start">
+      <div className="grid w-full max-w-full [grid-template-columns:repeat(auto-fit,minmax(260px,1fr))] gap-3 justify-items-start items-start content-start">
         {cards.length === 0 ? (
           <div className="col-span-full flex min-h-[160px] items-center justify-center rounded border border-dashed border-neutral-700 bg-neutral-900/60 p-6 text-sm font-mono text-white/60">
             No assets available
@@ -203,7 +203,7 @@ const EnhancedGameHand: React.FC<EnhancedGameHandProps> = ({
                 key={`${card.id}-${index}`}
                 type="button"
                 className={clsx(
-                  'group/card relative flex w-full items-start justify-center bg-transparent p-0 text-left transition-transform duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/80',
+                  'group/card relative flex w-full max-w-full min-w-0 items-start justify-center bg-transparent p-0 text-left transition-transform duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/80',
                   !canAfford && !disabled && 'cursor-not-allowed opacity-60 saturate-50',
                   disabled && 'cursor-default'
                 )}


### PR DESCRIPTION
## Summary
- replace the newsroom desk hand grid with an auto-fit template so columns appear only when space allows
- let each hand card button stretch and shrink with its column to avoid width creep
- document the responsive desk behavior in the gameplay update log

## Testing
- npm run lint *(fails: repository currently has pre-existing lint errors)*
- bun test --coverage --coverage-reporter=text *(fails: repository currently has failing tests related to browser-only APIs and legacy baselines)*

------
https://chatgpt.com/codex/tasks/task_e_68e53016bab08320b9d6e08d830abdd2