### PR TITLE
Prevent context menu during map pan

### DIFF
--- a/UPDATES_LOG.md
+++ b/UPDATES_LOG.md
@@ -2,6 +2,9 @@
 
 This document provides a chronological record of gameplay-impacting changes merged into State Shift Strategy. Each entry should include the merge date and a brief, human-readable summary so future contributors can quickly understand how the game has evolved.
 
+## 2025-10-07 – Block context menus during map pans
+- Right-click panning on the USA map now suppresses the browser context menu so conspirators can glide without interruptions.
+
 ## 2025-11-07 – Mouse-native map navigation
 - Let agents zoom the USA map with the scroll wheel instead of hunting the UI buttons.
 - Hold the right mouse button to drag and pan the conspiracy overlay like a proper blacksite analyst.

--- a/src/components/game/EnhancedUSAMap.tsx
+++ b/src/components/game/EnhancedUSAMap.tsx
@@ -500,9 +500,7 @@ const EnhancedUSAMap: React.FC<EnhancedUSAMapProps> = ({
     };
 
     const handleContextMenu = (event: MouseEvent) => {
-      if (isPanningRef.current) {
-        event.preventDefault();
-      }
+      event.preventDefault();
     };
 
     svg.addEventListener('wheel', handleWheel, { passive: false });


### PR DESCRIPTION
## Summary
- suppress the browser context menu on the USA map so right-click pans are uninterrupted
- record the interaction fix in the updates log

## Testing
- npm run lint *(fails: existing repository lint violations unrelated to this change)*
- bun test --coverage --coverage-reporter=text *(fails: existing failing tests unrelated to this change)*

------
https://chatgpt.com/codex/tasks/task_e_68e560a5c6288320b3786eb227a22f12