### PR TITLE
Fix test isolation, optimize bundle size, and improve code quality

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,88 @@
+# CLAUDE.md – Notater for fremtidige Claude-økter
+
+Dette dokumentet samler hardt-tilegnet kunnskap fra tidligere økter slik at
+neste Claude-instans ikke trenger å gjenoppdage de samme fellene. Les også
+`AGENTS.md` (overordnet stil/regler), `log.md` (full historikk) og
+`UPDATES_LOG.md` (gameplay-endringer).
+
+## Test-infrastruktur (bun:test)
+
+`bun test` kjører serielt, men `mock.module()` er **prosess-globalt og
+permanent**. En mock installert i én testfil lekker til alle påfølgende
+filer i samme `bun test`-kjøring og kan ikke "resettes" av `afterAll`.
+
+### Mønster: preload + delegerende mock
+
+For å mocke kun innenfor én fil uten å forurense andre filer:
+
+1. **Stash ekte modul-bindinger i `__tests__/__setup__/preload.ts`** (kjøres
+   via `bunfig.toml [test] preload = "__tests__/__setup__/preload.ts"`).
+   Bruk **spread-kopi** (`{ ...module }`) — ES-modulbindinger er live, så
+   en direkte referanse ville pekt på mocken etter at `mock.module` kjører,
+   noe som gir uendelig rekursjon i delegasjons-stuben.
+
+   ```ts
+   import * as realApplyEffectsMvp from '../../src/engine/applyEffects-mvp';
+   (globalThis as any).__TEST_REAL_MODULES__ = {
+     applyEffectsMvp: { ...realApplyEffectsMvp },
+     // …
+   };
+   ```
+
+2. **I testfilen:** installer mock som delegerer til den ekte modulen, med
+   en lokal `useStub`-toggle. Sett `useStub = true` i `beforeEach`,
+   `useStub = false` i `afterAll` — slik forblir mocken installert (kan
+   ikke fjernes), men oppfører seg som identitet utenfor egen fil.
+
+   ```ts
+   const real = (globalThis as any).__TEST_REAL_MODULES__.applyEffectsMvp;
+   let useStub = false;
+   mock.module('@/engine/applyEffects-mvp', () => ({
+     ...real,
+     applyEffectsMvp: (...a) =>
+       useStub ? a[0] : real.applyEffectsMvp(...a),
+   }));
+   ```
+
+### DOM-oppsett
+
+`preload.ts` installerer happy-dom én gang for hele kjøringen og setter
+`globalThis.document/window/localStorage`. **Ikke** installer en lokal
+happy-dom `Window` i individuelle testfiler — det overskriver preload-ets
+globaler **etter** at `@testing-library/react` har fanget en referanse til
+`document.body`, og resulterer i tomme DOM-tester.
+
+Bruk `@testing-library/react` (ikke `react-test-renderer`) for komponenter
+som bruker shadcn `Select`/Radix-portaler — `createPortal` er inkompatibel
+med `react-test-renderer` når en happy-dom `document` finnes.
+
+## Build / bundle
+
+- **Lazy-load tunge assets:** `src/assets/audio/paranormalSfx.ts` (~5 MB
+  base64) lastes via `loadProceduralSfx()` i `sfxManifest.ts` — egen chunk.
+  Mønster: hvis en modul er > 500 kB og kun trengs etter første render,
+  flytt den bak `import()`.
+- **`vite.config.ts → build.rollupOptions.output.manualChunks`** splitter
+  `react`, `@radix-ui`, `lucide-react`, `recharts/d3`, `@tanstack/zod/router`,
+  og `peerjs` til egne `vendor-*`-chunks for cache-granularitet.
+- **Unngå dobbeltimport-warnings:** Hvis modul A statisk importerer X og
+  modul B `import()`-er X, forsvinner code-split-gevinsten (Rollup vil
+  inlined begge i samme chunk). Sjekk Vite-bygget for "X is dynamically
+  imported by … but also statically imported" og fjern enten den statiske
+  eller den dynamiske importen.
+
+## ESLint
+
+- `src/assets/audio/paranormalSfx.ts` (6993 linjer base64) krasjer parser
+  med stack overflow → ligger i `eslint.config.js` `ignores`.
+- Eksisterende baseline: 445 `no-explicit-any`-feil og 53 advarsler — ikke
+  blokker for nye PR-er, men introduser ikke nye `any`.
+
+## Sjekkliste før commit
+
+```
+npx tsc --noEmit
+bun test
+npm run build           # bekrefter manualChunks fortsatt OK
+npm run lint            # OK å akseptere baseline-feil over
+```

--- a/UPDATES_LOG.md
+++ b/UPDATES_LOG.md
@@ -2,6 +2,22 @@
 
 This document provides a chronological record of gameplay-impacting changes merged into State Shift Strategy. Each entry should include the merge date and a brief, human-readable summary so future contributors can quickly understand how the game has evolved.
 
+## 2026-04-13 – Faster initial load via lazy SFX and vendor chunk splits
+- Timestamp: 2026-04-13T00:00:00Z
+- Files:
+  - `vite.config.ts`
+  - `src/assets/audio/sfxManifest.ts`
+  - `src/hooks/useAudio.ts`
+  - `src/components/game/EnhancedBalancingDashboard.tsx`
+  - `src/mvp/engine.ts`
+  - `eslint.config.js`
+  - `bunfig.toml`
+  - `__tests__/__setup__/preload.ts`
+  - `CLAUDE.md`
+  - `log.md`
+  - `UPDATES_LOG.md`
+- Summary: Procedural paranormal SFX now load lazily after the first render, and vendor libraries (React, Radix, Lucide, Recharts, TanStack/zod/router, PeerJS) are split into independently cacheable chunks. Initial gzip payload dropped from ~1.66 MB to ~1.20 MB. Test infrastructure was hardened with a shared preload that stashes real module bindings, eliminating cross-file `mock.module` pollution; full suite now passes 120/120.
+
 ## 2025-10-27 – Preview command now rebuilds before serving
 - Timestamp: 2025-10-27T00:00:00Z
 - Files:

--- a/__tests__/__setup__/preload.ts
+++ b/__tests__/__setup__/preload.ts
@@ -1,0 +1,68 @@
+// Bun test preload. Installs happy-dom globals BEFORE any test module is
+// evaluated, so @testing-library/react/dom can capture a valid document.body
+// at module init time.
+import { Window } from 'happy-dom';
+import * as realApplyEffectsMvp from '../../src/engine/applyEffects-mvp';
+import * as realComboEngine from '../../src/game/comboEngine';
+import * as realUseCardCollection from '../../src/hooks/useCardCollection';
+
+// Stash the genuine implementations BEFORE any test file gets a chance to
+// install bun:test module mocks. We capture the function references by value
+// (not the live module namespace) because ES module bindings are live —
+// reading `.applyEffectsMvp` from the namespace AFTER a mock would yield the
+// mocked function and cause infinite recursion.
+(globalThis as typeof globalThis & {
+  __TEST_REAL_MODULES__?: Record<string, unknown>;
+}).__TEST_REAL_MODULES__ = {
+  applyEffectsMvp: { ...realApplyEffectsMvp },
+  comboEngine: { ...realComboEngine },
+  useCardCollection: { ...realUseCardCollection },
+};
+
+const happyWindow = new Window();
+const globalRecord = globalThis as typeof globalThis & Record<string, unknown>;
+const propagateKeys = Object.getOwnPropertyNames(happyWindow).filter(
+  key => !(key in globalRecord),
+);
+for (const key of propagateKeys) {
+  globalRecord[key] = (happyWindow as Record<string, unknown>)[key];
+}
+
+const globalWithDom = globalThis as typeof globalThis & {
+  window: Window;
+  document: typeof happyWindow.document;
+  navigator: typeof happyWindow.navigator;
+  HTMLElement: typeof happyWindow.HTMLElement;
+  Node: typeof happyWindow.Node;
+};
+
+globalWithDom.window = happyWindow;
+globalWithDom.document = happyWindow.document;
+globalWithDom.navigator = happyWindow.navigator;
+globalWithDom.HTMLElement = happyWindow.HTMLElement;
+globalWithDom.Node = happyWindow.Node;
+
+// Minimal localStorage shim so modules that touch persistent storage at import
+// time (see src/data/extensionSystem.ts) don't crash the suite.
+if (typeof globalThis.localStorage === 'undefined') {
+  const store = new Map<string, string>();
+  Object.defineProperty(globalThis, 'localStorage', {
+    value: {
+      getItem: (key: string) => (store.has(key) ? store.get(key) ?? null : null),
+      setItem: (key: string, value: string) => {
+        store.set(key, value);
+      },
+      removeItem: (key: string) => {
+        store.delete(key);
+      },
+      clear: () => {
+        store.clear();
+      },
+      key: (index: number) => Array.from(store.keys())[index] ?? null,
+      get length() {
+        return store.size;
+      },
+    },
+    writable: true,
+  });
+}

--- a/__tests__/game/CardCollectionContent.test.ts
+++ b/__tests__/game/CardCollectionContent.test.ts
@@ -1,7 +1,12 @@
-import { describe, expect, it, mock } from 'bun:test';
+// happy-dom globals come from the bun:test preload (see
+// __tests__/__setup__/preload.ts referenced from bunfig.toml). The component
+// renders shadcn Select via React portals, which need a real document — so we
+// use @testing-library/react instead of react-test-renderer.
+import { afterAll, afterEach, beforeEach, describe, expect, it, mock } from 'bun:test';
 import React from 'react';
-import TestRenderer from 'react-test-renderer';
+import { cleanup, render } from '@testing-library/react';
 import type { GameCard } from '../../src/rules/mvp';
+import type * as UseCardCollectionModule from '../../src/hooks/useCardCollection';
 
 const cardWithoutText: GameCard = {
   id: 'card-without-text',
@@ -12,39 +17,73 @@ const cardWithoutText: GameCard = {
   cost: 3,
 };
 
+// bun:test's `mock.module` registrations persist for the entire test process,
+// so the stub below would otherwise leak into __tests__/hooks/useCardCollection
+// and pre-populate that suite's "empty database" expectations. We capture the
+// real hook from the bun:test preload and only divert to the stub while this
+// file's tests are running.
+const TEST_REAL_MODULES = (globalThis as typeof globalThis & {
+  __TEST_REAL_MODULES__?: { useCardCollection: typeof UseCardCollectionModule };
+}).__TEST_REAL_MODULES__;
+
+if (!TEST_REAL_MODULES) {
+  throw new Error('Test preload did not stash real modules. Check bunfig.toml preload setup.');
+}
+
+const realUseCardCollection = TEST_REAL_MODULES.useCardCollection;
+
+let useStub = false;
+
 mock.module('@/hooks/useCardCollection', () => ({
-  useCardCollection: () => ({
-    getDiscoveredCards: () => [cardWithoutText],
-    getCardStats: () => ({ discovered: true, timesPlayed: 0 }),
-    getCollectionStats: () => ({
-      totalCards: 1,
-      discoveredCards: 1,
-      completionPercentage: 100,
-      totalPlays: 0,
-    }),
-  }),
+  ...realUseCardCollection,
+  useCardCollection: (...args: Parameters<typeof realUseCardCollection.useCardCollection>) => {
+    if (!useStub) {
+      return realUseCardCollection.useCardCollection(...args);
+    }
+    return {
+      getDiscoveredCards: () => [cardWithoutText],
+      getCardStats: () => ({ discovered: true, timesPlayed: 0 }),
+      getCollectionStats: () => ({
+        totalCards: 1,
+        discoveredCards: 1,
+        completionPercentage: 100,
+        totalPlays: 0,
+      }),
+    };
+  },
 }));
+
+beforeEach(() => {
+  useStub = true;
+});
+
+afterAll(() => {
+  useStub = false;
+});
 
 const loadCardCollectionContent = async () => {
   const module = await import('../../src/components/game/CardCollection');
   return module.CardCollectionContent;
 };
 
+afterEach(() => {
+  cleanup();
+});
+
 describe('CardCollectionContent', () => {
   it('renders without crashing when card text is missing', async () => {
     const CardCollectionContent = await loadCardCollectionContent();
 
     expect(() => {
-      TestRenderer.create(React.createElement(CardCollectionContent));
+      render(React.createElement(CardCollectionContent));
     }).not.toThrow();
   });
 
   it('shows a fallback description when card text is missing', async () => {
     const CardCollectionContent = await loadCardCollectionContent();
 
-    const renderer = TestRenderer.create(React.createElement(CardCollectionContent));
-    const json = renderer.toJSON();
+    const { container } = render(React.createElement(CardCollectionContent));
 
-    expect(JSON.stringify(json)).toContain('No description available.');
+    expect(container.innerHTML).toContain('No description available.');
   });
 });

--- a/__tests__/game/TabloidNewspaperV2Pages.test.tsx
+++ b/__tests__/game/TabloidNewspaperV2Pages.test.tsx
@@ -1,31 +1,10 @@
-import { afterEach, beforeAll, describe, expect, it } from 'bun:test';
-import { Window } from 'happy-dom';
+// happy-dom globals are installed via the bun:test preload (see
+// __tests__/__setup__/preload.ts referenced from bunfig.toml). Re-installing a
+// fresh Window here would invalidate the document/window already captured by
+// @testing-library/react during its module init.
+import { afterEach, describe, expect, it } from 'bun:test';
+import { cleanup, render, screen } from '@testing-library/react';
 import type { PageBuilderData } from '@/components/game/TabloidNewspaperV2Pages';
-
-const happyWindow = new Window();
-const globalRecord = globalThis as typeof globalThis & Record<string, unknown>;
-const propagateKeys = Object.getOwnPropertyNames(happyWindow).filter(key => !(key in globalRecord));
-for (const key of propagateKeys) {
-  globalRecord[key] = (happyWindow as Record<string, unknown>)[key];
-}
-
-const globalWithDom = globalThis as typeof globalThis & {
-  window: Window;
-  document: typeof happyWindow.document;
-  navigator: typeof happyWindow.navigator;
-  HTMLElement: typeof happyWindow.HTMLElement;
-  Node: typeof happyWindow.Node;
-};
-
-globalWithDom.window = happyWindow;
-globalWithDom.document = happyWindow.document;
-globalWithDom.navigator = happyWindow.navigator;
-globalWithDom.HTMLElement = happyWindow.HTMLElement;
-globalWithDom.Node = happyWindow.Node;
-
-let render: typeof import('@testing-library/react').render;
-let screen: typeof import('@testing-library/react').screen;
-let cleanup: typeof import('@testing-library/react').cleanup;
 
 const createPageData = (overrides: Partial<PageBuilderData> = {}): PageBuilderData => ({
   heroHeadline: 'Shadow networks sync the midnight briefing',
@@ -56,11 +35,6 @@ const createPageData = (overrides: Partial<PageBuilderData> = {}): PageBuilderDa
   formattedAgendaQuotes: [],
   campaignArcGroups: [],
   ...overrides,
-});
-
-beforeAll(async () => {
-  const testingLibrary = await import('@testing-library/react');
-  ({ render, screen, cleanup } = testingLibrary);
 });
 
 afterEach(() => {

--- a/__tests__/hooks/useCampaignProgress.test.ts
+++ b/__tests__/hooks/useCampaignProgress.test.ts
@@ -1,21 +1,9 @@
+// happy-dom globals come from the bun:test preload (see
+// __tests__/__setup__/preload.ts referenced from bunfig.toml).
 import { describe, expect, it } from 'bun:test';
 import { act, renderHook } from '@testing-library/react';
-import { Window as HappyDOMWindow } from 'happy-dom';
 
 import { useCampaignProgress } from '../../src/hooks/useCampaignProgress';
-
-type MutableGlobal = typeof globalThis & {
-  window?: Window & typeof globalThis;
-  document?: Document;
-  navigator?: Navigator;
-};
-
-const happyDom = new HappyDOMWindow();
-const mutableGlobal = globalThis as MutableGlobal;
-
-mutableGlobal.window = happyDom as unknown as Window & typeof globalThis;
-mutableGlobal.document = happyDom.document;
-mutableGlobal.navigator = happyDom.navigator;
 
 describe('useCampaignProgress', () => {
   it('returns new progress state and nested arrays when completing the same mission twice', () => {

--- a/__tests__/hooks/useCardCollection.test.ts
+++ b/__tests__/hooks/useCardCollection.test.ts
@@ -1,19 +1,7 @@
-import { describe, expect, it, mock } from 'bun:test';
+// happy-dom globals come from the bun:test preload (see
+// __tests__/__setup__/preload.ts referenced from bunfig.toml).
+import { describe, expect, it, mock, spyOn } from 'bun:test';
 import { renderHook } from '@testing-library/react';
-import { Window as HappyDOMWindow } from 'happy-dom';
-
-type MutableGlobal = typeof globalThis & {
-  window?: Window & typeof globalThis;
-  document?: Document;
-  navigator?: Navigator;
-};
-
-const happyDom = new HappyDOMWindow();
-const mutableGlobal = globalThis as MutableGlobal;
-
-mutableGlobal.window = happyDom as unknown as Window & typeof globalThis;
-mutableGlobal.document = happyDom.document;
-mutableGlobal.navigator = happyDom.navigator;
 
 mock.module('@/data/cardDatabase', () => ({
   CARD_DATABASE: []
@@ -21,7 +9,7 @@ mock.module('@/data/cardDatabase', () => ({
 
 describe('useCardCollection', () => {
   it('returns a finite completion percentage and logs a warning when the database is empty', async () => {
-    const warnSpy = mock.spy(console, 'warn');
+    const warnSpy = spyOn(console, 'warn');
 
     const { useCardCollection } = await import('../../src/hooks/useCardCollection');
     const { result } = renderHook(() => useCardCollection());

--- a/__tests__/integration/extraExtra.test.ts
+++ b/__tests__/integration/extraExtra.test.ts
@@ -1,7 +1,26 @@
-import { beforeEach, describe, expect, it, mock } from 'bun:test';
+import { afterAll, beforeEach, describe, expect, it, mock } from 'bun:test';
 import * as actualFrontendNewsPools from '../../src/news/newsPools';
 import type { Card, GameState } from '../../src/mvp/validator';
 import type { TurnLog, PlayedLite } from '../../src/news/types';
+import type * as ApplyEffectsModule from '../../src/engine/applyEffects-mvp';
+import type * as ComboEngineModule from '../../src/game/comboEngine';
+
+// The preload (bunfig.toml -> __tests__/__setup__/preload.ts) stashes the
+// genuine modules on globalThis BEFORE any test file installs bun:test module
+// mocks. We pull them back here so our delegating mock can fall through to the
+// real implementations once the toggle flips off — without that, mock.module
+// pollution from this file would silently neutralise applyEffectsMvp /
+// comboEngine in every later test file.
+const TEST_REAL_MODULES = (globalThis as typeof globalThis & {
+  __TEST_REAL_MODULES__?: { applyEffectsMvp: typeof ApplyEffectsModule; comboEngine: typeof ComboEngineModule };
+}).__TEST_REAL_MODULES__;
+
+if (!TEST_REAL_MODULES) {
+  throw new Error('Test preload did not stash real modules. Check bunfig.toml preload setup.');
+}
+
+const realApplyEffectsMvp = TEST_REAL_MODULES.applyEffectsMvp;
+const realComboEngine = TEST_REAL_MODULES.comboEngine;
 
 const stubPools = {
   mastheads: ['Test Masthead'],
@@ -53,16 +72,43 @@ mock.module('@/news/newsPools', () => ({
   getPoolsIfReady: getPoolsIfReadyMock,
 }));
 
+// bun:test's `mock.module` registrations persist for the entire test process —
+// re-mocking with the original module from `afterAll` does not re-trigger
+// resolution in test files that have already been evaluated. To avoid
+// polluting other test files (notably src/mvp/__tests__/engine.editors.test.ts
+// and __tests__/game/newCardTypes.test.ts) we install a controllable bypass:
+// the mock factory delegates to the real module (captured by the bun:test
+// preload) unless the toggle is enabled, and the toggle is only enabled while
+// this file's tests are running.
+let useApplyEffectsStub = false;
+let useComboEngineStub = false;
+
 mock.module('@/engine/applyEffects-mvp', () => ({
-  applyEffectsMvp: (state: GameState) => state,
+  ...realApplyEffectsMvp,
+  applyEffectsMvp: (...args: Parameters<typeof realApplyEffectsMvp.applyEffectsMvp>) =>
+    useApplyEffectsStub ? args[0] : realApplyEffectsMvp.applyEffectsMvp(...args),
+  tickPersistentEffects: (...args: Parameters<typeof realApplyEffectsMvp.tickPersistentEffects>) =>
+    useApplyEffectsStub ? undefined : realApplyEffectsMvp.tickPersistentEffects(...args),
 }));
 
 mock.module('@/game/comboEngine', () => ({
-  applyComboRewards: (state: GameState) => state,
-  evaluateCombos: () => ({ results: [], totalReward: {}, logs: [] }),
-  getComboSettings: () => ({ enabled: false, fxEnabled: false, comboToggles: {}, maxCombosPerTurn: 0 }),
-  formatComboReward: () => '',
+  ...realComboEngine,
+  applyComboRewards: (...args: Parameters<typeof realComboEngine.applyComboRewards>) =>
+    useComboEngineStub ? args[0] : realComboEngine.applyComboRewards(...args),
+  evaluateCombos: (...args: Parameters<typeof realComboEngine.evaluateCombos>) =>
+    useComboEngineStub ? { results: [], totalReward: {}, logs: [] } : realComboEngine.evaluateCombos(...args),
+  getComboSettings: (...args: Parameters<typeof realComboEngine.getComboSettings>) =>
+    useComboEngineStub
+      ? { enabled: false, fxEnabled: false, comboToggles: {}, maxCombosPerTurn: 0 }
+      : realComboEngine.getComboSettings(...args),
+  formatComboReward: (...args: Parameters<typeof realComboEngine.formatComboReward>) =>
+    useComboEngineStub ? '' : realComboEngine.formatComboReward(...args),
 }));
+
+afterAll(() => {
+  useApplyEffectsStub = false;
+  useComboEngineStub = false;
+});
 
 const loadMvpEngine = () => import('../../src/mvp/engine');
 const loadHeadlineEngine = () => import('../../src/news/headlineEngine');
@@ -74,6 +120,8 @@ beforeEach(() => {
   getPoolsIfReadyMock.mockReset();
   getPoolsMock.mockImplementation(() => stubPools);
   getPoolsIfReadyMock.mockImplementation(() => stubPools);
+  useApplyEffectsStub = true;
+  useComboEngineStub = true;
 });
 
 const createCard = (id: string, faction: 'truth' | 'government', truthDelta: number): Card => ({

--- a/__tests__/integration/gameplayScreen.test.tsx
+++ b/__tests__/integration/gameplayScreen.test.tsx
@@ -1,75 +1,31 @@
-import { beforeAll, describe, it, expect, mock } from 'bun:test';
+// happy-dom + localStorage globals come from the bun:test preload (see
+// __tests__/__setup__/preload.ts referenced from bunfig.toml). Re-installing
+// here would invalidate the document/window @testing-library/react captured at
+// module init.
+import { describe, it, expect, mock } from 'bun:test';
+import { act, fireEvent, render, screen } from '@testing-library/react';
 import { dispatchBreakingNews } from '@/lib/newsEventHelpers';
 import type { GameCard } from '@/rules/mvp';
 import { buildFinalEdition as buildGameOverReport } from '@/utils/finalEdition';
 import type { GameState } from '@/hooks/gameStateTypes';
 import type { ArticleBlock } from '@/news/types';
 import type { CompositeStory, ExtraExtraFeedEntry } from '@/types/news';
-import { Window } from 'happy-dom';
-
-let render: typeof import('@testing-library/react').render;
-let screen: typeof import('@testing-library/react').screen;
-let act: typeof import('@testing-library/react').act;
-let fireEvent: typeof import('@testing-library/react').fireEvent;
-
-const happyWindow = new Window();
-const windowRecord = happyWindow as unknown as Record<string, unknown>;
-const globalRecord = globalThis as typeof globalThis & Record<string, unknown>;
-const propagateKeys = Object.getOwnPropertyNames(happyWindow).filter(key => !(key in globalRecord));
-for (const key of propagateKeys) {
-  globalRecord[key] = windowRecord[key];
-}
-
-const globalWithDom = globalThis as typeof globalThis & {
-  window: Window;
-  document: typeof happyWindow.document;
-  navigator: typeof happyWindow.navigator;
-  HTMLElement: typeof happyWindow.HTMLElement;
-  Node: typeof happyWindow.Node;
-};
-
-globalWithDom.window = happyWindow;
-globalWithDom.document = happyWindow.document;
-globalWithDom.navigator = happyWindow.navigator;
-globalWithDom.HTMLElement = happyWindow.HTMLElement;
-globalWithDom.Node = happyWindow.Node;
-
-const createStorage = () => {
-  const store = new Map<string, string>();
-  return {
-    getItem(key: string) {
-      return store.has(key) ? store.get(key)! : null;
-    },
-    setItem(key: string, value: string) {
-      store.set(key, String(value));
-    },
-    removeItem(key: string) {
-      store.delete(key);
-    },
-    clear() {
-      store.clear();
-    },
-    key(index: number) {
-      return Array.from(store.keys())[index] ?? null;
-    },
-    get length() {
-      return store.size;
-    },
-  } satisfies Storage;
-};
 
 const globalWithStorage = globalThis as typeof globalThis & {
-  localStorage: Storage;
   sessionStorage: Storage;
 };
 
-globalWithStorage.localStorage = createStorage();
-globalWithStorage.sessionStorage = createStorage();
-
-beforeAll(async () => {
-  const testingLibrary = await import('@testing-library/react');
-  ({ render, screen, act, fireEvent } = testingLibrary);
-});
+if (typeof globalWithStorage.sessionStorage === 'undefined') {
+  const store = new Map<string, string>();
+  globalWithStorage.sessionStorage = {
+    getItem: (key: string) => (store.has(key) ? store.get(key)! : null),
+    setItem: (key: string, value: string) => { store.set(key, String(value)); },
+    removeItem: (key: string) => { store.delete(key); },
+    clear: () => { store.clear(); },
+    key: (index: number) => Array.from(store.keys())[index] ?? null,
+    get length() { return store.size; },
+  } satisfies Storage;
+}
 
 describe('gameplay screen integrations', () => {
   it('surfaces breaking news from dispatched events', async () => {

--- a/__tests__/news/absurdComposer.spec.ts
+++ b/__tests__/news/absurdComposer.spec.ts
@@ -19,9 +19,46 @@ describe('absurd composite composer', () => {
     expect(story.sources).toHaveLength(2);
   });
 
-  test('threads faction connectors through copy', () => {
-    const truthStory = composeWithFixture(['TRUTH-A'], 'truth', 88);
-    const governmentStory = composeWithFixture(['GOV-A', 'GOV-B'], 'government', 88);
+  test('threads faction connectors through copy when articles lack content', () => {
+    // When articles have real headlines/bodies, the composer prefers that
+    // copy over template-generated text. To exercise the connector/template
+    // fallback path we build stub articles with empty headlines and bodies.
+    const stubPool: FixtureArticle[] = [
+      {
+        id: 'STUB-TRUTH-A',
+        faction: 'truth',
+        tags: ['florida-man', 'swamp', 'truth', 'broadcast'],
+        headline: '',
+        subhead: '',
+        byline: '',
+        body: '',
+        imagePrompt: '',
+      },
+      {
+        id: 'STUB-GOV-A',
+        faction: 'government',
+        tags: ['ufo', 'government', 'disinformation'],
+        headline: '',
+        subhead: '',
+        byline: '',
+        body: '',
+        imagePrompt: '',
+      },
+      {
+        id: 'STUB-GOV-B',
+        faction: 'government',
+        tags: ['ghost', 'government', 'containment'],
+        headline: '',
+        subhead: '',
+        byline: '',
+        body: '',
+        imagePrompt: '',
+      },
+    ];
+    const composeStub = createComposerWithPool(stubPool);
+
+    const truthStory = composeStub(['STUB-TRUTH-A'], 'truth', 88);
+    const governmentStory = composeStub(['STUB-GOV-A', 'STUB-GOV-B'], 'government', 88);
 
     expect(truthStory.headline).toMatch(/uncovers|broadcasts|amplifies|decrypts/);
     expect(governmentStory.headline).toMatch(/suppresses|redacts|obscures|counterspins/);

--- a/__tests__/newspaper/TurnEdition.test.tsx
+++ b/__tests__/newspaper/TurnEdition.test.tsx
@@ -1,31 +1,10 @@
-import { afterEach, beforeAll, describe, expect, it } from 'bun:test';
-import { Window } from 'happy-dom';
+// NOTE: happy-dom is installed on globalThis BEFORE any test module evaluates
+// via the bun:test preload (see __tests__/__setup__/preload.ts referenced from
+// bunfig.toml). That ordering matters because @testing-library/react reads
+// document/window at module init time.
+import { afterEach, describe, expect, it } from 'bun:test';
+import { cleanup, render, screen } from '@testing-library/react';
 import type { CompositeStory } from '@/types/news';
-
-const happyWindow = new Window();
-const globalRecord = globalThis as typeof globalThis & Record<string, unknown>;
-const propagateKeys = Object.getOwnPropertyNames(happyWindow).filter(key => !(key in globalRecord));
-for (const key of propagateKeys) {
-  globalRecord[key] = (happyWindow as Record<string, unknown>)[key];
-}
-
-const globalWithDom = globalThis as typeof globalThis & {
-  window: Window;
-  document: typeof happyWindow.document;
-  navigator: typeof happyWindow.navigator;
-  HTMLElement: typeof happyWindow.HTMLElement;
-  Node: typeof happyWindow.Node;
-};
-
-globalWithDom.window = happyWindow;
-globalWithDom.document = happyWindow.document;
-globalWithDom.navigator = happyWindow.navigator;
-globalWithDom.HTMLElement = happyWindow.HTMLElement;
-globalWithDom.Node = happyWindow.Node;
-
-let render: typeof import('@testing-library/react').render;
-let screen: typeof import('@testing-library/react').screen;
-let cleanup: typeof import('@testing-library/react').cleanup;
 
 const createStory = (overrides: Partial<CompositeStory> = {}): CompositeStory => ({
   tone: 'truth',
@@ -42,11 +21,6 @@ const createStory = (overrides: Partial<CompositeStory> = {}): CompositeStory =>
     { id: 'source-b', headline: 'Neighborhood scouts file proof' },
   ],
   ...overrides,
-});
-
-beforeAll(async () => {
-  const testingLibrary = await import('@testing-library/react');
-  ({ render, screen, cleanup } = testingLibrary);
 });
 
 afterEach(() => {

--- a/bunfig.toml
+++ b/bunfig.toml
@@ -1,3 +1,4 @@
 [test]
+preload = ["./__tests__/__setup__/preload.ts"]
 coverageSkipTestFiles = true
 coverageThreshold = { lines = 0.6, functions = 0.5, statements = 0.6, branches = 0.4 }

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -5,7 +5,12 @@ import reactRefresh from "eslint-plugin-react-refresh";
 import tseslint from "typescript-eslint";
 
 export default tseslint.config(
-  { ignores: ["dist"] },
+  {
+    // Auto-generated assets (procedural SFX data URIs etc.) and the build
+    // output are skipped — the SFX file in particular is large enough to blow
+    // the parser stack with a "Maximum call stack size exceeded" error.
+    ignores: ["dist", "src/assets/audio/paranormalSfx.ts"],
+  },
   {
     extends: [js.configs.recommended, ...tseslint.configs.recommended],
     files: ["**/*.{ts,tsx}"],

--- a/log.md
+++ b/log.md
@@ -1858,3 +1858,158 @@ The missing expansions issue has been resolved. **ManageExpansions.tsx** now pro
 Systematisk gjennomgang av hele kodebasen for å finne feil, mangler, og kvalitetsproblemer. Inkluderer TypeScript-kompilering, tester, linting, og strukturell kodegjennomgang.
 
 ## Status: Innledende research — venter på avklaring fra bruker
+
+---
+
+## Oppgave 2 — Resultat (2026-04-13, fortsatt på samme branch)
+
+Bruker bekreftet: (1) sjekk alt, (2) fiks underveis, (3) ingen kjente problemer,
+(4) bygg nå, (5) se på optimalisering. Følgende ble identifisert og rettet.
+
+### Funn 1 — Test-runneren manglet `node_modules`
+
+`npm install` (1013 pakker) ble kjørt for å låse opp ESLint og bun:test.
+
+### Funn 2 — Bun-tester delte ikke `happy-dom`-globaler riktig
+
+Flere `@testing-library/react`-baserte tester opprettet en *ny* `happy-dom`
+`Window` per fil og overskrev `globalThis.document` etter at testbiblioteket
+allerede hadde grepet referansen ved modul-init. Resultat: `render()` skrev
+til ett DOM-tre, `screen` queried et annet → empty `<body />`.
+
+**Rettet** ved å:
+- Legge til `__tests__/__setup__/preload.ts` (referert fra `bunfig.toml`) som
+  installerer happy-dom én gang FØR alle testfiler evalueres, samt en minimal
+  `localStorage`-shim for moduler som leser persistent storage på import-tid
+  (`src/data/extensionSystem.ts`).
+- Fjerne lokal happy-dom-installasjon fra:
+  `__tests__/newspaper/TurnEdition.test.tsx`,
+  `__tests__/game/TabloidNewspaperV2Pages.test.tsx`,
+  `__tests__/hooks/useCampaignProgress.test.ts`,
+  `__tests__/hooks/useCardCollection.test.ts`,
+  `__tests__/integration/gameplayScreen.test.tsx`.
+- Skifte `__tests__/game/CardCollectionContent.test.ts` fra
+  `react-test-renderer` (krasjet på shadcn `Select`-portaler i happy-dom DOM)
+  til `@testing-library/react`.
+
+### Funn 3 — `mock.module()` lekket på tvers av testfiler
+
+Bun's `mock.module()` registrerer modul-mocker *globalt* og kan ikke
+restaureres fra `afterAll` (det re-evaluerer ikke andre filers statiske
+import). `__tests__/integration/extraExtra.test.ts` mocket
+`@/engine/applyEffects-mvp` og `@/game/comboEngine` som no-ops, og
+`__tests__/game/CardCollectionContent.test.ts` mocket
+`@/hooks/useCardCollection` med en stubbet "1 card"-respons. Begge lekket inn
+i `src/mvp/__tests__/engine.editors.test.ts`,
+`__tests__/game/newCardTypes.test.ts`,
+`__tests__/hooks/useCardCollection.test.ts` og maskerte ekte motor- og
+hook-logikk (`Fox Muldrunk`, `Bat Boy Jr.`, Hybrid/Trap/Persistent-kort,
+`useCardCollection` tom-database).
+
+**Rettet** med følgende mønster:
+1. Preload (`__tests__/__setup__/preload.ts`) plukker ut funksjons-referansene
+   fra de virkelige modulene FØR noen testfil får anledning til å mocke dem,
+   og legger dem på `globalThis.__TEST_REAL_MODULES__`.
+2. Hvert testfilet som trenger å mocke samme modul installerer en
+   *delegerende* mock som kun avviker fra original-implementasjonen mens en
+   intern `useStub`-toggle står på `true`. Toggle skrus på i `beforeEach` og
+   av i `afterAll`, så søsker-tester får ekte modul.
+3. Funksjons-referansene må kopieres ut av modulnamespace (`{ ...module }`),
+   ikke leses som live binding — ellers ender vi i uendelig rekursjon når
+   stubben kaller "real" som peker tilbake til seg selv.
+
+Tester før: 14 fail / 7 errors. Tester etter: **120 pass / 0 fail / 0 errors**.
+
+### Funn 4 — `news-pools`-stub kollisjon i komposisjons-tester
+
+`smartNarrativeComposer.test.ts` brukte kort-IDer (`TRUTH-001`, `GOV-001`,
+`TRUTH-LEAK-001` osv.) som finnes i `CARD_ARTICLE_DATABASE`. Den anrikede
+generatoren tok over og brukte artikkel-innhold (Bigfoot etc.) i stedet for
+malen med kort-navn. Erstattet med unike test-IDer
+(`TEST-TRUTH-UFO-001` osv.).
+
+Tilsvarende fikk `__tests__/news/absurdComposer.spec.ts` ('threads faction
+connectors through copy') stubbet artikler med tomme felt for å tvinge
+composer ned i mal-fallback-stien.
+
+### Funn 5 — `mock.spy` finnes ikke i bun:test
+
+`__tests__/hooks/useCardCollection.test.ts` brukte `mock.spy()` (Jest API).
+Skiftet til `spyOn` importert fra `bun:test`.
+
+### Funn 6 — ESLint-parser-stack-overflow på prosedyrelyd
+
+`src/assets/audio/paranormalSfx.ts` (6993 linjer base64 data-URI'er, ~5 MB
+streng-konkatinering) får TypeScript-ESLint-parseren til å sprenge stacken.
+Lagt filen til `eslint.config.js`-`ignores`.
+
+### Funn 7 — To "dynamic-import-also-statically-imported" advarsler
+
+1. `src/mvp/engine.ts` importerte `@/game/aiEditorBinding` *både* statisk
+   (linje 20) og dynamisk i `startTurn` (linje 347). Den dynamiske
+   `import().then(…)` ga ingen verdi — modulet er allerede i samme chunk.
+   Slettet det dødt-ekvivalente blokken.
+2. `src/components/game/EnhancedBalancingDashboard.tsx` importerte
+   `CARD_DATABASE_CORE` direkte fra `@/data/core`, mens `cardDatabase.ts`
+   *også* dynamisk importerte samme modul. Endret dashbord til å bruke
+   `getCoreCards()` + `loadCardPool()` fra `cardDatabase` slik at
+   `data/core`-chunken faktisk kan splittes ut.
+
+### Funn 8 — Bundle-størrelse 6.05 MB
+
+Bygg-output (før): `dist/assets/index-*.js  6,050.46 kB │ gzip 1,659.32 kB`.
+
+Tiltak:
+- **Lazy-load prosedyre-SFX:** `paranormalSfx.ts` (~5 MB base64) ble
+  statisk importert via `sfxManifest.ts` → endret til `loadProceduralSfx()`
+  som dynamisk importerer modulet inne i `useAudio`. Resultat: egen
+  `paranormalSfx-*.js` chunk på 670 kB (484 kB gzip).
+- **`manualChunks` for vendor-libs:** `vendor-react`, `vendor-radix`,
+  `vendor-icons`, `vendor-charts`, `vendor-app`, `vendor-peerjs`. Hver kan
+  caches uavhengig av app-kode.
+
+Bygg-output (etter):
+```
+vendor-react   164.66 kB │  54.04 kB gzip
+vendor-radix   117.69 kB │  36.42 kB gzip
+vendor-app      96.83 kB │  25.84 kB gzip
+vendor-peerjs   88.16 kB │  24.10 kB gzip
+vendor-icons    24.03 kB │   5.16 kB gzip
+vendor-charts   22.17 kB │   8.55 kB gzip
+data/core      112.00 kB │  24.14 kB gzip   (lazy)
+paranormalSfx  670.66 kB │ 484.62 kB gzip   (lazy)
+index          4,753.82 kB │ 991.40 kB gzip
+```
+
+Totalt initial gzip-load: fra ~1.66 MB til ~1.20 MB (≈ 28 % mindre) med samme
+funksjonalitet og bedre cache-granularitet.
+
+### Funn 9 — ESLint auto-fix
+
+`eslint . --fix` ryddet 9 `prefer-const`-overtredelser i `src/hooks/aiHelpers.ts`
+og `src/hooks/useGameState.ts` (variabler erklært `let` men aldri reassignet).
+
+### Gjenstående (ikke kritisk)
+
+- 445 `@typescript-eslint/no-explicit-any`-feil — kosmetisk; krever stor
+  type-pass.
+- 34 `react-hooks/exhaustive-deps`-advarsler — bør gjennomgås for ekte
+  reactivity-feil.
+- 19 `react-refresh/only-export-components`-advarsler — kun dev-tooling.
+- Hovedbundle fortsatt 4.75 MB (991 kB gzip). Flere optimaliseringer er
+  mulige (kort-data + headline-engine kunne lazy-lastes, men det krever
+  betydelig refaktor av startup-flyten).
+
+### Build-helse — endelig sjekk
+
+```
+$ npx tsc --noEmit       → exit 0
+$ npx eslint .           → 498 problems (445 errors, 53 warnings)
+                           [alle gjenstående er @typescript-eslint/no-explicit-any
+                            + dev-tool-advarsler — ingen kompileringsblokkere]
+$ bun test               → 120 pass / 0 fail / 0 errors / 468 expect calls
+$ npm run build          → ✓ built in 19s
+```
+
+## Status: Ferdig
+

--- a/log.md
+++ b/log.md
@@ -1844,3 +1844,17 @@ The chosen approach (dynamic loading in component) is the cleanest and most main
 ## Conclusion
 
 The missing expansions issue has been resolved. **ManageExpansions.tsx** now properly discovers and displays all expansions including Halloween (200 cards) and Cryptids (300 cards), bringing the total available expansion cards to 500+ when enabled.
+
+---
+
+# Oppgave 2: Finn feil og mangler
+
+**Date:** 2026-04-12
+**Session:** claude/game-dev-documentation-s8M2K
+**Agent:** Claude Code (Opus 4.6)
+
+## Task
+
+Systematisk gjennomgang av hele kodebasen for å finne feil, mangler, og kvalitetsproblemer. Inkluderer TypeScript-kompilering, tester, linting, og strukturell kodegjennomgang.
+
+## Status: Innledende research — venter på avklaring fra bruker

--- a/src/assets/audio/sfxManifest.ts
+++ b/src/assets/audio/sfxManifest.ts
@@ -1,5 +1,4 @@
-import { UFO_ELVIS_SFX, CRYPTID_RUMBLE_SFX, RADIO_STATIC_SFX } from './paranormalSfx';
-
+// File-backed SFX (real audio files served from /public/audio).
 export const SFX_MANIFEST = {
   cardPlay: '/audio/card-play.mp3',
   flash: '/audio/card-play.mp3',
@@ -14,11 +13,26 @@ export const SFX_MANIFEST = {
   typewriter: '/audio/typewriter.mp3',
   lightClick: '/audio/click.mp3',
   error: '/audio/click.mp3',
-  'ufo-elvis': UFO_ELVIS_SFX,
-  'cryptid-rumble': CRYPTID_RUMBLE_SFX,
-  'radio-static': RADIO_STATIC_SFX,
 } as const;
 
-export type SfxKey = keyof typeof SFX_MANIFEST;
+// Procedural paranormal SFX live in a ~5 MB base64 module — keep them out of
+// the main bundle and only fetch the chunk when the audio system actually
+// initialises. Returns a map of key → data URI.
+export const PROCEDURAL_SFX_KEYS = ['ufo-elvis', 'cryptid-rumble', 'radio-static'] as const;
+export type ProceduralSfxKey = (typeof PROCEDURAL_SFX_KEYS)[number];
 
-export const SFX_KEYS = Object.keys(SFX_MANIFEST) as SfxKey[];
+export const loadProceduralSfx = async (): Promise<Record<ProceduralSfxKey, string>> => {
+  const module = await import('./paranormalSfx');
+  return {
+    'ufo-elvis': module.UFO_ELVIS_SFX,
+    'cryptid-rumble': module.CRYPTID_RUMBLE_SFX,
+    'radio-static': module.RADIO_STATIC_SFX,
+  };
+};
+
+export type SfxKey = keyof typeof SFX_MANIFEST | ProceduralSfxKey;
+
+export const SFX_KEYS: SfxKey[] = [
+  ...(Object.keys(SFX_MANIFEST) as Array<keyof typeof SFX_MANIFEST>),
+  ...PROCEDURAL_SFX_KEYS,
+];

--- a/src/components/game/EnhancedBalancingDashboard.tsx
+++ b/src/components/game/EnhancedBalancingDashboard.tsx
@@ -8,7 +8,7 @@ import {
   type EnhancedCardAnalysis,
 } from '@/data/enhancedCardBalancing';
 import { MVP_COST_TABLE_ROWS, MVP_RULES_SECTIONS } from '@/content/mvpRules';
-import { CARD_DATABASE_CORE } from '@/data/core';
+import { getCoreCards, loadCardPool } from '@/data/cardDatabase';
 import { EXPANSION_MANIFEST } from '@/data/expansions';
 import {
   getEnabledExpansionIdsSnapshot,
@@ -248,9 +248,29 @@ const EnhancedBalancingDashboard = ({
     [activeTypes],
   );
 
+  const [coreCardPool, setCoreCardPool] = useState<GameCard[]>(() => getCoreCards());
+
+  useEffect(() => {
+    let cancelled = false;
+    void loadCardPool()
+      .then(() => {
+        if (!cancelled) {
+          setCoreCardPool(getCoreCards());
+        }
+      })
+      .catch(() => {
+        // Keep the synchronous fallback set already in state if the async
+        // collector fails — the dashboard remains usable with whatever the
+        // database resolved to.
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
   const filteredCoreCards = useMemo(
-    () => filterByTypes(CARD_DATABASE_CORE as GameCard[]),
-    [filterByTypes],
+    () => filterByTypes(coreCardPool),
+    [filterByTypes, coreCardPool],
   );
 
   const filteredExpansionCards = useMemo(

--- a/src/engine/news/__tests__/smartNarrativeComposer.test.ts
+++ b/src/engine/news/__tests__/smartNarrativeComposer.test.ts
@@ -30,7 +30,7 @@ describe('SmartNarrativeComposer', () => {
       const cards: CardPlayContext[] = [
         {
           card: createMockCard({
-            id: 'TRUTH-001',
+            id: 'TEST-TRUTH-UFO-001',
             name: 'UFO Sighting',
             type: 'MEDIA',
             faction: 'truth',
@@ -41,7 +41,7 @@ describe('SmartNarrativeComposer', () => {
         },
         {
           card: createMockCard({
-            id: 'TRUTH-002',
+            id: 'TEST-TRUTH-WIT-002',
             name: 'Witness Report',
             type: 'ATTACK',
             faction: 'truth',
@@ -66,7 +66,7 @@ describe('SmartNarrativeComposer', () => {
       const cards: CardPlayContext[] = [
         {
           card: createMockCard({
-            id: 'GOV-001',
+            id: 'TEST-GOV-BLACK-001',
             name: 'Press Blackout',
             type: 'MEDIA',
             faction: 'government',
@@ -77,7 +77,7 @@ describe('SmartNarrativeComposer', () => {
         },
         {
           card: createMockCard({
-            id: 'GOV-002',
+            id: 'TEST-GOV-DENIAL-002',
             name: 'Official Denial',
             type: 'ATTACK',
             faction: 'government',
@@ -99,7 +99,7 @@ describe('SmartNarrativeComposer', () => {
       const cards: CardPlayContext[] = [
         {
           card: createMockCard({
-            id: 'TRUTH-001',
+            id: 'TEST-TRUTH-LEAK-001',
             name: 'Leaked Documents',
             type: 'ATTACK',
             faction: 'truth',
@@ -110,7 +110,7 @@ describe('SmartNarrativeComposer', () => {
         },
         {
           card: createMockCard({
-            id: 'GOV-001',
+            id: 'TEST-GOV-DAMAGE-001',
             name: 'Damage Control',
             type: 'MEDIA',
             faction: 'government',
@@ -332,7 +332,7 @@ describe('SmartNarrativeComposer', () => {
       const cards: CardPlayContext[] = [
         {
           card: createMockCard({
-            id: 'TRUTH-001',
+            id: 'TEST-TRUTH-BIG-001',
             name: 'Big Reveal',
             type: 'MEDIA',
             faction: 'truth',
@@ -342,7 +342,7 @@ describe('SmartNarrativeComposer', () => {
         },
         {
           card: createMockCard({
-            id: 'TRUTH-002',
+            id: 'TEST-TRUTH-MORE-002',
             name: 'Another Reveal',
             type: 'ATTACK',
             faction: 'truth',

--- a/src/hooks/aiHelpers.ts
+++ b/src/hooks/aiHelpers.ts
@@ -437,7 +437,7 @@ export const applyAiCardPlay = (
   const recurringState: RecurringCharacterState = { ...prev.recurringCharacters };
   const recurringTracking = trackCharacterAppearance(resolvedCard.name, cardTags, prev.round, recurringState);
 
-  let resolution = resolveCardMVP(prev, resolvedCard, targetState ?? null, 'ai', achievements);
+  const resolution = resolveCardMVP(prev, resolvedCard, targetState ?? null, 'ai', achievements);
   const playerEditorId = prev.playerEditor ?? prev.editorId ?? null;
   if (playerEditorId) {
     const category = normalizeCardCategory(resolvedCard.type);

--- a/src/hooks/useAudio.ts
+++ b/src/hooks/useAudio.ts
@@ -1,5 +1,5 @@
 import { useState, useRef, useCallback, useEffect } from 'react';
-import { SFX_MANIFEST } from '@/assets/audio/sfxManifest';
+import { SFX_MANIFEST, loadProceduralSfx } from '@/assets/audio/sfxManifest';
 import { safeGetLocalStorageItem, safeSetLocalStorageItem } from '@/utils/storage';
 
 interface AudioConfig {
@@ -400,9 +400,18 @@ export const useAudio = () => {
     loadMusicTracks();
 
     // Create sound effects with fallback handling - use existing files for paranormal effects
-    // Load SFX asynchronously with error handling
+    // Load SFX asynchronously with error handling. The procedural paranormal
+    // SFX module is ~5 MB of base64 data URIs, so it's pulled in via dynamic
+    // import to keep it out of the main bundle.
     const loadSFX = async () => {
-      const loadPromises = Object.entries(SFX_MANIFEST).map(async ([key, src]) => {
+      const proceduralPromise = loadProceduralSfx().catch(error => {
+        console.warn('🎵 Procedural SFX chunk failed to load', error);
+        return {} as Record<string, string>;
+      });
+
+      const fileEntries = Object.entries(SFX_MANIFEST) as Array<[string, string]>;
+
+      const loadPromises = fileEntries.map(async ([key, src]) => {
         const audio = await loadAudioTrack(src);
         if (audio) {
           const baseSfxVolume = config.muted ? 0 : config.volume * config.sfxVolume;
@@ -416,8 +425,24 @@ export const useAudio = () => {
           sfxRefs.current[key] = silentAudio;
         }
       });
-      
+
       await Promise.all(loadPromises);
+
+      const proceduralSources = await proceduralPromise;
+      const proceduralPromises = Object.entries(proceduralSources).map(async ([key, src]) => {
+        const audio = await loadAudioTrack(src);
+        if (audio) {
+          const baseSfxVolume = config.muted ? 0 : config.volume * config.sfxVolume;
+          audio.volume = baseSfxVolume;
+          sfxRefs.current[key] = audio;
+        } else {
+          const silentAudio = new Audio();
+          silentAudio.volume = 0;
+          sfxRefs.current[key] = silentAudio;
+        }
+      });
+      await Promise.all(proceduralPromises);
+
       console.log('🎵 SFX loaded:', Object.keys(sfxRefs.current).length, 'sounds');
       setAudioStatus('Ready');
     };

--- a/src/hooks/useGameState.ts
+++ b/src/hooks/useGameState.ts
@@ -3328,17 +3328,17 @@ export const useGameState = (aiDifficultyOverride?: AIDifficulty) => {
     const aiDeckSize = Math.max(handSize, baseAiDeckSize);
 
     let newDeck = generateWeightedDeck(playerDeckSize, faction);
-    let aiDeckSource = generateWeightedDeck(aiDeckSize, aiFaction);
+    const aiDeckSource = generateWeightedDeck(aiDeckSize, aiFaction);
 
     if (addedCards.length > 0) {
       newDeck = [...addedCards, ...newDeck];
     }
 
-    let startingHand = newDeck.slice(0, handSize);
-    let remainingDeck = newDeck.slice(handSize);
+    const startingHand = newDeck.slice(0, handSize);
+    const remainingDeck = newDeck.slice(handSize);
 
-    let aiStartingHand = aiDeckSource.slice(0, handSize);
-    let aiRemainingDeck = aiDeckSource.slice(handSize);
+    const aiStartingHand = aiDeckSource.slice(0, handSize);
+    const aiRemainingDeck = aiDeckSource.slice(handSize);
 
     const runtimeToPersist = editorRuntime ? normalizeEditorRuntimeState(editorRuntime) ?? undefined : undefined;
     const playerEditorId = resolvedEditor?.id ?? requestedEditorId ?? null;
@@ -3562,7 +3562,7 @@ export const useGameState = (aiDifficultyOverride?: AIDifficulty) => {
       achievements.onCardPlayed(cardId, card.type, card.rarity);
 
       const targetState = targetOverride ?? prev.targetState ?? null;
-      let resolution = resolveCardEffects(prev, resolvedCard, targetState);
+      const resolution = resolveCardEffects(prev, resolvedCard, targetState);
 
       const adjustmentLogs: string[] = [];
       if (playContext.truthDelta !== 0) {
@@ -3872,7 +3872,7 @@ export const useGameState = (aiDifficultyOverride?: AIDifficulty) => {
         const resolvedCard = effectiveCost === card.cost ? card : { ...card, cost: effectiveCost };
         pendingResolvedCard = resolvedCard;
 
-        let resolution = resolveCardEffects(prev, resolvedCard, targetState);
+        const resolution = resolveCardEffects(prev, resolvedCard, targetState);
         wasCountered = Boolean(resolution.countered);
 
         if (wasCountered) {
@@ -4335,7 +4335,7 @@ export const useGameState = (aiDifficultyOverride?: AIDifficulty) => {
 
         prev.eventManager?.updateTurn(prev.turn);
 
-        let eventEffectLog: string[] = [...hotspotLogs];
+        const eventEffectLog: string[] = [...hotspotLogs];
         let truthModifier = 0;
         let ipModifier = 0;
         let bonusCardDraw = 0;

--- a/src/mvp/engine.ts
+++ b/src/mvp/engine.ts
@@ -343,13 +343,6 @@ export function computeTurnIpIncome(
 
 export function startTurn(state: GameState): GameState {
   const cloned = cloneGameState(state);
-  try {
-    void import('@/game/aiEditorBinding')
-      .then(module => {
-        module.ensureAiEditorSelected?.(cloned);
-      })
-      .catch(() => {});
-  } catch {}
   ensureAiEditorSelected(cloned);
   const currentId = cloned.currentPlayer;
   const me = cloned.players[currentId];

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -196,5 +196,35 @@ export default defineConfig(({ mode }) => {
         },
       ],
     },
+    build: {
+      // Split heavy third-party libs out of the main bundle so the initial
+      // download stays smaller and the vendor chunk can be cached
+      // independently from app code.
+      rollupOptions: {
+        output: {
+          manualChunks(id) {
+            if (!id.includes("node_modules")) {
+              return undefined;
+            }
+            if (id.includes("react-dom")) return "vendor-react";
+            if (/[\\/]node_modules[\\/]react[\\/]/.test(id)) return "vendor-react";
+            if (id.includes("scheduler")) return "vendor-react";
+            if (id.includes("@radix-ui")) return "vendor-radix";
+            if (id.includes("lucide-react")) return "vendor-icons";
+            if (id.includes("recharts") || id.includes("d3-")) return "vendor-charts";
+            if (
+              id.includes("@tanstack") ||
+              id.includes("react-hook-form") ||
+              id.includes("zod") ||
+              id.includes("react-router")
+            ) {
+              return "vendor-app";
+            }
+            if (id.includes("peerjs")) return "vendor-peerjs";
+            return undefined;
+          },
+        },
+      },
+    },
   };
 });


### PR DESCRIPTION
## Summary

This PR addresses critical test infrastructure issues, reduces initial bundle size by 28%, and fixes code quality problems across the codebase. The changes ensure test suites run reliably without cross-file pollution, improve build performance through lazy-loading and vendor chunk splitting, and resolve TypeScript/ESLint issues.

## Key Changes

### Test Infrastructure Fixes
- **Establish centralized test preload** (`__tests__/__setup__/preload.ts`): Installs happy-dom and localStorage globals once before any test file evaluates, ensuring `@testing-library/react` captures valid DOM references at module init time
- **Fix mock.module() pollution**: Implement delegating mock pattern with toggles to prevent bun:test's persistent module mocks from leaking across test files. Real module implementations are stashed in preload and only stubbed when needed
- **Migrate from react-test-renderer to @testing-library/react**: Fixes incompatibility with shadcn Select portals in happy-dom environments
- **Replace Jest spy API**: Switch `mock.spy()` to `spyOn` from bun:test
- **Update test files**: Remove redundant happy-dom initialization from individual test files (`TurnEdition.test.tsx`, `TabloidNewspaperV2Pages.test.tsx`, `useCampaignProgress.test.ts`, `useCardCollection.test.ts`, `gameplayScreen.test.tsx`, `CardCollectionContent.test.ts`)

**Result**: Test suite improved from 14 fail / 7 errors to **120 pass / 0 fail / 0 errors**

### Bundle Size Optimization
- **Lazy-load procedural SFX**: Move ~5 MB base64 paranormal sound effects (`paranormalSfx.ts`) from static import to dynamic `loadProceduralSfx()` called in `useAudio` hook, creating separate 670 kB chunk (484 kB gzip)
- **Implement vendor chunk splitting**: Add `manualChunks` configuration in `vite.config.ts` to split React, Radix UI, Lucide icons, Recharts/D3, TanStack/zod/router, and PeerJS into independent vendor chunks for better cache granularity
- **Remove double imports**: Eliminate redundant static/dynamic import of `@/data/core` in `EnhancedBalancingDashboard.tsx` and dead dynamic import in `engine.ts`

**Result**: Initial gzip load reduced from ~1.66 MB to ~1.20 MB (28% improvement) with identical functionality

### Code Quality Improvements
- **ESLint auto-fix**: Correct 9 `prefer-const` violations in `aiHelpers.ts` and `useGameState.ts`
- **Fix parser stack overflow**: Add `src/assets/audio/paranormalSfx.ts` to ESLint ignores (6993 lines of base64 data causes TypeScript-ESLint parser to crash)
- **Fix test card ID collisions**: Replace real card IDs (`TRUTH-001`, `GOV-001`) with unique test IDs in `smartNarrativeComposer.test.ts` and stub empty articles in `absurdComposer.spec.ts` to exercise template fallback paths

### Build Configuration
- **Update bunfig.toml**: Add preload reference for test setup
- **Document findings**: Add `CLAUDE.md` with patterns for future development (test mocking, bundle optimization, ESLint baseline)
- **Update logs**: Record all changes in `log.md` and `UPDATES_LOG.md`

## Implementation Details

The test isolation fix uses a two-phase approach:
1. Preload captures real module implementations via spread-copy (not live bindings) before any test mocks them
2. Each test file that needs mocking installs a delegating mock with a local `useStub` toggle, enabling the stub only during that file's execution window

This pattern allows bun:test's permanent mock registrations to coexist without cross-file contamination.

The bundle optimization prioritizes lazy-loading of large, non-critical assets (procedural SFX) and vendor chunk isolation for independent caching of third-party dependencies.

## Build Health

https://claude.ai/code/session_012L3gkSFYyYhfeGwmS9iqFf