### PR TITLE
Fix Vite server binding for Lovable preview

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -4,15 +4,23 @@ import path from "path";
 import { componentTagger } from "lovable-tagger";
 
 // https://vitejs.dev/config/
-export default defineConfig(({ mode }) => ({
-  server: {
-    host: "::",
-    port: 8080,
-  },
-  plugins: [react(), mode === "development" && componentTagger()].filter(Boolean),
-  resolve: {
-    alias: {
-      "@": path.resolve(__dirname, "./src"),
+export default defineConfig(({ mode }) => {
+  const resolvedPort = Number(process.env.PORT) || 5173;
+
+  return {
+    server: {
+      host: "0.0.0.0",
+      port: resolvedPort,
     },
-  },
-}));
+    preview: {
+      host: "0.0.0.0",
+      port: resolvedPort,
+    },
+    plugins: [react(), mode === "development" && componentTagger()].filter(Boolean),
+    resolve: {
+      alias: {
+        "@": path.resolve(__dirname, "./src"),
+      },
+    },
+  };
+});


### PR DESCRIPTION
## Summary
- allow the dev and preview servers to bind to 0.0.0.0 so Lovable can proxy requests
- reuse a PORT environment variable when provided and default to Vite's standard port for both dev and preview

## Testing
- npm run lint *(fails: pre-existing lint violations in the repo)*
- bun test --coverage --coverage-reporter=text *(fails: pre-existing failing test suites in the repo)*

------
https://chatgpt.com/codex/tasks/task_e_68e551582b6c83208ba3cf9c31ca4d9e