### PR TITLE
Fix overtime truth momentum pivot handling

### DIFF
--- a/tools/ai-simulation.ts
+++ b/tools/ai-simulation.ts
@@ -460,12 +460,14 @@ function buildOvertimeState(
   const truthSide: Side = state.factions.A === 'truth' ? 'A' : 'B';
   const governmentSide: Side = truthSide === 'A' ? 'B' : 'A';
 
+  const truthPivot = options.overtimePivot ?? state.startingTruth ?? 50;
+
   return {
     turn: state.turn,
     maxTurns: state.maxTurns,
     truth: state.truth,
     startingTruth: state.startingTruth,
-    truthMomentum: state.truth - state.startingTruth,
+    truthMomentum: state.truth - truthPivot,
     truthHistory,
     truthControlledStates,
     governmentControlledStates,
@@ -473,7 +475,7 @@ function buildOvertimeState(
     governmentIp: state.ip[governmentSide],
     overtimeConfig: {
       maxTurns: state.maxTurns,
-      truthPivot: options.overtimePivot ?? state.startingTruth,
+      truthPivot: truthPivot,
       truthTolerance: options.overtimeTolerance,
       territoryMargin: options.overtimeMargin,
       defaultWinner: options.overtimeDefaultWinner,


### PR DESCRIPTION
## Summary
- compute overtime truth momentum against the configured overtime pivot so CLI overrides apply

## Testing
- not run (explanation: existing repository-level commands fail unrelated to this change)


------
https://chatgpt.com/codex/tasks/task_e_68e65483492c8320ab63cfee9e59a1e7