### PR TITLE
Retune truth main story subhead flavor

### DIFF
--- a/UPDATES_LOG.md
+++ b/UPDATES_LOG.md
@@ -51,6 +51,9 @@ This document provides a chronological record of gameplay-impacting changes merg
 - Added regression coverage ensuring TabloidNewspaperV2 renders unique hero headlines against the dispatch list.
 - Confirmed hero dispatch absences fall back to redacted copy instead of duplicating the main headline.
 
+## 2025-10-08 – Truth main story subhead retuned
+- Replaced the snack-quality aside in truth main stories with a reality-anchor status update to keep front page copy conspiratorially grounded.
+
 ## 2025-10-08 – Pressure-sensitive target rotation tuning
 - Reweighted per-turn target penalties with pressure signal ownership and remaining defense so stacked zone plays hit the 0.22 ceiling after the first commitment.
 - Ensured fallback plans and regression coverage record planned targets, keeping AI memory synced with queued repeats and documenting the tuning in the November 17 analysis log.

--- a/src/engine/news/mainStory.ts
+++ b/src/engine/news/mainStory.ts
@@ -109,7 +109,7 @@ export function generateMainStory(
 
     headline = `${subject} ${v1} AS ${n2} ${v2} — ${n3} ${v3}!`;
     subhead = clampLen(
-      `Witnesses report escalating weirdness${commonTags.length ? ` (${commonTags.slice(0, 2).join(', ')})` : ''}. Officials baffled; snacks remain excellent.`,
+      `Witnesses report escalating weirdness${commonTags.length ? ` (${commonTags.slice(0, 2).join(', ')})` : ''}. Officials baffled; reality anchors remain perfectly aligned.`,
     );
     parts = [v1, v2, v3];
   } else {


### PR DESCRIPTION
## Summary
- replace the truth-faction main story subhead aside with a conspiratorial status report about reality anchors
- document the copy shift in the updates log for October 8, 2025

## Testing
- npm run lint *(fails: repository has longstanding lint violations outside this change)*
- bun test --coverage --coverage-reporter=text *(fails: existing test suite failures unrelated to this change)*

------
https://chatgpt.com/codex/tasks/task_e_68e662823e4883209d1ebc0087a66bd3