### PR TITLE
Restore triple-play dispatch column

### DIFF
--- a/UPDATES_LOG.md
+++ b/UPDATES_LOG.md
@@ -2,6 +2,10 @@
 
 This document provides a chronological record of gameplay-impacting changes merged into State Shift Strategy. Each entry should include the merge date and a brief, human-readable summary so future contributors can quickly understand how the game has evolved.
 
+## 2025-11-19 – Restore triple-play dispatch column
+- Reinstated the Extra Extra dispatch column on the end-of-turn newspaper so triple-play bonus stories print when generated.
+- Added regression coverage ensuring the dispatch column hides cleanly when no triple-play articles are produced.
+
 ## 2025-11-18 – Continuity overtime protocol and sim hooks
 - Added the Continuity Overtime Protocol as the top-priority victory condition so capped matches resolve via Truth momentum, territorial control, or resource edge instead of the deterministic coin flip.
 - Threaded max-turn metadata and overtime configuration through the AI simulation harness, exposing new CLI knobs and logging the overtime method in batch reports.

--- a/src/components/game/TabloidNewspaperV2.tsx
+++ b/src/components/game/TabloidNewspaperV2.tsx
@@ -740,6 +740,7 @@ const TabloidNewspaperV2 = ({
   const heroTriggerChance = heroEvent?.triggerChance ?? null;
   const heroConditionalChance = heroEvent?.conditionalChance ?? null;
   const comboNarrative = issue?.comboArticle ?? null;
+  const frontPageArticles = issue?.generatedStory?.articles ?? [];
   const bylinePool = dataset.bylines && dataset.bylines.length ? dataset.bylines : FALLBACK_DATA.bylines;
   const sourcePool = dataset.sources && dataset.sources.length ? dataset.sources : FALLBACK_DATA.sources;
   const byline = issue?.byline ?? pick(bylinePool, FALLBACK_DATA.bylines?.[0] ?? 'By: Anonymous Insider');
@@ -1146,6 +1147,39 @@ const TabloidNewspaperV2 = ({
 
             {/* COLUMN 2: Stats & Secondary Headlines */}
             <aside className="space-y-4">
+              {/* Front Page Articles */}
+              {frontPageArticles.length > 0 ? (
+                <section className="rounded-md border border-newspaper-border bg-white/70 p-4 shadow-sm">
+                  <h3 className="mb-3 border-b-2 border-newspaper-border pb-2 text-sm font-black uppercase tracking-wide text-newspaper-text">
+                    Extra Extra Dispatch
+                  </h3>
+                  <div className="space-y-3 text-newspaper-text">
+                    {frontPageArticles.map(article => {
+                      const cardTypeLabel = article.cardType
+                        ? `[${String(article.cardType).toUpperCase()}]`
+                        : '[CARD]';
+                      return (
+                        <article
+                          key={article.cardId}
+                          className="space-y-2 border-b border-dashed border-newspaper-border/60 pb-3 last:border-0 last:pb-0"
+                        >
+                          <div className="flex flex-wrap items-center justify-between gap-2 text-[10px] font-semibold uppercase tracking-wide text-newspaper-text/60">
+                            <span>{cardTypeLabel}</span>
+                          </div>
+                          <h4 className="text-base font-semibold leading-snug text-newspaper-headline">
+                            {article.headline}
+                          </h4>
+                          <p className="text-xs italic text-newspaper-text/70">{article.subhead}</p>
+                          <p className="text-sm leading-relaxed text-newspaper-text/80">
+                            {article.body?.[0] ?? 'Details pending transmission.'}
+                          </p>
+                        </article>
+                      );
+                    })}
+                  </div>
+                </section>
+              ) : null}
+
               {/* Combo Dispatch */}
               {comboNarrative ? (
                 <section className="rounded-md border border-newspaper-border bg-white/70 p-4 shadow-sm">

--- a/src/components/game/__tests__/TabloidNewspaperV2.frontPage.test.tsx
+++ b/src/components/game/__tests__/TabloidNewspaperV2.frontPage.test.tsx
@@ -118,7 +118,7 @@ type BankArticle = {
 };
 
 let bankArticles = new Map<string, BankArticle>();
-let activeIssue = buildIssue();
+let activeIssue: NarrativeIssue;
 
 const loadArticleBankMock = mock(async () => ({
   getById(id: string) {
@@ -174,6 +174,8 @@ const buildIssue = (): NarrativeIssue => ({
   generatedStory: buildGeneratedStory(),
 });
 
+activeIssue = buildIssue();
+
 mock.module('@/engine/newspaper/IssueGenerator', () => ({
   generateIssue: async () => activeIssue,
 }));
@@ -225,7 +227,7 @@ afterAll(() => {
 });
 
 describe('TabloidNewspaperV2 front page integration', () => {
-  test('renders hero headline without duplicating dispatch headlines', async () => {
+  test('renders dispatch column when triple-play articles are available', async () => {
     bankArticles = new Map(
       articleFixtures.slice(1).map(entry => [
         entry.cardId,
@@ -246,10 +248,13 @@ describe('TabloidNewspaperV2 front page integration', () => {
     const heroHeadlineText = heroHeading.textContent ?? '';
     expect(heroHeadlineText).toContain('Hero Entry Overrides Prime Time');
 
-    expect(screen.queryByRole('heading', { name: /Extra Extra Dispatch/i })).toBeNull();
+    const dispatchHeading = await screen.findByRole('heading', { name: /Extra Extra Dispatch/i });
+    expect(dispatchHeading).toBeTruthy();
+    expect(screen.getByText('Dispatch Two Surges Signal')).toBeTruthy();
+    expect(screen.getByText('Dispatch Three Containment Grid')).toBeTruthy();
   });
 
-  test('does not render dispatch column when article bank is empty', async () => {
+  test('does not render dispatch column when no triple-play articles are generated', async () => {
     loadArticleBankMock.mockImplementationOnce(async () => ({
       getById() {
         return null;
@@ -259,10 +264,7 @@ describe('TabloidNewspaperV2 front page integration', () => {
       },
     }));
 
-    activeIssue.generatedStory.articles = activeIssue.generatedStory.articles.map(article => ({
-      ...article,
-      body: [],
-    }));
+    activeIssue.generatedStory.articles = [];
 
     render(<TabloidNewspaperV2 {...baseProps} />);
 


### PR DESCRIPTION
## Summary
- restore the Extra Extra dispatch section in the tabloid when generated triple-play articles are available
- expand the front page integration tests to cover both the triple-play render path and the empty state
- log the reinstated dispatch behaviour in the updates log

## Testing
- bun test src/components/game/__tests__/TabloidNewspaperV2.frontPage.test.tsx *(passes with expected localStorage warnings from extension manager mocks)*

------
https://chatgpt.com/codex/tasks/task_e_68e65a01a338832081a077d8955b4aae