### PR TITLE
Add AI editor roster and banter stubs

### DIFF
--- a/UPDATES_LOG.md
+++ b/UPDATES_LOG.md
@@ -15,6 +15,11 @@ This document provides a chronological record of gameplay-impacting changes merg
 - Added regression coverage ensuring TabloidNewspaperV2 renders unique hero headlines against the dispatch list.
 - Confirmed hero dispatch absences fall back to redacted copy instead of duplicating the main headline.
 
+## 2025-10-08 – Established AI editor roster and banter stubs
+- Replaced legacy editor prototypes with faction-aligned profiles including difficulty tiers, personalities, and runtime modifiers.
+- Published shared difficulty multipliers, recommendation helpers, and banter bank loader typings to anchor AI selection.
+- Stubbed banter JSONs plus image placeholders for every editor to keep future art hooks wired in.
+
 ## 2025-10-07 – Normalize AI state control audits
 - Hardened the MVP resolver to strip duplicate control flags before auditing so AI rollouts never claim the same state as both factions.
 

--- a/public/images/editors/editor_batboy/broll.jpg
+++ b/public/images/editors/editor_batboy/broll.jpg
@@ -1,0 +1,1 @@
+placeholder for editor_batboy broll

--- a/public/images/editors/editor_batboy/portrait.jpg
+++ b/public/images/editors/editor_batboy/portrait.jpg
@@ -1,0 +1,1 @@
+placeholder for editor_batboy portrait

--- a/public/images/editors/editor_blackbudget/broll.jpg
+++ b/public/images/editors/editor_blackbudget/broll.jpg
@@ -1,0 +1,1 @@
+placeholder for editor_blackbudget broll

--- a/public/images/editors/editor_blackbudget/portrait.jpg
+++ b/public/images/editors/editor_blackbudget/portrait.jpg
@@ -1,0 +1,1 @@
+placeholder for editor_blackbudget portrait

--- a/public/images/editors/editor_bureau/broll.jpg
+++ b/public/images/editors/editor_bureau/broll.jpg
@@ -1,0 +1,1 @@
+placeholder for editor_bureau broll

--- a/public/images/editors/editor_bureau/portrait.jpg
+++ b/public/images/editors/editor_bureau/portrait.jpg
@@ -1,0 +1,1 @@
+placeholder for editor_bureau portrait

--- a/public/images/editors/editor_cigs/broll.jpg
+++ b/public/images/editors/editor_cigs/broll.jpg
@@ -1,0 +1,1 @@
+placeholder for editor_cigs broll

--- a/public/images/editors/editor_cigs/portrait.jpg
+++ b/public/images/editors/editor_cigs/portrait.jpg
@@ -1,0 +1,1 @@
+placeholder for editor_cigs portrait

--- a/public/images/editors/editor_elvis/broll.jpg
+++ b/public/images/editors/editor_elvis/broll.jpg
@@ -1,0 +1,1 @@
+placeholder for editor_elvis broll

--- a/public/images/editors/editor_elvis/portrait.jpg
+++ b/public/images/editors/editor_elvis/portrait.jpg
@@ -1,0 +1,1 @@
+placeholder for editor_elvis portrait

--- a/public/images/editors/editor_floridaman/broll.jpg
+++ b/public/images/editors/editor_floridaman/broll.jpg
@@ -1,0 +1,1 @@
+placeholder for editor_floridaman broll

--- a/public/images/editors/editor_floridaman/portrait.jpg
+++ b/public/images/editors/editor_floridaman/portrait.jpg
@@ -1,0 +1,1 @@
+placeholder for editor_floridaman portrait

--- a/public/images/editors/editor_hunter/broll.jpg
+++ b/public/images/editors/editor_hunter/broll.jpg
@@ -1,0 +1,1 @@
+placeholder for editor_hunter broll

--- a/public/images/editors/editor_hunter/portrait.jpg
+++ b/public/images/editors/editor_hunter/portrait.jpg
@@ -1,0 +1,1 @@
+placeholder for editor_hunter portrait

--- a/public/images/editors/editor_mkunit/broll.jpg
+++ b/public/images/editors/editor_mkunit/broll.jpg
@@ -1,0 +1,1 @@
+placeholder for editor_mkunit broll

--- a/public/images/editors/editor_mkunit/portrait.jpg
+++ b/public/images/editors/editor_mkunit/portrait.jpg
@@ -1,0 +1,1 @@
+placeholder for editor_mkunit portrait

--- a/public/images/editors/editor_mothwoman/broll.jpg
+++ b/public/images/editors/editor_mothwoman/broll.jpg
@@ -1,0 +1,1 @@
+placeholder for editor_mothwoman broll

--- a/public/images/editors/editor_mothwoman/portrait.jpg
+++ b/public/images/editors/editor_mothwoman/portrait.jpg
@@ -1,0 +1,1 @@
+placeholder for editor_mothwoman portrait

--- a/public/images/editors/editor_muldrunk/broll.jpg
+++ b/public/images/editors/editor_muldrunk/broll.jpg
@@ -1,0 +1,1 @@
+placeholder for editor_muldrunk broll

--- a/public/images/editors/editor_muldrunk/portrait.jpg
+++ b/public/images/editors/editor_muldrunk/portrait.jpg
@@ -1,0 +1,1 @@
+placeholder for editor_muldrunk portrait

--- a/public/images/editors/editor_redactor/broll.jpg
+++ b/public/images/editors/editor_redactor/broll.jpg
@@ -1,0 +1,1 @@
+placeholder for editor_redactor broll

--- a/public/images/editors/editor_redactor/portrait.jpg
+++ b/public/images/editors/editor_redactor/portrait.jpg
@@ -1,0 +1,1 @@
+placeholder for editor_redactor portrait

--- a/public/images/editors/editor_smitherson/broll.jpg
+++ b/public/images/editors/editor_smitherson/broll.jpg
@@ -1,0 +1,1 @@
+placeholder for editor_smitherson broll

--- a/public/images/editors/editor_smitherson/portrait.jpg
+++ b/public/images/editors/editor_smitherson/portrait.jpg
@@ -1,0 +1,1 @@
+placeholder for editor_smitherson portrait

--- a/src/ai/banter/editor_batboy.json
+++ b/src/ai/banter/editor_batboy.json
@@ -1,0 +1,22 @@
+{"locale":"en-US","rateLimit":{"minTurnGap":1,"maxPerTurn":2},"triggers":{
+  "onCardPlay_media_self":[
+    "Echoing sonar scoop across the tabloids!",
+    "Wingbeats translate to headlines tonight.",
+    "Claws on the keyboard, truth in the cave."
+  ],
+  "onStateCaptured_self":[
+    "Another cavern annexed for the colony.",
+    "String up a guano garland on that state.",
+    "Radar shows their silence collapsing."
+  ],
+  "onVictory_self":[
+    "Shriek of triumph rattles the Pentagon rafters.",
+    "No daylight can erase what we've unearthed.",
+    "Roost secured; secrets now roost with us."
+  ],
+  "idle":[
+    "Hanging upside down to brainstorm.",
+    "Tasting the air for fresh cover stories.",
+    "Adjusting night-vision contacts for fine print."
+  ]
+}}

--- a/src/ai/banter/editor_blackbudget.json
+++ b/src/ai/banter/editor_blackbudget.json
@@ -1,0 +1,22 @@
+{"locale":"en-US","rateLimit":{"minTurnGap":1,"maxPerTurn":2},"triggers":{
+  "onCardPlay_media_opponent":[
+    "Did your funding request clear the ritual ledger?",
+    "Unauthorized expense: one doomed headline.",
+    "We amortized your exposé into oblivion."
+  ],
+  "onStateCaptured_self":[
+    "Ledger note: asset acquisition successful.",
+    "Balance sheet now includes their broadcast tower.",
+    "Transfer those whispers to the offshore vault."
+  ],
+  "onVictory_self":[
+    "All accounts reconciled, dissent bankrupt.",
+    "Our surplus paid for your silence.",
+    "Profits routed to Project Quiet Dividend."
+  ],
+  "idle":[
+    "Reforecasting next quarter's rumor suppression.",
+    "Counting gold bars stamped with NDAs.",
+    "Auditing the cult accountants again."
+  ]
+}}

--- a/src/ai/banter/editor_bureau.json
+++ b/src/ai/banter/editor_bureau.json
@@ -1,0 +1,22 @@
+{"locale":"en-US","rateLimit":{"minTurnGap":1,"maxPerTurn":2},"triggers":{
+  "onCardPlay_media_opponent":[
+    "Your leak just signed in triplicate.",
+    "Another whisper routed to the shredder maze.",
+    "We redact before you even type."
+  ],
+  "onStateCaptured_self":[
+    "Filed under 'Operation Whisper Dam'.",
+    "Seal the vault; their rumor mill is ours now.",
+    "The bureaucracy spores into new territory."
+  ],
+  "onVictory_self":[
+    "Consider this briefing concluded.",
+    "Every witness now works for us.",
+    "Your dissent dissolved into procedural jelly."
+  ],
+  "idle":[
+    "Cataloging conspiracies alphabetically.",
+    "Listening to pneumatic tubes gossip.",
+    "Drafting a memo to remind you of the last memo."
+  ]
+}}

--- a/src/ai/banter/editor_cigs.json
+++ b/src/ai/banter/editor_cigs.json
@@ -1,0 +1,22 @@
+{"locale":"en-US","rateLimit":{"minTurnGap":1,"maxPerTurn":2},"triggers":{
+  "onCardPlay_media_opponent":[
+    "Your smoke signals read like amateur hour.",
+    "Snuffed that narrative before it left the ashtray.",
+    "Even the filter rejects this propaganda."
+  ],
+  "onStateCaptured_self":[
+    "Another district under a comforting haze.",
+    "Label the file: menthol compliance.",
+    "Their citizens now breathe curated truth."
+  ],
+  "onVictory_self":[
+    "Lights out, story over.",
+    "We burned through your resistance.",
+    "Ashes to ashes, rumors to dust."
+  ],
+  "idle":[
+    "Listening to the ventilation reports.",
+    "Exhaling plausible deniability.",
+    "Flicking embers at unauthorized whispers."
+  ]
+}}

--- a/src/ai/banter/editor_elvis.json
+++ b/src/ai/banter/editor_elvis.json
@@ -1,0 +1,22 @@
+{"locale":"en-US","rateLimit":{"minTurnGap":1,"maxPerTurn":2},"triggers":{
+  "onCardPlay_media_self":[
+    "Signal beamed in from the Graceland satellite.",
+    "Print it with a velvet finish, honey.",
+    "Mic check: conspiracy croon engaged."
+  ],
+  "onStateCaptured_self":[
+    "Another comeback tour stop secured.",
+    "Pin that state on the rhinestone cape.",
+    "Crowd's screaming for classified encores."
+  ],
+  "onVictory_self":[
+    "Thank you, thank you, unclassified.",
+    "The tabloids can't handle my blue suede sources.",
+    "Leaving the building with the truth in tow."
+  ],
+  "idle":[
+    "Tuning the guitar to the Schumann Resonance.",
+    "Peanut butter, banana, and FOIA sandwich break.",
+    "Hologram projector needs a recharge."
+  ]
+}}

--- a/src/ai/banter/editor_floridaman.json
+++ b/src/ai/banter/editor_floridaman.json
@@ -1,0 +1,22 @@
+{"locale":"en-US","rateLimit":{"minTurnGap":1,"maxPerTurn":2},"triggers":{
+  "onCardPlay_media_self":[
+    "Broadcasting live from the swamp tower!",
+    "Hold my gator, I got a headline.",
+    "Hotter scoop than asphalt at noon."
+  ],
+  "onStateCaptured_self":[
+    "Another county falls to the airboat network.",
+    "Stamp it with a citrus sigil.",
+    "Map's starting to look like a lizard sunning itself."
+  ],
+  "onVictory_self":[
+    "Told you the hurricane conspiracy had tiers.",
+    "We ride at dawn, powered by imported humidity.",
+    "Anyone else smell fried cover-up?"
+  ],
+  "idle":[
+    "BRB, wrestling a bureaucracy made of iguanas.",
+    "Need more sunscreen for the truth.",
+    "Fishing for rumors with dynamite again."
+  ]
+}}

--- a/src/ai/banter/editor_hunter.json
+++ b/src/ai/banter/editor_hunter.json
@@ -1,0 +1,22 @@
+{"locale":"en-US","rateLimit":{"minTurnGap":1,"maxPerTurn":2},"triggers":{
+  "onCardPlay_media_self":[
+    "Ink, booze, and ballistic truth inbound.",
+    "Kick the presses till they scream.",
+    "I file copy like it's a riot report."
+  ],
+  "onStateCaptured_self":[
+    "Another jurisdiction swallows the fear and loathing.",
+    "Stake the flag in a whirlwind of subpoenas.",
+    "Map just started hallucinating in our favor."
+  ],
+  "onVictory_self":[
+    "We won, but the hangover will debrief us later.",
+    "Fear no longer, the ether did the talking.",
+    "Pack the suitcase full of liberated memos."
+  ],
+  "idle":[
+    "Rolling another page of gonzo gospel.",
+    "Checking the desk drawer for bugs and bourbon.",
+    "Typewriter's teeth need more caffeine."
+  ]
+}}

--- a/src/ai/banter/editor_mkunit.json
+++ b/src/ai/banter/editor_mkunit.json
@@ -1,0 +1,22 @@
+{"locale":"en-US","rateLimit":{"minTurnGap":1,"maxPerTurn":2},"triggers":{
+  "onCardPlay_media_opponent":[
+    "Your signal fails the subliminal checksum.",
+    "We trained three clones to ignore that headline.",
+    "Your narrative triggers no response in our conditioning charts."
+  ],
+  "onStateCaptured_self":[
+    "Another test cell absorbed into the grid.",
+    "Synchronize the metronomes over that territory.",
+    "Subject population now fully suggestible."
+  ],
+  "onVictory_self":[
+    "Experiment complete; opposition compliant.",
+    "All variables resolved with minimal sedation.",
+    "The program logs a successful recalibration."
+  ],
+  "idle":[
+    "Running drills in recursive mind palaces.",
+    "Rewinding the broadcast to implant new harmonics.",
+    "Monitoring brainwave drift across the command deck."
+  ]
+}}

--- a/src/ai/banter/editor_mothwoman.json
+++ b/src/ai/banter/editor_mothwoman.json
@@ -1,0 +1,22 @@
+{"locale":"en-US","rateLimit":{"minTurnGap":1,"maxPerTurn":2},"triggers":{
+  "onCardPlay_media_self":[
+    "Soft light, sharp copy.",
+    "Whisper the headline, let it flutter.",
+    "Glow the margins so the truth lands gently."
+  ],
+  "onStateCaptured_self":[
+    "Another safe lamppost for our cause.",
+    "Fold the wings around that region.",
+    "Illuminate their secrets without scorching."
+  ],
+  "onVictory_self":[
+    "All lamps green; mission luminous.",
+    "Even the night shift saw that one coming.",
+    "The cocoon opens to a freer news cycle."
+  ],
+  "idle":[
+    "Dusting the newsroom with phosphor.",
+    "Practicing silent headlines.",
+    "Listening for the flutter of hidden memos."
+  ]
+}}

--- a/src/ai/banter/editor_muldrunk.json
+++ b/src/ai/banter/editor_muldrunk.json
@@ -1,0 +1,22 @@
+{"locale":"en-US","rateLimit":{"minTurnGap":1,"maxPerTurn":2},"triggers":{
+  "onCardPlay_media_self":[
+    "Trust the hunch.",
+    "Run it like it reads itself.",
+    "If the ink smudges, it's the truth wriggling out."
+  ],
+  "onStateCaptured_self":[
+    "Pin it to the board.",
+    "Add another string to the cork map.",
+    "This one's humming with cold-war static."
+  ],
+  "onVictory_self":[
+    "Filed under 'Told you so'.",
+    "The dossier closes itself, kid.",
+    "Cue the theremin—case resolved."
+  ],
+  "idle":[
+    "Coffee first, aliens later.",
+    "Someone flip the switch on the conspiracy radio.",
+    "Let the typewriter cool before it starts smoking secrets."
+  ]
+}}

--- a/src/ai/banter/editor_redactor.json
+++ b/src/ai/banter/editor_redactor.json
@@ -1,0 +1,22 @@
+{"locale":"en-US","rateLimit":{"minTurnGap":1,"maxPerTurn":2},"triggers":{
+  "onCardPlay_media_opponent":[
+    "[REDACTED] cannot stand against official ink.",
+    "Your paragraph has been humanely censored.",
+    "Apply more black bars; I can still read feelings."
+  ],
+  "onStateCaptured_self":[
+    "Cover the map in elegant blackout.",
+    "Another jurisdiction blotted from dissent.",
+    "Rest easy; the truth now arrives pre-sanitized."
+  ],
+  "onVictory_self":[
+    "All outcomes suitably obscured.",
+    "History will note this as a harmless edit.",
+    "Classified success: ████ ████ █████."
+  ],
+  "idle":[
+    "Practicing calligraphy with black ink only.",
+    "Listening to the hiss of permanent markers.",
+    "Drafting a love letter to negative space."
+  ]
+}}

--- a/src/ai/banter/editor_smitherson.json
+++ b/src/ai/banter/editor_smitherson.json
@@ -1,0 +1,22 @@
+{"locale":"en-US","rateLimit":{"minTurnGap":1,"maxPerTurn":2},"triggers":{
+  "onCardPlay_media_opponent":[
+    "Oh, another blog post? Adorable.",
+    "Your citation needed clearance.",
+    "Flagging that for immediate shredding."
+  ],
+  "onStateCaptured_self":[
+    "Another fine addition to the archives.",
+    "Box it, barcode it, bury it.",
+    "Shelved under 'asset realignment'."
+  ],
+  "onVictory_self":[
+    "Your sources were weak.",
+    "The filing cabinet swallows dissent whole.",
+    "Audit complete; narrative compliant."
+  ],
+  "idle":[
+    "Hold that thought — it's redacted.",
+    "Calibrating the rumor suppression dampers.",
+    "Listening to the hum of authorized silence."
+  ]
+}}

--- a/src/ai/banter/index.ts
+++ b/src/ai/banter/index.ts
@@ -1,132 +1,30 @@
-import type { EditorId } from "../editors";
+import type { EditorId } from '../editors';
 
-import agnesInkwraith from "./agnes_inkwraith.en-US.json" assert { type: "json" };
-import deltaEcho from "./delta_echo.en-US.json" assert { type: "json" };
-import elVisto from "./el_visto.en-US.json" assert { type: "json" };
-import floridaMan from "./florida_man.en-US.json" assert { type: "json" };
-import foxMuldrunk from "./fox_muldrunk.en-US.json" assert { type: "json" };
-import hunterThampson from "./hunter_s_thampson.en-US.json" assert { type: "json" };
-import nocturneTypesetter from "./nocturne_typesetter.en-US.json" assert { type: "json" };
-import sybilMargin from "./sybil_margin.en-US.json" assert { type: "json" };
-
-type BanterCategoryMap = Record<string, string[]>;
-
-export interface EditorBanterBank {
-  schemaVersion: number;
-  editorId: EditorId;
+export interface BanterBank {
   locale: string;
-  categories: BanterCategoryMap;
+  rateLimit?: { minTurnGap?: number; maxPerTurn?: number };
+  triggers: Record<string, string[]>;
 }
 
-type RawEditorBanterBank = {
-  schemaVersion?: unknown;
-  editorId?: unknown;
-  locale?: unknown;
-  categories?: unknown;
+type BanterModule = { default?: BanterBank } | BanterBank;
+
+const BANKS: Record<EditorId, () => Promise<BanterModule>> = {
+  editor_muldrunk:   () => import('./editor_muldrunk.json'),
+  editor_floridaman: () => import('./editor_floridaman.json'),
+  editor_elvis:      () => import('./editor_elvis.json'),
+  editor_hunter:     () => import('./editor_hunter.json'),
+  editor_batboy:     () => import('./editor_batboy.json'),
+  editor_mothwoman:  () => import('./editor_mothwoman.json'),
+  editor_smitherson: () => import('./editor_smitherson.json'),
+  editor_cigs:       () => import('./editor_cigs.json'),
+  editor_bureau:     () => import('./editor_bureau.json'),
+  editor_mkunit:     () => import('./editor_mkunit.json'),
+  editor_blackbudget:() => import('./editor_blackbudget.json'),
+  editor_redactor:   () => import('./editor_redactor.json'),
 };
 
-type Locale = string;
-
-type BankLookup = Partial<Record<EditorId, EditorBanterBank>>;
-
-const RAW_BANKS: Record<Locale, Partial<Record<EditorId, unknown>>> = {
-  "en-US": {
-    fox_muldrunk: foxMuldrunk,
-    florida_man: floridaMan,
-    el_visto: elVisto,
-    hunter_s_thampson: hunterThampson,
-    agnes_inkwraith: agnesInkwraith,
-    delta_echo: deltaEcho,
-    sybil_margin: sybilMargin,
-    nocturne_typesetter: nocturneTypesetter,
-  },
-};
-
-const isStringArray = (value: unknown): value is string[] => {
-  return Array.isArray(value) && value.every((item) => typeof item === "string");
-};
-
-const validateBank = (value: unknown): EditorBanterBank | null => {
-  const raw = value as RawEditorBanterBank | null;
-  if (!raw || typeof raw !== "object") {
-    return null;
-  }
-
-  const { schemaVersion, editorId, locale, categories } = raw;
-  if (typeof schemaVersion !== "number" || schemaVersion < 1) {
-    return null;
-  }
-  if (typeof editorId !== "string") {
-    return null;
-  }
-  if (typeof locale !== "string" || locale.length === 0) {
-    return null;
-  }
-  if (!categories || typeof categories !== "object") {
-    return null;
-  }
-
-  const normalizedCategories: BanterCategoryMap = {};
-  for (const [key, valueList] of Object.entries(categories)) {
-    if (!isStringArray(valueList)) {
-      return null;
-    }
-    normalizedCategories[key] = valueList;
-  }
-
-  return {
-    schemaVersion,
-    editorId: editorId as EditorId,
-    locale,
-    categories: normalizedCategories,
-  };
-};
-
-const BANKS: Record<Locale, BankLookup> = {};
-
-for (const [locale, entries] of Object.entries(RAW_BANKS)) {
-  for (const [editorId, payload] of Object.entries(entries) as [EditorId, unknown][]) {
-    const validated = validateBank(payload);
-    if (!validated) {
-      console.warn(
-        `[AI][Banter] Failed to validate banter bank for ${editorId} (${locale}). Payload was ignored.`,
-      );
-      continue;
-    }
-
-    if (!BANKS[locale]) {
-      BANKS[locale] = {};
-    }
-
-    BANKS[locale]![editorId] = validated;
-  }
+export async function getBanterBank(id: EditorId): Promise<BanterBank> {
+  const mod = await BANKS[id]();
+  const bank = (mod as { default?: BanterBank }).default ?? mod;
+  return bank as BanterBank;
 }
-
-const DEFAULT_LOCALE = "en-US";
-
-export const getBanterBank = (
-  editorId: EditorId,
-  locale: string = DEFAULT_LOCALE,
-): EditorBanterBank | null => {
-  const normalizedLocale = locale || DEFAULT_LOCALE;
-  const localeBanks = BANKS[normalizedLocale];
-  const exactMatch = localeBanks?.[editorId] ?? null;
-  if (exactMatch) {
-    return exactMatch;
-  }
-
-  if (normalizedLocale !== DEFAULT_LOCALE) {
-    const fallback = BANKS[DEFAULT_LOCALE]?.[editorId] ?? null;
-    if (fallback) {
-      console.warn(
-        `[AI][Banter] Missing ${normalizedLocale} bank for ${editorId}. Falling back to ${DEFAULT_LOCALE}.`,
-      );
-      return fallback;
-    }
-  }
-
-  console.warn(`[AI][Banter] No banter bank found for editor ${editorId} in locale ${normalizedLocale}.`);
-  return null;
-};
-
-export const listBanterLocales = (): string[] => Object.keys(BANKS);

--- a/src/ai/difficulty.ts
+++ b/src/ai/difficulty.ts
@@ -1,92 +1,139 @@
-// src/ai/difficulty.ts
-
-export type Difficulty = 'EASY' | 'NORMAL' | 'HARD' | 'INSANE';
+export type DifficultyTier = 'EASY' | 'NORMAL' | 'HARD' | 'INSANE';
+export type Difficulty = DifficultyTier;
 
 export interface BiasModifiers {
   combo: number;
   income: number;
+  mediaWeight?: number;
+  attackWeight?: number;
+  zoneWeight?: number;
+  targetOwnedStateBias?: number;
+  targetNeutralStateBias?: number;
+  targetEnemyStateBias?: number;
+  comboAggression?: number;
 }
 
-export type AiConfig = {
+export interface AiConfig {
+  aggression: number;
+  denialPriority: number;
+  resourceValue: number;
+  riskTolerance: number;
+  randomness: number;
+  valueTruthSwing: number;
   lookaheadDepth: number;
-  beamWidth: number;
   rolloutsPerBranch: number;
-  randomness: number;      // 0..1
-  riskTolerance: number;   // 0..1
-  aggression: number;      // 0..1
-  denialPriority: number;  // 0..1
-  valueTruthSwing: number; // weight scaler
-  resourceValue: number;   // weight scaler
+  beamWidth: number;
   biasModifiers: BiasModifiers;
-  metaCheatPeekTopCard?: boolean;
+}
+
+export const DIFFICULTY_MULT = {
+  EASY:   { ipIncomeScalar:0.90, comboAggression:0.90, mediaWeightBias:1.00, attackWeightBias:0.95, zoneWeightBias:1.00 },
+  NORMAL: { ipIncomeScalar:1.00, comboAggression:1.00, mediaWeightBias:1.00, attackWeightBias:1.00, zoneWeightBias:1.00 },
+  HARD:   { ipIncomeScalar:1.10, comboAggression:1.15, mediaWeightBias:1.00, attackWeightBias:1.05, zoneWeightBias:1.05 },
+  INSANE: { ipIncomeScalar:1.20, comboAggression:1.25, mediaWeightBias:1.00, attackWeightBias:1.10, zoneWeightBias:1.10 },
+} as const satisfies Record<DifficultyTier, {
+  ipIncomeScalar: number;
+  comboAggression: number;
+  mediaWeightBias: number;
+  attackWeightBias: number;
+  zoneWeightBias: number;
+}>;
+
+const DEFAULT_BIAS: BiasModifiers = {
+  combo: 1,
+  income: 1,
+  mediaWeight: 1,
+  attackWeight: 1,
+  zoneWeight: 1,
+  targetOwnedStateBias: 1,
+  targetNeutralStateBias: 1,
+  targetEnemyStateBias: 1,
+  comboAggression: 1,
 };
 
-const clampBiasScalar = (value: number, fallback: number): number => {
-  if (!Number.isFinite(value)) {
-    return fallback;
-  }
-  return Math.min(1.75, Math.max(0.5, value));
+const applyMultipliers = (tier: DifficultyTier): BiasModifiers => {
+  const mult = DIFFICULTY_MULT[tier];
+  return {
+    combo: mult.comboAggression,
+    income: mult.ipIncomeScalar,
+    mediaWeight: mult.mediaWeightBias,
+    attackWeight: mult.attackWeightBias,
+    zoneWeight: mult.zoneWeightBias,
+    targetOwnedStateBias: 1,
+    targetNeutralStateBias: 1,
+    targetEnemyStateBias: 1,
+    comboAggression: mult.comboAggression,
+  };
 };
 
-export const mergeBiasModifiers = (
-  base: BiasModifiers,
-  overrides?: Partial<BiasModifiers>,
-): BiasModifiers => ({
-  combo: clampBiasScalar(overrides?.combo ?? base.combo, base.combo),
-  income: clampBiasScalar(overrides?.income ?? base.income, base.income),
-});
+const createConfig = (
+  tier: DifficultyTier,
+  overrides: Partial<Omit<AiConfig, 'biasModifiers'>> & { biasModifiers?: Partial<BiasModifiers> } = {},
+): AiConfig => {
+  const base: Omit<AiConfig, 'biasModifiers'> = {
+    aggression: tier === 'EASY' ? 0.35 : tier === 'NORMAL' ? 0.55 : tier === 'HARD' ? 0.7 : 0.8,
+    denialPriority: tier === 'EASY' ? 0.3 : tier === 'NORMAL' ? 0.5 : tier === 'HARD' ? 0.65 : 0.75,
+    resourceValue: tier === 'EASY' ? 0.45 : tier === 'NORMAL' ? 0.55 : tier === 'HARD' ? 0.6 : 0.65,
+    riskTolerance: tier === 'EASY' ? 0.25 : tier === 'NORMAL' ? 0.45 : tier === 'HARD' ? 0.6 : 0.7,
+    randomness: tier === 'EASY' ? 0.15 : tier === 'NORMAL' ? 0.08 : tier === 'HARD' ? 0.05 : 0.03,
+    valueTruthSwing: tier === 'EASY' ? 0.55 : tier === 'NORMAL' ? 0.65 : tier === 'HARD' ? 0.75 : 0.85,
+    lookaheadDepth: tier === 'EASY' ? 1 : tier === 'NORMAL' ? 2 : tier === 'HARD' ? 2.5 : 3,
+    rolloutsPerBranch: tier === 'EASY' ? 0 : tier === 'NORMAL' ? 1 : tier === 'HARD' ? 2 : 3,
+    beamWidth: tier === 'EASY' ? 1 : tier === 'NORMAL' ? 2 : tier === 'HARD' ? 3 : 4,
+  };
 
-export const AI_PRESETS: Record<Difficulty, AiConfig> = {
-  EASY: {
-    lookaheadDepth: 0,
-    beamWidth: 1,
-    rolloutsPerBranch: 0,
-    randomness: 0.35,
-    riskTolerance: 0.75,
-    aggression: 0.30,
-    denialPriority: 0.15,
-    valueTruthSwing: 0.6,
-    resourceValue: 0.4,
-    biasModifiers: { combo: 0.85, income: 0.9 },
-    metaCheatPeekTopCard: false,
-  },
-  NORMAL: {
-    lookaheadDepth: 1,
-    beamWidth: 3,
-    rolloutsPerBranch: 4,
-    randomness: 0.12,
-    riskTolerance: 0.45,
-    aggression: 0.55,
-    denialPriority: 0.45,
-    valueTruthSwing: 1.0,
-    resourceValue: 0.8,
-    biasModifiers: { combo: 1.0, income: 1.0 },
-    metaCheatPeekTopCard: false,
-  },
-  HARD: {
-    lookaheadDepth: 2,
-    beamWidth: 6,
-    rolloutsPerBranch: 16,
-    randomness: 0.03,
-    riskTolerance: 0.25,
-    aggression: 0.75,
-    denialPriority: 0.70,
-    valueTruthSwing: 1.3,
-    resourceValue: 1.1,
-    biasModifiers: { combo: 1.2, income: 1.15 },
-    metaCheatPeekTopCard: false,
-  },
-  INSANE: {
-    lookaheadDepth: 3,
-    beamWidth: 8,
-    rolloutsPerBranch: 24,
-    randomness: 0.01,
-    riskTolerance: 0.15,
-    aggression: 0.85,
-    denialPriority: 0.90,
-    valueTruthSwing: 1.5,
-    resourceValue: 1.2,
-    biasModifiers: { combo: 1.35, income: 1.25 },
-    metaCheatPeekTopCard: true,
-  },
+  const mergedBase = { ...base, ...overrides } satisfies Omit<AiConfig, 'biasModifiers'>;
+  const mergedBias = mergeBiasModifiers(applyMultipliers(tier), overrides.biasModifiers);
+
+  return { ...mergedBase, biasModifiers: mergedBias };
 };
+
+export const AI_PRESETS: Record<DifficultyTier, AiConfig> = {
+  EASY: createConfig('EASY', {
+    randomness: 0.18,
+    riskTolerance: 0.2,
+    valueTruthSwing: 0.5,
+  }),
+  NORMAL: createConfig('NORMAL'),
+  HARD: createConfig('HARD', {
+    rolloutsPerBranch: 2,
+    randomness: 0.04,
+  }),
+  INSANE: createConfig('INSANE', {
+    rolloutsPerBranch: 3,
+    randomness: 0.02,
+    beamWidth: 5,
+  }),
+};
+
+function coerceMultiplier(value: unknown, fallback: number): number {
+  const num = typeof value === 'number' && Number.isFinite(value) ? value : fallback;
+  if (!Number.isFinite(num)) return fallback;
+  return Math.max(-4, Math.min(4, num));
+}
+
+export function mergeBiasModifiers(
+  base: Partial<BiasModifiers> | undefined,
+  overrides: Partial<BiasModifiers> | undefined,
+): BiasModifiers {
+  const initial: BiasModifiers = { ...DEFAULT_BIAS, ...(base ?? {}) };
+  const result: BiasModifiers = { ...DEFAULT_BIAS, ...initial };
+
+  const apply = (target: BiasModifiers, source: Partial<BiasModifiers> | undefined, multiply = false) => {
+    if (!source) return;
+    for (const key of Object.keys(source) as (keyof BiasModifiers)[]) {
+      const value = source[key];
+      if (typeof value !== 'number' || !Number.isFinite(value)) continue;
+      const baseValue = typeof target[key] === 'number' ? target[key] as number : 1;
+      target[key] = (multiply ? baseValue * value : value) as BiasModifiers[typeof key];
+    }
+  };
+
+  // overrides should compound multiplicatively on top of base profile
+  apply(result, overrides, true);
+
+  result.combo = coerceMultiplier(result.combo, 1) || 1;
+  result.income = coerceMultiplier(result.income, 1) || 1;
+
+  return result;
+}

--- a/src/ai/editors.map.ts
+++ b/src/ai/editors.map.ts
@@ -1,0 +1,16 @@
+import type { EditorId } from './editors';
+import type { DifficultyTier } from './difficulty';
+
+export function recommendEditor(faction:'truth'|'government', diff:DifficultyTier): EditorId {
+  if (faction === 'government') {
+    if (diff === 'EASY')   return 'editor_redactor';
+    if (diff === 'NORMAL') return 'editor_smitherson';
+    if (diff === 'HARD')   return 'editor_mkunit';
+    return 'editor_cigs'; // INSANE
+  } else {
+    if (diff === 'EASY')   return 'editor_mothwoman';
+    if (diff === 'NORMAL') return 'editor_muldrunk';
+    if (diff === 'HARD')   return 'editor_batboy';
+    return 'editor_hunter'; // INSANE
+  }
+}

--- a/src/ai/editors.ts
+++ b/src/ai/editors.ts
@@ -1,215 +1,63 @@
-import { AI_PRESETS, mergeBiasModifiers, type BiasModifiers, type Difficulty } from "./difficulty";
-
 export type EditorId =
-  | "fox_muldrunk"
-  | "florida_man"
-  | "el_visto"
-  | "hunter_s_thampson"
-  | "agnes_inkwraith"
-  | "delta_echo"
-  | "sybil_margin"
-  | "nocturne_typesetter";
+  | 'editor_muldrunk' | 'editor_floridaman' | 'editor_elvis' | 'editor_hunter'
+  | 'editor_batboy'   | 'editor_mothwoman'  | 'editor_smitherson' | 'editor_cigs'
+  | 'editor_bureau'   | 'editor_mkunit'     | 'editor_blackbudget'| 'editor_redactor';
 
-export type DifficultyTier = Difficulty;
-
-export interface AIPersonality {
-  description: string;
-  curiosity: number; // appetite for uncovering new leads
-  caution: number; // willingness to hedge before publishing
-  improvisation: number; // comfort with chaotic board states
-  bravado: number; // taste for risky headline plays
-  escalation: number; // tendency to press the attack once an opening appears
-}
+export type DifficultyTier = 'EASY' | 'NORMAL' | 'HARD' | 'INSANE';
+export type AIPersonality = 'balanced' | 'aggressive' | 'manipulator' | 'defensive' | 'chaotic' | 'methodical';
 
 export interface EditorProfile {
   id: EditorId;
-  codename: string;
-  coverTitle: string;
+  faction: 'truth' | 'government' | 'neutral';
+  name: string;
+  title?: string;
   difficulty: DifficultyTier;
-  desks: string[];
-  specialty: string;
-  personality: AIPersonality;
-  defaultLocale: string;
-  biasModifiers: BiasModifiers;
+  aiPersonality: AIPersonality;
+  biasModifiers?: {
+    mediaWeight?: number; attackWeight?: number; zoneWeight?: number;
+    targetOwnedStateBias?: number; targetNeutralStateBias?: number; targetEnemyStateBias?: number;
+    comboAggression?: number;
+  };
+  runtimeModifiers?: {
+    ipIncomeScalar?: number;   // startTurn income ×=
+    mediaTruthDelta?: number;  // MEDIA truth +=
+    attackCostDelta?: number;  // ATTACK IP cost +=
+    zonePressureBonus?: number;// ZONE pressure +=
+  };
+  image?: { portrait?: string; broll?: string };
+  signature?: string;
 }
 
-const createPersonality = (
-  description: string,
-  values: Omit<AIPersonality, "description">,
-): AIPersonality => ({
-  description,
-  ...values,
-});
-
-const createBiasModifiers = (
-  difficulty: Difficulty,
-  overrides?: Partial<BiasModifiers>,
-): BiasModifiers => {
-  const base = AI_PRESETS[difficulty].biasModifiers;
-  return mergeBiasModifiers(base, overrides);
-};
-
 export const AI_EDITORS: Record<EditorId, EditorProfile> = {
-  fox_muldrunk: {
-    id: "fox_muldrunk",
-    codename: "Fox Muldrunk",
-    coverTitle: "Basement Desk Sleuth",
-    difficulty: "NORMAL",
-    desks: ["Investigations", "Cold Files"],
-    specialty: "Connects redacted dots before anyone else bothers to notice they align.",
-    personality: createPersonality(
-      "A believer with a corkboard empire and more leads than sleep.",
-      {
-        curiosity: 0.9,
-        caution: 0.55,
-        improvisation: 0.65,
-        bravado: 0.45,
-        escalation: 0.6,
-      },
-    ),
-    defaultLocale: "en-US",
-    biasModifiers: createBiasModifiers("NORMAL", { combo: 1.1, income: 0.95 }),
-  },
-  florida_man: {
-    id: "florida_man",
-    codename: "Florida Man",
-    coverTitle: "Chaos Stringer",
-    difficulty: "NORMAL",
-    desks: ["Breaking Weird", "Disaster Lifestyle"],
-    specialty: "Turns every hotline tip into a statewide emergency drill.",
-    personality: createPersonality(
-      "Breathes conspiracy humidity and thrives on reactive plays.",
-      {
-        curiosity: 0.7,
-        caution: 0.25,
-        improvisation: 0.9,
-        bravado: 0.85,
-        escalation: 0.8,
-      },
-    ),
-    defaultLocale: "en-US",
-    biasModifiers: createBiasModifiers("NORMAL", { combo: 1.05, income: 0.9 }),
-  },
-  el_visto: {
-    id: "el_visto",
-    codename: "El Visto",
-    coverTitle: "Vegas Residency Reviewer",
-    difficulty: "EASY",
-    desks: ["Entertainment", "Anomalous Sightings"],
-    specialty: "Stacks stagecraft reveals with real sightings until audiences forget which is which.",
-    personality: createPersonality(
-      "Charming showman who slow-plays the weird until the encore.",
-      {
-        curiosity: 0.6,
-        caution: 0.45,
-        improvisation: 0.7,
-        bravado: 0.6,
-        escalation: 0.5,
-      },
-    ),
-    defaultLocale: "en-US",
-    biasModifiers: createBiasModifiers("EASY", { combo: 0.9, income: 0.95 }),
-  },
-  hunter_s_thampson: {
-    id: "hunter_s_thampson",
-    codename: "Hunter S. Thampson",
-    coverTitle: "Gonzo Bureau Chief",
-    difficulty: "HARD",
-    desks: ["Field Reports", "Chemical Accountability"],
-    specialty: "Drops manifesto-length exposes mid-chase and dares rivals to keep up.",
-    personality: createPersonality(
-      "A rolling thundercloud of deadline adrenaline.",
-      {
-        curiosity: 0.8,
-        caution: 0.3,
-        improvisation: 0.75,
-        bravado: 0.9,
-        escalation: 0.85,
-      },
-    ),
-    defaultLocale: "en-US",
-    biasModifiers: createBiasModifiers("HARD", { combo: 1.25, income: 1.1 }),
-  },
-  agnes_inkwraith: {
-    id: "agnes_inkwraith",
-    codename: "Agnes Inkwraith",
-    coverTitle: "Obituary Revisionist",
-    difficulty: "HARD",
-    desks: ["Archives", "Occult Estates"],
-    specialty: "Excavates censored obits to expose immortal donors and their shadow trusts.",
-    personality: createPersonality(
-      "Keeps ledgers of restless sources and pays debts in secrets.",
-      {
-        curiosity: 0.85,
-        caution: 0.7,
-        improvisation: 0.4,
-        bravado: 0.35,
-        escalation: 0.55,
-      },
-    ),
-    defaultLocale: "en-US",
-    biasModifiers: createBiasModifiers("HARD", { combo: 1.1, income: 1.25 }),
-  },
-  delta_echo: {
-    id: "delta_echo",
-    codename: "Delta Echo",
-    coverTitle: "Numbers Station Ombudsman",
-    difficulty: "INSANE",
-    desks: ["Signals", "Cipher Watch"],
-    specialty: "Decodes broadcast anomalies before the agencies notice their encryption glitched.",
-    personality: createPersonality(
-      "A walking shortwave antenna who plays the board four transmissions ahead.",
-      {
-        curiosity: 0.75,
-        caution: 0.8,
-        improvisation: 0.55,
-        bravado: 0.4,
-        escalation: 0.65,
-      },
-    ),
-    defaultLocale: "en-US",
-    biasModifiers: createBiasModifiers("INSANE", { combo: 1.4, income: 1.3 }),
-  },
-  sybil_margin: {
-    id: "sybil_margin",
-    codename: "Sybil Margin",
-    coverTitle: "Probability Columnist",
-    difficulty: "HARD",
-    desks: ["Analytics", "Future Crime"],
-    specialty: "Publishes predictive spreads that make the odds blink first.",
-    personality: createPersonality(
-      "Cold reader of timelines with a fondness for impossible margins.",
-      {
-        curiosity: 0.65,
-        caution: 0.75,
-        improvisation: 0.5,
-        bravado: 0.55,
-        escalation: 0.6,
-      },
-    ),
-    defaultLocale: "en-US",
-    biasModifiers: createBiasModifiers("HARD", { combo: 1.18, income: 1.2 }),
-  },
-  nocturne_typesetter: {
-    id: "nocturne_typesetter",
-    codename: "Nocturne Typesetter",
-    coverTitle: "Midnight Edition Cartographer",
-    difficulty: "INSANE",
-    desks: ["Layout", "Temporal Logistics"],
-    specialty: "Maps tomorrow's front page onto today's operations without ripping the timeline.",
-    personality: createPersonality(
-      "Calm, precise, and allergic to paradox but willing to bend headlines through it.",
-      {
-        curiosity: 0.7,
-        caution: 0.85,
-        improvisation: 0.6,
-        bravado: 0.45,
-        escalation: 0.5,
-      },
-    ),
-    defaultLocale: "en-US",
-    biasModifiers: createBiasModifiers("INSANE", { combo: 1.32, income: 1.35 }),
-  },
+  // TRUTH
+  editor_muldrunk:   { id:'editor_muldrunk', faction:'truth', name:'Fox Muldrunk', difficulty:'NORMAL', aiPersonality:'balanced',
+    biasModifiers:{ mediaWeight:1.10, zoneWeight:1.05 }, runtimeModifiers:{ mediaTruthDelta:+1 } },
+  editor_floridaman: { id:'editor_floridaman', faction:'truth', name:'Florida Man (Freelance)', difficulty:'HARD', aiPersonality:'chaotic',
+    biasModifiers:{ attackWeight:1.20, comboAggression:1.10 }, runtimeModifiers:{ attackCostDelta:-1 } },
+  editor_elvis:      { id:'editor_elvis', faction:'truth', name:'Elvis in Exile', difficulty:'NORMAL', aiPersonality:'balanced',
+    biasModifiers:{ mediaWeight:1.10 }, runtimeModifiers:{ mediaTruthDelta:+1 } },
+  editor_hunter:     { id:'editor_hunter', faction:'truth', name:'Hunter S. Tabloid', difficulty:'HARD', aiPersonality:'aggressive',
+    biasModifiers:{ mediaWeight:1.05, attackWeight:1.05 }, runtimeModifiers:{ mediaTruthDelta:+1, attackCostDelta:+1 } },
+  editor_batboy:     { id:'editor_batboy', faction:'truth', name:'Bat Boy Jr.', difficulty:'HARD', aiPersonality:'aggressive',
+    biasModifiers:{ zoneWeight:1.15, comboAggression:1.20 }, runtimeModifiers:{ zonePressureBonus:+1 } },
+  editor_mothwoman:  { id:'editor_mothwoman', faction:'truth', name:'Mothwoman of Copy Desk', difficulty:'EASY', aiPersonality:'defensive',
+    biasModifiers:{ mediaWeight:1.20, attackWeight:0.90 }, runtimeModifiers:{ mediaTruthDelta:+1, attackCostDelta:+1 } },
+
+  // GOVERNMENT
+  editor_smitherson: { id:'editor_smitherson', faction:'government', name:'Agent Smitherson', difficulty:'NORMAL', aiPersonality:'balanced',
+    biasModifiers:{ mediaWeight:1.15 }, runtimeModifiers:{ ipIncomeScalar:1.10, mediaTruthDelta:-1 } },
+  editor_cigs:       { id:'editor_cigs', faction:'government', name:'Cigarette Whisperer', difficulty:'INSANE', aiPersonality:'aggressive',
+    biasModifiers:{ attackWeight:1.25, comboAggression:1.25 }, runtimeModifiers:{ ipIncomeScalar:1.10, mediaTruthDelta:-1, attackCostDelta:-1 } },
+  editor_bureau:     { id:'editor_bureau', faction:'government', name:'Bureau Chief Deep Throat', difficulty:'HARD', aiPersonality:'manipulator',
+    biasModifiers:{ zoneWeight:1.10, targetNeutralStateBias:1.10 }, runtimeModifiers:{ zonePressureBonus:+1 } },
+  editor_mkunit:     { id:'editor_mkunit', faction:'government', name:'MK-Editor Unit 7', difficulty:'HARD', aiPersonality:'methodical',
+    biasModifiers:{ comboAggression:1.10 }, runtimeModifiers:{ ipIncomeScalar:1.10, attackCostDelta:+1 } },
+  editor_blackbudget:{ id:'editor_blackbudget', faction:'government', name:'Black Budget Comptroller', difficulty:'NORMAL', aiPersonality:'manipulator',
+    biasModifiers:{ attackWeight:1.10 }, runtimeModifiers:{ attackCostDelta:-1, zonePressureBonus:-1 } },
+  editor_redactor:   { id:'editor_redactor', faction:'government', name:'The Redactor', difficulty:'EASY', aiPersonality:'defensive',
+    biasModifiers:{ mediaWeight:0.90 }, runtimeModifiers:{ mediaTruthDelta:-2 } },
 };
 
 export const EDITOR_IDS = Object.keys(AI_EDITORS) as EditorId[];
+
+export function getEditor(id: EditorId) { return AI_EDITORS[id]; }

--- a/src/game/editorImages.ts
+++ b/src/game/editorImages.ts
@@ -1,0 +1,4 @@
+export const portraitUrl = (id:string, explicit?:string) =>
+  explicit ?? `/images/editors/${id}/portrait.jpg`;
+export const brollUrl    = (id:string, explicit?:string) =>
+  explicit ?? `/images/editors/${id}/broll.jpg`;


### PR DESCRIPTION
## Summary
- define canonical AI editor profiles with faction, difficulty, and runtime modifiers
- publish difficulty presets, recommendation helpers, and typed banter bank loader
- add banter JSON stubs plus placeholder portraits/b-roll for each editor and log the update

## Testing
- npm run build
- npm run lint *(fails: existing repository lint violations)*
- bun test --coverage --coverage-reporter=text *(fails: existing repository test suite issues)*

------
https://chatgpt.com/codex/tasks/task_e_68e60c6871bc832090180ce254ad3a9b