### PR TITLE
Restore Vite preview default port for Lovable

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -15,7 +15,7 @@ export default defineConfig(({ mode }) => {
   const previewPort = resolvePort(process.env.PREVIEW_PORT);
 
   const serverPort = sharedPort ?? devPort ?? 5173;
-  const previewServerPort = sharedPort ?? previewPort ?? 4173;
+  const previewServerPort = previewPort ?? sharedPort ?? 4173;
 
   return {
     server: {


### PR DESCRIPTION
## Summary
- keep the dev server bound to 0.0.0.0 while allowing separate port resolution for dev and preview flows
- default the preview server to 4173 unless Lovable overrides PORT/PREVIEW_PORT so the `/?__lovable_token` probe stops returning 404s

## Testing
- npm run lint *(fails: repository has pre-existing lint violations)*
- bun test --coverage --coverage-reporter=text *(fails: repository has pre-existing failing test suites)*

------
https://chatgpt.com/codex/tasks/task_e_68e551582b6c83208ba3cf9c31ca4d9e