### PR TITLE
Respect relic bonus draws during MVP turn start

### DIFF
--- a/UPDATES_LOG.md
+++ b/UPDATES_LOG.md
@@ -2,6 +2,10 @@
 
 This document provides a chronological record of gameplay-impacting changes merged into State Shift Strategy. Each entry should include the merge date and a brief, human-readable summary so future contributors can quickly understand how the game has evolved.
 
+## 2025-11-16 – Tabloid relic bonuses power card draws
+- The MVP engine now honors relic-provided bonus draws, targeting larger hands and logging the relic boost when a turn begins.
+- Added regression coverage to confirm a mocked relic grants the extra cards during turn start resolution.
+
 ## 2025-11-15 – Surface opponent editor identity
 - Updated the AI opponent HUD to show the active editor's name instead of generic handler titles in both desktop and mobile panels.
 - Synced the opponent status card to share that editor label so players can cross-check difficulty context at a glance.

--- a/__tests__/game/startTurnRelicDraw.test.ts
+++ b/__tests__/game/startTurnRelicDraw.test.ts
@@ -1,0 +1,96 @@
+import { startTurn } from '@/mvp/engine';
+import type { Card, GameState, PlayerState } from '@/mvp/validator';
+import type { PlayerId } from '@/engine/applyEffects-mvp';
+import type { TabloidRelicRuntimeState } from '@/expansions/tabloidRelics/RelicTypes';
+import {
+  getExpansionFeaturesSnapshot,
+  hydrateExpansionFeatures,
+} from '@/data/expansions/features';
+
+describe('startTurn relic card draw bonuses', () => {
+  const originalFeatures = getExpansionFeaturesSnapshot();
+
+  beforeEach(() => {
+    hydrateExpansionFeatures({
+      editors: originalFeatures.editors,
+      tabloidRelics: true,
+    });
+  });
+
+  afterEach(() => {
+    hydrateExpansionFeatures(originalFeatures);
+  });
+
+  const createCard = (id: string): Card => ({
+    id,
+    name: `Mock Card ${id}`,
+    type: 'MEDIA',
+    faction: 'truth',
+    rarity: 'common',
+    cost: 1,
+    effects: { truthDelta: 1 },
+  });
+
+  const createPlayer = (playerId: PlayerId, overrides: Partial<PlayerState> = {}): PlayerState => ({
+    id: playerId,
+    faction: 'truth',
+    deck: Array.from({ length: 12 }, (_, index) => createCard(`${playerId}-deck-${index}`)),
+    hand: [],
+    discard: [],
+    ip: 10,
+    states: [],
+    activeEditorId: null,
+    ...overrides,
+  });
+
+  it('draws additional cards from relic bonus at turn start', () => {
+    const runtime: TabloidRelicRuntimeState = {
+      entries: [
+        {
+          uid: 'mock-relic',
+          ruleId: 'mock-relic',
+          label: 'Mock Relic',
+          rarity: 'common',
+          summary: 'Unit test relic',
+          duration: 1,
+          remaining: 1,
+          status: 'active',
+          triggeredOnRound: 1,
+          effects: {
+            cardDrawBonus: 2,
+          },
+        },
+      ],
+      lastIssueRound: 1,
+      lastUpdatedTurn: 1,
+      selectionHistory: [],
+    };
+
+    const gameState: GameState = {
+      turn: 1,
+      currentPlayer: 'P1',
+      truth: 50,
+      players: {
+        P1: createPlayer('P1'),
+        P2: createPlayer('P2'),
+      },
+      pressureByState: {},
+      stateDefense: {},
+      playsThisTurn: 0,
+      turnPlays: [],
+      log: [],
+      headlineLog: [],
+      extraExtraFeed: [],
+      turnBuffer: [],
+      winner: null,
+      victoryType: null,
+      tabloidRelicsRuntime: runtime,
+    };
+
+    const result = startTurn(gameState);
+    const updatedPlayer = result.players.P1;
+
+    expect(updatedPlayer.hand).toHaveLength(7);
+    expect(result.log.some(entry => entry.includes('includes +2 relic bonus'))).toBe(true);
+  });
+});

--- a/src/mvp/engine.ts
+++ b/src/mvp/engine.ts
@@ -61,13 +61,14 @@ const shuffleCards = (cards: Card[], rng: () => number): Card[] => {
 const drawUpToFive = (
   player: PlayerState,
   rng: () => number = Math.random,
+  targetHandSize = 5,
 ): { player: PlayerState; reshuffled: boolean } => {
   const deck = [...player.deck];
   const hand = [...player.hand];
   const discard = [...player.discard];
   let reshuffled = false;
 
-  while (hand.length < 5) {
+  while (hand.length < targetHandSize) {
     if (deck.length === 0) {
       if (discard.length === 0) {
         break;
@@ -354,6 +355,7 @@ export function startTurn(state: GameState): GameState {
   me.ip = relicResult.ip;
   opponent.ip = relicResult.aiIp;
   cloned.tabloidRelicsRuntime = relicResult.runtime;
+  const bonusCardDraw = Math.max(0, relicResult.bonusCardDraw ?? 0);
   const { baseIncome, maintenance, swingTax, catchUpBonus, netIncome, ipGap, stateGap, stateIncomeDetails } = computeTurnIpIncome(
     me,
     opponent,
@@ -458,10 +460,21 @@ export function startTurn(state: GameState): GameState {
     discard: workingDiscard,
   };
 
-  const { player: drawnPlayer, reshuffled } = drawUpToFive(preparedPlayer);
+  const initialHandSize = preparedPlayer.hand.length;
+  const targetHandSize = 5 + bonusCardDraw;
+  const { player: drawnPlayer, reshuffled } = drawUpToFive(preparedPlayer, Math.random, targetHandSize);
+  const cardsDrawn = Math.max(0, drawnPlayer.hand.length - initialHandSize);
 
   if (reshuffled) {
     logEntries.push(`${currentId} reshuffles discard into deck.`);
+  }
+
+  if (bonusCardDraw > 0) {
+    const shortfall = Math.max(0, targetHandSize - drawnPlayer.hand.length);
+    const shortfallNote = shortfall > 0 ? ` (short ${shortfall})` : '';
+    logEntries.push(
+      `${currentId} draw phase targets ${targetHandSize} cards (includes +${bonusCardDraw} relic bonus, drew ${cardsDrawn})${shortfallNote}.`,
+    );
   }
 
   const updatedPlayer: PlayerState = {


### PR DESCRIPTION
## Summary
- extend the MVP engine draw routine to respect tabloid relic bonus card draws and log the boosted hand target
- add regression coverage that confirms a mocked relic delivers extra cards when a turn begins
- document the relic draw support in the updates log

## Testing
- npm run lint *(fails: existing repository lint violations)*
- bun test --coverage --coverage-reporter=text *(fails: pre-existing test and environment failures)*

------
https://chatgpt.com/codex/tasks/task_e_68e64132564c832087b15bdad42ce5b2