### PR TITLE
Add runtime modifier helper for editors

### DIFF
--- a/src/game/editorRuntimeModifiers.ts
+++ b/src/game/editorRuntimeModifiers.ts
@@ -1,0 +1,20 @@
+import type { DifficultyTier } from '@/ai/difficulty';
+import { DIFFICULTY_MULT } from '@/ai/difficulty';
+import type { EditorProfile } from '@/ai/editors';
+
+export function resolveEffectiveMods(editor: EditorProfile, diff: DifficultyTier) {
+  const d = DIFFICULTY_MULT[diff];
+  const r = editor.runtimeModifiers ?? {};
+  return {
+    ipIncomeScalar:    (r.ipIncomeScalar ?? 1) * d.ipIncomeScalar,
+    mediaTruthDelta:   (r.mediaTruthDelta ?? 0),
+    attackCostDelta:   (r.attackCostDelta ?? 0),
+    zonePressureBonus: (r.zonePressureBonus ?? 0),
+    weightBias: {
+      media:  (editor.biasModifiers?.mediaWeight  ?? 1) * d.mediaWeightBias,
+      attack: (editor.biasModifiers?.attackWeight ?? 1) * d.attackWeightBias,
+      zone:   (editor.biasModifiers?.zoneWeight   ?? 1) * d.zoneWeightBias,
+      comboAggression: (editor.biasModifiers?.comboAggression ?? 1) * d.comboAggression,
+    },
+  };
+}


### PR DESCRIPTION
## Summary
- add a helper that resolves editor runtime modifiers while applying the active difficulty multipliers for incomes and weight biases

## Testing
- `npm run lint` *(fails: existing lint violations across unrelated files)*
- `bun test --coverage --coverage-reporter=text` *(fails: existing integration and engine test failures along with missing exports)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68e6103c52c08320b96a6fc62b5abde6