### PR TITLE
Move discard cost reminder into Newsroom tooltip

### DIFF
--- a/UPDATES_LOG.md
+++ b/UPDATES_LOG.md
@@ -59,6 +59,10 @@ This document provides a chronological record of gameplay-impacting changes merg
   thumbing through a classified suspect folder before launch.
 - Recolored actions and dossier cards to lean into the Paranoid Times manila-folder aesthetic while keeping mechanics unchanged.
 
+## 2025-10-07 – Move discard cost reminder into tooltip
+- Removed the Newsroom Desk footer notice above the "Go to Press" button so the action bar stays focused on the turn control.
+- Expanded the Discards hover tooltip to always include the free-first-discard reminder and added a no-queue message for clarity.
+
 ## 2025-10-07 – Safeguard zone pressure audits
 - Stop ZONE cards from stacking pressure on states the acting player already controls so game-state audits no longer trip controlled-state invariants.
 - Harden the broadsheet rarity helper with normalized inputs and a global fallback to silence missing-function errors in archive views.

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -2800,54 +2800,56 @@ const Index = () => {
               align="end"
               className="max-w-xs space-y-2 border border-newspaper-border bg-newspaper-bg px-3 py-2 text-[0.65rem] font-mono text-newspaper-text shadow-lg"
             >
-              {pendingDiscards.length === 0 ? (
+              <div className="space-y-2">
                 <div className="space-y-1">
                   <div className="text-[0.6rem] font-semibold uppercase tracking-[0.35em] text-newspaper-border">
-                    Discard Queue
+                    {pendingDiscards.length === 0
+                      ? 'Discard Queue'
+                      : `Queued Discards (${pendingDiscards.length})`}
                   </div>
-                  <p className="leading-relaxed">
-                    First discard each turn is free. Extra discards cost 10 IP, then +5 IP per card.
-                  </p>
-                </div>
-              ) : (
-                <div className="space-y-1">
-                  <div className="text-[0.6rem] font-semibold uppercase tracking-[0.35em] text-newspaper-border">
-                    Queued Discards ({pendingDiscards.length})
-                  </div>
-                  {queuedDiscardNames.length > 0 && (
-                    <div className="leading-relaxed text-newspaper-text/80">
-                      {queuedDiscardNames.join(', ')}
-                    </div>
-                  )}
-                  <div className="leading-relaxed">
-                    IP impact:{' '}
-                    <span
-                      className={clsx(
-                        'font-semibold',
-                        discardPreview.ipCost > 0 ? 'text-truth-red' : 'text-emerald-500'
+                  {pendingDiscards.length === 0 ? (
+                    <div className="leading-relaxed text-newspaper-text/80">No cards queued for discard.</div>
+                  ) : (
+                    <>
+                      {queuedDiscardNames.length > 0 && (
+                        <div className="leading-relaxed text-newspaper-text/80">
+                          {queuedDiscardNames.join(', ')}
+                        </div>
                       )}
-                    >
-                      {discardPreview.ipCost > 0 ? `-${discardPreview.ipCost} IP` : 'Free'}
-                    </span>
-                  </div>
-                  {discardPreview.costBreakdown.length > 0 && (
-                    <div className="text-newspaper-text/70">
-                      Cost steps:{' '}
-                      {discardPreview.costBreakdown
-                        .map((cost, index) =>
-                          index === 0
-                            ? '1st: 0 (free)'
-                            : (() => {
-                                const position = index + 1;
-                                const suffix = position === 2 ? 'nd' : position === 3 ? 'rd' : 'th';
-                                return `${position}${suffix}: ${cost}`;
-                              })()
-                        )
-                        .join(' · ')}
-                    </div>
+                      <div className="leading-relaxed">
+                        IP impact:{' '}
+                        <span
+                          className={clsx(
+                            'font-semibold',
+                            discardPreview.ipCost > 0 ? 'text-truth-red' : 'text-emerald-500'
+                          )}
+                        >
+                          {discardPreview.ipCost > 0 ? `-${discardPreview.ipCost} IP` : 'Free'}
+                        </span>
+                      </div>
+                      {discardPreview.costBreakdown.length > 0 && (
+                        <div className="text-newspaper-text/70">
+                          Cost steps:{' '}
+                          {discardPreview.costBreakdown
+                            .map((cost, index) =>
+                              index === 0
+                                ? '1st: 0 (free)'
+                                : (() => {
+                                    const position = index + 1;
+                                    const suffix = position === 2 ? 'nd' : position === 3 ? 'rd' : 'th';
+                                    return `${position}${suffix}: ${cost}`;
+                                  })()
+                            )
+                            .join(' · ')}
+                        </div>
+                      )}
+                    </>
                   )}
                 </div>
-              )}
+                <p className="leading-relaxed text-newspaper-text/70">
+                  First discard each turn is free. Extra discards cost 10 IP, then +5 IP per card.
+                </p>
+              </div>
             </TooltipContent>
           </Tooltip>
         </header>
@@ -2867,11 +2869,6 @@ const Index = () => {
           />
         </div>
         <footer className="border-t border-newspaper-border/60 px-3 pb-3 pt-2 sm:pt-3">
-          {pendingDiscards.length === 0 && (
-            <div className="mb-2 rounded border border-newspaper-border/60 bg-newspaper-border/10 px-3 py-2 text-[0.65rem] font-mono text-newspaper-border">
-              <span>First discard each turn is free. Extra discards cost 10 IP, then +5 IP per card.</span>
-            </div>
-          )}
           <Button
             id="end-turn-button"
             onClick={handleEndTurn}


### PR DESCRIPTION
## Summary
- move the Newsroom Desk discard reminder into the Discards tooltip so the cost guidance lives with the queue details
- add an empty-queue message in the tooltip and remove the footer callout above the Go to Press button
- document the UI tweak in the updates log

## Testing
- npm run lint *(fails: existing lint violations in unrelated files)*
- bun test --coverage --coverage-reporter=text *(fails: pre-existing test expectations in MVP editor and combo suites)*

------
https://chatgpt.com/codex/tasks/task_e_68e5408281c08320abc80e1becc658d6