### PR TITLE
Refine Extra Extra trio scoring logic

### DIFF
--- a/UPDATES_LOG.md
+++ b/UPDATES_LOG.md
@@ -2,6 +2,10 @@
 
 This document provides a chronological record of gameplay-impacting changes merged into State Shift Strategy. Each entry should include the merge date and a brief, human-readable summary so future contributors can quickly understand how the game has evolved.
 
+## 2025-11-09 – Rebalance Extra Extra trio scoring
+- Extra Extra now compares full trio impact totals (truth, IP, captures, damage) so a coordinated newsroom push can defeat a lone government haymaker.
+- Deterministic tie breakers fall back to the existing truth-delta safeguards, keeping deadlocks aligned with the draw flow while preserving dispatch selection.
+
 ## 2025-11-08 – Separate hero dispatch from front page rotation
 - Decouple the hero briefing from the dispatch carousel so the generated front page only features non-hero headlines while backfilling up to three supporting stories.
 - Added regression coverage ensuring TabloidNewspaperV2 renders unique hero headlines against the dispatch list.

--- a/__tests__/news/headlineEngine.test.ts
+++ b/__tests__/news/headlineEngine.test.ts
@@ -184,6 +184,45 @@ describe('evaluateExtraExtra', () => {
     expect(outcome.focusPlays).toHaveLength(6);
   });
 
+  it('prefers the combined trio impact over a single massive play', async () => {
+    const { evaluateExtraExtra } = await loadEngine();
+
+    const plays: PlayedLite[] = [
+      { id: 't1', name: 'Truth Signal', type: 'MEDIA', faction: 'truth', truth: 4 },
+      { id: 't2', name: 'Truth Relay', type: 'ATTACK', faction: 'truth', ip: 3 },
+      { id: 't3', name: 'Truth Sweep', type: 'ZONE', faction: 'truth', captures: 3 },
+      { id: 'g1', name: 'Gov Hammer', type: 'ATTACK', faction: 'government', damage: 9 },
+      { id: 'g2', name: 'Gov Silence', type: 'MEDIA', faction: 'government' },
+      { id: 'g3', name: 'Gov Drift', type: 'ZONE', faction: 'government' },
+    ];
+
+    const outcome = evaluateExtraExtra(plays);
+
+    expect(outcome.trigger).toBe(true);
+    expect(outcome.winningFaction).toBe('truth');
+    expect(outcome.focusPlays.map(play => play.id)).toEqual(['t1', 't2', 't3']);
+  });
+
+  it('falls back to the truth-delta safeguard when trio impacts tie', async () => {
+    const { evaluateExtraExtra } = await loadEngine();
+
+    const plays: PlayedLite[] = [
+      { id: 't1', name: 'Truth Accord', type: 'MEDIA', faction: 'truth', truth: 3 },
+      { id: 't2', name: 'Truth Broadcast', type: 'MEDIA', faction: 'truth', ip: 2 },
+      { id: 't3', name: 'Truth Sweep', type: 'MEDIA', faction: 'truth', captures: 1 },
+      { id: 'g1', name: 'Gov Accord', type: 'MEDIA', faction: 'government', truth: -3 },
+      { id: 'g2', name: 'Gov Broadcast', type: 'MEDIA', faction: 'government', ip: -2 },
+      { id: 'g3', name: 'Gov Sweep', type: 'MEDIA', faction: 'government', captures: 1 },
+    ];
+
+    const outcome = evaluateExtraExtra(plays);
+
+    expect(outcome.trigger).toBe(true);
+    expect(outcome.winningFaction).toBe('draw');
+    expect(outcome.truthDelta).toBe(0);
+    expect(outcome.focusPlays).toHaveLength(6);
+  });
+
   it('captures composed triple headline data for qualifying trio', async () => {
     const { evaluateExtraExtra, generateExtraExtra, summarize } = await loadEngine();
 

--- a/src/news/headlineEngine.ts
+++ b/src/news/headlineEngine.ts
@@ -81,34 +81,60 @@ export interface ExtraExtraOutcome {
   composeSignature: string | null;
 }
 
-const computePlayValue = (play: PlayedLite): number => {
-  if (!play) {
+interface TrioImpactTotals {
+  truth: number;
+  ip: number;
+  captures: number;
+  damage: number;
+  magnitude: number;
+}
+
+const sanitizeImpact = (value: number | undefined): number => {
+  if (typeof value !== 'number' || !Number.isFinite(value)) {
     return 0;
   }
 
-  const values: number[] = [];
+  return Math.abs(value);
+};
 
-  if (typeof play.truth === 'number' && Number.isFinite(play.truth)) {
-    values.push(Math.abs(play.truth));
+const computeTrioImpactTotals = (plays: PlayedLite[]): TrioImpactTotals => {
+  const trio = plays.slice(0, 3);
+  const totals: TrioImpactTotals = {
+    truth: 0,
+    ip: 0,
+    captures: 0,
+    damage: 0,
+    magnitude: 0,
+  };
+
+  for (const play of trio) {
+    totals.truth += sanitizeImpact(play.truth);
+    totals.ip += sanitizeImpact(play.ip);
+    totals.captures += sanitizeImpact(play.captures);
+    totals.damage += sanitizeImpact(play.damage);
   }
 
-  if (typeof play.ip === 'number' && Number.isFinite(play.ip)) {
-    values.push(Math.abs(play.ip));
+  totals.magnitude = totals.truth + totals.ip + totals.captures + totals.damage;
+
+  return totals;
+};
+
+const compareTrioImpacts = (left: PlayedLite[], right: PlayedLite[]): number => {
+  const leftTotals = computeTrioImpactTotals(left);
+  const rightTotals = computeTrioImpactTotals(right);
+  const comparisonOrder: (keyof TrioImpactTotals)[] = ['magnitude', 'truth', 'ip', 'captures', 'damage'];
+
+  for (const key of comparisonOrder) {
+    if (leftTotals[key] > rightTotals[key]) {
+      return 1;
+    }
+
+    if (leftTotals[key] < rightTotals[key]) {
+      return -1;
+    }
   }
 
-  if (typeof play.captures === 'number' && Number.isFinite(play.captures)) {
-    values.push(Math.abs(play.captures) * 2);
-  }
-
-  if (typeof play.damage === 'number' && Number.isFinite(play.damage)) {
-    values.push(Math.abs(play.damage));
-  }
-
-  if (!values.length) {
-    return 0;
-  }
-
-  return Math.max(...values);
+  return 0;
 };
 
 const collectFactionTrio = (
@@ -155,17 +181,6 @@ const collectDrawFocus = (plays: PlayedLite[]): PlayedLite[] => {
   }
 
   return result;
-};
-
-const highestFactionValue = (plays: PlayedLite[]): number => {
-  if (!plays.length) {
-    return 0;
-  }
-
-  return plays.reduce((max, play) => {
-    const value = computePlayValue(play);
-    return value > max ? value : max;
-  }, 0);
 };
 
 export const evaluateExtraExtra = (
@@ -328,10 +343,9 @@ export const evaluateExtraExtra = (
     });
   }
 
-  const truthValue = highestFactionValue(truthTrio);
-  const governmentValue = highestFactionValue(governmentTrio);
+  const trioComparison = compareTrioImpacts(truthTrio, governmentTrio);
 
-  if (truthValue > governmentValue) {
+  if (trioComparison > 0) {
     return enrich({
       trigger: true,
       winningFaction: 'truth',
@@ -340,7 +354,7 @@ export const evaluateExtraExtra = (
     });
   }
 
-  if (governmentValue > truthValue) {
+  if (trioComparison < 0) {
     return enrich({
       trigger: true,
       winningFaction: 'government',


### PR DESCRIPTION
## Summary
- compare Extra Extra faction showdowns by summing trio truth/IP/capture/damage impacts with deterministic tiebreaks
- keep dispatch selection aligned with the winning trio and extend coverage for high-impact and tied scenarios
- log the scoring update in the project update log

## Testing
- npm run lint *(fails: existing repository lint violations outside the touched files)*
- bun test --coverage --coverage-reporter=text *(fails: existing suite failures unrelated to the changes)*

------
https://chatgpt.com/codex/tasks/task_e_68e571c7a1a88320992b6dfc0c3ddc3d