### PR TITLE
Handle MVP deck reshuffle during draw step

### DIFF
--- a/UPDATES_LOG.md
+++ b/UPDATES_LOG.md
@@ -39,6 +39,10 @@ This document provides a chronological record of gameplay-impacting changes merg
 - Map AI difficulty settings to the new editor roster, falling back from legacy IDs and automatically selecting the correct partner at game start.
 - Added runtime safety nets so MVP engines auto-bind an editor before applying difficulty-scaled modifiers.
 
+## 2025-10-08 – Deck reshuffle safeguards at turn start
+- MVP turn upkeep now shuffles the discard pile into a fresh deck whenever the draw step would otherwise stall, guaranteeing hands refill to five cards.
+- Added debug logging and regression coverage to confirm reshuffles clear the discard and keep leftover cards in the new deck.
+
 ## 2025-10-08 – Established AI editor roster and banter stubs
 - Replaced legacy editor prototypes with faction-aligned profiles including difficulty tiers, personalities, and runtime modifiers.
 - Published shared difficulty multipliers, recommendation helpers, and banter bank loader typings to anchor AI selection.

--- a/src/mvp/__tests__/engine.income.test.ts
+++ b/src/mvp/__tests__/engine.income.test.ts
@@ -7,7 +7,7 @@ import {
   evaluateCatchUpAdjustments,
   startTurn,
 } from '@/mvp/engine';
-import type { GameState, PlayerState } from '@/mvp/validator';
+import type { Card, GameState, PlayerState } from '@/mvp/validator';
 
 type PartialPlayer = Partial<PlayerState> & Pick<PlayerState, 'ip'>;
 
@@ -20,6 +20,16 @@ const makePlayer = (partial: PartialPlayer): PlayerState => ({
   ip: partial.ip,
   states: partial.states ?? [],
   nextAttackMultiplier: partial.nextAttackMultiplier,
+});
+
+const makeCard = (id: string, faction: 'truth' | 'government' = 'truth'): Card => ({
+  id,
+  name: id,
+  type: 'ATTACK',
+  rarity: 'common',
+  cost: 0,
+  faction,
+  effects: { ipDelta: { opponent: 0 } },
 });
 
 const makeState = (currentPlayer: PlayerState, opponentIp = 0): GameState => ({
@@ -230,5 +240,56 @@ describe('startTurn upkeep integration', () => {
     const trailerTurn = startTurn(trailerState);
     expect(trailerTurn.log.at(-1)).toContain('catch-up bonus');
     expect(trailerTurn.log.at(-1)).toMatch(/behind/);
+  });
+
+  it('reshuffles the discard pile when the deck is exhausted while drawing', () => {
+    const player = makePlayer({
+      id: 'P1',
+      ip: 10,
+      hand: [makeCard('hand-1'), makeCard('hand-2')],
+      deck: [makeCard('deck-1')],
+      discard: [makeCard('discard-1'), makeCard('discard-2'), makeCard('discard-3')],
+    });
+    const state = makeState(player, 0);
+
+    const originalRandom = Math.random;
+    const sequence = [0.42, 0.18, 0.73];
+    let index = 0;
+    Math.random = () => {
+      const value = sequence[index];
+      index = Math.min(sequence.length, index + 1);
+      return value ?? 0.5;
+    };
+
+    try {
+      const updated = startTurn(state);
+      const updatedPlayer = updated.players.P1;
+
+      expect(updatedPlayer.hand).toHaveLength(5);
+      expect(updatedPlayer.discard).toHaveLength(0);
+      expect(updatedPlayer.deck).toHaveLength(1);
+
+      const reshuffleLog = updated.log.find(entry => entry.includes('reshuffles discard into deck'));
+      expect(reshuffleLog).toBeDefined();
+
+      const originalHandIds = new Set(player.hand.map(card => card.id));
+      const originalDeckIds = new Set(player.deck.map(card => card.id));
+      const originalDiscardIds = new Set(player.discard.map(card => card.id));
+
+      const drawnIds = updatedPlayer.hand
+        .map(card => card.id)
+        .filter(id => !originalHandIds.has(id));
+      expect(drawnIds).toHaveLength(3);
+
+      const drawnFromDiscard = drawnIds.filter(id => originalDiscardIds.has(id));
+      expect(drawnFromDiscard.length).toBeGreaterThanOrEqual(2);
+
+      const remainingDeckIds = updatedPlayer.deck.map(card => card.id);
+      remainingDeckIds.forEach(id => {
+        expect(originalDeckIds.has(id) || originalDiscardIds.has(id)).toBe(true);
+      });
+    } finally {
+      Math.random = originalRandom;
+    }
   });
 });

--- a/src/mvp/engine.ts
+++ b/src/mvp/engine.ts
@@ -49,16 +49,50 @@ const getEffectiveCardCost = (state: GameState, playerId: PlayerId, card: Card):
   return Math.max(0, Math.floor(adjusted));
 };
 
-const drawUpToFive = (player: PlayerState): PlayerState => {
+const shuffleCards = (cards: Card[], rng: () => number): Card[] => {
+  const shuffled = [...cards];
+  for (let i = shuffled.length - 1; i > 0; i -= 1) {
+    const j = Math.floor(rng() * (i + 1));
+    [shuffled[i], shuffled[j]] = [shuffled[j], shuffled[i]];
+  }
+  return shuffled;
+};
+
+const drawUpToFive = (
+  player: PlayerState,
+  rng: () => number = Math.random,
+): { player: PlayerState; reshuffled: boolean } => {
   const deck = [...player.deck];
   const hand = [...player.hand];
-  while (hand.length < 5 && deck.length > 0) {
+  const discard = [...player.discard];
+  let reshuffled = false;
+
+  while (hand.length < 5) {
+    if (deck.length === 0) {
+      if (discard.length === 0) {
+        break;
+      }
+      const reshuffledDeck = shuffleCards(discard, rng);
+      deck.push(...reshuffledDeck);
+      discard.length = 0;
+      reshuffled = true;
+    }
+
+    if (deck.length === 0) {
+      break;
+    }
+
     hand.push(deck.shift()!);
   }
+
   return {
-    ...player,
-    deck,
-    hand,
+    player: {
+      ...player,
+      deck,
+      hand,
+      discard,
+    },
+    reshuffled,
   };
 };
 
@@ -424,7 +458,11 @@ export function startTurn(state: GameState): GameState {
     discard: workingDiscard,
   };
 
-  const drawnPlayer = drawUpToFive(preparedPlayer);
+  const { player: drawnPlayer, reshuffled } = drawUpToFive(preparedPlayer);
+
+  if (reshuffled) {
+    logEntries.push(`${currentId} reshuffles discard into deck.`);
+  }
 
   const updatedPlayer: PlayerState = {
     ...drawnPlayer,


### PR DESCRIPTION
## Summary
- shuffle the discard pile into the deck inside the MVP draw helper when five cards can’t be drawn
- ensure `startTurn` persists the reshuffled piles and logs the reshuffle for debugging
- add regression coverage for the reshuffle flow and document the gameplay change in the updates log

## Testing
- bun test --coverage --coverage-reporter=text *(fails: pre-existing test failures)*
- npm run lint *(fails: repository lint debt)*


------
https://chatgpt.com/codex/tasks/task_e_68e63b2857ec83208c51849fc28b8b05