### PR TITLE
Show AI opponent editor name in opponent HUD

### DIFF
--- a/UPDATES_LOG.md
+++ b/UPDATES_LOG.md
@@ -2,6 +2,10 @@
 
 This document provides a chronological record of gameplay-impacting changes merged into State Shift Strategy. Each entry should include the merge date and a brief, human-readable summary so future contributors can quickly understand how the game has evolved.
 
+## 2025-11-15 – Surface opponent editor identity
+- Updated the AI opponent HUD to show the active editor's name instead of generic handler titles in both desktop and mobile panels.
+- Synced the opponent status card to share that editor label so players can cross-check difficulty context at a glance.
+
 ## 2025-11-14 – Editors react to state swings
 - Routed editor banter through the state change logs so players hear from their editor when territories flip or fall back to neutral.
 - Added mirrored "state lost" callouts for AI takeovers to mirror the existing capture chatter and keep newsfeeds lively.

--- a/src/components/game/AIStatus.tsx
+++ b/src/components/game/AIStatus.tsx
@@ -9,7 +9,7 @@ import { SecretAgenda as AgendaType } from '@/data/agendaDatabase';
 
 interface AIStatusProps {
   difficulty: AIDifficulty;
-  personalityName?: string;
+  editorName?: string;
   isThinking?: boolean;
   currentPlayer: 'human' | 'ai';
   aiControlledStates: number;
@@ -25,7 +25,7 @@ interface AIStatusProps {
 
 const AIStatus = ({
   difficulty,
-  personalityName,
+  editorName,
   isThinking = false,
   currentPlayer,
   aiControlledStates,
@@ -76,9 +76,9 @@ const AIStatus = ({
         </div>
       </div>
 
-      {personalityName && (
+      {editorName && (
         <div className="text-xs text-gray-400 mb-2 font-mono">
-          {personalityName}
+          {editorName}
         </div>
       )}
 

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -13,6 +13,7 @@ import TabloidNewspaper from '@/components/game/TabloidNewspaper';
 import GameMenu from '@/components/game/GameMenu';
 import SecretAgenda from '@/components/game/SecretAgenda';
 import AIStatus from '@/components/game/AIStatus';
+import { AI_EDITORS } from '@/ai/editors';
 import EnhancedBalancingDashboard from '@/components/game/EnhancedBalancingDashboard';
 import Options from '@/components/game/Options';
 import { useGameState } from '@/hooks/useGameState';
@@ -2287,6 +2288,8 @@ const Index = () => {
     ? Math.min(100, (aiAgenda.progress / aiAgenda.target) * 100)
     : 0;
   const aiAssessment = gameState.aiStrategist?.getStrategicAssessment(gameState);
+  const aiEditorProfile = gameState.aiEditor ? AI_EDITORS[gameState.aiEditor] : null;
+  const aiOpponentName = aiEditorProfile?.name ?? gameState.aiStrategist?.personality.name ?? null;
   const secretAgendasEnabled = gameState.secretAgendasEnabled !== false;
 
   const renderSecretAgendaPanel = (variant: 'overlay' | 'mobile') => {
@@ -2432,10 +2435,8 @@ const Index = () => {
     return (
       <div className="space-y-3 text-[11px] text-newspaper-text/90">
         <div className="flex items-center justify-between">
-          <span className="text-[10px] uppercase tracking-[0.3em] text-newspaper-text/60">Handler</span>
-          <span className="font-mono text-newspaper-text">
-            {gameState.aiStrategist?.personality.name || 'Unknown'}
-          </span>
+          <span className="text-[10px] uppercase tracking-[0.3em] text-newspaper-text/60">Editor</span>
+          <span className="font-mono text-newspaper-text">{aiOpponentName ?? 'Unknown'}</span>
         </div>
         <div className="grid grid-cols-2 gap-2 text-center">
           <div className="rounded border border-newspaper-border/40 bg-newspaper-bg/30 px-2 py-1">
@@ -2505,7 +2506,7 @@ const Index = () => {
         <div className="rounded border border-newspaper-border bg-newspaper-bg p-3 shadow-sm">
           <AIStatus
             difficulty={gameState.aiDifficulty}
-            personalityName={gameState.aiStrategist?.personality.name}
+            editorName={aiOpponentName ?? undefined}
             isThinking={gameState.phase === 'ai_turn'}
             currentPlayer={gameState.currentPlayer}
             aiControlledStates={aiControlledStates}


### PR DESCRIPTION
## Summary
- show the AI editor profile name in the opponent HUD instead of the strategist title fallback
- thread the editor name through the collapsible mobile status card so the label is consistent across layouts
- document the UI tweak in the update log for player-facing change tracking

## Testing
- npm run lint *(fails: repository has pre-existing lint violations unrelated to this change)*
- bun test --coverage --coverage-reporter=text *(fails: existing tests error due to unmet environment mocks and combo headline expectations)*

------
https://chatgpt.com/codex/tasks/task_e_68e6243b17408320bacd009f9406c22d