### PR TITLE
Add editor banter for state losses

### DIFF
--- a/UPDATES_LOG.md
+++ b/UPDATES_LOG.md
@@ -2,6 +2,10 @@
 
 This document provides a chronological record of gameplay-impacting changes merged into State Shift Strategy. Each entry should include the merge date and a brief, human-readable summary so future contributors can quickly understand how the game has evolved.
 
+## 2025-11-14 – Editors react to state swings
+- Routed editor banter through the state change logs so players hear from their editor when territories flip or fall back to neutral.
+- Added mirrored "state lost" callouts for AI takeovers to mirror the existing capture chatter and keep newsfeeds lively.
+
 ## 2025-11-13 – Wire AI editor runtime hooks into MVP engine
 - Bound the AI editor selection helper defensively at turn start, scaling income, attack costs, and MEDIA/ZONE payoffs by the active editor's modifiers.
 - Ensured the MVP resolver respects editor difficulty scalars even when AI expansions are toggled lazily for older save data.

--- a/src/systems/cardResolution.ts
+++ b/src/systems/cardResolution.ts
@@ -414,6 +414,8 @@ export function resolveCardMVP(
   let truthBonusFromHotspots = 0;
   let emittedSelfCaptureBanter = false;
   let emittedOpponentCaptureBanter = false;
+  let emittedSelfLossBanter = false;
+  let emittedOpponentLossBanter = false;
   for (const state of newStates) {
     const beforePressurePlayer = beforeState.pressureByState[state.id]?.[PLAYER_ID] ?? 0;
     const afterPressurePlayer = engineState.pressureByState[state.id]?.[PLAYER_ID] ?? 0;
@@ -455,6 +457,10 @@ export function resolveCardMVP(
         emittedSelfCaptureBanter = true;
         queueBanterForTrigger(gameState, getStateChangeTrigger('captured', 'self'));
       }
+      if (previousOwner === 'ai' && !emittedOpponentLossBanter) {
+        emittedOpponentLossBanter = true;
+        queueBanterForTrigger(gameState, getStateChangeTrigger('lost', 'opponent'));
+      }
     } else if (previousOwner !== 'ai' && owner === 'ai') {
       const aiFaction = gameState.faction === 'truth' ? 'government' : 'truth';
       capturedStateIds.push(state.id);
@@ -466,6 +472,20 @@ export function resolveCardMVP(
       if (!emittedOpponentCaptureBanter) {
         emittedOpponentCaptureBanter = true;
         queueBanterForTrigger(gameState, getStateChangeTrigger('captured', 'opponent'));
+      }
+      if (previousOwner === 'player' && !emittedSelfLossBanter) {
+        emittedSelfLossBanter = true;
+        queueBanterForTrigger(gameState, getStateChangeTrigger('lost', 'self'));
+      }
+    } else if (previousOwner === 'player' && owner === 'neutral') {
+      if (!emittedSelfLossBanter) {
+        emittedSelfLossBanter = true;
+        queueBanterForTrigger(gameState, getStateChangeTrigger('lost', 'self'));
+      }
+    } else if (previousOwner === 'ai' && owner === 'neutral') {
+      if (!emittedOpponentLossBanter) {
+        emittedOpponentLossBanter = true;
+        queueBanterForTrigger(gameState, getStateChangeTrigger('lost', 'opponent'));
       }
     } else if (targetStateId === state.id && card.type === 'ZONE') {
       const deltaPlayer = afterPressurePlayer - beforePressurePlayer;


### PR DESCRIPTION
## Summary
- trigger banter when states slip away to opponents or return to neutral control so editors react to losses as well as captures
- document the new chatter hooks in the updates log for future release notes

## Testing
- `npm run lint` *(fails: repository currently has pre-existing lint violations across multiple files)*
- `bun test --coverage --coverage-reporter=text`


------
https://chatgpt.com/codex/tasks/task_e_68e6201d6ac08320b56955efb667e599