### PR TITLE
Add editor banter triggers for gameplay events

### DIFF
--- a/UPDATES_LOG.md
+++ b/UPDATES_LOG.md
@@ -2,6 +2,10 @@
 
 This document provides a chronological record of gameplay-impacting changes merged into State Shift Strategy. Each entry should include the merge date and a brief, human-readable summary so future contributors can quickly understand how the game has evolved.
 
+## 2025-11-11 – Editors comment on plays and captures
+- Introduced a banter engine with rate limits so player editors react to card plays, state flips, and match outcomes without flooding the log.
+- Added a temporary console fallback while waiting on a dedicated toast surface for editor chatter.
+
 ## 2025-11-10 – Paranoid flavor realignment across pools
 - Refreshed state pool, agenda issue, and hotspot flavor to emphasize conspiracy levers over food motifs and documented paranoia intents inline.
 - Updated copy-driven fixtures to remove culinary phrasing and reflagged QR loyalty checks, maritime leaks, and dimensional portals.

--- a/src/ai/banter/banterEngine.ts
+++ b/src/ai/banter/banterEngine.ts
@@ -1,0 +1,113 @@
+import { getBanterBank } from './index';
+import { getEditor, type EditorId } from '../editors';
+
+export type TriggerKey =
+  | 'onCardPlay_media_self' | 'onCardPlay_media_opponent'
+  | 'onCardPlay_attack_self'| 'onCardPlay_attack_opponent'
+  | 'onCardPlay_zone_self'  | 'onCardPlay_zone_opponent'
+  | 'onStateCaptured_self'  | 'onStateCaptured_opponent'
+  | 'onStateLost_self'      | 'onStateLost_opponent'
+  | 'onTruthThreshold_75'   | 'onTruthThreshold_95'
+  | 'onComboActivated_self' | 'onComboActivated_opponent'
+  | 'onVictory_self'        | 'onDefeat_self'
+  | 'idle';
+
+type CardPlayCategory = 'ATTACK' | 'MEDIA' | 'ZONE';
+
+type BanterRateLimit = { minTurnGap?: number; maxPerTurn?: number };
+
+export type BanterUi = (message: string) => void;
+
+export const defaultBanterUi: BanterUi = message => {
+  if (typeof window !== 'undefined') {
+    const toast = (window as unknown as { uiToastBanter?: (msg: string) => void }).uiToastBanter;
+    if (typeof toast === 'function') {
+      toast(message);
+      return;
+    }
+  }
+  if (typeof console !== 'undefined' && typeof console.warn === 'function') {
+    console.warn(message);
+  }
+};
+
+const defaultRateLimit: Required<BanterRateLimit> = { minTurnGap: 1, maxPerTurn: 2 };
+
+const cardPlayTriggers: Record<'self' | 'opponent', Record<CardPlayCategory, TriggerKey>> = {
+  self: {
+    ATTACK: 'onCardPlay_attack_self',
+    MEDIA: 'onCardPlay_media_self',
+    ZONE: 'onCardPlay_zone_self',
+  },
+  opponent: {
+    ATTACK: 'onCardPlay_attack_opponent',
+    MEDIA: 'onCardPlay_media_opponent',
+    ZONE: 'onCardPlay_zone_opponent',
+  },
+};
+
+const stateChangeTriggers: Record<'captured' | 'lost', Record<'self' | 'opponent', TriggerKey>> = {
+  captured: {
+    self: 'onStateCaptured_self',
+    opponent: 'onStateCaptured_opponent',
+  },
+  lost: {
+    self: 'onStateLost_self',
+    opponent: 'onStateLost_opponent',
+  },
+};
+
+let lastTurnSpoken = -999;
+let spokenThisTurn = 0;
+
+const resolveRateLimit = (rateLimit?: BanterRateLimit) => {
+  const min = Number.isFinite(rateLimit?.minTurnGap)
+    ? Math.max(0, Math.trunc(rateLimit?.minTurnGap as number))
+    : defaultRateLimit.minTurnGap;
+  const max = Number.isFinite(rateLimit?.maxPerTurn)
+    ? Math.max(0, Math.trunc(rateLimit?.maxPerTurn as number))
+    : defaultRateLimit.maxPerTurn;
+  return { minTurnGap: min, maxPerTurn: max };
+};
+
+export const getCardPlayTrigger = (
+  category: CardPlayCategory,
+  perspective: 'self' | 'opponent',
+): TriggerKey => cardPlayTriggers[perspective][category];
+
+export const getStateChangeTrigger = (
+  change: 'captured' | 'lost',
+  perspective: 'self' | 'opponent',
+): TriggerKey => stateChangeTriggers[change][perspective];
+
+export async function emitBanter(
+  editorId: string,
+  trigger: TriggerKey,
+  turn: number,
+  ui: BanterUi,
+): Promise<void> {
+  try {
+    const bank = await getBanterBank(editorId as EditorId);
+    const rateLimit = resolveRateLimit(bank.rateLimit);
+    if (turn !== lastTurnSpoken) {
+      lastTurnSpoken = turn;
+      spokenThisTurn = 0;
+    }
+    if (spokenThisTurn >= rateLimit.maxPerTurn) {
+      return;
+    }
+    if (spokenThisTurn > 0 && turn - lastTurnSpoken < rateLimit.minTurnGap) {
+      return;
+    }
+    const options = bank.triggers?.[trigger] ?? [];
+    if (!options.length) {
+      return;
+    }
+    const choice = options[Math.floor(Math.random() * options.length)];
+    const name = getEditor(editorId as EditorId)?.name ?? 'Editor';
+    ui(`[${name}] ${choice}`);
+    spokenThisTurn += 1;
+  } catch {
+    // no-op by design – banter should never block gameplay
+  }
+}

--- a/src/hooks/aiHelpers.ts
+++ b/src/hooks/aiHelpers.ts
@@ -10,11 +10,23 @@ import type { TurnPlay } from '@/game/combo.types';
 import type { PlayedLite } from '@/news/headlineEngine';
 import type { PlayerId } from '@/mvp/validator';
 import type { WeightedHotspotCandidate } from '@/systems/paranormalHotspots';
+import { emitBanter, defaultBanterUi, getCardPlayTrigger } from '@/ai/banter/banterEngine';
 
 import type { CardPlayRecord, GameState } from './gameStateTypes';
 import { mergeStateEventHistories } from './stateEventHistory';
 
 const CAPTURE_REGEX = /(captured|seized)\s+([^!]+)!/i;
+
+const normalizeCardCategory = (value: GameCard['type']): 'ATTACK' | 'MEDIA' | 'ZONE' => {
+  const normalized = String(value ?? '').toUpperCase();
+  if (normalized.includes('ZONE')) {
+    return 'ZONE';
+  }
+  if (normalized.includes('MEDIA')) {
+    return 'MEDIA';
+  }
+  return 'ATTACK';
+};
 
 const matchesResolvedHotspot = (
   active: WeightedHotspotCandidate | null,
@@ -404,6 +416,11 @@ export const applyAiCardPlay = (
   }
 
   const resolution = resolveCardMVP(prev, resolvedCard, targetState ?? null, 'ai', achievements);
+  const playerEditorId = prev.playerEditor ?? prev.editorId ?? null;
+  if (playerEditorId) {
+    const category = normalizeCardCategory(resolvedCard.type);
+    void emitBanter(playerEditorId, getCardPlayTrigger(category, 'opponent'), prev.turn, defaultBanterUi);
+  }
   const logEntries = [...prev.log, ...resolution.logEntries];
   const strategyLogEntries = buildStrategyLogEntries(reasoning, strategyDetails);
 

--- a/src/hooks/useGameState.ts
+++ b/src/hooks/useGameState.ts
@@ -91,6 +91,7 @@ import { loadNewsPools } from '@/news/newsPools';
 import type { ArticleBlock, TurnLog, PlayedLite } from '@/news/headlineEngine';
 import { initNewsPools } from '@/engine/news/newsPools';
 import type { GameOverReport } from '@/types/finalEdition';
+import { emitBanter, defaultBanterUi, getCardPlayTrigger } from '@/ai/banter/banterEngine';
 
 const omitClashKey = (key: string, value: unknown) => (key === 'clash' ? undefined : value);
 
@@ -470,6 +471,13 @@ const dispatchEditorTelemetry = (payload: EditorTelemetryPayload): void => {
   }
 
   // [EDITORS_TELEMETRY]
+  void emitBanter(
+    payload.editorId,
+    payload.playerWon ? 'onVictory_self' : 'onDefeat_self',
+    payload.turn,
+    defaultBanterUi,
+  );
+
   if (typeof window !== 'undefined') {
     const analytics = (window as typeof window & {
       shadowgovAnalytics?: {
@@ -3143,6 +3151,11 @@ export const useGameState = (aiDifficultyOverride?: AIDifficulty) => {
       const factionLabel: 'TRUTH' | 'GOV' = String(resolvedCard.faction ?? '').toUpperCase().includes('GOV')
         ? 'GOV'
         : 'TRUTH';
+
+      const playerEditorId = prev.playerEditor ?? prev.editorId ?? null;
+      if (playerEditorId) {
+        void emitBanter(playerEditorId, getCardPlayTrigger(derivedType, 'self'), prev.turn, defaultBanterUi);
+      }
 
       pushToNewsBuffer({
         id: resolvedCard.id,

--- a/src/systems/cardResolution.ts
+++ b/src/systems/cardResolution.ts
@@ -22,6 +22,12 @@ import {
   type HotspotResolutionOutcome,
 } from '@/systems/paranormalHotspots';
 import type { EditorId } from '@/game/editors';
+import {
+  emitBanter,
+  defaultBanterUi,
+  getStateChangeTrigger,
+  type TriggerKey,
+} from '@/ai/banter/banterEngine';
 
 type Faction = 'government' | 'truth';
 
@@ -113,6 +119,24 @@ export interface CardPlayResolution {
 
 const PLAYER_ID: PlayerId = 'P1';
 const AI_ID: PlayerId = 'P2';
+
+const resolvePlayerEditorId = (snapshot: GameSnapshot): string | null => {
+  const enriched = snapshot as GameSnapshot & {
+    playerEditorId?: EditorId | null;
+    playerEditor?: EditorId | null;
+    editorId?: EditorId | null;
+  };
+  const candidate = enriched.playerEditorId ?? enriched.playerEditor ?? enriched.editorId ?? null;
+  return typeof candidate === 'string' && candidate.length > 0 ? candidate : null;
+};
+
+const queueBanterForTrigger = (snapshot: GameSnapshot, trigger: TriggerKey) => {
+  const editorId = resolvePlayerEditorId(snapshot);
+  if (!editorId) {
+    return;
+  }
+  void emitBanter(editorId, trigger, snapshot.turn ?? 0, defaultBanterUi);
+};
 
 export type CardActor = 'human' | 'ai';
 
@@ -388,6 +412,8 @@ export function resolveCardMVP(
   const resolvedHotspots: string[] = [];
   const hotspotResolutions: CardHotspotResolution[] = [];
   let truthBonusFromHotspots = 0;
+  let emittedSelfCaptureBanter = false;
+  let emittedOpponentCaptureBanter = false;
   for (const state of newStates) {
     const beforePressurePlayer = beforeState.pressureByState[state.id]?.[PLAYER_ID] ?? 0;
     const afterPressurePlayer = engineState.pressureByState[state.id]?.[PLAYER_ID] ?? 0;
@@ -425,6 +451,10 @@ export function resolveCardMVP(
       if (targetStateId === state.id) {
         nextTargetState = null;
       }
+      if (!emittedSelfCaptureBanter) {
+        emittedSelfCaptureBanter = true;
+        queueBanterForTrigger(gameState, getStateChangeTrigger('captured', 'self'));
+      }
     } else if (previousOwner !== 'ai' && owner === 'ai') {
       const aiFaction = gameState.faction === 'truth' ? 'government' : 'truth';
       capturedStateIds.push(state.id);
@@ -432,6 +462,10 @@ export function resolveCardMVP(
       logEntries.push(`⚠️ ${card.name} seized ${state.name} for the enemy!`);
       if (targetStateId === state.id) {
         nextTargetState = null;
+      }
+      if (!emittedOpponentCaptureBanter) {
+        emittedOpponentCaptureBanter = true;
+        queueBanterForTrigger(gameState, getStateChangeTrigger('captured', 'opponent'));
       }
     } else if (targetStateId === state.id && card.type === 'ZONE') {
       const deltaPlayer = afterPressurePlayer - beforePressurePlayer;


### PR DESCRIPTION
## Summary
- add a reusable banter engine with rate limiting and trigger helpers for editors
- invoke editor banter when cards are played, states change hands, and games end
- record the feature addition in the updates log

## Testing
- npm run lint *(fails: existing lint violations throughout the repo)*
- bun test --coverage --coverage-reporter=text *(fails: pre-existing unit and integration test failures)*

------
https://chatgpt.com/codex/tasks/task_e_68e6143b79188320ab5878117d945cd2