### PR TITLE
Tune hard AI neutral capture prioritization

### DIFF
--- a/UPDATES_LOG.md
+++ b/UPDATES_LOG.md
@@ -2,6 +2,10 @@
 
 This document provides a chronological record of gameplay-impacting changes merged into State Shift Strategy. Each entry should include the merge date and a brief, human-readable summary so future contributors can quickly understand how the game has evolved.
 
+## 2025-11-23 – Hard AI reprioritizes neutral captures
+- Weighted ZONE capture pressure by combined IP value, location leverage, and defense so neutral haymakers outshine low-importance grabs.
+- Tuned pressure heuristics to respect that valuation during turn planning, keeping Hard difficulty focused on high-IP swing states.
+
 ## 2025-11-22 – Instant triple-headline tabloid surges
 - Primed the Extra Extra headline caches at module load so triple-card combos deliver tabloid-grade headlines without waiting for async preload hooks.
 - Added defensive cache access guards to fall back gracefully if JSON parsing ever fails during startup.

--- a/src/ai/__tests__/unifiedAiPlanning.test.ts
+++ b/src/ai/__tests__/unifiedAiPlanning.test.ts
@@ -221,6 +221,69 @@ const createGrassrootsScenario = () => ({
   extraExtraFeed: [],
 });
 
+const createNeutralPressureShowdown = () => ({
+  aiHand: [GRASSROOTS_A, GRASSROOTS_B],
+  hand: [GRASSROOTS_A, GRASSROOTS_B],
+  aiIP: 18,
+  ip: 14,
+  truth: 40,
+  faction: 'government' as const,
+  currentPlayer: 'ai' as const,
+  turn: 3,
+  round: 1,
+  cardsPlayedThisRound: [],
+  players: {
+    P1: {
+      id: 'P1',
+      faction: 'truth' as const,
+      deck: [],
+      hand: [],
+      discard: [],
+      ip: 14,
+      states: [],
+    },
+    P2: {
+      id: 'P2',
+      faction: 'government' as const,
+      deck: [],
+      hand: [],
+      discard: [],
+      ip: 18,
+      states: [],
+    },
+  },
+  states: [
+    {
+      id: 'NY',
+      name: 'New York',
+      abbreviation: 'NY',
+      baseIP: 5,
+      defense: 5,
+      pressure: 0,
+      contested: false,
+      owner: 'neutral' as const,
+    },
+    {
+      id: 'WY',
+      name: 'Wyoming',
+      abbreviation: 'WY',
+      baseIP: 1,
+      defense: 1,
+      pressure: 0,
+      contested: false,
+      owner: 'neutral' as const,
+    },
+  ],
+  controlledStates: [],
+  playerControlledStates: [],
+  aiControlledStates: [],
+  turnPlays: [],
+  turnBuffer: [],
+  log: [],
+  headlineLog: [],
+  extraExtraFeed: [],
+});
+
 const createPlanningState = () => ({
   aiHand: [MEDIA_CARD, ZONE_CARD, ATTACK_CARD, HIGH_COST_ATTACK, COMBO_MEDIA],
   aiIP: 12,
@@ -433,5 +496,22 @@ describe('Unified AI planning', () => {
     const secondPriority = enhancedSecond.priority;
     expect(firstPriority - secondPriority).toBeCloseTo(0.22, 2);
     expect(secondPriority).toBeLessThan(0.3);
+  });
+
+  it('prefers higher-IP neutral targets when pressure cards tie on hard difficulty', () => {
+    const strategist = AIFactory.createStrategist('hard');
+    const planningState = createNeutralPressureShowdown();
+
+    const plan = chooseTurnActions({
+      strategist: strategist as EnhancedAIStrategist,
+      gameState: planningState,
+      maxActions: 1,
+      priorityThreshold: 0.18,
+    });
+
+    expect(plan.actions.length).toBe(1);
+    const action = plan.actions[0]!;
+    expect(action.card.type).toBe('ZONE');
+    expect(action.targetState).toBe('NY');
   });
 });

--- a/src/data/aiStrategy.ts
+++ b/src/data/aiStrategy.ts
@@ -735,15 +735,21 @@ class LegacyAIStrategist {
       if (state.owner === 'ai') continue;
 
       const signal = signalLookup.get(state.abbreviation);
-      let priority = this.personality.territorial * zoneWeights.baseMultiplier + chainBonus + factionBonus;
-
-      // High IP and strategic positions matter more for territorial personalities
-      priority += (state.baseIP ?? 0)
-        * 0.04
+      const locationBonus = this.getLocationBonus(state);
+      const defense = Math.max(1, state.defense ?? 1);
+      const baseIP = Math.max(0, state.baseIP ?? 0);
+      const captureValue = (baseIP * (1 + locationBonus * 2)) / Math.sqrt(defense);
+      const captureWeight = 0.04
         * (1 + this.personality.territorial)
         * zoneWeights.highValueMultiplier
+        * zoneWeights.locationMultiplier
         * this.biasModifiers.income;
-      priority += this.getLocationBonus(state) * zoneWeights.locationMultiplier;
+      const capturePressureScaling = 0.5 + Math.min(1.5, captureValue / 2);
+
+      let priority = this.personality.territorial * zoneWeights.baseMultiplier + chainBonus + factionBonus;
+
+      // Strategic capture value combines IP potential, terrain, and resistance
+      priority += captureValue * captureWeight;
 
       if (state.owner === 'player') {
         priority += this.personality.aggressiveness * 0.3 * zoneWeights.ownerAggressionMultiplier;
@@ -755,20 +761,24 @@ class LegacyAIStrategist {
         const remainingAfterPlay = Math.max(0, signal.remaining - pressureDelta);
         const signalMultiplier = zoneWeights.signalCaptureMultiplier * this.biasModifiers.combo;
         if (signal.remaining <= pressureDelta) {
-          priority += 0.7 * signalMultiplier;
+          priority += 0.7 * signalMultiplier * capturePressureScaling;
         } else if (remainingAfterPlay <= 1) {
-          priority += 0.5 * signalMultiplier;
+          priority += 0.5 * signalMultiplier * capturePressureScaling;
         } else {
           priority += Math.max(
             0,
-            (pressureDelta / Math.max(1, signal.defense)) * 0.4 * signalMultiplier,
+            (pressureDelta / Math.max(1, signal.defense))
+              * 0.4
+              * signalMultiplier
+              * capturePressureScaling,
           );
         }
       } else if (pressureDelta > 0 && state.owner !== 'ai') {
-        priority += (pressureDelta / Math.max(1, state.defense ?? 1))
+        priority += (pressureDelta / defense)
           * 0.25
           * zoneWeights.signalCaptureMultiplier
-          * this.biasModifiers.combo;
+          * this.biasModifiers.combo
+          * capturePressureScaling;
       }
 
       if (evaluation.dangerSignals.opponentAggression > 0.6 && state.owner === 'player') {


### PR DESCRIPTION
## Summary
- derive a capture value that blends base IP, location leverage, and defense before weighting zone card priorities
- scale pressure-based bonuses by that capture value so low-IP neutral states no longer outweigh higher-value targets
- cover the hard difficulty preference with a new neutral showdown regression test and log the behavior shift

## Testing
- npm run lint *(fails: repository contains pre-existing lint violations across legacy components)*
- bun test --coverage --coverage-reporter=text *(fails: baseline suite includes known failures in AI planning and combo/editor modifier specs)*

------
https://chatgpt.com/codex/tasks/task_e_68e67f6f609c8320814197a8cd161b59