### PR TITLE
Replace culinary motifs with paranoid levers

### DIFF
--- a/UPDATES_LOG.md
+++ b/UPDATES_LOG.md
@@ -2,6 +2,10 @@
 
 This document provides a chronological record of gameplay-impacting changes merged into State Shift Strategy. Each entry should include the merge date and a brief, human-readable summary so future contributors can quickly understand how the game has evolved.
 
+## 2025-11-10 – Paranoid flavor realignment across pools
+- Refreshed state pool, agenda issue, and hotspot flavor to emphasize conspiracy levers over food motifs and documented paranoia intents inline.
+- Updated copy-driven fixtures to remove culinary phrasing and reflagged QR loyalty checks, maritime leaks, and dimensional portals.
+
 ## 2025-11-09 – Rebalance Extra Extra trio scoring
 - Extra Extra now compares full trio impact totals (truth, IP, captures, damage) so a coordinated newsroom push can defeat a lone government haymaker.
 - Deterministic tie breakers fall back to the existing truth-delta safeguards, keeping deadlocks aligned with the draw flow while preserving dispatch selection.

--- a/src/data/agendaIssues.ts
+++ b/src/data/agendaIssues.ts
@@ -43,16 +43,17 @@ const ISSUE_ACTIVE_KEY = 'shadowgov.activeAgendaIssue';
 
 const baseIssues: AgendaIssueDefinition[] = [
   {
+    // Paranoia intent: Make saucer hysteria feel like a logistics breach spilling from orbit to ground teams.
     id: 'ufo',
     label: 'Cosmic Cover Stories',
-    description: 'Saucer sightings, crash cart buffets, and orbital bake-offs dominate the rumor mill.',
+    description: 'Saucer sightings, orbital misdirection, and redirected witness corridors dominate the rumor mill.',
     priorityThemes: ['Desert Disclosure', 'Statewide Spectacle', 'Crash Site Compliance'],
     supportingThemes: ['Truth Momentum', 'Traveling Influence'],
     factionQuips: {
       truth: [
-        'Truth kitchen radios hum in sympathy with the mothership.',
-        'Operatives swap recipes for meteorite reduction glaze.',
-        'Witness hotline interns keep binoculars next to the blenders.',
+        'Truthline scanners hum in sympathy with the mothership.',
+        'Operatives trade contrail decryption keys before the telemetry hits prime time.',
+        'Witness hotline interns keep binoculars next to the signal scramblers.',
       ],
       government: [
         'Containment crews log every contrail as “decorative mist.”',
@@ -60,7 +61,7 @@ const baseIssues: AgendaIssueDefinition[] = [
         'Audit squads requisition anti-gravity disclaimers by the crate.',
       ],
       neutral: [
-        'Station gossip wonders if the cafeteria roof will open again tonight.',
+        'Station gossip wonders if the observation deck will open again tonight.',
         'Archivists arrange foil hats by alphabetical order, just in case.',
       ],
     },
@@ -68,7 +69,7 @@ const baseIssues: AgendaIssueDefinition[] = [
       verbs: {
         ATTACK: [
           'CRACKS SECRET HANGAR',
-          'BREACHES ORBITAL BUFFET',
+          'BREACHES ORBITAL LOCKBOX',
           'OVERRIDES LAUNCH PAD LOCKDOWN',
         ],
         MEDIA: [
@@ -100,24 +101,25 @@ const baseIssues: AgendaIssueDefinition[] = [
     },
   },
   {
+    // Paranoia intent: Frame cryptid encounters as clandestine negotiation theaters with living anomalies.
     id: 'cryptid',
-    label: 'Cryptid Culinary Summit',
-    description: 'Mythic potlucks, creature diplomacy, and monster RSVP lists keep the presses running hot.',
-    priorityThemes: ['Mythic Diplomacy', 'Cryptid Hospitality', 'Traveling Influence'],
+    label: 'Cryptid Accord Conclave',
+    description: 'Mythic summits, covert creature diplomacy, and monster RSVP lists keep the presses running hot.',
+    priorityThemes: ['Mythic Diplomacy', 'Cryptid Liaison Ops', 'Traveling Influence'],
     supportingThemes: ['Statewide Spectacle'],
     factionQuips: {
       truth: [
-        'Scout teams leave gluten-free offerings for every hoofprint.',
-        'Archivists label coolers “fang-friendly” and hope for the best.',
-        'Potluck coordinators debate whether swamp gas counts as seasoning.',
+        'Scout teams hide resonance beacons beside every hoofprint.',
+        'Archivists label containment crates “fang-friendly” and hope for the best.',
+        'Signal wranglers debate whether swamp gas counts as camouflage.',
       ],
       government: [
         'Containment liaisons practice smiling while holding tranquilizer darts.',
-        'Logistics briefs rename cryptids as “unregistered catering staff.”',
+        'Logistics briefs rename cryptids as “unregistered field assets.”',
         'Budget monitors request itemized receipts for every claw mark.',
       ],
       neutral: [
-        'Local diners post “Cryptids Eat Free” chalkboards just to stay on theme.',
+        'Local stations post “Cryptids Wave Back” alerts just to stay on theme.',
       ],
     },
     newspaper: {
@@ -128,53 +130,54 @@ const baseIssues: AgendaIssueDefinition[] = [
           'AMBUSHES ROGUE HOWLERS',
         ],
         MEDIA: [
-          'SPOTLIGHTS BEASTLY BUFFET',
-          'STREAMS SASQUATCH SOIREE',
+          'SPOTLIGHTS BEASTLY SUMMIT',
+          'STREAMS SASQUATCH SUMMIT',
           'PRINTS CLAW-SIGNED REVIEWS',
         ],
         ZONE: [
           'CORDONS OFF CRYPTID CAMPSITE',
           'STAKES OUT HOOFPRINT HOTELS',
-          'LINES TRAIL WITH OFFERING TABLES',
+          'LINES TRAIL WITH SENSOR ARRAYS',
         ],
       },
       subheads: {
         truth: [
-          'Conspiracy caterers swear the howling harmonizes with their playlist.',
-          'Witnesses report potluck tables levitating to make room for scaled VIPs.',
+          'Conspiracy handlers swear the howling harmonizes with their playlist.',
+          'Witnesses report staging platforms levitating to make room for scaled VIPs.',
         ],
         government: [
-          'Containment crews release “Do Not Feed the Monster” pamphlets in six languages.',
+          'Containment crews release “Do Not Approach the Monster” pamphlets in six languages.',
           'Officials stress the claws on the guest list are purely decorative.',
         ],
       },
-      tags: ['#IssueCryptid', '#MonsterMixer'],
+      tags: ['#IssueCryptid', '#MonsterSummit'],
       heroKickers: [
-        'Weekly focus: Cryptid Catering Ops',
-        'All eyes on the Cryptid Culinary Summit',
+        'Weekly focus: Cryptid Accord Maneuvers',
+        'All eyes on the Cryptid Accord Conclave',
       ],
     },
   },
   {
+    // Paranoia intent: Emphasize how cover stories weaponize bureaucracy and fiscal fog machines.
     id: 'coverup',
     label: 'Coverup Control Grid',
-    description: 'Budget smokescreens, narrative lockdowns, and classified casseroles set the tempo.',
+    description: 'Budget smokescreens, narrative lockdowns, and encrypted control grids set the tempo.',
     priorityThemes: ['Narrative Containment', 'Information Discipline', 'Fiscal Obfuscation'],
     supportingThemes: ['Narrative Fusion', 'Synergy Sustainment'],
     fallbackWeight: 0.85,
     factionQuips: {
       truth: [
         'Leaks division double-binds every memo with twine and conspiracy twinkle.',
-        'Whistle chefs garnish casseroles with shredded nondisclosure agreements.',
+        'Whistle tacticians lace dossiers with shredded nondisclosure agreements.',
         'Radio hosts practice whispering “follow the money” in seven octaves.',
       ],
       government: [
-        'Spin rooms install emergency shredders next to every serving tray.',
-        'Budget auditors label each ladle as a potential breach vector.',
-        'Briefing captains assign code names to every casserole lid.',
+        'Spin rooms install emergency shredders next to every briefing lectern.',
+        'Budget auditors label each courier bag as a potential breach vector.',
+        'Briefing captains assign code names to every redaction stack.',
       ],
       neutral: [
-        'Interns rehearse plausible deniability between coffee runs.',
+        'Interns rehearse plausible deniability between courier runs.',
         'Archivists sort cover stories by degree of scorch marks.',
       ],
     },
@@ -198,12 +201,12 @@ const baseIssues: AgendaIssueDefinition[] = [
       },
       subheads: {
         truth: [
-          'Leaks taskforce says the documents smell faintly of barbecue smoke.',
+          'Leaks taskforce says the documents smell faintly of ozone.',
           'Sources insist the cover story tripped over its own budget line.',
         ],
         government: [
           'Containment desk adds extra binders to weigh down suspiciously buoyant files.',
-          'Officials deny the smell of burnt ledger even as alarms blink politely.',
+          'Officials deny the static crackle even as alarms blink politely.',
         ],
       },
       tags: ['#IssueCoverup', '#RedactionRodeo'],

--- a/src/data/eventDatabase.ts
+++ b/src/data/eventDatabase.ts
@@ -87,6 +87,7 @@ export const getTruthDelta = (event: GameEvent): number => {
 export const EVENT_DATABASE: GameEvent[] = [
   // COMMON EVENTS (80 events) — Tabloid randoms for the newspaper (low impact, balanced)
   {
+    // Paranoia intent: Show tourist virality accelerating unauthorized disclosure loops faster than official denials.
     id: 'ufo_selfie_over_capitol',
     title: 'UFO Selfie',
     headline: 'TOURIST: "Saucer Behind Me, Not a Filter"',
@@ -95,7 +96,7 @@ export const EVENT_DATABASE: GameEvent[] = [
     rarity: 'common',
     effects: { truth: 6, ip: -1 },
     weight: 6,
-    flavorText: 'BREAKING: Local diners added "Cosmic Combo" to the breakfast menu within the hour. A souvenir shop sold out of alien plushies before noon. Meteorologists say the weather-balloon union is considering a strike after the PR disaster.'
+    flavorText: 'BREAKING: Street cams caught twelve strangers refreshing the feed in sync before sprinting to the same rooftop relay. Souvenir vendors suddenly stocked burner antennas. Meteorologists muttered that the weather-balloon union wants hazard pay for narrative containment.'
   },
   {
     id: 'media_blackout_17min',
@@ -131,6 +132,7 @@ export const EVENT_DATABASE: GameEvent[] = [
     flavorText: 'BULLETIN: Executives apologized using a pre-recorded apology-gif that looped itself. Community notes flagged the apology as "oddly enthusiastic." Trend analysts recommend clearing cache and expectations.'
   },
   {
+    // Paranoia intent: Highlight consumer paranoia weaponizing household appliances as listening posts.
     id: 'masked_whistle_popcorn',
     title: 'Masked Whistle',
     headline: 'ANONYMOUS VOICE: "MICROWAVES ARE LISTENING"',
@@ -139,7 +141,7 @@ export const EVENT_DATABASE: GameEvent[] = [
     rarity: 'common',
     effects: { truth: 7 },
     weight: 6,
-    flavorText: 'BREAKING: Appliance stores sold out of "mute stickers" for kitchenware by lunchtime. A neighborhood potluck served silent popcorn as protest. Tech bloggers insist the real threat is "butter fingerprints on evidence."'
+    flavorText: 'BREAKING: Appliance stores sold out of "mute stickers" for kitchenware by lunchtime. Neighborhood watch groups rewired microwaves into impromptu Faraday cages. Tech bloggers insist the real threat is the firmware handshake hidden in every "pop".'
   },
   {
     id: 'press_conf_water_breaks',
@@ -186,6 +188,7 @@ export const EVENT_DATABASE: GameEvent[] = [
     flavorText: 'CAMPUS WATCH: Librarians rolled out extra step ladders for the flood of citations. The registrar added a course titled "Intro to Uncomfortable Graphs." Meanwhile, goldfish attendance soared.'
   },
   {
+    // Paranoia intent: Reveal budget obfuscation masking covert logistics slush funds.
     id: 'mystery_budget_special_projects',
     title: 'Budget Bump',
     headline: '"SPECIAL PROJECTS" EATS WHOLE PAGE OF ZEROES',
@@ -194,9 +197,10 @@ export const EVENT_DATABASE: GameEvent[] = [
     rarity: 'common',
     effects: { ip: 4, truth: -1 },
     weight: 6,
-    flavorText: 'LEDGER EXTRA: The line item "snacks & silence" costs more than a small moon. A staffer whispered the password is "donut." Procurement immediately ordered a dozen—of both.'
+    flavorText: 'LEDGER EXTRA: The line item "silence retainers" costs more than a small moon. A staffer whispered the passphrase is a nine-digit routing number. Procurement immediately ordered armored vans to keep the receipts moving.'
   },
   {
+    // Paranoia intent: Show how disappearances leave breadcrumb leaks for anyone watching the static.
     id: 'reporter_vanishes_near_nowhere',
     title: 'Reporter Vanishes',
     headline: 'AWARD-WINNER LAST SEEN NEAR PLACE "THAT ISN\'T THERE"',
@@ -205,7 +209,7 @@ export const EVENT_DATABASE: GameEvent[] = [
     rarity: 'common',
     effects: { truth: 8, ip: -1 },
     weight: 5,
-    flavorText: 'NEWS ALERT: Their notebook contained a doodle labelled "Page 13." A local diner swears someone matching their description tipped in photocopies. The parking meter never started counting.'
+    flavorText: 'NEWS ALERT: Their notebook contained a doodle labelled "Page 13." Streetlights flickered in sequence as someone dropped photocopies through the storm drain. The parking meter never started counting.'
   },
   {
     id: 'weather_pins_and_strings',
@@ -887,6 +891,7 @@ export const EVENT_DATABASE: GameEvent[] = [
     flavorText: 'CIVIC BRANDING: The font is officially "Sans Accountability." Souvenir shirts read "I visited ???." The highway shrugged in both directions.'
   },
   {
+    // Paranoia intent: Turn mundane receipts into traceable leak ledgers.
     id: 'truth_cafe_receipts',
     title: 'Receipt Revelations',
     headline: 'COFFEE RECEIPTS INCLUDE FOOTNOTES & SOURCES',
@@ -895,7 +900,7 @@ export const EVENT_DATABASE: GameEvent[] = [
     rarity: 'common',
     effects: { truth: 5, ip: -1 },
     weight: 7,
-    flavorText: 'LATTÉ PRESS: Milk foamed into the shape of a pie chart. The tip jar read "for sources." Customers left caffeinated and cited.'
+    flavorText: 'LEDGER LOG: Thermal paper now prints cross-referenced citations with every order. The tip jar read "for sources." Patrons left with caffeine jitters and subpoena-grade footnotes.'
   },
   {
     id: 'park_statue_moves_a_bit',
@@ -2099,15 +2104,16 @@ export const STATE_EVENTS_DATABASE: { [stateId: string]: GameEvent[] } = {
       flavorGov: "Predictive crowd control keeps coastal events safe.",
       flavorTruth: "They're choreographing crackdowns with light shows!"
     },
-    {
-      id: "ct_nutmeg_packet_manifest", title: "Nutmeg Packets Hide Whistleblower Drop",
-      content: "Every diner sugar caddy in New Haven came with microfilm listing slush fund beneficiaries by spice blend.",
-      type: "capture", rarity: "common", weight: 9,
-      effects: { truthChange: 2, ipChange: -1 },
-      conditions: { capturedBy: "truth" },
-      flavorTruth: "Season your pancakes and expose their payroll!",
-      flavorGov: "Culinary tourism sometimes experiments with augmented reality recipes."
-    }
+      {
+        // Paranoia intent: Turn innocuous tabletop fixtures into serialized leak dispensers.
+        id: "ct_nutmeg_packet_manifest", title: "Nutmeg Packets Hide Whistleblower Drop",
+        content: "Every tabletop dispenser in New Haven flipped its false bottom to reveal microfilm listing slush fund beneficiaries by spice code.",
+        type: "capture", rarity: "common", weight: 9,
+        effects: { truthChange: 2, ipChange: -1 },
+        conditions: { capturedBy: "truth" },
+        flavorTruth: "Twist the packet rack and the payroll prints itself!",
+        flavorGov: "Tourism boards occasionally beta test augmented reality placards."
+      }
   ],
 
   // District of Columbia
@@ -2157,15 +2163,16 @@ export const STATE_EVENTS_DATABASE: { [stateId: string]: GameEvent[] } = {
       flavorGov: "Maritime safety corridors keep traffic predictable.",
       flavorTruth: "They digitized the river to catalogue dissent!"
     },
-    {
-      id: "dc_briefing_brunch", title: "Capitol Hill Brunch Requires Loyalty QR",
-      content: "Beltway cafes added secret QR menus that redirected diners to pledge-of-secrecy forms before serving mimosas.",
-      type: "capture", rarity: "rare", weight: 5,
-      effects: { ipChange: 4, truthChange: -2 },
-      conditions: { capturedBy: "government" },
-      flavorGov: "Constituent outreach sometimes includes optional security orientations.",
-      flavorTruth: "They're gating breakfast behind loyalty oaths!"
-    }
+      {
+        // Paranoia intent: Portray everyday meetups as covert loyalty screening checkpoints.
+        id: "dc_briefing_brunch", title: "Capitol Hill QR Checkpoint Seizes Day Plans",
+        content: "Beltway lounges added covert QR overlays that redirected visitors to pledge-of-secrecy forms before granting access to seating charts.",
+        type: "capture", rarity: "rare", weight: 5,
+        effects: { ipChange: 4, truthChange: -2 },
+        conditions: { capturedBy: "government" },
+        flavorGov: "Constituent outreach sometimes includes optional security orientations.",
+        flavorTruth: "They're gating calendar invites behind loyalty oaths!"
+      }
   ],
 
   // Delaware
@@ -2255,15 +2262,16 @@ export const STATE_EVENTS_DATABASE: { [stateId: string]: GameEvent[] } = {
       flavorTruth: "They weaponized sea shanties for orbital mind control!",
       flavorGov: "Joint maritime aerospace drills ensure splashdown readiness."
     },
-    {
-      id: "fl_key_lime_exposure", title: "Key Lime Pie Recipe Exposes Cover Ops",
-      content: "Miami baker livestreamed a family recipe that revealed classified shipping lanes scribbled in lime zest.",
-      type: "capture", rarity: "common", weight: 10,
-      effects: { truthChange: 2, ipChange: -1 },
-      conditions: { capturedBy: "truth" },
-      flavorTruth: "Dessert literally iced the conspiracy diagram!",
-      flavorGov: "Culinary influencers sometimes riff on fanciful supply-chain lore."
-    },
+      {
+        // Paranoia intent: Show domestic livestreams leaking maritime surveillance routes.
+        id: "fl_key_lime_exposure", title: "Key Lime Broadcast Exposes Cover Ops",
+        content: "A Miami stream overlayed inherited instructions with coordinates that spelled out classified shipping lanes mid-demo.",
+        type: "capture", rarity: "common", weight: 10,
+        effects: { truthChange: 2, ipChange: -1 },
+        conditions: { capturedBy: "truth" },
+        flavorTruth: "The family signal literally traced the conspiracy diagram!",
+        flavorGov: "Influencers sometimes riff on fanciful supply-chain lore."
+      },
     {
       id: "fl_hurricane_missile_net", title: "Hurricane Drones Redirect Storm Gossip",
       content: "A ring of weather-control drones muted pirate radio during landfall, steering dissident broadcasts out to sea.",
@@ -2460,15 +2468,16 @@ export const STATE_EVENTS_DATABASE: { [stateId: string]: GameEvent[] } = {
 
   // Illinois
   "IL": [
-    {
-      id: "il_pizza_portal", title: "Chicago Deep Dish Opens Portal to Italy", 
-      content: "Scientists discover that the depth of Chicago pizza creates dimensional rifts to the Mediterranean!",
-      type: "capture", rarity: "uncommon", weight: 9,
-      effects: { truthChange: 2, cardDraw: 2 },
-      conditions: { capturedBy: "truth" },
-      flavorTruth: "Culinary physics defies explanation!",
-      flavorGov: "Cultural exchange program enhances international relations."
-    },
+      {
+        // Paranoia intent: Frame iconic city myths as cover for dimensional espionage.
+        id: "il_pizza_portal", title: "Chicago Deep Dish Opens Portal to Italy",
+        content: "Scientists discover that the depth of Chicago ovens masks dimensional rifts linking to Mediterranean safehouses!",
+        type: "capture", rarity: "uncommon", weight: 9,
+        effects: { truthChange: 2, cardDraw: 2 },
+        conditions: { capturedBy: "truth" },
+        flavorTruth: "Spatial geometry is doing all the smuggling!",
+        flavorGov: "Cultural exchange programs enhance international relations."
+      },
     {
       id: "il_wind_power", title: "Government Harnesses Chicago Wind for Mind Control", 
       content: "The Windy City's gusts carry subliminal messages to control urban populations!",

--- a/src/data/stateThemedPools.ts
+++ b/src/data/stateThemedPools.ts
@@ -248,12 +248,13 @@ export const STATE_THEMED_POOLS: StateThemedPool[] = [
         weight: 2,
         effect: { ipDelta: 2 },
       }),
+      // Paranoia intent: Collapse citrus agritech into a psychic mesh for leak interception.
       createEffect({
         id: 'fl_event_citrus_psychic_bloom',
         label: 'Citrus Psychic Bloom',
         headline: 'ORANGE GROVES BLOSSOM WITH WIFI SIGNALS',
         subhead: 'Phones auto-connect to network named “THE TRUTH”.',
-        summary: 'Harvest teams record impossible, hyper-clear dreams after squeezing the crop. Rival networks scramble to jam the orchard.',
+        summary: 'Grove canopies pulse telepathic bursts that sync every listening post in the county, forcing rival networks to jam or risk exposure.',
         icon: '🍊',
         weight: 1,
         effect: { truthDelta: 2, pressureDelta: 1 },
@@ -340,12 +341,13 @@ export const STATE_THEMED_POOLS: StateThemedPool[] = [
       states: ['NJ', '34'],
     },
     bonuses: [
+      // Paranoia intent: Map turnpike chatter into a rolling kompromat exchange masked as logistics talk.
       createEffect({
         id: 'nj_bonus_turnpike_cb_rally',
         label: 'Turnpike CB Rally',
         headline: 'TRUCKERS JAM CHANNEL 19 WITH REDACTED RECIPES',
         subhead: 'Every ingredient is a project codename.',
-        summary: 'Rest stop parking lots hum with rigs swapping hush-hush intelligence disguised as slow-cooker gossip.',
+        summary: 'Rest stops buzz as rigs swap clearance matrices disguised as folksy dispatch tips, feeding intercept teams a live blackmail log.',
         icon: '📻',
         weight: 3,
         effect: { truthDelta: 2, ipDelta: 1 },
@@ -360,16 +362,17 @@ export const STATE_THEMED_POOLS: StateThemedPool[] = [
         weight: 2,
         effect: { ipDelta: 3 },
       }),
-      createEffect({
-        id: 'nj_bonus_pine_barrens_signal',
-        label: 'Pine Barrens Signal Fire',
-        headline: 'BLUE FLAMES SPELL OUT ROUTING NUMBERS',
-        subhead: 'Campers roast marshmallows, memorize offshore accounts.',
-        summary: 'Night hikers watch will-o’-wisps render clandestine bank transfers in the treetops. Treasury teams take frantic notes.',
-        icon: '🔥',
-        weight: 1,
-        effect: { truthDelta: 1, pressureDelta: 1 },
-      }),
+        // Paranoia intent: Weaponize Pine Barrens folklore into an offshore money trail revelation.
+        createEffect({
+          id: 'nj_bonus_pine_barrens_signal',
+          label: 'Pine Barrens Signal Fire',
+          headline: 'BLUE FLAMES SPELL OUT ROUTING NUMBERS',
+          subhead: 'Campers trace sigils in the air, memorize offshore accounts.',
+          summary: 'Night hikers watch will-o’-wisps render clandestine bank transfers in the treetops while Treasury listeners triangulate the laundering path.',
+          icon: '🔥',
+          weight: 1,
+          effect: { truthDelta: 1, pressureDelta: 1 },
+        }),
     ],
     events: [
       createEffect({
@@ -432,12 +435,13 @@ export const STATE_THEMED_POOLS: StateThemedPool[] = [
         weight: 2,
         effect: { ipDelta: 2 },
       }),
+      // Paranoia intent: Turn geothermal tourism into a covert transcript siphon under ranger supervision.
       createEffect({
         id: 'pacific_bonus_volcano_listening_post',
         label: 'Volcano Listening Post',
         headline: 'KILAUEA STEAM RUMORS MATCH PENTAGON MINUTES',
         subhead: 'Tour guides blame “vogged-out influencers.”',
-        summary: 'Lava vents sigh transcripts of classified hearings; agents roast marshmallows while taking immaculate notes.',
+        summary: 'Lava vents hiss verbatim committee minutes while guides shuffle visitors past hidden receivers masked as safety beacons.',
         icon: '🌋',
         weight: 1,
         effect: { truthDelta: 1, pressureDelta: 1 },
@@ -556,12 +560,13 @@ export const STATE_THEMED_POOLS: StateThemedPool[] = [
       states: ['MT', 'ID', 'WY'],
     },
     bonuses: [
+      // Paranoia intent: Reframe mountain supply runs as a plausible deniability pipeline for black-budget gear.
       createEffect({
         id: 'mountain_bonus_powder_cache_caravan',
         label: 'Powder Cache Caravan',
         headline: 'SNOWCATS DELIVER “AVALANCHE PREPAREDNESS” CRATES',
         subhead: 'Each crate whispers radio passwords when opened.',
-        summary: 'Mountain patrols haul unmarked containers up switchbacks, leaving spare dossiers beside the trail mix.',
+        summary: 'Mountain patrols haul unmarked containers up switchbacks, staging decoy safety briefings while sliding contraband dossiers into lodge lockers.',
         icon: '🎿',
         weight: 3,
         effect: { ipDelta: 2 },
@@ -576,24 +581,26 @@ export const STATE_THEMED_POOLS: StateThemedPool[] = [
         weight: 2,
         effect: { truthDelta: 2, pressureDelta: 1 },
       }),
+      // Paranoia intent: Convert farmland infrastructure into an antenna field that scrambles surveillance parity.
       createEffect({
         id: 'mountain_bonus_idaho_tater_array',
-        label: 'Idaho Tater Array',
-        headline: 'POTATO FARMS AIM SPUD-POWERED RADARS SKYWARD',
-        subhead: 'Extension office files “culinary innovation” paperwork.',
-        summary: 'Irrigation rigs become spiral antennas that bake truth signals into every casserole heading downrange.',
-        icon: '🥔',
+        label: 'Gem State Resonance Array',
+        headline: 'POTATO BELT TOWERS HUM LIKE CLASSIFIED RADAR',
+        subhead: 'Extension office files “agrotone calibration” paperwork.',
+        summary: 'Irrigation pivots align into a shimmering lattice that amplifies clandestine broadcasts straight into buried repeater bunkers.',
+        icon: '📡',
         weight: 1,
         effect: { truthDelta: 1, ipDelta: 1 },
       }),
     ],
     events: [
+      // Paranoia intent: Use wildlife drills to normalize bio-surveillance handoffs without revealing handlers.
       createEffect({
         id: 'mountain_event_grizzly_signal_drill',
         label: 'Grizzly Signal Drill',
         headline: 'RANGERS TRAIN BEARS TO DELIVER FLASH DRIVES',
         subhead: 'Official statement calls it “wildlife enrichment.”',
-        summary: 'Tagged grizzlies stroll into operations tents with USB collars, dropping undeniable footage before wandering off for berries.',
+        summary: 'Tagged grizzlies stroll into operations tents with USB collars, drop undeniable footage, then lumber off toward decoy tracking beacons.',
         icon: '🐻',
         weight: 3,
         effect: { truthDelta: 2 },
@@ -710,12 +717,13 @@ export const STATE_THEMED_POOLS: StateThemedPool[] = [
         weight: 3,
         effect: { truthDelta: 2, ipDelta: 1 },
       }),
+      // Paranoia intent: Turn industrial downtime into a confidential leak vector hidden in plain sight.
       createEffect({
         id: 'heartland_bonus_factory_breakroom_tipline',
         label: 'Factory Breakroom Tipline',
         headline: 'AUTOMAKERS INSTALL “ANONYMOUS GOSSIP” BUTTON',
         subhead: 'Union steward files it under “wellness.”',
-        summary: 'Coffee machines now dispense latte art featuring classified schematics—everyone pretends it’s normal foam.',
+        summary: 'Breakroom kiosks now eject anonymized schematics through innocuous maintenance alerts, letting whistle crews photograph without suspicion.',
         icon: '☕',
         weight: 2,
         effect: { ipDelta: 2 },
@@ -732,12 +740,13 @@ export const STATE_THEMED_POOLS: StateThemedPool[] = [
       }),
     ],
     events: [
+      // Paranoia intent: Expose buried vote tampering by weaponizing county fair nostalgia.
       createEffect({
         id: 'heartland_event_siloed_votes_recount',
         label: 'Siloed Votes Recount',
         headline: 'COUNTY FAIR BLUE-RIBBON BOOTHS DEMAND AUDIT',
-        subhead: 'Judges swear the pies are “purely agricultural.”',
-        summary: 'Prize entries hide ballots exposing clandestine caucus tallies, forcing bureaucrats to eat humble pie on camera.',
+        subhead: 'Judges swear the exhibits are “purely agricultural.”',
+        summary: 'Prize exhibits crack open hidden ballot caches mid-judging, forcing bureaucrats to read the forged tallies aloud under stadium lights.',
         icon: '🥧',
         weight: 3,
         effect: { truthDelta: 2 },
@@ -768,7 +777,7 @@ export const STATE_THEMED_POOLS: StateThemedPool[] = [
     tag: {
       id: 'great_lakes_signal',
       label: 'Great Lakes Signal',
-      description: 'Freshwater horizons bounce encrypted gossip between ore boats and supper clubs.',
+      description: 'Freshwater horizons bounce encrypted gossip between ore boats and clandestine lounges.',
       states: ['MI', 'WI', 'MN'],
     },
     bonuses: [
@@ -782,13 +791,14 @@ export const STATE_THEMED_POOLS: StateThemedPool[] = [
         weight: 3,
         effect: { ipDelta: 2 },
       }),
+      // Paranoia intent: Recast supper clubs as shell organizations broadcasting whistleblower dossiers.
       createEffect({
         id: 'lakes_bonus_supersupper_briefing',
-        label: 'Super Supper Briefing',
-        headline: 'FRIDAY FISH FRY ANNOUNCES “MYSTERY FILET SPECIAL”',
-        subhead: 'Tickets include hushpuppies and clearance wristbands.',
-        summary: 'Community halls fry cod while a back-room projector spills sealed whistleblower footage onto the bingo board.',
-        icon: '🐟',
+        label: 'Harbor Safehouse Briefing',
+        headline: 'FRIDAY COVER CHARGE INCLUDES SURVEILLANCE CLEARANCE',
+        subhead: 'Tickets arrive pre-stamped with routing codes.',
+        summary: 'Community halls dim the lights and stream sealed whistleblower footage through hidden sonar uplinks behind the stage curtain.',
+        icon: '📡',
         weight: 2,
         effect: { truthDelta: 2 },
       }),
@@ -864,16 +874,17 @@ export const STATE_THEMED_POOLS: StateThemedPool[] = [
         weight: 2,
         effect: { truthDelta: 2, pressureDelta: 1 },
       }),
-      createEffect({
-        id: 'gulf_bonus_shrimp_boat_sensor_net',
-        label: 'Shrimp Boat Sensor Net',
-        headline: 'TRAWLERS DRAG MILES OF BUGGED NETTING',
-        subhead: 'Coast Guard paperwork labels it “research gear.”',
-        summary: 'Every catch includes miniature black boxes chirping intercepted cabinet chatter over the deck speakers.',
-        icon: '🦐',
-        weight: 1,
-        effect: { truthDelta: 1, ipDelta: 1 },
-      }),
+        // Paranoia intent: Turn working fleets into mobile SIGINT nets disguised as routine hauls.
+        createEffect({
+          id: 'gulf_bonus_shrimp_boat_sensor_net',
+          label: 'Shrimp Boat Sensor Net',
+          headline: 'TRAWLERS DRAG MILES OF BUGGED NETTING',
+          subhead: 'Coast Guard paperwork labels it “research gear.”',
+          summary: 'Hull-mounted pods scrape up encrypted cabinet chatter and rebroadcast it across the fleet’s tracking channel before regulators can jam it.',
+          icon: '🦐',
+          weight: 1,
+          effect: { truthDelta: 1, ipDelta: 1 },
+        }),
     ],
     events: [
       createEffect({
@@ -968,12 +979,13 @@ export const STATE_THEMED_POOLS: StateThemedPool[] = [
         weight: 2,
         effect: { ipDelta: 2 },
       }),
+      // Paranoia intent: Turn trail culture into a breadcrumb network for whistleblowers on the move.
       createEffect({
         id: 'appalachian_event_trail_of_leaks',
         label: 'Trail of Leaks',
         headline: 'HIKERS FIND QR CODES BURNED INTO SHELTER LOGBOOKS',
         subhead: 'Park service blames “overzealous influencers.”',
-        summary: 'Every waypoint unlocks a dead drop containing truth-saturated ration bars and unredacted memos.',
+        summary: 'Every waypoint unlocks a dead drop of unredacted memos and burner credentials tucked behind fake safety advisories.',
         icon: '🥾',
         weight: 1,
         effect: { truthDelta: 1, pressureDelta: 1 },
@@ -1142,26 +1154,28 @@ export const STATE_THEMED_POOLS: StateThemedPool[] = [
         weight: 3,
         effect: { truthDelta: 2, ipDelta: 1 },
       }),
-      createEffect({
-        id: 'rumor_bonus_maple_syrup_memory',
-        label: 'Maple Syrup Memory Cache',
-        headline: 'SUGAR SHACK BARRELS STORE CLASSIFIED AUDIO',
-        subhead: 'Producers stamp them “for pancakes only.”',
-        summary: 'Each pour leaks sweet recordings of closed-door caucuses; breakfast crowds share the drip in knowing silence.',
-        icon: '🍁',
-        weight: 2,
-        effect: { truthDelta: 2 },
-      }),
-      createEffect({
-        id: 'rumor_bonus_white_mountain_retreat',
-        label: 'White Mountain Retreat',
-        headline: 'SKI LODGE OFFERS “ANONYMIZED” PRESS PACKAGES',
-        subhead: 'Brochure features silhouettes carrying attaché cases.',
-        summary: 'Guests receive unmarked dossiers with their lift tickets, plus cocoa branded with latitude-longitude riddles.',
-        icon: '🏔️',
-        weight: 1,
-        effect: { ipDelta: 2 },
-      }),
+        // Paranoia intent: Transform heritage trades into dead-drop networks with plausible deniability.
+        createEffect({
+          id: 'rumor_bonus_maple_syrup_memory',
+          label: 'Maple Syrup Memory Cache',
+          headline: 'SUGAR SHACK BARRELS STORE CLASSIFIED AUDIO',
+          subhead: 'Producers stamp them “for archive inventory only.”',
+          summary: 'Each barrel hums encoded caucus recordings through condenser coils, letting co-ops swap kompromat under the guise of inventory checks.',
+          icon: '🍁',
+          weight: 2,
+          effect: { truthDelta: 2 },
+        }),
+        // Paranoia intent: Position resort amenities as recruitment fronts distributing surveillance riddles.
+        createEffect({
+          id: 'rumor_bonus_white_mountain_retreat',
+          label: 'White Mountain Retreat',
+          headline: 'SKI LODGE OFFERS “ANONYMIZED” PRESS PACKAGES',
+          subhead: 'Brochure features silhouettes carrying attaché cases.',
+          summary: 'Guests receive unmarked dossiers with their lift tickets and elevator keycards that flicker latitude-longitude riddles in ultraviolet.',
+          icon: '🏔️',
+          weight: 1,
+          effect: { ipDelta: 2 },
+        }),
     ],
     events: [
       createEffect({
@@ -1174,16 +1188,17 @@ export const STATE_THEMED_POOLS: StateThemedPool[] = [
         weight: 3,
         effect: { truthDelta: 3 },
       }),
-      createEffect({
-        id: 'rumor_event_green_mountain_flash_mob',
-        label: 'Green Mountain Flash Mob',
-        headline: 'FARMERS MARKET FREEZES, PERFORMS DATA DROP',
-        subhead: 'Produce still weighs out; secrets weigh more.',
-        summary: 'Vendors spell out encryption keys with heirloom carrots before shrugging and handing over the receipts.',
-        icon: '🥕',
-        weight: 2,
-        effect: { ipDelta: 2 },
-      }),
+        // Paranoia intent: Stage market performances that smuggle encryption keys through choreography.
+        createEffect({
+          id: 'rumor_event_green_mountain_flash_mob',
+          label: 'Green Mountain Flash Mob',
+          headline: 'FARMERS MARKET FREEZES, PERFORMS DATA DROP',
+          subhead: 'Produce still weighs out; secrets weigh more.',
+          summary: 'Vendors align stalls into a living QR lattice, flickering encryption keys via barcode scanners before resuming small talk.',
+          icon: '🥕',
+          weight: 2,
+          effect: { ipDelta: 2 },
+        }),
       createEffect({
         id: 'rumor_event_whitecap_signal_boat',
         label: 'Whitecap Signal Boat',
@@ -1200,7 +1215,7 @@ export const STATE_THEMED_POOLS: StateThemedPool[] = [
     tag: {
       id: 'ozark_veil',
       label: 'Ozark Veil Syndicate',
-      description: 'Karst caves and riverboats host polite conspiracies with barbecue catering.',
+      description: 'Karst caves and riverboats host polite conspiracies with velvet-rope cover stories.',
       states: ['AR', 'OK', 'MO'],
     },
     bonuses: [
@@ -1214,23 +1229,25 @@ export const STATE_THEMED_POOLS: StateThemedPool[] = [
         weight: 3,
         effect: { truthDelta: 2, ipDelta: 1 },
       }),
+      // Paranoia intent: Recast leisure cruises as covert auction floors for compromised patents.
       createEffect({
         id: 'ozark_bonus_riverboat_intel_buffet',
         label: 'Riverboat Intel Buffet',
         headline: 'PADDLEWHEEL CASINO RUNS “UNMARKED DOCUMENT” CARVING STATION',
-        subhead: 'Dealer assures patrons it’s “smoked brisket.”',
-        summary: 'Buffet trays conceal microfiche between ribs and coleslaw; diners leave sticky-fingered and fully briefed.',
+        subhead: 'Dealer assures patrons it’s “routine hospitality.”',
+        summary: 'Service trolleys conceal microfiche drawers beneath silver covers, and high rollers trade kompromat chips while the band plays on.',
         icon: '🛥️',
         weight: 2,
         effect: { ipDelta: 2 },
       }),
+      // Paranoia intent: Turn fan culture meetups into mobile airspace surveillance rings.
       createEffect({
         id: 'ozark_bonus_thunderbird_tailgate',
         label: 'Thunderbird Tailgate',
         headline: 'HIGHWAY REST STOP HOSTS CRYPTID FAN CLUB',
-        subhead: 'State troopers grill burgers, ignore the wingspan.',
-        summary: 'Enthusiasts swap Polaroids with embedded map overlays, fueling field teams with protein and perfect intel.',
-        icon: '🍔',
+        subhead: 'State troopers set up cones, ignore the wingspan.',
+        summary: 'Enthusiasts trade Polaroids with embedded map overlays, activating skywatch relays every time the mascot unfurls its wings.',
+        icon: '🛰️',
         weight: 1,
         effect: { truthDelta: 1, pressureDelta: 1 },
       }),


### PR DESCRIPTION
## Summary
- retune state-themed pool bonuses and events with conspiracy-forward summaries and inline paranoia intent notes
- refresh agenda issues to remove culinary framing, adjust supporting tags, and align quips with paranoid-times lore
- update hotspot events and logs to strip lingering food motifs, replacing them with surveillance-leaning narratives

## Testing
- rg -i "culinary"


------
https://chatgpt.com/codex/tasks/task_e_68e57535bce483208c369c42cbcc6ad0