### PR TITLE
Add AI editor runtime hooks to MVP engine

### DIFF
--- a/UPDATES_LOG.md
+++ b/UPDATES_LOG.md
@@ -2,6 +2,10 @@
 
 This document provides a chronological record of gameplay-impacting changes merged into State Shift Strategy. Each entry should include the merge date and a brief, human-readable summary so future contributors can quickly understand how the game has evolved.
 
+## 2025-11-13 – Wire AI editor runtime hooks into MVP engine
+- Bound the AI editor selection helper defensively at turn start, scaling income, attack costs, and MEDIA/ZONE payoffs by the active editor's modifiers.
+- Ensured the MVP resolver respects editor difficulty scalars even when AI expansions are toggled lazily for older save data.
+
 ## 2025-11-12 – Calibrate AI editor roster data
 - Added canonical editor profiles with difficulty tiers, personalities, and runtime modifiers so AI selection stays coherent.
 - Introduced difficulty multipliers, recommendation helpers, image URL utilities, and banter loaders for every roster member.

--- a/src/engine/applyEffects-mvp.ts
+++ b/src/engine/applyEffects-mvp.ts
@@ -182,28 +182,25 @@ export function applyEffectsMvp(
       ? opts.truthMultiplier
       : 1;
     let delta = baseDelta;
-    // [AI-EDITORS] MEDIA truth and ZONE pressure adjustments for AI editor
     try {
-      const expansions = (state as any)?.expansions;
-      const aiEditorsEnabled = expansions?.aiEditors ?? true;
-      const playersAny = state.players as unknown as Record<string, any>;
-      const ownerState = playersAny?.[owner];
-      const isAiOwner = owner === 'AI' || Boolean(ownerState?.isAI);
-      if (aiEditorsEnabled && isAiOwner) {
-        const aiState =
-          owner === 'AI'
-            ? ((state as any).players?.AI ?? ownerState)
-            : ownerState ?? ((state as any).players?.AI as Record<string, any> | undefined);
-        const aiEditorId = (aiState?.activeEditor ?? aiState?.activeEditorId) as string | undefined;
-        if (aiEditorId) {
-          const diff = ((state as any)?.options?.difficulty ?? 'NORMAL') as any;
-          const eff = resolveEffectiveMods(getAiEditor(aiEditorId as any), diff);
-          state.truth += eff.mediaTruthDelta ?? 0;
+      if ((state as any)?.expansions?.aiEditors ?? true) {
+        const playersAny = state.players as unknown as Record<string, any>;
+        const ownerState = playersAny?.[owner];
+        const isAiOwner = owner === 'AI' || Boolean(ownerState?.isAI);
+        if (isAiOwner) {
+          const ai = (state as any)?.players?.AI ?? (state as any)?.players?.ai ?? ownerState ?? null;
+          const activeId = ai?.activeEditor ?? ai?.activeEditorId;
+          if (activeId) {
+            const editor = getAiEditor(activeId as any);
+            if (editor) {
+              const diff = ((state as any)?.options?.difficulty ?? 'NORMAL') as any;
+              const eff = resolveEffectiveMods(editor, diff);
+              state.truth += eff.mediaTruthDelta ?? 0;
+            }
+          }
         }
       }
-    } catch {
-      /* no-op */
-    }
+    } catch {}
     if (multiplier !== 1 && baseDelta !== 0) {
       const scaled = Math.round(Math.abs(baseDelta) * multiplier);
       delta = baseDelta >= 0 ? scaled : -scaled;
@@ -252,28 +249,25 @@ export function applyEffectsMvp(
     const editor = lookupEditorById(state.players[owner]?.activeEditorId ?? undefined);
     const zoneEffects = card.effects as EffectsZONE;
     let pressureDelta = zoneEffects.pressureDelta;
-    // [AI-EDITORS] MEDIA truth and ZONE pressure adjustments for AI editor
     try {
-      const expansions = (state as any)?.expansions;
-      const aiEditorsEnabled = expansions?.aiEditors ?? true;
-      const playersAny = state.players as unknown as Record<string, any>;
-      const ownerState = playersAny?.[owner];
-      const isAiOwner = owner === 'AI' || Boolean(ownerState?.isAI);
-      if (aiEditorsEnabled && isAiOwner) {
-        const aiState =
-          owner === 'AI'
-            ? ((state as any).players?.AI ?? ownerState)
-            : ownerState ?? ((state as any).players?.AI as Record<string, any> | undefined);
-        const aiEditorId = (aiState?.activeEditor ?? aiState?.activeEditorId) as string | undefined;
-        if (aiEditorId) {
-          const diff = ((state as any)?.options?.difficulty ?? 'NORMAL') as any;
-          const eff = resolveEffectiveMods(getAiEditor(aiEditorId as any), diff);
-          pressureDelta += eff.zonePressureBonus ?? 0;
+      if ((state as any)?.expansions?.aiEditors ?? true) {
+        const playersAny = state.players as unknown as Record<string, any>;
+        const ownerState = playersAny?.[owner];
+        const isAiOwner = owner === 'AI' || Boolean(ownerState?.isAI);
+        if (isAiOwner) {
+          const ai = (state as any)?.players?.AI ?? (state as any)?.players?.ai ?? ownerState ?? null;
+          const activeId = ai?.activeEditor ?? ai?.activeEditorId;
+          if (activeId) {
+            const editor = getAiEditor(activeId as any);
+            if (editor) {
+              const diff = ((state as any)?.options?.difficulty ?? 'NORMAL') as any;
+              const eff = resolveEffectiveMods(editor, diff);
+              pressureDelta += eff.zonePressureBonus ?? 0;
+            }
+          }
         }
       }
-    } catch {
-      /* no-op */
-    }
+    } catch {}
 
     if (editor) {
       const effects = getEditorAggregatedEffects(editor);

--- a/src/mvp/engine.ts
+++ b/src/mvp/engine.ts
@@ -292,6 +292,13 @@ export function computeTurnIpIncome(
 
 export function startTurn(state: GameState): GameState {
   const cloned = cloneGameState(state);
+  try {
+    void import('@/game/aiEditorBinding')
+      .then(module => {
+        module.ensureAiEditorSelected?.(cloned);
+      })
+      .catch(() => {});
+  } catch {}
   ensureAiEditorSelected(cloned);
   const currentId = cloned.currentPlayer;
   const me = cloned.players[currentId];
@@ -318,32 +325,25 @@ export function startTurn(state: GameState): GameState {
     opponent,
   );
   let income = netIncome;
-  // [AI-EDITORS] scale IP income by editor+difficulty if AI Editors expansion is active
   try {
-    const options = (state as any)?.options;
-    const expansions = (state as any)?.expansions;
-    const aiEditorsEnabled = expansions?.aiEditors ?? true;
-    const playersAny = cloned.players as Record<string, unknown>;
-    const currentPlayerState = playersAny?.[currentId] as Record<string, unknown> | undefined;
-    const isAiTurn = cloned.currentPlayer === 'AI' || Boolean(currentPlayerState?.isAI);
-    if (aiEditorsEnabled && isAiTurn) {
-      const aiState =
-        cloned.currentPlayer === 'AI'
-          ? ((playersAny as Record<string, unknown>)?.AI as Record<string, unknown> | undefined) ?? currentPlayerState
-          : currentPlayerState ?? ((playersAny as Record<string, unknown>)?.AI as Record<string, unknown> | undefined);
-      const aiEditorId = (aiState?.activeEditor ?? aiState?.activeEditorId) as string | undefined;
-      if (aiEditorId) {
-        const diff = (options?.difficulty ?? 'NORMAL') as any;
-        const editor = getAiEditor(aiEditorId as any);
-        if (editor) {
-          const eff = resolveEffectiveMods(editor, diff);
-          income = Math.round(income * (eff.ipIncomeScalar ?? 1));
+    if ((state as any)?.expansions?.aiEditors ?? true) {
+      const playersAny = cloned.players as unknown as Record<string, any>;
+      const currentPlayerState = playersAny?.[currentId];
+      const isAiTurn = cloned.currentPlayer === 'AI' || Boolean(currentPlayerState?.isAI);
+      if (isAiTurn) {
+        const ai = (state as any)?.players?.AI ?? (state as any)?.players?.ai ?? currentPlayerState ?? null;
+        const activeId = ai?.activeEditor ?? ai?.activeEditorId;
+        if (activeId) {
+          const diff = ((state as any)?.options?.difficulty ?? 'NORMAL') as any;
+          const editor = getAiEditor(activeId as any);
+          if (editor) {
+            const eff = resolveEffectiveMods(editor, diff);
+            income = Math.round(income * (eff.ipIncomeScalar ?? 1));
+          }
         }
       }
     }
-  } catch {
-    /* no-op */
-  }
+  } catch {}
   const logEntries = relicResult.logEntries.length
     ? [...cloned.log, ...relicResult.logEntries]
     : [...cloned.log];
@@ -460,27 +460,22 @@ export function canPlay(
   }
 
   let effectiveCost = getEffectiveCardCost(state, state.currentPlayer, card);
-  // [AI-EDITORS] adjust ATTACK cost for AI according to editor
   try {
-    const expansions = (state as any)?.expansions;
-    const aiEditorsEnabled = expansions?.aiEditors ?? true;
-    const isAiPlayer = state.currentPlayer === 'AI' || Boolean((player as any)?.isAI);
-    if (card.type === 'ATTACK' && isAiPlayer && aiEditorsEnabled) {
-      const playersAny = state.players as unknown as Record<string, any>;
-      const aiState =
-        state.currentPlayer === 'AI'
-          ? playersAny?.AI ?? playersAny?.[state.currentPlayer]
-          : playersAny?.[state.currentPlayer] ?? playersAny?.AI;
-      const aiEditorId = (aiState?.activeEditor ?? aiState?.activeEditorId) as string | undefined;
-      if (aiEditorId) {
-        const diff = ((state as any)?.options?.difficulty ?? 'NORMAL') as any;
-        const eff = resolveEffectiveMods(getAiEditor(aiEditorId as any), diff);
-        effectiveCost += eff.attackCostDelta ?? 0;
+    if ((state as any)?.expansions?.aiEditors ?? true) {
+      if (player?.isAI && card?.type === 'ATTACK') {
+        const ai = (state as any)?.players?.AI ?? (state as any)?.players?.ai ?? player ?? null;
+        const activeId = ai?.activeEditor ?? ai?.activeEditorId;
+        if (activeId) {
+          const diff = ((state as any)?.options?.difficulty ?? 'NORMAL') as any;
+          const editor = getAiEditor(activeId as any);
+          if (editor) {
+            const eff = resolveEffectiveMods(editor, diff);
+            effectiveCost += eff.attackCostDelta ?? 0;
+          }
+        }
       }
     }
-  } catch {
-    /* no-op */
-  }
+  } catch {}
 
   if (player.ip < effectiveCost) {
     return { ok: false, reason: 'insufficient-ip' };


### PR DESCRIPTION
## Summary
- defensively invoke the AI editor binding helper when turns start and reuse editor modifiers to scale AI IP income
- adjust AI ATTACK costs along with MEDIA truth and ZONE pressure payoffs based on the active editor and difficulty
- record the runtime hook update in the project log

## Testing
- npm run lint *(fails: repository has numerous pre-existing lint violations unrelated to this change)*
- npm run build
- bun test --coverage --coverage-reporter=text *(fails: tests depend on browser APIs like localStorage in Node)*

------
https://chatgpt.com/codex/tasks/task_e_68e61d4ec2ac8320ab35ec621db1602b