### PR TITLE
Normalize AI state control before audits

### DIFF
--- a/UPDATES_LOG.md
+++ b/UPDATES_LOG.md
@@ -2,6 +2,9 @@
 
 This document provides a chronological record of gameplay-impacting changes merged into State Shift Strategy. Each entry should include the merge date and a brief, human-readable summary so future contributors can quickly understand how the game has evolved.
 
+## 2025-10-07 – Normalize AI state control audits
+- Hardened the MVP resolver to strip duplicate control flags before auditing so AI rollouts never claim the same state as both factions.
+
 ## 2025-10-07 – Block context menus during map pans
 - Right-click panning on the USA map now suppresses the browser context menu so conspirators can glide without interruptions.
 

--- a/src/systems/__tests__/gameStateAudit.test.ts
+++ b/src/systems/__tests__/gameStateAudit.test.ts
@@ -2,6 +2,8 @@ import { describe, expect, it } from 'bun:test';
 
 import { auditGameState, GameStateAuditError } from '@/mvp/gameStateAudit';
 import type { GameState, PlayerState } from '@/mvp/validator';
+import { resolveCardMVP, type GameSnapshot } from '@/systems/cardResolution';
+import type { GameCard } from '@/rules/mvp';
 
 const createPlayer = (overrides: Partial<PlayerState> = {}): PlayerState => ({
   id: 'P1',
@@ -128,5 +130,50 @@ describe('auditGameState', () => {
     });
 
     expect(() => auditGameState(state)).toThrow(/IP cannot be negative/);
+  });
+
+  it('normalizes conflicting state control before auditing resolved plays', () => {
+    const snapshot: GameSnapshot = {
+      truth: 50,
+      ip: 12,
+      aiIP: 15,
+      hand: [],
+      aiHand: [],
+      controlledStates: ['NV'],
+      aiControlledStates: ['NV'],
+      round: 1,
+      turn: 1,
+      faction: 'truth',
+      states: [
+        {
+          id: 'NV',
+          name: 'Nevada',
+          abbreviation: 'NV',
+          baseIP: 2,
+          baseDefense: 3,
+          defense: 3,
+          pressure: 0,
+          pressurePlayer: 0,
+          pressureAi: 0,
+          contested: false,
+          owner: 'player',
+        },
+      ],
+    };
+
+    const mediaCard: GameCard = {
+      id: 'test-media',
+      name: 'Test Broadcast',
+      type: 'MEDIA',
+      faction: 'truth',
+      rarity: 'common',
+      cost: 0,
+      effects: { truthDelta: 0 },
+    };
+
+    const resolution = resolveCardMVP(snapshot, mediaCard, null, 'human');
+
+    expect(resolution.controlledStates).toContain('NV');
+    expect(resolution.aiControlledStates).not.toContain('NV');
   });
 });

--- a/src/systems/cardResolution.ts
+++ b/src/systems/cardResolution.ts
@@ -168,9 +168,11 @@ const toEngineState = (
   const stateDefense: EngineGameState['stateDefense'] = {};
   const playerStates = new Set<string>();
   const aiStates = new Set<string>();
+  const ownerById = new Map<string, StateOwner>();
 
   for (const state of snapshot.states) {
     stateDefense[state.id] = state.defense;
+    ownerById.set(state.id, state.owner);
     const owner = state.owner;
     const fallbackPressure = Math.max(0, state.pressure ?? 0);
     let playerPressure = Number.isFinite(state.pressurePlayer)
@@ -214,11 +216,30 @@ const toEngineState = (
     aiStates.add(id);
   }
 
-  for (const id of playerStates) {
+  const normalizedPlayerStates = new Set(playerStates);
+  const normalizedAiStates = new Set(aiStates);
+
+  for (const id of Array.from(normalizedPlayerStates)) {
+    if (!normalizedAiStates.has(id)) {
+      continue;
+    }
+
+    const declaredOwner = ownerById.get(id);
+    if (declaredOwner === 'ai') {
+      normalizedPlayerStates.delete(id);
+    } else if (declaredOwner === 'player') {
+      normalizedAiStates.delete(id);
+    } else {
+      normalizedPlayerStates.delete(id);
+      normalizedAiStates.delete(id);
+    }
+  }
+
+  for (const id of normalizedPlayerStates) {
     pressureByState[id] = { P1: 0, P2: 0 };
   }
 
-  for (const id of aiStates) {
+  for (const id of normalizedAiStates) {
     pressureByState[id] = { P1: 0, P2: 0 };
   }
 
@@ -234,7 +255,7 @@ const toEngineState = (
         hand: snapshot.hand as Card[],
         discard: [],
         ip: snapshot.ip,
-        states: Array.from(playerStates),
+        states: Array.from(normalizedPlayerStates),
         activeEditorId: snapshot.playerEditorId ?? null,
       },
       [AI_ID]: {
@@ -244,7 +265,7 @@ const toEngineState = (
         hand: snapshot.aiHand as Card[],
         discard: [],
         ip: snapshot.aiIP,
-        states: Array.from(aiStates),
+        states: Array.from(normalizedAiStates),
         activeEditorId: snapshot.aiEditorId ?? null,
       },
     },


### PR DESCRIPTION
## Summary
- normalize conflicting player and AI state control flags before running the MVP game-state audit
- cover the normalization logic with a regression test that exercises resolveCardMVP
- log the fix in the project update ledger

## Testing
- npm run lint *(fails: repository has pre-existing lint errors around any-typed code and hook deps)*
- bun test --coverage --coverage-reporter=text *(fails: suite contains known failing combo, AI planning, and headline tests)*

------
https://chatgpt.com/codex/tasks/task_e_68e5648440e08320ba5466fed9b7d69c