### PR TITLE
Adjust enhanced AI rollout budgets by difficulty

### DIFF
--- a/UPDATES_LOG.md
+++ b/UPDATES_LOG.md
@@ -2,6 +2,10 @@
 
 This document provides a chronological record of gameplay-impacting changes merged into State Shift Strategy. Each entry should include the merge date and a brief, human-readable summary so future contributors can quickly understand how the game has evolved.
 
+## 2025-11-24 – Calibrate enhanced AI rollout budgets
+- Let enhanced MCTS difficulties respect the tuned rollout budgets (medium ≈16, hard ≈48, insane ≈120) instead of forcing a 200-iteration floor.
+- Documented the rollout multiplier in the AI factory so future tuning can bump the shared budget knob intentionally.
+
 ## 2025-11-23 – Hard AI reprioritizes neutral captures
 - Weighted ZONE capture pressure by combined IP value, location leverage, and defense so neutral haymakers outshine low-importance grabs.
 - Tuned pressure heuristics to respect that valuation during turn planning, keeping Hard difficulty focused on high-IP swing states.

--- a/src/ai/__tests__/unifiedAiPlanning.test.ts
+++ b/src/ai/__tests__/unifiedAiPlanning.test.ts
@@ -1,9 +1,10 @@
 import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
 
 import '@/test/setupLocalStorage';
+import { AI_PRESETS } from '@/ai/difficulty';
 import { chooseTurnActions } from '@/ai/enhancedController';
 import type { Difficulty } from '@/ai';
-import { AIFactory } from '@/data/aiFactory';
+import { AIFactory, toEnhancedProfile } from '@/data/aiFactory';
 import type { AIDifficulty, AIStrategist, CardPlay, GameStateEvaluation } from '@/data/aiStrategy';
 import { EnhancedAIStrategist, type EnhancedCardPlay } from '@/data/enhancedAIStrategy';
 import type { GameCard } from '@/rules/mvp';
@@ -374,6 +375,22 @@ describe('Unified AI planning', () => {
 
   afterEach(() => {
     Math.random = originalRandom;
+  });
+
+  it('assigns increasing rollout budgets with difficulty presets', () => {
+    const mediumProfile = toEnhancedProfile(AI_PRESETS.NORMAL);
+    const hardProfile = toEnhancedProfile(AI_PRESETS.HARD);
+    const insaneProfile = toEnhancedProfile(AI_PRESETS.INSANE);
+
+    const mediumRollouts = Math.round(mediumProfile.rollouts ?? 0);
+    const hardRollouts = Math.round(hardProfile.rollouts ?? 0);
+    const insaneRollouts = Math.round(insaneProfile.rollouts ?? 0);
+
+    expect(hardRollouts).toBeGreaterThan(mediumRollouts);
+    expect(insaneRollouts).toBeGreaterThan(hardRollouts);
+    expect(hardRollouts).toBeGreaterThanOrEqual(48);
+    expect(insaneRollouts).toBeGreaterThanOrEqual(120);
+    expect(mediumRollouts).toBeLessThan(200);
   });
 
   it.each(DIFFICULTIES)('produces a deterministic plan on %s difficulty', difficulty => {

--- a/src/data/aiFactory.ts
+++ b/src/data/aiFactory.ts
@@ -17,10 +17,21 @@ const PRESET_BY_DIFFICULTY: Record<AIDifficulty, AiConfig> = {
   insane: AI_PRESETS.INSANE,
 };
 
-const toEnhancedProfile = (preset: AiConfig): EnhancedAiDifficultyProfile => {
+export const ROLLOUT_BUDGET_MULTIPLIER = 8;
+
+/**
+ * Translate the classic AI config into the richer enhanced strategist profile.
+ *
+ * The rollout mapping intentionally keeps budgets modest so medium (~16), hard (~48),
+ * and insane (~120) difficulties scale predictably. The multiplier below is the
+ * single place to tune those budgets if future balance passes need deeper searches.
+ */
+export const toEnhancedProfile = (preset: AiConfig): EnhancedAiDifficultyProfile => {
   const planningDepth = Math.max(1, Math.min(4, Math.round(preset.lookaheadDepth + 1)));
-  const rollouts = preset.rolloutsPerBranch > 0
-    ? Math.max(0, Math.round(preset.rolloutsPerBranch * Math.max(1, preset.beamWidth) * 8))
+  const branchRollouts = Math.max(0, Math.round(preset.rolloutsPerBranch));
+  const beamWidth = Math.max(1, Math.round(preset.beamWidth));
+  const rollouts = branchRollouts > 0
+    ? Math.max(0, branchRollouts * beamWidth * ROLLOUT_BUDGET_MULTIPLIER)
     : 0;
 
   return {

--- a/src/data/enhancedAIStrategy.ts
+++ b/src/data/enhancedAIStrategy.ts
@@ -445,9 +445,10 @@ export class EnhancedAIStrategist implements AIStrategist {
 
     // Use MCTS only on hard+ difficulties due to computational cost
     if (this.personality.planningDepth >= 3) {
-      const iterations = this.difficultyProfile.rollouts && this.difficultyProfile.rollouts > 0
-        ? Math.max(200, Math.round(this.difficultyProfile.rollouts))
-        : this.personality.planningDepth * 500;
+      const rolloutBudget = this.difficultyProfile.rollouts ?? 0;
+      const iterations = rolloutBudget > 0
+        ? Math.max(1, Math.round(rolloutBudget))
+        : Math.max(1, this.personality.planningDepth * 500);
       return this.runMCTS(gameState, iterations, evaluation); // iterations
     }
 


### PR DESCRIPTION
## Summary
- let the enhanced strategist honor the configured rollout budgets instead of imposing a 200-iteration floor
- document and export the rollout budget multiplier so difficulty profiles (medium ≈16, hard ≈48, insane ≈120) are easier to tune
- extend the unified AI planning suite with a regression guard that enforces the expected rollout ordering across difficulties

## Testing
- npm run lint *(fails: repository contains pre-existing lint violations)*
- NO_COLOR=1 bun test --coverage --coverage-reporter=text *(fails: repository contains numerous failing suites prior to this change)*
- NO_COLOR=1 bun test src/ai/__tests__/unifiedAiPlanning.test.ts --coverage --coverage-reporter=text

------
https://chatgpt.com/codex/tasks/task_e_68e68e18c7c48320a70edcce2e37692f