### PR TITLE
Handle terminal nodes in enhanced MCTS

### DIFF
--- a/UPDATES_LOG.md
+++ b/UPDATES_LOG.md
@@ -2,6 +2,10 @@
 
 This document provides a chronological record of gameplay-impacting changes merged into State Shift Strategy. Each entry should include the merge date and a brief, human-readable summary so future contributors can quickly understand how the game has evolved.
 
+## 2025-11-25 – Keep enhanced MCTS exploring terminal leaves
+- Taught the enhanced strategist to score and backpropagate terminal rollouts instead of bailing out of the search loop when a branch dead-ends mid-iteration.
+- Added a regression harness that forces a terminal child and confirms the planner still evaluates the remaining branch.
+
 ## 2025-11-24 – Calibrate enhanced AI rollout budgets
 - Let enhanced MCTS difficulties respect the tuned rollout budgets (medium ≈16, hard ≈48, insane ≈120) instead of forcing a 200-iteration floor.
 - Documented the rollout multiplier in the AI factory so future tuning can bump the shared budget knob intentionally.

--- a/src/ai/__tests__/unifiedAiPlanning.test.ts
+++ b/src/ai/__tests__/unifiedAiPlanning.test.ts
@@ -531,4 +531,127 @@ describe('Unified AI planning', () => {
     expect(action.card.type).toBe('ZONE');
     expect(action.targetState).toBe('NY');
   });
+
+  it('continues exploring alternate branches after encountering a terminal MCTS child', () => {
+    const strategist = new EnhancedAIStrategist('insane');
+    strategist.personality = { ...strategist.personality, planningDepth: 4 };
+
+    interface TestMctsState {
+      id: string;
+      terminal?: boolean;
+      simulationReward?: number;
+      transitions?: Record<string, TestMctsState>;
+    }
+
+    type MctsHarness = EnhancedAIStrategist & {
+      runMCTS: (
+        gameState: TestMctsState,
+        iterations: number,
+        baseEvaluation?: GameStateEvaluation
+      ) => EnhancedCardPlay | null;
+      generateAllPossiblePlays: (gameState: TestMctsState) => CardPlay[];
+      simulateMove: (gameState: TestMctsState, move: CardPlay) => TestMctsState;
+      simulateGame: (gameState: TestMctsState) => number;
+      isGameOver: (gameState: TestMctsState) => boolean;
+      selectRandomMove: (
+        gameState: TestMctsState,
+        evaluation?: GameStateEvaluation
+      ) => CardPlay | null;
+      enhancePlay: (
+        play: CardPlay,
+        gameState: TestMctsState,
+        evaluation: GameStateEvaluation
+      ) => EnhancedCardPlay;
+      evaluateGameState: (gameState: TestMctsState) => GameStateEvaluation;
+    };
+
+    const harness = strategist as unknown as MctsHarness;
+
+    const baseEvaluation: GameStateEvaluation = {
+      territorialControl: 0,
+      resourceAdvantage: 0,
+      handQuality: 0,
+      threatLevel: 0,
+      agendaProgress: 0,
+      pressureMomentum: 0,
+      truthObjective: 0,
+      opponentResourceThreat: 0,
+      opponentHandThreat: 0,
+      agendaSignals: [],
+      pressureSignals: { aiTargets: [], opponentTargets: [], contested: [] },
+      dangerSignals: {
+        imminentCapture: [],
+        imminentLoss: [],
+        truthCrisis: 0,
+        resourceCrunch: 0,
+        opponentAggression: 0,
+      },
+      planningWeight: 0,
+      overallScore: 0,
+    };
+
+    harness.evaluateGameState = () => baseEvaluation;
+    harness.enhancePlay = (play: CardPlay) => ({
+      ...play,
+      synergies: [],
+      deceptionValue: 0,
+      threatResponse: false,
+    });
+
+    const moveMap = new Map<string, CardPlay[]>([
+      [
+        'root',
+        [
+          { cardId: 'deep-branch', priority: 0.2, reasoning: 'Long line' },
+          { cardId: 'terminal-branch', priority: 0.9, reasoning: 'Ends quickly' },
+        ],
+      ],
+      ['terminal-branch', []],
+      ['deep-branch', []],
+    ]);
+
+    harness.generateAllPossiblePlays = (state: TestMctsState) => {
+      const moves = moveMap.get(state.id);
+      return moves ? moves.map(move => ({ ...move })) : [];
+    };
+    harness.simulateMove = (state: TestMctsState, move: CardPlay) => {
+      const next = state.transitions?.[move.cardId];
+      return next ? { ...next } : { id: move.cardId, terminal: true, simulationReward: 0, transitions: {} };
+    };
+    harness.isGameOver = (state: TestMctsState) => Boolean(state.terminal);
+
+    const simulateCalls: string[] = [];
+    harness.simulateGame = (state: TestMctsState) => {
+      simulateCalls.push(state.id);
+      return typeof state.simulationReward === 'number' ? state.simulationReward : 0;
+    };
+    harness.selectRandomMove = () => null;
+
+    const rootState: TestMctsState = {
+      id: 'root',
+      transitions: {
+        'terminal-branch': {
+          id: 'terminal-branch',
+          terminal: true,
+          simulationReward: 1,
+          transitions: {},
+        },
+        'deep-branch': {
+          id: 'deep-branch',
+          terminal: true,
+          simulationReward: 9,
+          transitions: {},
+        },
+      },
+      simulationReward: 0,
+    };
+
+    const iterations = 4;
+    const bestPlay = harness.runMCTS(rootState, iterations, baseEvaluation);
+
+    expect(simulateCalls.length).toBe(iterations);
+    expect(simulateCalls.filter(id => id === 'deep-branch').length).toBeGreaterThan(0);
+    expect(bestPlay).not.toBeNull();
+    expect(bestPlay?.cardId).toBe('deep-branch');
+  });
 });

--- a/src/data/enhancedAIStrategy.ts
+++ b/src/data/enhancedAIStrategy.ts
@@ -472,7 +472,11 @@ export class EnhancedAIStrategist implements AIStrategist {
       let node = this.selectNode(root);
 
       if (node.unexploredMoves.length === 0) {
-        break;
+        if (node.children.length === 0 || this.isGameOver(node.gameState)) {
+          const terminalReward = this.simulateGame(node.gameState);
+          this.backpropagate(node, terminalReward);
+        }
+        continue;
       }
 
       // Expansion


### PR DESCRIPTION
## Summary
- prevent enhanced MCTS rollouts from aborting the search loop when a selected node is already terminal
- add a regression harness that forces a terminal child and confirms the planner still explores remaining branches
- log the change in `UPDATES_LOG.md`

## Testing
- npm run lint *(fails: repository currently contains numerous pre-existing lint errors outside this change)*
- bun test --coverage --coverage-reporter=text *(fails: integration suites rely on browser APIs like localStorage and other longstanding issues)*

------
https://chatgpt.com/codex/tasks/task_e_68e695978d588320b048be4ba13e5468