### PR TITLE
Align AI editor selection with difficulty tiers

### DIFF
--- a/UPDATES_LOG.md
+++ b/UPDATES_LOG.md
@@ -23,6 +23,10 @@ This document provides a chronological record of gameplay-impacting changes merg
 - Added regression coverage ensuring TabloidNewspaperV2 renders unique hero headlines against the dispatch list.
 - Confirmed hero dispatch absences fall back to redacted copy instead of duplicating the main headline.
 
+## 2025-10-08 – Difficulty-aware AI editor binding
+- Map AI difficulty settings to the new editor roster, falling back from legacy IDs and automatically selecting the correct partner at game start.
+- Added runtime safety nets so MVP engines auto-bind an editor before applying difficulty-scaled modifiers.
+
 ## 2025-10-08 – Established AI editor roster and banter stubs
 - Replaced legacy editor prototypes with faction-aligned profiles including difficulty tiers, personalities, and runtime modifiers.
 - Published shared difficulty multipliers, recommendation helpers, and banter bank loader typings to anchor AI selection.

--- a/src/engine/applyEffects-mvp.ts
+++ b/src/engine/applyEffects-mvp.ts
@@ -12,6 +12,7 @@ import type {
 } from '@/mvp/validator';
 import { getEditorAggregatedEffects, getEditorById as lookupEditorById } from '@/game/editors';
 import { resolveEffectiveMods } from '@/game/editorRuntimeModifiers';
+import { ensureAiEditorSelected } from '@/game/aiEditorBinding';
 
 export type PlayerId = 'P1' | 'P2';
 
@@ -169,6 +170,7 @@ export function applyEffectsMvp(
   opts: MediaResolutionOptions = {},
   rng: () => number = Math.random,
 ): GameState {
+  ensureAiEditorSelected(state);
   if (card.type === 'ATTACK') {
     applyAttackEffect(state, owner, card.effects as EffectsATTACK, rng);
     return state;

--- a/src/game/aiEditorBinding.ts
+++ b/src/game/aiEditorBinding.ts
@@ -1,0 +1,25 @@
+import { recommendEditor } from '@/ai/editors.map';
+import { AI_EDITORS, type EditorId } from '@/ai/editors';
+import type { DifficultyTier } from '@/ai/difficulty';
+
+function getAiSideRef(state: any) {
+  return state?.players?.AI ?? state?.players?.ai ?? state?.ai ?? null;
+}
+
+function readDifficulty(state: any): DifficultyTier {
+  const d = state?.options?.difficulty
+    ?? (typeof localStorage !== 'undefined' ? localStorage.getItem('difficulty') : null);
+  return (['EASY', 'NORMAL', 'HARD', 'INSANE'] as const).includes(d as any) ? (d as DifficultyTier) : 'NORMAL';
+}
+
+export function ensureAiEditorSelected(state: any) {
+  if (!(state?.expansions?.aiEditors ?? true)) return;
+  const ai = getAiSideRef(state);
+  if (!ai) return;
+  if (ai.activeEditor && AI_EDITORS[ai.activeEditor as EditorId]) return;
+
+  const aiFaction = ai.faction === 'government' ? 'government' : 'truth';
+  const diff = readDifficulty(state);
+  ai.activeEditor = recommendEditor(aiFaction, diff);
+}
+

--- a/src/game/editorRuntimeModifiers.ts
+++ b/src/game/editorRuntimeModifiers.ts
@@ -1,5 +1,4 @@
-import type { DifficultyTier } from '@/ai/difficulty';
-import { DIFFICULTY_MULT } from '@/ai/difficulty';
+import { DIFFICULTY_MULT, type DifficultyTier } from '@/ai/difficulty';
 import type { EditorProfile } from '@/ai/editors';
 
 export function resolveEffectiveMods(editor: EditorProfile, diff: DifficultyTier) {

--- a/src/hooks/useGameState.ts
+++ b/src/hooks/useGameState.ts
@@ -21,6 +21,8 @@ import {
 import { type AIDifficulty } from '@/data/aiStrategy';
 import { AIFactory } from '@/data/aiFactory';
 import { EnhancedAIStrategist } from '@/data/enhancedAIStrategy';
+import { recommendEditor } from '@/ai/editors.map';
+import { AI_EDITORS } from '@/ai/editors';
 import { chooseTurnActions } from '@/ai/enhancedController';
 import { EVENT_DATABASE, EventManager, type GameEvent, type ParanormalHotspotPayload } from '@/data/eventDatabase';
 import { processAiActions } from './aiTurnActions';
@@ -31,6 +33,7 @@ import { resolveCardMVP, type CardPlayResolution, type CardHotspotResolution } f
 import { useStateEvents } from '@/hooks/useStateEvents';
 import { applyTruthDelta, type TruthActorId } from '@/utils/truth';
 import type { Difficulty } from '@/ai';
+import type { DifficultyTier } from '@/ai/difficulty';
 import { getDifficulty } from '@/state/settings';
 import { featureFlags } from '@/state/featureFlags';
 import { getComboSettings } from '@/game/comboEngine';
@@ -166,12 +169,20 @@ const resolveActiveEditorFromState = (state: GameState) => {
 
 const AI_DIFFICULTY_ORDER: readonly AIDifficulty[] = ['easy', 'medium', 'hard', 'insane'] as const;
 
-const DEFAULT_AI_EDITOR_ASSIGNMENTS: Record<AIDifficulty, Record<'truth' | 'government', EditorId>> = {
-  easy: { truth: 'the_redactor', government: 'the_redactor' },
-  medium: { truth: 'ed_muldrunk', government: 'ed_floridaman' },
-  hard: { truth: 'ed_el_visto', government: 'ed_gonzo' },
-  insane: { truth: 'ed_gonzo', government: 'ed_el_visto' },
+const LEGACY_EDITOR_ID_ALIASES: Record<string, EditorId> = {
+  the_redactor: 'editor_redactor',
+  ed_muldrunk: 'editor_muldrunk',
+  ed_floridaman: 'editor_floridaman',
+  ed_el_visto: 'editor_elvis',
+  ed_gonzo: 'editor_hunter',
 };
+
+const AI_DIFFICULTY_TO_TIER = {
+  easy: 'EASY',
+  medium: 'NORMAL',
+  hard: 'HARD',
+  insane: 'INSANE',
+} as const satisfies Record<AIDifficulty, DifficultyTier>;
 
 const LEGACY_AI_DIFFICULTY_ALIASES: Record<string, AIDifficulty> = {
   legendary: 'insane',
@@ -198,8 +209,23 @@ const normalizeEditorId = (value: unknown): EditorId | null => {
   if (typeof value !== 'string') {
     return null;
   }
+
   const trimmed = value.trim();
-  return trimmed.length > 0 ? (trimmed as EditorId) : null;
+  if (trimmed.length === 0) {
+    return null;
+  }
+
+  const directId = trimmed as EditorId;
+  if (Object.prototype.hasOwnProperty.call(AI_EDITORS, directId)) {
+    return directId;
+  }
+
+  const alias = LEGACY_EDITOR_ID_ALIASES[trimmed.toLowerCase()];
+  if (alias && Object.prototype.hasOwnProperty.call(AI_EDITORS, alias)) {
+    return alias;
+  }
+
+  return null;
 };
 
 const resolveAiEditorAssignment = ({
@@ -221,17 +247,13 @@ const resolveAiEditorAssignment = ({
     return null;
   }
 
-  const mapping = DEFAULT_AI_EDITOR_ASSIGNMENTS[normalizedDifficulty];
-  const mapped = mapping?.[aiFaction];
-  if (mapped) {
-    return mapped;
+  const tier = AI_DIFFICULTY_TO_TIER[normalizedDifficulty];
+  if (!tier) {
+    return null;
   }
 
-  if (normalizedDifficulty === 'easy') {
-    return 'the_redactor';
-  }
-
-  return null;
+  const recommended = recommendEditor(aiFaction, tier);
+  return normalizeEditorId(recommended) ?? null;
 };
 
 const createInitialAiBanterCooldown = (): AIBanterCooldownState => ({

--- a/src/mvp/engine.ts
+++ b/src/mvp/engine.ts
@@ -14,6 +14,7 @@ import type { Card, EffectsATTACK, EffectsMEDIA, EffectsZONE, GameState, PlayerS
 import type { MediaResolutionOptions } from './media';
 import { applyTruthDelta } from '@/utils/truth';
 import { resolveEffectiveMods } from '@/game/editorRuntimeModifiers';
+import { ensureAiEditorSelected } from '@/game/aiEditorBinding';
 import {
   getEditorAggregatedEffects,
   getEditorById as lookupEditorById,
@@ -291,6 +292,7 @@ export function computeTurnIpIncome(
 
 export function startTurn(state: GameState): GameState {
   const cloned = cloneGameState(state);
+  ensureAiEditorSelected(cloned);
   const currentId = cloned.currentPlayer;
   const me = cloned.players[currentId];
   const opponent = cloned.players[otherPlayer(currentId)];
@@ -447,6 +449,7 @@ export function canPlay(
   card: Card,
   targetStateId?: string,
 ): { ok: boolean; reason?: string; cost?: number } {
+  ensureAiEditorSelected(state);
   if (state.playsThisTurn >= 3) {
     return { ok: false, reason: 'play-limit' };
   }
@@ -503,6 +506,7 @@ export function playCard(
   rng: () => number = Math.random,
 ): GameState {
   const cloned = cloneGameState(state);
+  ensureAiEditorSelected(cloned);
   const currentId = cloned.currentPlayer;
   const player = cloned.players[currentId];
   const cardIndex = player.hand.findIndex(card => card.id === cardId);


### PR DESCRIPTION
## Summary
- add an AI editor binding helper that auto-selects the proper roster entry based on faction and difficulty
- update game state initialization to translate legacy editor ids, map difficulty settings to tiers, and reuse the new recommendations
- hook the binding helper into the MVP engine/applyEffects flow and document the change in the updates log

## Testing
- npm run lint *(fails: pre-existing lint violations across repo)*
- bun test --coverage --coverage-reporter=text *(fails: pre-existing unit and integration test regressions)*

------
https://chatgpt.com/codex/tasks/task_e_68e61ae1986c8320a636f658c98bbfd9