### PR TITLE
Gate Extra Extra column behind triple plays

### DIFF
--- a/UPDATES_LOG.md
+++ b/UPDATES_LOG.md
@@ -226,6 +226,10 @@ This document provides a chronological record of gameplay-impacting changes merg
 - Teach the newspaper issue generator to spotlight captured states, major truth swings, and rotating highlights on the dispatch archive.
 - Keep hero articles in sync with the front-page package so combo main stories continue to render correctly.
 
+## 2025-10-08 – Gate Extra Extra coverage behind triple plays
+- Removed the standing “Extra Extra Dispatch” column from the turn newspaper so the bonus headline only appears when a faction actually lands three plays.
+- Hid the final edition bulletin module whenever no triple-play articles were filed to avoid implying a bonus that never triggered.
+
 ## 2025-10-08 – Diversify generated card articles
 - Expand card article generator pools with new tag-aware headlines, subheads, and body segments to reduce repetition.
 - Compose longer faction articles by layering tag-specific follow-ups, escalations, and closers for each card.

--- a/src/components/game/FinalEditionLayout.tsx
+++ b/src/components/game/FinalEditionLayout.tsx
@@ -252,6 +252,7 @@ const FinalEditionLayout = ({ report }: FinalEditionLayoutProps) => {
       ? 'mt-1 text-2xl font-black tracking-tight text-victory-accent drop-shadow-[0_2px_8px_rgba(0,0,0,0.35)]'
       : 'mt-1 text-2xl font-black tracking-tight text-newspaper-headline';
   const bulletinArticles = report.extraExtraFeed.slice(-4).reverse();
+  const hasBulletins = bulletinArticles.length > 0;
   const highlightCardClass =
     tone === 'victory'
       ? 'rounded-md border border-victory-foreground/30 bg-gradient-to-br from-victory-start/80 via-victory-mid/74 to-victory-end/80 text-victory-foreground shadow-[0_16px_36px_rgba(0,0,0,0.35)]'
@@ -547,14 +548,14 @@ const FinalEditionLayout = ({ report }: FinalEditionLayoutProps) => {
         </NewspaperSection>
       </section>
 
-      <NewspaperSection tone={tone} className="p-5">
-        <div className="flex items-center justify-between">
-          <h2 className={sectionHeadingClass}>Extra Extra Bulletins</h2>
-          <Badge className={cn(badgeClass, 'rounded-full px-3 py-0.5 text-[11px] tracking-[0.3em]')}>
-            {bulletinArticles.length}
-          </Badge>
-        </div>
-        {bulletinArticles.length > 0 ? (
+      {hasBulletins ? (
+        <NewspaperSection tone={tone} className="p-5">
+          <div className="flex items-center justify-between">
+            <h2 className={sectionHeadingClass}>Extra Extra Bulletins</h2>
+            <Badge className={cn(badgeClass, 'rounded-full px-3 py-0.5 text-[11px] tracking-[0.3em]')}>
+              {bulletinArticles.length}
+            </Badge>
+          </div>
           <div className="mt-4 space-y-4">
             {bulletinArticles.map((article, index) => {
               const badgeToneClass = getBulletinBadgeClass(article.tone, tone);
@@ -599,12 +600,8 @@ const FinalEditionLayout = ({ report }: FinalEditionLayoutProps) => {
               );
             })}
           </div>
-        ) : (
-          <p className={cn('mt-4 rounded border border-dashed px-3 py-4 text-sm italic', mutedBodyClass)}>
-            No newsroom bulletins were filed during this match.
-          </p>
-        )}
-      </NewspaperSection>
+        </NewspaperSection>
+      ) : null}
 
       <NewspaperSection tone={tone} className="p-5">
         <h2 className={sectionHeadingClass}>After-Action Notes</h2>

--- a/src/components/game/TabloidNewspaperV2.tsx
+++ b/src/components/game/TabloidNewspaperV2.tsx
@@ -744,7 +744,6 @@ const TabloidNewspaperV2 = ({
   const sourcePool = dataset.sources && dataset.sources.length ? dataset.sources : FALLBACK_DATA.sources;
   const byline = issue?.byline ?? pick(bylinePool, FALLBACK_DATA.bylines?.[0] ?? 'By: Anonymous Insider');
   const sourceLine = issue?.sourceLine ?? pick(sourcePool, FALLBACK_DATA.sources?.[0] ?? 'Source: Redacted Dossier');
-  const frontPageArticles = issue?.generatedStory?.articles ?? [];
   const breakingStamp = issue?.stamps.breaking ?? null;
   const classifiedStamp = issue?.stamps.classified ?? null;
 
@@ -1147,37 +1146,6 @@ const TabloidNewspaperV2 = ({
 
             {/* COLUMN 2: Stats & Secondary Headlines */}
             <aside className="space-y-4">
-              {/* Front Page Articles */}
-              {frontPageArticles.length ? (
-                <section className="rounded-md border border-newspaper-border bg-white/70 p-4 shadow-sm">
-                  <h3 className="mb-3 border-b-2 border-newspaper-border pb-2 text-sm font-black uppercase tracking-wide text-newspaper-text">
-                    Extra Extra Dispatch
-                  </h3>
-                  <div className="space-y-3 text-newspaper-text">
-                    {frontPageArticles.map(article => {
-                      const cardTypeLabel = `[${article.cardType.toUpperCase()}]`;
-                      return (
-                        <article
-                          key={article.cardId}
-                          className="space-y-2 border-b border-dashed border-newspaper-border/60 pb-3 last:border-0 last:pb-0"
-                        >
-                          <div className="flex flex-wrap items-center justify-between gap-2 text-[10px] font-semibold uppercase tracking-wide text-newspaper-text/60">
-                            <span>{cardTypeLabel}</span>
-                          </div>
-                          <h4 className="text-base font-semibold leading-snug text-newspaper-headline">
-                            {article.headline}
-                          </h4>
-                          <p className="text-xs italic text-newspaper-text/70">{article.subhead}</p>
-                          <p className="text-sm leading-relaxed text-newspaper-text/80">
-                            {article.body[0] ?? 'Details pending transmission.'}
-                          </p>
-                        </article>
-                      );
-                    })}
-                  </div>
-                </section>
-              ) : null}
-
               {/* Combo Dispatch */}
               {comboNarrative ? (
                 <section className="rounded-md border border-newspaper-border bg-white/70 p-4 shadow-sm">

--- a/src/components/game/__tests__/FinalEditionLayout.extraFeed.test.tsx
+++ b/src/components/game/__tests__/FinalEditionLayout.extraFeed.test.tsx
@@ -120,7 +120,7 @@ describe('FinalEditionLayout extra extra bulletins', () => {
     renderer.unmount();
   });
 
-  test('shows fallback copy when no bulletins are recorded', async () => {
+  test('omits bulletin section when no bulletins are recorded', async () => {
     ensureLocalStorage();
 
     const { default: FinalEditionLayout } = await import('../FinalEditionLayout');
@@ -130,7 +130,8 @@ describe('FinalEditionLayout extra extra bulletins', () => {
     const output = extractText(renderer.toJSON()).join(' ');
     const normalized = output.replace(/\s+/g, ' ').trim();
 
-    expect(normalized).toContain('No newsroom bulletins were filed during this match.');
+    expect(normalized).not.toContain('Extra Extra Bulletins');
+    expect(normalized).not.toContain('No newsroom bulletins were filed during this match.');
 
     renderer.unmount();
   });

--- a/src/components/game/__tests__/TabloidNewspaperV2.frontPage.test.tsx
+++ b/src/components/game/__tests__/TabloidNewspaperV2.frontPage.test.tsx
@@ -23,7 +23,7 @@ globalThis.navigator = windowRef.navigator as Navigator;
 globalThis.HTMLElement = windowRef.HTMLElement as unknown as typeof globalThis.HTMLElement;
 globalThis.CustomEvent = windowRef.CustomEvent as unknown as typeof globalThis.CustomEvent;
 
-const { render, screen, cleanup, within } = await import('@testing-library/react');
+const { render, screen, cleanup } = await import('@testing-library/react');
 
 mock.module('@/lib/newspaperData', () => ({
   loadNewspaperData: async () => ({
@@ -240,29 +240,16 @@ describe('TabloidNewspaperV2 front page integration', () => {
       ]),
     );
 
-    const expectedDispatchCount = activeIssue.generatedStory.articles.length;
-
     render(<TabloidNewspaperV2 {...baseProps} />);
 
     const heroHeading = await screen.findByRole('heading', { level: 2 });
     const heroHeadlineText = heroHeading.textContent ?? '';
     expect(heroHeadlineText).toContain('Hero Entry Overrides Prime Time');
 
-    const dispatchHeading = await screen.findByRole('heading', { name: /Extra Extra Dispatch/i });
-    const dispatchSection = dispatchHeading.closest('section');
-    expect(dispatchSection).not.toBeNull();
-
-    const dispatchHeadlines = within(dispatchSection as HTMLElement)
-      .getAllByRole('heading', { level: 4 })
-      .map(node => node.textContent ?? '');
-
-    expect(dispatchHeadlines).toHaveLength(expectedDispatchCount);
-    dispatchHeadlines.forEach(text => {
-      expect(text).not.toContain(heroHeadlineText);
-    });
+    expect(screen.queryByRole('heading', { name: /Extra Extra Dispatch/i })).toBeNull();
   });
 
-  test('shows fallback copy for dispatches when article bank is empty', async () => {
+  test('does not render dispatch column when article bank is empty', async () => {
     loadArticleBankMock.mockImplementationOnce(async () => ({
       getById() {
         return null;
@@ -277,18 +264,11 @@ describe('TabloidNewspaperV2 front page integration', () => {
       body: [],
     }));
 
-    const expectedDispatchCount = activeIssue.generatedStory.articles.length;
-
     render(<TabloidNewspaperV2 {...baseProps} />);
 
     const headline = await screen.findByRole('heading', { level: 2 });
     expect(headline.textContent ?? '').toContain('Hero Entry Overrides Prime Time');
 
-    const dispatchHeading = await screen.findByRole('heading', { name: /Extra Extra Dispatch/i });
-    const dispatchSection = dispatchHeading.closest('section');
-    expect(dispatchSection).not.toBeNull();
-
-    const fallbackBodies = within(dispatchSection as HTMLElement).getAllByText('Details pending transmission.');
-    expect(fallbackBodies).toHaveLength(expectedDispatchCount);
+    expect(screen.queryByRole('heading', { name: /Extra Extra Dispatch/i })).toBeNull();
   });
 });


### PR DESCRIPTION
## Summary
- remove the always-on "Extra Extra Dispatch" column from the end-of-turn newspaper so the bonus headline only appears when a faction actually plays three cards
- hide the final edition bulletin stack whenever no triple-play articles were generated
- adjust related tests and changelog entries to cover the gated behaviour

## Testing
- npm run lint *(fails: repository currently has pre-existing lint violations unrelated to this change)*
- bun test --coverage --coverage-reporter=text *(fails: repository currently has numerous failing suites unrelated to this change)*

------
https://chatgpt.com/codex/tasks/task_e_68e64daba8c88320a8e869477ee76944